### PR TITLE
XML Documentation xsd and samples how it could look like

### DIFF
--- a/CodeSniffer/Standards/Generic/Docs/Files/LineLengthStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/Files/LineLengthStandard.xml
@@ -1,7 +1,26 @@
-<documentation title="Line Length">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="Line Length" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
+    <properties>
+        <property name="lineLimit" type="integer" default="80">
+            <description>
+                <![CDATA[
+                The limit that the length of a line should not exceed.
+                ]]>
+            </description>
+        </property>
+        <property name="absoluteLineLimit" type="integer" default="100">
+            <description>
+                <![CDATA[
+                The limit that the length of a line must not exceed.
+
+                Set to zero (0) to disable.
+                ]]>
+            </description>
+        </property>
+    </properties>
     <standard>
     <![CDATA[
-    It is recommended to keep lines at approximately 80 characters long for better code readability.
+    Checks all lines in the file, and throws warnings if they are over 80 characters in length and errors if they are over 100. Both these figures can be changed by extending this sniff in your own standard.
     ]]>
     </standard>
 </documentation>

--- a/CodeSniffer/Standards/Generic/Docs/Formatting/MultipleStatementAlignmentStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/Formatting/MultipleStatementAlignmentStandard.xml
@@ -1,4 +1,23 @@
-<documentation title="Aligning Blocks of Assignments">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="Aligning Blocks of Assignments" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
+    <properties>
+        <property name="maxPadding" type="integer" default="1000">
+            <description>
+            <![CDATA[
+            The maximum amount of padding before the alignment is ignored.
+
+            If the amount of padding required to align this assignment with the surrounding assignments exceeds this number, the assignment will be ignored and no errors or warnings will be thrown.
+            ]]>
+            </description>
+        </property>
+        <property name="maxPadding" type="boolean" default="false">
+            <description>
+            <![CDATA[
+            If true, multi-line assignments are not checked.
+            ]]>
+            </description>
+        </property>
+    </properties>
     <standard>
     <![CDATA[
       There should be one space on either side of an equals sign used to assign a value to a variable. In the case of a block of related assignments, more space may be inserted to promote readability.

--- a/CodeSniffer/Standards/Generic/Docs/Functions/OpeningFunctionBraceBsdAllmanStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/Functions/OpeningFunctionBraceBsdAllmanStandard.xml
@@ -1,4 +1,5 @@
-<documentation title="Opening Brace in Function Declarations">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="Opening Brace in Function Declarations" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
     <standard>
     <![CDATA[
     Function declarations follow the "BSD/Allman style". The function brace is on the line following the function declaration and is indented to the same column as the start of the function declaration.

--- a/CodeSniffer/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/Functions/OpeningFunctionBraceKernighanRitchieStandard.xml
@@ -1,4 +1,5 @@
-<documentation title="Opening Brace in Function Declarations">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="Opening Brace in Function Declarations" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
     <standard>
     <![CDATA[
     Function declarations follow the "Kernighan/Ritchie style". The function brace is on the same line as the function declaration. One space is required between the closing parenthesis and the brace.

--- a/CodeSniffer/Standards/Generic/Docs/NamingConventions/UpperCaseConstantNameStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/NamingConventions/UpperCaseConstantNameStandard.xml
@@ -1,4 +1,5 @@
-<documentation title="Constant Names">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="Constant Names" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
     <standard>
     <![CDATA[
      Constants should always be all-uppercase, with underscores to separate words.

--- a/CodeSniffer/Standards/Generic/Docs/PHP/DisallowShortOpenTagStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/PHP/DisallowShortOpenTagStandard.xml
@@ -1,7 +1,22 @@
-<documentation title="PHP Code Tags">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="PHP Code Tags" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
     <standard>
     <![CDATA[
     Always use <?php ?> to delimit PHP code, not the <? ?> shorthand. This is the most portable way to include PHP code on differing operating systems and setups.
     ]]>
     </standard>
+    <code_comparison>
+           <code title="Valid: file with long open tag">
+           <![CDATA[
+<?php
+// contents...
+           ]]>
+           </code>
+           <code title="Invalid: file with short open tag">
+           <![CDATA[
+<?
+// contents...
+           ]]>
+           </code>
+       </code_comparison>
 </documentation>

--- a/CodeSniffer/Standards/Generic/Docs/PHP/LowerCaseConstantStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/PHP/LowerCaseConstantStandard.xml
@@ -1,4 +1,5 @@
-<documentation title="PHP Constants">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="PHP Constants" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
     <standard>
     <![CDATA[
     The <em>true</em>, <em>false</em> and <em>null</em> constants must always be lowercase.

--- a/CodeSniffer/Standards/Generic/Docs/PHP/UpperCaseConstantStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/PHP/UpperCaseConstantStandard.xml
@@ -1,4 +1,5 @@
-<documentation title="PHP Constants">
+<?xml version="1.0" encoding="UTF-8" ?>
+<documentation title="PHP Constants" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../tests/documentation.xsd">
     <standard>
     <![CDATA[
     The <em>true</em>, <em>false</em> and <em>null</em> constants must always be uppercase.

--- a/tests/documentation.xsd
+++ b/tests/documentation.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+ 
+    <xs:element name="documentation" type="documentation"/>
+ 
+    <xs:complexType name="documentation">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+           <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+           <xs:sequence minOccurs="1" maxOccurs="unbounded">
+               <xs:element name="standard" type="xs:string" minOccurs="1" maxOccurs="1"/>
+               <xs:element name="code_comparison" type="code_comparison" minOccurs="0" maxOccurs="unbounded"/>
+           </xs:sequence>
+        </xs:sequence>
+        <xs:attribute name="title" type="xs:string" use="required" />
+    </xs:complexType>
+ 
+    <xs:complexType name="properties">
+        <xs:sequence>
+            <xs:element name="property" type="property" maxOccurs="unbounded" minOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+ 
+    <xs:complexType name="property">
+        <xs:sequence>
+            <xs:element name="description" type="xs:string" maxOccurs="1" minOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="boolean"/>
+                    <xs:enumeration value="integer"/>
+                    <xs:enumeration value="string"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="default" type="xs:string" use="required" />
+    </xs:complexType>
+ 
+    <xs:complexType name="code_comparison">
+        <xs:sequence>
+            <xs:element name="code" maxOccurs="unbounded" minOccurs="1">
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="title" type="xs:string" use="required"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+ 
+</xs:schema>


### PR DESCRIPTION
I've had a little discussed with @gsherwood about how to contribute to the sniffs documentation and he suggested to improve upon the existing xml documentation.

Should you pull this I will then start to add documentation for every sniff in "Generic".

What i mainly added was documentation for the available properties, their type and a default value.

I'm looking to improve the docs to be able to build something like http://edorian.github.com/php-coding-standard-generator/ for PHP_CodeSniffer and because I've send quite some time trying to figure out what sniffs do ;)

---

If you don't like the formatting just let me know, this is just an example of how it could look like :)

Credit for the xsd file goes to @gooh
