### PR TITLE
Add sniff for FIXME comments as errors to TodoSniff.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -82,6 +82,22 @@ class Generic_Sniffs_Commenting_TodoSniff implements PHP_CodeSniffer_Sniff
             $phpcsFile->addWarning($error, $stackPtr, $type, $data);
         }
 
+        if (preg_match('|[^a-z]+fixme[^a-z]+(.*)|i', $content, $matches) !== 0) {
+            // Clear whitespace and some common characters not required at
+            // the end of a to-do message to make the warning more informative.
+            $type        = 'FixmeCommentFound';
+            $todoMessage = trim($matches[1]);
+            $todoMessage = trim($todoMessage, '[]().');
+            $error       = 'Comment refers to a FIXME task';
+            $data        = array($todoMessage);
+            if ($todoMessage !== '') {
+                $type   = 'FixmeTaskFound';
+                $error .= ' "%s"';
+            }
+
+            $phpcsFile->addError($error, $stackPtr, $type, $data);
+        }
+
     }//end process()
 
 

--- a/CodeSniffer/Standards/Generic/Tests/Commenting/TodoUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Commenting/TodoUnitTest.inc
@@ -19,4 +19,26 @@ Debug::bam('test');
 // To do this, use a function!
 // notodo! NOTODO! NOtodo!
 //TODO.
+
+/**
+ * FIXME: really need to fix this before I commit.
+ *
+ */
+
+// FIXME: this is broken, don't forget to fix it
+error_log('test');
+
+// FIXME remove this.
+Debug::bam('test');
+
+// fixme - fix this.
+
+// Extract info from the array.
+// FIXME: this is just a stub, fill in later
+
+// Extract info from the array (fixme: finish later)
+// To do this, use a function!
+// nofixme! NOFIXME! NOfixme!
+//FIXME.
+
 ?>

--- a/CodeSniffer/Standards/Generic/Tests/Commenting/TodoUnitTest.js
+++ b/CodeSniffer/Standards/Generic/Tests/Commenting/TodoUnitTest.js
@@ -19,4 +19,25 @@ alert('test');
 // To do this, use a function!
 // notodo! NOTODO! NOtodo!
 //TODO.
+
+/**
+ * FIXME: Write this comment
+ *
+ */
+
+// FIXME: remove this.
+alert('test');
+
+// FIXME remove this.
+alert('test');
+
+// fixme - remove this.
+
+// Extract info from the array.
+// FIXME: can this be done faster?
+
+// Extract info from the array (fixme: make it faster)
+// To do this, use a function!
+// nofixme! NOFIXME! NOfixme!
+//FIXME.
 ?>

--- a/CodeSniffer/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -44,7 +44,33 @@ class Generic_Tests_Commenting_TodoUnitTest extends AbstractSniffUnitTest
      */
     public function getErrorList($testFile='TodoUnitTest.inc')
     {
-        return array();
+        switch ($testFile) {
+        case 'TodoUnitTest.inc':
+            return array(
+                    24 => 1,
+                    28 => 1,
+                    31 => 1,
+                    34 => 1,
+                    37 => 1,
+                    39 => 1,
+                    42 => 1,
+                   );
+            break;
+        case 'TodoUnitTest.js':
+            return array(
+                    24 => 1,
+                    28 => 1,
+                    31 => 1,
+                    34 => 1,
+                    37 => 1,
+                    39 => 1,
+                    42 => 1,
+                   );
+            break;
+        default:
+            return array();
+            break;
+        }//end switch
 
     }//end getErrorList()
 


### PR DESCRIPTION
Patch to add FIXME comments to the TODO comments sniff: FIXME comments produce an error rather than a warning, and have FixmeCommentFound or FixmeTaskFound message class.

Updated tests included (and test-suite passes successfully).
