### PR TITLE
Allow for changing $maxPercentage in CommentedOutCode using the xml configuration

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -45,7 +45,7 @@ class Squiz_Sniffs_PHP_CommentedOutCodeSniff implements PHP_CodeSniffer_Sniff
      *
      * @var int
      */
-    protected $maxPercentage = 35;
+    public $maxPercentage = 35;
 
 
     /**


### PR DESCRIPTION
Usually public properties are used for class properties that can be configured using the xml `<property>` tags.

This seems to be one of the cases where it would make sense to allow this and makes it consistent with the other sniffs
