### PR TITLE
Adding the php extension as one of the default extensions

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -89,7 +89,7 @@ class PHP_CodeSniffer_CLI
         $defaults['interactive'] = false;
         $defaults['local']       = false;
         $defaults['showSources'] = false;
-        $defaults['extensions']  = array();
+        $defaults['extensions']  = array('php');
         $defaults['sniffs']      = array();
         $defaults['ignored']     = array();
         $defaults['reportFile']  = null;


### PR DESCRIPTION
The php extension should be included as one of the default extensions to check when checking directories. This can cause, and already caused, a lot of trouble with CodeSniffer users when they were trying to sniff directories.
