### PR TITLE
Fix usage of parameter --standard

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -262,6 +262,13 @@ class PHP_CodeSniffer
         } else if (is_file(dirname(__FILE__).'/CodeSniffer/Standards/'.$path) === true) {
             // Check for included sniffs.
             include dirname(__FILE__).'/CodeSniffer/Standards/'.$path;
+        } else if (!empty($GLOBALS['phpcs'])
+            && ($values = $GLOBALS['phpcs']->getCommandLineValues())
+            && !empty($values['standard'])
+            && is_file(dirname($values['standard']).'/'.$path) === true
+        ) {
+            // Check if this is a CLI run and the standard dir parameter is set.
+            include dirname($values['standard']).'/'.$path;
         } else {
             // Everything else.
             @include $path;
@@ -796,6 +803,11 @@ class PHP_CodeSniffer
 
                 $path = $parts[0].'/Sniffs/'.$parts[1].'/'.$parts[2].'Sniff.php';
                 $path = realpath(dirname(__FILE__).'/CodeSniffer/Standards/'.$path);
+
+                // Check if the standardDir parameter is set.
+                if (!$path && !empty($this->standardDir)) {
+                    $path = realpath($this->standardDir.'/Sniffs/'.$parts[1].'/'.$parts[2].'Sniff.php');
+                }
             }
         }//end if
 


### PR DESCRIPTION
This is a follow up of this pull request: https://github.com/pear/PHP_CodeSniffer/pull/3#issuecomment-3859114

Point Nr. 1 from the previous pull request was already fixed in latest dev - thanks :)

Point Nr. 2 the usage of the parameter `--standard` still needs some work. I've added a description of the issue and the way I decided to solve it to the commit itself: https://github.com/das-peter/PHP_CodeSniffer/commit/ad0926ba24d4065614ca877ad3fde295ef00ff2e#commitcomment-953994

Thanks in advance & cheers
Peter
