### PR TITLE
Ability to "explain" a standard to see what sniffs are registered

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -534,6 +534,30 @@ class PHP_CodeSniffer
 
 
     /**
+     * Explain the coding standard with the sniffs registered
+     *
+     * @param string $standard The standard we want to explain
+     * @param array  $sniffs   The sniff names to restrict the allowed
+     *                         listeners to.
+     *
+     * @return void
+     */
+    public function explain($standard, $sniffs)
+    {
+        $this->setTokenListeners($standard, $sniffs);
+
+        echo 'The "'.$standard.'" standard has the following sniffs registered:';
+        echo PHP_EOL.PHP_EOL;
+        foreach ($this->listeners as $sniff) {
+            echo $sniff.PHP_EOL;
+        }
+
+        echo PHP_EOL;
+
+    }//end explain()
+
+
+    /**
      * Processes multi-file sniffs.
      *
      * @return void


### PR DESCRIPTION
Other than running the phpcs command over a file/folder with -vvv there is no easy way to see which sniffs are registered. This feature branch tries to resolve that.
