### PR TITLE
Allow javascript style closure syntax in FunctionCallSignatureSniff

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -180,6 +180,8 @@ class PEAR_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSniffe
             $functionIndent = strlen($tokens[$i]['content']);
         }
 
+        $closureUsedInFunctionCall = false;
+
         // Each line between the parenthesis should be indented n spaces.
         $closeBracket = $tokens[$openBracket]['parenthesis_closer'];
         $lastLine     = $tokens[$openBracket]['line'];
@@ -242,21 +244,29 @@ class PEAR_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSniffe
 
             // Skip the rest of a closure.
             if ($tokens[$i]['code'] === T_CLOSURE) {
+                $closureUsedInFunctionCall  = true;
                 $i        = $tokens[$i]['scope_closer'];
                 $lastLine = $tokens[$i]['line'];
                 continue;
             }
         }//end for
 
-        if ($tokens[($openBracket + 1)]['content'] !== $phpcsFile->eolChar) {
-            $error = 'Opening parenthesis of a multi-line function call must be the last content on the line';
-            $phpcsFile->addError($error, $stackPtr, 'ContentAfterOpenBracket');
-        }
+        /*If a closure was used in the function call skip those checks to allow the following call syntax:              
+        usort($array, function($a, $b) {                                                                                
+           return strncmp($a->x, $b->x);                                                                                
+        });                                                                                                             
+        */                                                                                                              
+        if(!$closureUsedInFunctionCall) {
+            if ($tokens[($openBracket + 1)]['content'] !== $phpcsFile->eolChar) {
+                $error = 'Opening parenthesis of a multi-line function call must be the last content on the line';
+                $phpcsFile->addError($error, $stackPtr, 'ContentAfterOpenBracket');
+            }
 
-        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($closeBracket - 1), null, true);
-        if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
-            $error = 'Closing parenthesis of a multi-line function call must be on a line by itself';
-            $phpcsFile->addError($error, $closeBracket, 'CloseBracketLine');
+            $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($closeBracket - 1), null, true);
+            if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
+                $error = 'Closing parenthesis of a multi-line function call must be on a line by itself';
+                $phpcsFile->addError($error, $closeBracket, 'CloseBracketLine');
+            }
         }
 
     }//end processMultiLineCall()


### PR DESCRIPTION
When using custom sorting functions the syntax I've seen used most often was the following adapted, i assume, from javascript:

``` php
 usort($rawData, function($a, $b) use ($sorting) {                                                           
     return strnatcasecmp($a->getAttribute($sorting), $b->getAttribute($sorting));                           
 });      
```

The sniffs forbids this forcing a syntax like:

``` php
usort(
    $rawData, 
    function($a, $b) use ($sorting) {                                                           
        return strnatcasecmp($a->getAttribute($sorting), $b->getAttribute($sorting));                           
    }
);
```

which I don't see people use all that much. Hence the pull request.

It is quite possible that this is the wrong solution. My basic requirement would be "Use most of the sniff".

So If you'd rather have a flag for this or have any other way that doesn't require overriding the massive method like maybe just factoring out the checks in a protected methods that I could override would do it would be great too.

So feel free to close this and tell me how to solve it if that solution is not acceptable :) 
