### PR TITLE
Fixed "whitespace" search after last closing tag.

### DIFF
--- a/CodeSniffer/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/CodeSniffer/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -56,10 +56,25 @@ class Zend_Sniffs_Files_ClosingTagSniff implements PHP_CodeSniffer_Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(T_INLINE_HTML, ($stackPtr + 1), null, true);
         if ($next === false) {
-            $error = 'A closing tag is not permitted at the end of a PHP file';
-            $phpcsFile->addError($error, $stackPtr, 'NotAllowed');
+            // We've found the last closing tag in the file so the only thing
+            // potentially remaining is inline HTML. Now we need to figure out
+            // whether or not it's just a bunch of whitespace.
+            $inlineHtml = '';
+            for ($i = $stackPtr + 1;
+                isset($tokens[$i]) && $tokens[$i]['code'] === T_INLINE_HTML;
+                $i++
+            ) {
+                $inlineHtml .= $tokens[$i]['content'];
+            }
+
+            // Check if the remaining inline HTML is just whitespace.
+            $inlineHtml = trim($inlineHtml);
+            if (empty($inlineHtml)) {
+                $error = 'A closing tag is not permitted at the end of a PHP file';
+                $phpcsFile->addError($error, $stackPtr, 'NotAllowed');
+            }
         }
 
     }//end process()


### PR DESCRIPTION
A T_WHITESPACE token cannot technically exist after the last closing tag, only "whitespace" in the form of one or more T_INLINE_HTML tokens.
