### PR TITLE
Fixed issues with Zend ClosingTagSniff.

### DIFF
--- a/CodeSniffer/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/CodeSniffer/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -57,7 +57,7 @@ class Zend_Sniffs_Files_ClosingTagSniff implements PHP_CodeSniffer_Sniff
         $tokens = $phpcsFile->getTokens();
 
         $next = $phpcsFile->findNext(T_INLINE_HTML, ($stackPtr + 1), null, true);
-        if ($next === true) {
+        if ($next !== false) {
             return;
         }
 
@@ -66,11 +66,6 @@ class Zend_Sniffs_Files_ClosingTagSniff implements PHP_CodeSniffer_Sniff
         // whether or not it's just a bunch of whitespace.
         $content = '';
         for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-            if ($tokens[$i]['code'] !== T_INLINE_HTML) {
-                // This can't be the last closing tag if there is more code found.
-                return;
-            }
-
             $content .= $tokens[$i]['content'];
         }
 


### PR DESCRIPTION
1. PHP_CodeSniffer_File::findNext() never returns true; changed to !== false.
2. Removed conditional that would never get executed.

This is a continuation of [this pull request](https://github.com/squizlabs/PHP_CodeSniffer/pull/21) and [this commit comment](https://github.com/squizlabs/PHP_CodeSniffer/commit/64a8c8333709f15f865a971f34477d86f3ab7766#commitcomment-1146198).
