### PR TITLE
Fix can not match some new errors of gjslint.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -94,7 +94,7 @@ class Generic_Sniffs_Debug_ClosureLinterSniff implements PHP_CodeSniffer_Sniff
 
         foreach ($output as $finding) {
             $matches    = array();
-            $numMatches = preg_match('/^(.*):([0-9]+):\(([0-9]+)\)(.*)$/', $finding, $matches);
+            $numMatches = preg_match('/^(.*):([0-9]+):\(.*?([0-9]+)\)(.*)$/', $finding, $matches);
             if ($numMatches === 0) {
                 continue;
             }


### PR DESCRIPTION
As following javascript code:

``` javascript
// foo.js
var foo = 1
var bar = 2;
```

``` shell
gjslint --nosummary --notime --unix_mode  foo.js
```

will ouput like this:

``` shell
foo.js:1:(New Error 0010) Missing semicolon at end of line
Found 1 errors, including 1 new errors, in 1 files (0 files OK).

Some of the errors reported by GJsLint may be auto-fixable using the script
fixjsstyle. Please double check any changes it makes and report any bugs. The
script can be run by executing:

fixjsstyle --nosummary --notime foo.js
```

But PHP Codesniffer can not catch the error.
