### PR TITLE
Constant naming false positive on goto labels.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -85,6 +85,7 @@ class Generic_Sniffs_NamingConventions_UpperCaseConstantNameSniff implements PHP
                              T_NAMESPACE,
                              T_USE,
                              T_AS,
+                             T_GOTO,
                             );
 
             if (in_array($tokens[$functionKeyword]['code'], $declarations) === true) {
@@ -136,9 +137,16 @@ class Generic_Sniffs_NamingConventions_UpperCaseConstantNameSniff implements PHP
             }
 
             // Is this an instance of declare()
-            $prevPtr = $phpcsFile->findPrevious(array(T_WHITESPACE, T_OPEN_PARENTHESIS), ($stackPtr - 1), null, true);
-            if ($tokens[$prevPtr]['code'] === T_DECLARE) {
+            $prevPtrDeclare = $phpcsFile->findPrevious(array(T_WHITESPACE, T_OPEN_PARENTHESIS), ($stackPtr - 1), null, true);
+            if ($tokens[$prevPtrDeclare]['code'] === T_DECLARE) {
                 return;
+            }
+
+            // Is this a goto label target?
+            if ($tokens[$nextPtr]['code'] === T_COLON) {
+                if (in_array($tokens[$prevPtr]['code'], array(T_SEMICOLON, T_OPEN_CURLY_BRACKET, T_COLON), true)) {
+                    return;
+                }
             }
 
             // This is a real constant.

--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
@@ -106,4 +106,21 @@ class A {
 }
 
 A::constant('anything-not-in-uppercase');
+
+// goto
+goto gotolabel;
+
+gototarget1:
+
+function ConstTest() {
+    gototarget2:
+}
+
+switch($foo)
+{
+    case $bar:
+    gototarget3:
+}
+
+
 ?>

--- a/CodeSniffer/Tokens.php
+++ b/CodeSniffer/Tokens.php
@@ -74,6 +74,10 @@ if (defined('T_NS_SEPARATOR') === false) {
     define('T_NS_SEPARATOR', 1051);
 }
 
+if (defined('T_GOTO') === false) {
+    define('T_GOTO', 1053);
+}
+
 // Some PHP 5.4 tokens, replicated for lower versions.
 if (defined('T_TRAIT') === false) {
     define('T_TRAIT', 1052);


### PR DESCRIPTION
goto labels give false positives for constant namings because codesniffer takes them as constants. But they are not. The pull request fixes this.
