### PR TITLE
Exclude Patterns are not recognized on Windows

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1135,9 +1135,13 @@ class PHP_CodeSniffer
             }
 
             $replacements = array(
-                             '\\,' => ',',
-                             '*'   => '.*',
-                            );
+                '\\,' => ',',
+                '*'   => '.*',
+            );
+            
+            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+                $replacements[ '/' ] = DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR;
+            }
 
             $pattern = strtr($pattern, $replacements);
             if (preg_match("|{$pattern}|i", $path) === 1) {


### PR DESCRIPTION
When defining exlude patterns one most likely uses something like "&lt;exclude-pattern>_/tests/_&lt;/exclude-pattern>"

A path like that will fail to be recognized on Windows platforms since the directory sepeartor is "\". This commit converts slashes to the correct format while keeping support for both platforms.

[edit] There are stars in front and at the back of /tests/ but for some reason they are not visible in the comment.
