### PR TITLE
Add support for shorthand array syntax to ArrayBracketSpacingSniff.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc
@@ -6,4 +6,14 @@ $myArray  [  'key'  ]            = $value;
 if ($array[($index + 1)] === true) {
 } else if ($array  [ ($index + 1) ] === null) {
 }
+$deepArray['a']['b']   = $value;
+$deepArray ['a']['b']  = $value;
+$deepArray['a'] ['b']  = $value;
+$deepArray ['a'] ['b'] = $value;
+$deepArray['a'][ 'b']  = $value;
+$ob->arrayProp['a']    = $value;
+$ob->arrayProp ['a']   = $value;
+$ob->arrayProp[ 'a' ]  = $value;
+$array = ['value1', 'value2'];
+$array = [ 'value1', 'value2' ];
 ?>

--- a/CodeSniffer/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
@@ -43,10 +43,16 @@ class Squiz_Tests_Arrays_ArrayBracketSpacingUnitTest extends AbstractSniffUnitTe
     public function getErrorList()
     {
         return array(
-                3 => 1,
-                4 => 2,
-                5 => 3,
-                7 => 3,
+                3  => 1,
+                4  => 2,
+                5  => 3,
+                7  => 3,
+                10 => 1,
+                11 => 1,
+                12 => 2,
+                13 => 1,
+                15 => 1,
+                16 => 2,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Adds support and unit tests for PHP 5.4 shorthand array syntax to ArrayBracketSpacingSniff.

This version just skips sniffing if it believes that the syntax is a shorthand array, rather than applying a different set of rules, but it would be easy to adapt the code to apply a new set of rules instead.

Fixes http://pear.php.net/bugs/bug.php?id=19416
