### PR TITLE
Fixed Sniff inclusion on Windows.

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -767,7 +767,7 @@ class PHP_CodeSniffer
             if (in_array($sniff, $excludedSniffs) === true) {
                 continue;
             } else {
-                $files[] = $sniff;
+                $files[] = realpath($sniff);
             }
         }
 


### PR DESCRIPTION
There is a bug which prevents Sniffs inclusion when running on windows.

For example, using the new PSR1 standard ruleset which has 4 rules:

```
<ruleset name="PSR-1">
  <description>The PSR1 coding standard.</description>
  <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
    <severity>0</severity>
  </rule>
  <rule ref="Generic.Files.ByteOrderMark"/>
  <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
  <rule ref="Generic.NamingConventions.CamelCapsFunctionName"/>
</ruleset>

```

In CodeSniffer.php:643, you get a list of sniff files via getSniffFiles(). The fetched list looks like this:

```
Array 
(
    [0] => D:\Projects\PHP_CodeSniffer\CodeSniffer\Standards\Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
    [1] => D:\Projects\PHP_CodeSniffer\CodeSniffer\Standards\Generic/Sniffs/Files/ByteOrderMarkSniff.php
    [2] => D:\Projects\PHP_CodeSniffer\CodeSniffer\Standards\Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
    [3] => D:\Projects\PHP_CodeSniffer\CodeSniffer\Standards\Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
)
```

Notice the mixing of / and \ directory separators.

Afterwards in CodeSniffer.php:668:

```
$sniffPos = strrpos($file, DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR);
if ($sniffPos === false) {
    continue;
}
```

you filter out all files which do not contain `DIRECTORY_SEPARATOR.'Sniffs'.DIRECTORY_SEPARATOR`, which evaluates to `\Sniffs\` on Windows. Since the above files contain `/Sniffs/`, none of the 4 sniff files are included.

To solve this I used realpath() in getSniffFiles() to convert all directory separators to their appropriate value (\ on windows, / on linux) which will match DIRECTORY_SEPARATOR used in comparison.
