### PR TITLE
Add a composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "squizlabs/PHP_CodeSniffer",
-    "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards."
+    "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
     "homepage": "http://github.com/squizlabs/PHP_CodeSniffer",
     "license": "BSD-3-Clause",
     "version": "1.3.4",
@@ -21,6 +21,6 @@
     },
     "autoload": {
         "psr-0": {"PHP_CodeSniffer": "CodeSniffer/"}
-    }
+    },
     "bin": ["scripts/phpcs"]
 }


### PR DESCRIPTION
I'm taking an initial try at this using a modified version of the composer file I used to install PHP_CodeSniffer locally. Others who are better with composer can surely improve upon this initial file, but this at least gets the ball rolling. 
