### PR TITLE
Function comment sniff throws wrong errors if the comment closing line is malformed.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -155,6 +155,10 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sn
             $error = 'Missing function doc comment';
             $phpcsFile->addError($error, $stackPtr, 'Missing');
             return;
+        } else if (trim($tokens[$commentEnd]['content']) !== '*/') {
+            $error = 'Wrong function doc comment end; expected "*/", found "%s"';
+            $phpcsFile->addError($error, $commentEnd, 'WrongEnd', array(trim($tokens[$commentEnd]['content'])));
+            return;
         }
 
         // If there is any code between the function keyword and the doc block

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -543,4 +543,11 @@ $callback = function ($bar) use ($foo)
                 $bar += $foo;
             };
 
+/**
+ * Comment should end with '*', not '**' before the slash.
+ **/
+function test123() {
+
+}
+
 ?>

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -116,6 +116,7 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
                 474 => 1,
                 500 => 1,
                 526 => 1,
+                548 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
"*_/" instead of "_/" causes confusion.
