### PR TITLE
Coding standards fix

### DIFF
--- a/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -78,8 +78,12 @@ class PSR1_Sniffs_Files_SideEffectsSniff implements PHP_CodeSniffer_Sniff
      * Processes this sniff, when one of its tokens is encountered.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the token stack.
+     * @param int                  $start     The first position
+     *                                        in the token stack
+     * @param int                  $end       The last position
+     *                                        in the token stack
+     * @param array                $tokens    The stack of tokens that make up
+     *                                        the file
      *
      * @return void
      */

--- a/CodeSniffer/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -152,7 +152,7 @@ class PSR2_Sniffs_ControlStructures_SwitchDeclarationSniff implements PHP_CodeSn
                     $nextCloser
                 );
 
-                if ($nextCode !== FALSE) {
+                if ($nextCode !== false) {
                     $prevCode = $phpcsFile->findPrevious(T_WHITESPACE, ($nextCode - 1), $nextCase, true);
                     if ($tokens[$prevCode]['code'] !== T_COMMENT) {
                         $error = 'There must be a comment when fall-through is intentional in a non-empty case body';

--- a/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -208,12 +208,12 @@ class Squiz_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff implements 
                     } else if ($gap !== 1) {
                         // Just make sure this is not actually an indent.
                         if ($tokens[$whitespace]['line'] === $tokens[($whitespace - 1)]['line']) {
-                          $error = 'Expected 1 space between comma and argument "%s"; %s found';
-                          $data  = array(
-                                    $arg,
-                                    $gap,
-                                   );
-                          $phpcsFile->addError($error, $nextToken, 'SpacingBeforeArg', $data);
+                            $error = 'Expected 1 space between comma and argument "%s"; %s found';
+                            $data  = array(
+                                        $arg,
+                                        $gap,
+                                    );
+                            $phpcsFile->addError($error, $nextToken, 'SpacingBeforeArg', $data);
                         }
                     }//end if
                 } else {

--- a/CodeSniffer/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -78,11 +78,12 @@ class Squiz_Sniffs_Functions_MultiLineFunctionDeclarationSniff extends PEAR_Snif
     /**
      * Processes the contents of a single set of brackets.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the open bracket
-     *                                        in the stack passed in $tokens.
-     * @param array                $tokens    The stack of tokens that make up
-     *                                        the file.
+     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                  $openBracket The position of the open bracket
+     *                                          in the stack passed in $tokens.
+     * @param array                $tokens      The stack of tokens that make up
+     *                                          the file.
+     * @param string               $type        The type of the token
      *
      * @return void
      */


### PR DESCRIPTION
1) Doc comment for vars didn't match actual variable name
2) FALSE was uppercase, changed to lowercase
3) Incorrect line indentation
4) Missing few doc comments

PHP_CodeSniffer $ php scripts/phpcs --ignore=_/tests/_ . -n
Time: 17 seconds, Memory: 31.25Mb

PHP_CodeSniffer $ phpunit tests/AllTests.php
Time: 6 seconds, Memory: 49.00Mb
OK, but incomplete or skipped tests!
Tests: 222, Assertions: 150, Skipped: 3.
