### PR TITLE
[BUGFIX] Add namespace support for Squiz.Classes.SelfMemberReference

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
@@ -64,4 +64,21 @@ class MyClass {
 
 MyClass::walk();
 
+namespace TYPO3\CMS\Reports;
+
+class Status {
+	const NOTICE = -2;
+	const INFO = -1;
+	const OK = 0;
+	const WARNING = 1;
+	const ERROR = 2;
+}
+
+namespace TYPO3\CMS\Reports\Report\Status;
+
+class Status implements \TYPO3\CMS\Reports\ReportInterface {
+	public function getHighestSeverity(array $statusCollection) {
+		$highestSeverity = \TYPO3\CMS\Reports\Status::NOTICE;
+	}
+}
 ?>


### PR DESCRIPTION
With the namespace feature of PHP it is possible to name two classes with the same name if there are in different namespaces.
If this classes got a relation, the sniff "Squiz.Classes.SelfMemberReference" will throw a false positive violation.

Imagine you got the following code:

``` php
namespace TYPO3\CMS\Reports;

class Status {
    const NOTICE = -2;
    const INFO = -1;
    const OK = 0;
    const WARNING = 1;
    const ERROR = 2;
}

namespace TYPO3\CMS\Reports\Report\Status;

class Status implements \TYPO3\CMS\Reports\ReportInterface {
    public function getHighestSeverity(array $statusCollection) {
        $highestSeverity = \TYPO3\CMS\Reports\Status::NOTICE;
    }
}
```

The sniff Squiz.Classes.SelfMemberReference says, that `$highestSeverity = \TYPO3\CMS\Reports\Status::NOTICE;` is wrong and can change to `$highestSeverity = self::NOTICE;`. But this is wrong, because both classes has the same name but different namespaces.
