### PR TITLE
Correct PSR2 EOF compliance

### DIFF
--- a/CodeSniffer/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
@@ -67,14 +67,27 @@ class PSR2_Sniffs_Files_EndFileNewlineSniff implements PHP_CodeSniffer_Sniff
         $tokens   = $phpcsFile->getTokens();
         $stackPtr = ($phpcsFile->numTokens - 1);
 
-        // Go looking for the last non-empty line.
-        $lastLine = $tokens[$stackPtr]['line'];
-        while ($tokens[$stackPtr]['code'] === T_WHITESPACE) {
-            $stackPtr--;
+        if ($tokens[$stackPtr]['code'] === T_WHITESPACE 
+            && $tokens[$stackPtr]['content'] === "\n" 
+            && $tokens[$stackPtr-1]['content'] !== "\n"
+        ) {
+            // exactly one newline at end of file.
+            // Granted, $stackPtr-1 content could be whitespace, and therefore
+            // PSR2-illegal, but that's another sniff.
+            $blankLines = 1;
+        } elseif ($tokens[$stackPtr]['code'] !== T_WHITESPACE) {
+            // last token isn't a whitespace at all
+            $blankLines = 0;
+        } else {
+            $trailing_newlines = 0;
+            while ($tokens[$stackPtr]['code'] === T_WHITESPACE
+                && $tokens[$stackPtr]['content'] === "\n"
+            ) {
+                $blankLines++;
+                $stackPtr--;
+            }
         }
 
-        $lastCodeLine = $tokens[$stackPtr]['line'];
-        $blankLines   = $lastLine - $lastCodeLine;
         if ($blankLines === 0) {
             $error = 'Expected 1 blank line at end of file; 0 found';
             $data  = array($blankLines);

--- a/CodeSniffer/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/CodeSniffer/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -43,7 +43,7 @@ class PSR2_Tests_Files_EndFileNewlineUnitTest extends AbstractSniffUnitTest
     public function getErrorList($testFile='')
     {
         switch ($testFile) {
-        case 'EndFileNewlineUnitTest.2.inc':
+        case 'EndFileNewlineUnitTest.1.inc':
         case 'EndFileNewlineUnitTest.3.inc':
             return array(
                     2 => 1,


### PR DESCRIPTION
Enforces the correct number of newline characters at the end of files in PSR2. Fixes https://pear.php.net/bugs/bug.php?id=19615

Section 2.2 of PSR2 states:

> All PHP files MUST end with a single blank line.

The sniff as it is now actually insists on two blank lines. /cc @pmjones
