### PR TITLE
Prevent error by OperatorSpacingSniff when using a negative number as a case label

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -157,6 +157,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                               T_DOUBLE_ARROW,
                               T_COLON,
                               T_INLINE_THEN,
+                              T_CASE,
                              );
 
             if (in_array($tokens[$prev]['code'], $invalidTokens) === true) {

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -105,4 +105,9 @@ $boo = -$foo;
 function foo($boo = -1) {}
 $foo = array('boo' => -1);
 $x = $test ? -1 : 1;
+
+switch ($foo) {
+	case -1:
+		break;
+}
 ?>

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
@@ -46,3 +46,8 @@ result *=4;
 result*=4;
 
 $.localScroll({offset: {top: -32}});
+
+switch (result) {
+	case -1:
+		break;
+}


### PR DESCRIPTION
Without this PR, `Squiz_Whitespace_OperatorSpacingSniff` would complain about

``` php
switch ($foo) {
    case -1:
        // ...
        break;
}
```

stating there should be a space after the minus.
