### PR TITLE
Allow 5.3 namespaces in Sniffs

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -991,7 +991,12 @@ class PHP_CodeSniffer
 
         foreach ($this->listeners as $listenerClass) {
             // Work out the internal code for this sniff.
-            $parts = explode('_', $listenerClass);
+            if (false === strstr($listenerClass, '\\')) {
+                $parts = explode('_', $listenerClass);
+            } else {
+                $parts = explode('\\', $listenerClass);
+            }
+
             $code  = $parts[0].'.'.$parts[2].'.'.$parts[3];
             $code  = substr($code, 0, -5);
 


### PR DESCRIPTION
My sniffs use 5.3 namespaces.

So when I use my coding standard, it gets registered, but PHP_CodeSniffer assumes underscores where I use a namespace.

Hence, my run fails with "Cannot redeclare class 'Vendor\Sniffs\Something\FooSniff'" later.

So the fix I introduced seems simple - without going reflection-crazy, I create a second variable which will do Vendor\Sniffs\Something\FooSniff along with the current default of Vendor_Sniffs_Something_FooSniff.

Then I test if the 5.3 variation was found (without triggering autoload) - if so, I override the name ($className) which is used to internally register it my Sniff.

Then all is good.
