### PR TITLE
Fixes an error when using native "\SoapClient::__*" method.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -63,7 +63,19 @@ class Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff extends PHP_Co
      *
      * @var array
      */
-    protected $methodsDoubleUnderscore = array('soapcall');
+    protected $methodsDoubleUnderscore = array(
+                                          'soapcall', 
+                                          'getlastrequest', 
+                                          'getlastresponse', 
+                                          'getlastrequestheaders', 
+                                          'getlastresponseheaders', 
+                                          'getfunctions', 
+                                          'gettypes', 
+                                          'dorequest', 
+                                          'setcookie', 
+                                          'setlocation', 
+                                          'setsoapheaders',
+                                         );
 
     /**
      * A list of all PHP magic functions.


### PR DESCRIPTION
If the developer create a class extending the PHP native class \Soap_Client and override any of its method starting by a double underscore, like "__soapCall", PHPCS throws an error because "only magic methods should be prefixed with a double underscore".

Those methods aren't "magic method", but they're named with two underscore, and as they are PHP native methods, I think they should be allowed by PHPCS.
