### PR TITLE
Fix --report-gitblame issue in windows machines

### DIFF
--- a/CodeSniffer/Reports/Gitblame.php
+++ b/CodeSniffer/Reports/Gitblame.php
@@ -87,13 +87,13 @@ class PHP_CodeSniffer_Reports_Gitblame extends PHP_CodeSniffer_Reports_VersionCo
             echo 'Getting GIT blame info for '.basename($filename).'... ';
         }
 
-        $fileParts = explode('/', $filename);
+        $fileParts = explode(DIRECTORY_SEPARATOR, $filename);
         $found     = false;
         $location  = '';
         while (empty($fileParts) === false) {
             array_pop($fileParts);
-            $location = implode($fileParts, '/');
-            if (is_dir($location.'/.git') === true) {
+            $location = implode($fileParts, DIRECTORY_SEPARATOR);
+            if (is_dir($location . DIRECTORY_SEPARATOR.'.git') === true) {
                 $found = true;
                 break;
             }


### PR DESCRIPTION
This way the --report-gitblame works on windows as well.

The former way it always thrown the following error:
`ERROR: Could not locate .git directory`
