### PR TITLE
Fix composer autoload info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name%5B%5D=PHP_CodeSniffer",
         "source": "https://github.com/squizlabs/PHP_CodeSniffer"
     },
+    "autoload": {
+        "files": [ "CodeSniffer.php" ]
+    },
     "suggests": {
         "phpunit/php-timer": "*"
     },


### PR DESCRIPTION
I've needed to add an autoload section to the `composer.json` package metadata to get your classes autoloaded with the composer `vendor/autoload.php` file.
