### PR TITLE
Fixes compatibility/autoloading issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name%5B%5D=PHP_CodeSniffer",
         "source": "https://github.com/squizlabs/PHP_CodeSniffer"
     },
-    "autoload": {
-        "files": [ "CodeSniffer.php" ]
-    },
     "suggests": {
         "phpunit/php-timer": "*"
     },


### PR DESCRIPTION
For example, if I install phpunit and php_codesniffer, and then run a test that fails, I get the following:
https://gist.github.com/4066400

This is because the autoload_real.php from composer will contain (because of autoload config property):
`require $vendorDir . '/squizlabs/php_codesniffer/CodeSniffer.php';`

If I uncomment the above, my expected error occurs exactly as it should:
https://gist.github.com/4066411

Removing the autoload configuration from composer.json will prevent this line from being added. The line itself has no value for php_codesniffer as the phpcs 'binary' already includes it implicitly (albeit indirectly). Please correct me if anyone foresees issues here though...
