### PR TITLE
Avoid false warnings when return value is spread over more then one line 

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -100,7 +100,11 @@ class Squiz_Sniffs_PHP_NonExecutableCodeSniff implements PHP_CodeSniffer_Sniff
                 );
 
                 if ($next !== false) {
-                    $lastLine = $tokens[($stackPtr + 1)]['line'];
+                    $end = $phpcsFile->findNext(
+                        array(T_SEMICOLON),
+                        ($stackPtr + 1)
+                    );
+                    $lastLine = $tokens[$end]['line'];
                     for ($i = ($stackPtr + 1); $i < $next; $i++) {
                         if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$emptyTokens) === true) {
                             continue;

--- a/CodeSniffer/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.inc
@@ -155,6 +155,21 @@ function foo($color) {
     }
 }
 
+function returnOverMultipleLines($color) {
+    switch ($color) {
+        case 'red':
+            return someFunction(
+                'multiple',
+                'arguments'
+            );
+        default:
+            return array(
+                'multiline',
+                'array'
+            );
+    }
+}
+
 exit();
 
 // Errors are thrown from here down from the exit() above.

--- a/CodeSniffer/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -79,11 +79,11 @@ class Squiz_Tests_PHP_NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 146 => 1,
                 149 => 1,
                 152 => 1,
-                161 => 1,
-                162 => 1,
-                163 => 1,
-                164 => 2,
-                168 => 1,
+                176 => 1,
+                177 => 1,
+                178 => 1,
+                179 => 2,
+                183 => 1,
                );
 
     }//end getWarningList()


### PR DESCRIPTION
When return value inside switch statement is spread over more then one line, it will trigger false warnings. Fix + tests included
