### PR TITLE
[BUGFIX] Squiz.Classes.SelfMemberReferenceSniff runs endless

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -150,13 +150,16 @@ class Squiz_Sniffs_Classes_SelfMemberReferenceSniff extends PHP_CodeSniffer_Stan
      */
     protected function getNamespaceOfScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $namespaceDeclaration      = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr);
-        $endOfNamespaceDeclaration = $phpcsFile->findNext(T_SEMICOLON, $namespaceDeclaration);
+        $namespace = '\\';
+        $namespaceDeclaration = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr);
 
-        $namespace = $this->getDeclarationNameWithNamespace(
-            $phpcsFile->getTokens(),
-            ($endOfNamespaceDeclaration - 1)
-        );
+        if ($namespaceDeclaration !== false) {
+            $endOfNamespaceDeclaration = $phpcsFile->findNext(T_SEMICOLON, $namespaceDeclaration);
+            $namespace = $this->getDeclarationNameWithNamespace(
+                $phpcsFile->getTokens(),
+                ($endOfNamespaceDeclaration - 1)
+            );
+        }
 
         return $namespace;
 

--- a/CodeSniffer/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
@@ -64,6 +64,14 @@ class MyClass {
 
 MyClass::walk();
 
+class Controller
+{
+    public function Action()
+    {
+        Doctrine\Common\Util\Debug::dump();
+    }
+}
+
 namespace TYPO3\CMS\Reports;
 
 class Status {


### PR DESCRIPTION
If a PHP class without a namespace calls a static method with a namespace (e.g. Doctrine\Common\Util\Debug::dump()) this sniff ends in a loop without a exit.

How to reproduce this?
Save this source code to a single file:

``` php
<?php

class Controller
{
    public function Action()
    {
        Doctrine\Common\Util\Debug::dump();
    }
}
```

Execute the following command

```
php scripts/phpcs --standard=Squiz --sniffs=Squiz.Classes.SelfMemberReference /Path/To/Your/file1.php -v
```

PHP_CodeSniffer does not come to an end.
This commit fix this behaviour.
