### PR TITLE
Improve depndency to be a little more stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "classmap": [ "." ]
     },
     "suggests": {
-        "phpunit/php-timer": "*"
+        "phpunit/php-timer": "dev-master"
     },
     "require": {
         "php": ">=5.1.2"


### PR DESCRIPTION
Specify the branch that should be used to that composer doesn't pick one at "random".

Using \* might lead to issues when php-timer gets feature branches
