### PR TITLE
CodingStandardsIgnore not working anymore with summary report

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -111,7 +111,7 @@
  * @author    Marc McIntyre <mmcintyre@squiz.net>
  * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @version   Release: 1.4.2
+ * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 class PHP_CodeSniffer_File
@@ -1107,7 +1107,7 @@ class PHP_CodeSniffer_File
 
             if (strpos($tokenContent, "\t") === false) {
                 // There are no tabs in this content.
-                $currColumn += (strlen($tokenContent) - 1);
+                $currColumn += strlen($tokenContent);
             } else {
                 // We need to determine the length of each tab.
                 $tabs = preg_split(
@@ -1118,7 +1118,6 @@ class PHP_CodeSniffer_File
                 );
 
                 $tabNum       = 0;
-                $adjustedTab  = false;
                 $tabsToSpaces = array();
                 $newContent   = '';
 
@@ -1140,7 +1139,6 @@ class PHP_CodeSniffer_File
                             // This is the first tab, and we are already at a
                             // tab stop, so this tab counts as a single space.
                             $currColumn++;
-                            $adjustedTab = true;
                         } else {
                             $currColumn++;
                             while (($currColumn % PHP_CODESNIFFER_TAB_WIDTH) != 0) {
@@ -1155,10 +1153,6 @@ class PHP_CodeSniffer_File
                     }//end if
                 }//end foreach
 
-                if ($tabNum === 1 && $adjustedTab === true) {
-                    $currColumn--;
-                }
-
                 $tokens[$i]['content'] = $newContent;
             }//end if
 
@@ -1166,8 +1160,6 @@ class PHP_CodeSniffer_File
                 && $tokens[($i + 1)]['line'] !== $tokens[$i]['line']
             ) {
                 $currColumn = 1;
-            } else {
-                $currColumn++;
             }
         }//end for
 


### PR DESCRIPTION
All the errors and warnings that normally should be ignores using the CodingStandardsIgnore comments are also counted in the summary report.
This results in a different amount of errors between summary report and the full report.

(errorCount and warningCount are incremented but the system can't remove the ignored errors when recordErrors === false)
