### PR TITLE
Simplify and speed-up search for backslash in File

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -616,7 +616,7 @@ class PHP_CodeSniffer_File
         $contents = str_replace($this->eolChar, '', $contents);
         $contents = str_replace("\n", '\n', $contents);
         $contents = str_replace("\r", '\r', $contents);
-        if (preg_match('/(\\\\.)+/', $contents) === 1) {
+        if (strpos($contents, '\\') !== false) {
             $error = 'File has mixed line endings; this may cause incorrect results';
             $this->addWarning($error, 0, 'Internal.LineEndings.Mixed');
         }


### PR DESCRIPTION
Hi Greg,

This is a small improvement following up on #62. Basically, there's no need for the `/(\\\\.)+/` regex (matches backslash followed by any character, repeated 1+ times - that was to be able to capture the actual wrong line ending and inform the user).

To just check whether a string contains a backslash, strpos should be both faster and easier to understand.
