### PR TITLE
should only test when comments are used

### DIFF
--- a/CodeSniffer/CommentParser/ParameterElement.php
+++ b/CodeSniffer/CommentParser/ParameterElement.php
@@ -291,6 +291,9 @@ class PHP_CodeSniffer_CommentParser_ParameterElement extends PHP_CodeSniffer_Com
         PHP_CodeSniffer_CommentParser_ParameterElement $other
     ) {
         // Compares the index before param comment.
+        if (strlen($other->_commentWhitespace)) === 0 && strlen($this->_commentWhitespace) === 0) {
+            return true;
+        }
         $otherComment
             = (strlen($other->_varName) + strlen($other->_commentWhitespace));
         $thisComment


### PR DESCRIPTION
when comments must be provided it sould be check by an other test.

https://github.com/opensky/Symfony2-coding-standard/issues/46
