### PR TITLE
The notifysend report presumes that a version of notify-send later than 0.7.2 is installed. This is not always the case.

### DIFF
--- a/CodeSniffer/Reports/Notifysend.php
+++ b/CodeSniffer/Reports/Notifysend.php
@@ -52,6 +52,13 @@ class PHP_CodeSniffer_Reports_Notifysend implements PHP_CodeSniffer_Report
      */
     protected $showOk = true;
 
+    /**
+     * Version of installed notify-send executable.
+     *
+     * @var string
+     */
+    protected $version = null;
+
 
     /**
      * Load configuration data.
@@ -74,6 +81,12 @@ class PHP_CodeSniffer_Reports_Notifysend implements PHP_CodeSniffer_Report
         if ($showOk !== null) {
             $this->showOk = (boolean) $showOk;
         }
+
+        $this->version = str_replace(
+            'notify-send ',
+            '',
+            exec($this->path . ' --version')
+        );
 
     }//end __construct()
 
@@ -192,10 +205,13 @@ class PHP_CodeSniffer_Reports_Notifysend implements PHP_CodeSniffer_Report
      */
     protected function getBasicCommand()
     {
-        return escapeshellcmd($this->path)
+        $command = escapeshellcmd($this->path)
             . ' --category dev.validate'
-            . ' -a phpcs'
             . ' -t ' . (int) $this->timeout;
+        if (version_compare($this->version, '0.7.3', '>=')) {
+            $command .= ' -a phpcs';
+        }
+        return $command;
 
     }//end getBasicCommand()
 


### PR DESCRIPTION
Since version 0.7.3 of notify-send, the utility takes an -a (or '--app-name') option for specifying an app-name for the icon displayed. 

Attempting to set this option for versions earlier than 0.7.3 causes an 'Unknown option' error, preventing the notifysend report from being of any great use.

This pull request fixes that by determining the version number of notify-send and only using the --app-name option if appropriate to do so,
