### PR TITLE
Spacing errors between equal signs and default values in function declarations.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -125,7 +125,7 @@ class Squiz_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff implements 
 
                 $spacesAfter = 0;
                 if ($tokens[($nextToken + 1)]['code'] === T_WHITESPACE) {
-                    $spacesAfter = strlen($tokens[($nextParam + 1)]['content']);
+                    $spacesAfter = strlen($tokens[($nextToken + 1)]['content']);
                 }
 
                 if ($spacesAfter !== $this->equalsSpacing) {


### PR DESCRIPTION
Unfortunately I was not able to write a test case for this, because the bug hits especially for coding standards where the spacing after the equal sign is > 0. I'm setting the equalsSpacing property to 1 for Drupal.

But even for the Squiz standard the error message is wrong if you have one space before and two after the equal sign in a function declaration.

How can we test this?
