### PR TITLE
Add cssLint support and concatenation with spaces.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
@@ -104,9 +104,7 @@ class Generic_Sniffs_Debug_CSSLintSniff implements PHP_CodeSniffer_Sniff
             }
 
             if ($lineToken !== null) {
-                if ($this->considerWarningAsError === true) {
-                    $phpcsFile->addWarning($message, $lineToken, 'ExternalTool');
-                }
+                $phpcsFile->addWarning($message, $lineToken, 'ExternalTool');
             }
         }//end for
 


### PR DESCRIPTION
Hi there.

It'l be cool to have cssLint integration to PHP_CodeSniffer like jsLint or jsHint.
There is no (I didn't found) sniffer for validate concat surrounded 1 space.
