### PR TITLE
Curly brackets don't always have a scope_closer

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -223,7 +223,7 @@ class Squiz_Sniffs_PHP_NonExecutableCodeSniff implements PHP_CodeSniffer_Sniff
             }
 
             if ($tokens[$start]['code'] === T_OPEN_CURLY_BRACKET) {
-                $start = $tokens[$start]['scope_closer'];
+                $start = $tokens[$start]['bracket_closer'];
                 continue;
             }
 


### PR DESCRIPTION
Fixes a notice that happens when sniffing code that uses curly brackets for string indexing.
