### PR TITLE
Allow multilanguage comments.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -153,7 +153,7 @@ class Squiz_Sniffs_Commenting_BlockCommentSniff implements PHP_CodeSniffer_Sniff
                 $phpcsFile->addError($error, $commentLines[1], 'FirstLineIndent', $data);
             }
 
-            if (preg_match('|[A-Z]|', $commentText[0]) === 0) {
+            if (preg_match('|\p{Lu}|u', $commentText[0]) === 0) {
                 $error = 'Block comments must start with a capital letter';
                 $phpcsFile->addError($error, $commentLines[1], 'NoCapital');
             }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
@@ -188,7 +188,7 @@ class Squiz_Sniffs_Commenting_ClassCommentSniff implements PHP_CodeSniffer_Sniff
             $newlineCount += $newlineBetween;
 
             $testLong = trim($long);
-            if (preg_match('|[A-Z]|', $testLong[0]) === 0) {
+            if (preg_match('|\p{Lu}|u', $testLong[0]) === 0) {
                 $error = 'Class comment long description must start with a capital letter';
                 $phpcsFile->addError($error, ($commentStart + $newlineCount), 'LongNotCapital');
             }
@@ -216,8 +216,7 @@ class Squiz_Sniffs_Commenting_ClassCommentSniff implements PHP_CodeSniffer_Sniff
             $error = 'Class comment short description must be on a single line';
             $phpcsFile->addError($error, ($commentStart + 1), 'ShortSingleLine');
         }
-
-        if (preg_match('|[A-Z]|', $testShort[0]) === 0) {
+        if (preg_match('|\p{Lu}|u', $testShort[0]) === 0) {
             $error = 'Class comment short description must start with a capital letter';
             $phpcsFile->addError($error, ($commentStart + 1), 'ShortNotCapital');
         }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -222,7 +222,7 @@ class Squiz_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
             $newlineCount += $newlineBetween;
 
             $testLong = trim($long);
-            if (preg_match('|[A-Z]|', $testLong[0]) === 0) {
+            if (preg_match('|\p{Lu}|u', $testLong[0]) === 0) {
                 $error = 'File comment long description must start with a capital letter';
                 $phpcsFile->addError($error, ($commentStart + $newlineCount), 'LongNotCapital');
             }
@@ -255,7 +255,7 @@ class Squiz_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
                 $phpcsFile->addError($error, ($commentStart + 1), 'ShortSingleLine');
             }
 
-            if (preg_match('|[A-Z]|', $testShort[0]) === 0) {
+            if (preg_match('|\p{Lu}|u', $testShort[0]) === 0) {
                 $error = 'File comment short description must start with a capital letter';
                 $phpcsFile->addError($error, ($commentStart + 1), 'ShortNotCapital');
             }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -249,7 +249,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sn
             $newlineCount += $newlineBetween;
 
             $testLong = trim($long);
-            if (preg_match('|[A-Z]|', $testLong[0]) === 0) {
+            if (preg_match('|\p{Lu}|u', $testLong[0]) === 0) {
                 $error = 'Function comment long description must start with a capital letter';
                 $phpcsFile->addError($error, ($commentStart + $newlineCount), 'LongNotCapital');
             }
@@ -278,7 +278,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sn
             $phpcsFile->addError($error, ($commentStart + 1), 'ShortSingleLine');
         }
 
-        if (preg_match('|[A-Z]|', $testShort[0]) === 0) {
+        if (preg_match('|\p{Lu}|u', $testShort[0]) === 0) {
             $error = 'Function comment short description must start with a capital letter';
             $phpcsFile->addError($error, ($commentStart + 1), 'ShortNotCapital');
         }
@@ -735,7 +735,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sn
                     // Param comments must start with a capital letter and
                     // end with the full stop.
                     $firstChar = $paramComment{0};
-                    if (preg_match('|[A-Z]|', $firstChar) === 0) {
+                    if (preg_match('|\p{Lu}|u', $firstChar) === 0) {
                         $error = 'Param comment must start with a capital letter';
                         $this->currentFile->addError($error, $errorPos, 'ParamCommentNotCapital');
                     }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -224,7 +224,7 @@ class Squiz_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Snif
             return;
         }
 
-        if (preg_match('|[A-Z]|', $commentText[0]) === 0) {
+        if (preg_match('|\p{Lu}|u', $commentText[0]) === 0) {
             $error = 'Inline comments must start with a capital letter';
             $phpcsFile->addError($error, $topComment, 'NotCapital');
         }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -148,7 +148,7 @@ class Squiz_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_Stand
                 $newlineCount += $newlineBetween;
 
                 $testLong = trim($long);
-                if (preg_match('|[A-Z]|', $testLong[0]) === 0) {
+                if (preg_match('|\p{Lu}|u', $testLong[0]) === 0) {
                     $error = 'Variable comment long description must start with a capital letter';
                     $phpcsFile->addError($error, ($commentStart + $newlineCount), 'LongNotCapital');
                 }
@@ -162,7 +162,7 @@ class Squiz_Sniffs_Commenting_VariableCommentSniff extends PHP_CodeSniffer_Stand
                 $phpcsFile->addError($error, ($commentStart + 1), 'ShortSingleLine');
             }
 
-            if (preg_match('|[A-Z]|', $testShort[0]) === 0) {
+            if (preg_match('|\p{Lu}|u', $testShort[0]) === 0) {
                 $error = 'Variable comment short description must start with a capital letter';
                 $phpcsFile->addError($error, ($commentStart + 1), 'ShortNotCapital');
             }


### PR DESCRIPTION
Hi.
NoCapital rule allows only english start of comments. Could you alleviate this rule?
