### PR TITLE
PSR2 causes a notice on functions called '_'

### DIFF
--- a/CodeSniffer/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
@@ -62,7 +62,7 @@ class PSR2_Sniffs_Methods_MethodDeclarationSniff extends PHP_CodeSniffer_Standar
             return;
         }
 
-        if ($methodName[0] === '_' && $methodName[1] !== '_') {
+        if ($methodName[0] === '_' && isset($methodName[1]) && $methodName[1] !== '_') {
             $error = 'Method name "%s" should not be prefixed with an underscore to indicate visibility';
             $data  = array($methodName);
             $phpcsFile->addWarning($error, $stackPtr, 'Underscore', $data);


### PR DESCRIPTION
When running PHPCS with the PSR2 standard I got a notice that $methodName[1] was undefined. Turns out we have a function called '_', which causes the sniff to check for the second character (which doesn't exist).

So I added an isset() to make sure the second character exists. I purposely made it part of the condition because if you have a function called '_' it isn't used to indicate visibility.
