### PR TITLE
keywords must be lower case per PSR2

### DIFF
--- a/CodeSniffer/Standards/PSR2/ruleset.xml
+++ b/CodeSniffer/Standards/PSR2/ruleset.xml
@@ -61,6 +61,9 @@
 
  <!-- 2.5 Keywords and True/False/Null -->
 
+ <!-- PHP keywords MUST be in lower case. -->
+ <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
+
  <!-- The PHP constants true, false, and null MUST be in lower case. -->
  <rule ref="Generic.PHP.LowerCaseConstant"/>
 


### PR DESCRIPTION
2.5. Keywords and True/False/Null

PHP keywords MUST be in lower case.
