### PR TITLE
Generic.Classes.DuplicateClassName reports multiple class duplication

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -60,7 +60,14 @@ class Generic_Sniffs_Classes_DuplicateClassNameSniff implements PHP_CodeSniffer_
         $tokens = $phpcsFile->getTokens();
 
         $namespace = '';
-        $stackPtr  = $phpcsFile->findNext(array(T_CLASS, T_INTERFACE, T_NAMESPACE), 0);
+
+	$endBlockPtr = $phpcsFile->findNext( array( T_CLOSE_TAG ), $stackPtr );
+	if(  $endBlockPtr === false   ){
+		$endBlockPtr = null;
+	}
+
+        $stackPtr  = $phpcsFile->findNext(array(T_CLASS, T_INTERFACE, T_NAMESPACE), $stackPtr, $endBlockPtr );
+
         while ($stackPtr !== false) {
             // Keep track of what namespace we are in.
             if ($tokens[$stackPtr]['code'] === T_NAMESPACE) {
@@ -101,7 +108,7 @@ class Generic_Sniffs_Classes_DuplicateClassNameSniff implements PHP_CodeSniffer_
                 }
             }
 
-            $stackPtr = $phpcsFile->findNext(array(T_CLASS, T_INTERFACE, T_NAMESPACE), ($stackPtr + 1));
+            $stackPtr = $phpcsFile->findNext(array(T_CLASS, T_INTERFACE, T_NAMESPACE), ($stackPtr + 1), $endBlockPtr );
         }//end while
 
     }//end process()


### PR DESCRIPTION
Generic.Classes.DuplicateClassName reports multiple class duplication if class has open tag in body - i.e:

``` php
<?php
class Test{
    public function testOne(){
     ?>
     <p>some html here</p>
    <?php 
   }
}
```

Now if you analyze this class with Generic Standard, CS reports class duplication. When you apply PR all works as expected - no duplications reported.

This code also works after PR:

``` php
<?php
class Test{
    public function testOne(){
     ?>
     <p>some html here</p>
    <?php 
   }
}

class Test{

}
```

After PR reports one duplication instead of 2 duplication reported now.
