### PR TITLE
Squiz.WhiteSpace.SuperfluousWhitespace - Option to ignore multiple blank lines

### DIFF
--- a/CodeSniffer/Standards/PSR2/ruleset.xml
+++ b/CodeSniffer/Standards/PSR2/ruleset.xml
@@ -37,7 +37,7 @@
  <!-- There MUST NOT be trailing whitespace at the end of non-blank lines. -->
  <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
   <properties>
-   <property name="ignoreBlankLines" value="true"/>
+   <property name="ignoreWhitespaceOnBlankLines" value="true"/>
    </properties>
  </rule>
  <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -44,13 +44,19 @@ class Squiz_Sniffs_WhiteSpace_SuperfluousWhitespaceSniff implements PHP_CodeSnif
                                   );
 
     /**
-     * If TRUE, whitespace rules are not checked for blank lines.
-     *
-     * Blank lines are those that contain only whitespace.
+     * If TRUE, whitespaces are not checked on blank lines.
      *
      * @var boolean
      */
-    public $ignoreBlankLines = false;
+    public $ignoreWhitespaceOnBlankLines = false;
+
+
+    /**
+     * If TRUE, multiple blank lines in a function are not checked
+     *
+     * @var boolean
+     */
+    public $ignoreMultipleBlanklines = false;
 
 
     /**
@@ -189,7 +195,7 @@ class Squiz_Sniffs_WhiteSpace_SuperfluousWhitespaceSniff implements PHP_CodeSnif
             }
 
             // Ignore blank lines if required.
-            if ($this->ignoreBlankLines === true
+            if ($this->ignoreWhitespaceOnBlankLines === true
                 && $tokens[($stackPtr - 1)]['line'] !== $tokens[$stackPtr]['line']
             ) {
                 return;
@@ -206,7 +212,7 @@ class Squiz_Sniffs_WhiteSpace_SuperfluousWhitespaceSniff implements PHP_CodeSnif
                 Check for multiple blanks lines in a function.
             */
 
-            if ($phpcsFile->hasCondition($stackPtr, T_FUNCTION) === true) {
+            if (!$this->ignoreMultipleBlanklines && $phpcsFile->hasCondition($stackPtr, T_FUNCTION) === true) {
                 if ($tokens[($stackPtr - 1)]['line'] < $tokens[$stackPtr]['line'] && $tokens[($stackPtr - 2)]['line'] === $tokens[($stackPtr - 1)]['line']) {
                     // This is an empty line and the line before this one is not
                     //  empty, so this could be the start of a multiple empty

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.css
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.css
@@ -13,7 +13,7 @@
     float: left;
 }
 
-/* @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines true */
+/* @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreWhitespaceOnBlankLines true */
 .HelpWidgetType-new-bug-title{
     float: left;
 }
@@ -21,5 +21,5 @@
 .HelpWidgetType-new-bug-title{
     float: left;
 }
-/* @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false */
+/* @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreWhitespaceOnBlankLines false */
 

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.js
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.js
@@ -22,7 +22,7 @@ function myFunction()
 
 
 }
-
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultipleBlanklines true
 function myFunction2()
 {
     alert('code here');
@@ -31,8 +31,9 @@ function myFunction2()
     alert('code here');
 
 }
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultipleBlanklines false
 
-// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines true
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreWhitespaceOnBlankLines true
 
 function myFunction2()
 {
@@ -42,6 +43,6 @@ function myFunction2()
     
 }
 
-// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreWhitespaceOnBlankLines false
 
 

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
@@ -23,7 +23,7 @@ function myFunction()
 
 
 }
-
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultipleBlanklines true
 function myFunction2()
 {
     echo 'code here';
@@ -32,8 +32,8 @@ function myFunction2()
     echo 'code here';
 
 }
-
-// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines true
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultipleBlanklines false
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreWhitespaceOnBlankLines true
 
 function myFunction2()
 {
@@ -43,7 +43,7 @@ function myFunction2()
     
 }
 
-// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreWhitespaceOnBlankLines false
 
 ?>
 

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -54,7 +54,6 @@ class Squiz_Tests_WhiteSpace_SuperfluousWhitespaceUnitTest extends AbstractSniff
                     7  => 1,
                     16 => 1,
                     23 => 1,
-                    30 => 1,
                     48 => 1,
                    );
             break;
@@ -67,8 +66,7 @@ class Squiz_Tests_WhiteSpace_SuperfluousWhitespaceUnitTest extends AbstractSniff
                     6  => 1,
                     15 => 1,
                     22 => 1,
-                    29 => 1,
-                    47 => 1,
+                    48 => 1,
                    );
             break;
         case 'SuperfluousWhitespaceUnitTest.1.css':


### PR DESCRIPTION
I think that the **Squiz.WhiteSpace.SuperfluousWhitespace** does more than one thing. Except checking useless whitespaces (space, tab) on any lines, it also checks whether there is _more than one line_ inside function, no matter if there are white spaces on that line.

I think it should not be hard-coded to one rule as these are two different things.
