### PR TITLE
make composer test ext-tokenizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "phpunit/php-timer": "dev-master"
     },
     "require": {
-        "php": ">=5.1.2"
+        "php": ">=5.1.2",
+        "ext-tokenizer": "*"
     },
     "bin": [
         "scripts/phpcs"


### PR DESCRIPTION
Made composer.json compatible with CodeSniffer_CLI::checkDependencies() so an incompatibility would be reported as early as possible.
