### PR TITLE
Feature-Request: symlinked standard

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -731,7 +731,7 @@ class PHP_CodeSniffer
 
         if (is_dir($dir) === true) {
             // available since PHP 5.2.11 and 5.3.1
-            if (defined('RecursiveDirectoryIterator::FOLLOW_SYMLINKS')) {
+            if (defined('RecursiveDirectoryIterator::FOLLOW_SYMLINKS') === true) {
                 $di = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::FOLLOW_SYMLINKS));
             } else {
                 $di = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));


### PR DESCRIPTION
Replaces #103.

@gsherwood Any change to convince you on this one? Won't do any harm, really!

The issue is, that it is being the only missing feature for CodeSniffer to break the development workflow when managing standards with composer only. (pear has to many quirks to bother).

For integration/ deployment of those standards I like to use [a composer installer](https://github.com/goatherd/phpcs_installer) or even [abstract standard](https://github.com/foobugs-standards/abstract-standard).
With it any standard will get installed within the most recent, official CodeSniffer package and is available directly by just a single line to a composer.json. Like in `vendor/bin/phpcs --standard=foo`.

Yet the issue is that CodeSniffer will not work nicely from within a git clone of that standard. If I use absolute paths CodeSniffer would scan itself (since within the standards path). Not using the composer.json would require me to keep CodeSniffer (and phpunit and so on) installed somewhere else on my box. That may be fine for some, but is more work to keep up-to-date or switch versions for testing. Travis needs a pear installed CodeSniffer as well, when the project could just be set up with composer - exactly the way it would be for any user.
