### PR TITLE
Feautre-Request: allow standards bootstrap

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -651,6 +651,22 @@ class PHP_CodeSniffer
             }
         }//end if
 
+        // Allow standard to use custom bootstrapping (at class scope)
+        // Assume a bootstrap.php at the standard base directory.
+        $bootstrapFn = self::$standardDir . DIRECTORY_SEPARATOR . 'bootstrap.php';
+        // Override with ruleset 'bootstrap' key.
+        if (isset($ruleset) && isset($ruleset['bootstrap'])) {
+            $bootstrapFn = str_replace('/', DIRECTORY_SEPARATOR, $ruleset['bootstrap']);
+            if (substr($bootstrapFn, 0, 1) !== DIRECTORY_SEPARATOR) {
+                $bootstrapFn = self::$standardDir . DIRECTORY_SEPARATOR . $bootstrapFn;
+            }
+        }
+        // load if name is a valid file name
+        $bootstrapFn = realpath($bootstrapFn);
+        if ($bootstrapFn && file_exists($bootstrapFn)) {
+            include_once $bootstrapFn;
+        }
+
         $files = $this->getSniffFiles(self::$standardDir, $standard);
 
         if (empty($sniffs) === false) {
@@ -1077,7 +1093,7 @@ class PHP_CodeSniffer
      *
      * @return void
      */
-    public function setSniffProperty($listenerClass, $name, $value) 
+    public function setSniffProperty($listenerClass, $name, $value)
     {
         // Setting a property for a sniff we are not using.
         if (isset($this->listeners[$listenerClass]) === false) {


### PR DESCRIPTION
If a standard _Foo_ has  a `Foo/bootstrap.php` or defines a `<bootstrap>some/Path</bootstrap` that script will be executed from `PHP_CodeSniffer::setTokenListeners()`.

Purpose is inclusion of additional libraries, bootstrapping or patches.
Two applications that might benefit from those:
- standards that do share a lot of code/ use many classes that are not sniffs.
- [pdc](https://github.com/packfire/pdc)-like tools that do test dynamic features and could be written much more easily with CodeSniffer

That point was used since it allows customisations of CodeSniffer itself and is early in the execution (exactly after the standard was selected/ the ruleset was read).

Obviously it would be possible to use a lot of static code and singletons, but that is bad design and likely much more work.

It would fix a cross-standard inclusion like in #99 (if I understood the problem there correctly).

What do you think of this little feature?
