### PR TITLE
Ignore PhpStorm project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /CodeSniffer.conf
+.idea/*


### PR DESCRIPTION
This PR adds the line

```
.idea/*
```

to `.gitignore` to ignore [PhpStorm](http://www.jetbrains.com/phpstorm/) project files.
