### PR TITLE
Respect ignoreComments in AbstractPatternSniff::processPattern

### DIFF
--- a/CodeSniffer/Standards/AbstractPatternSniff.php
+++ b/CodeSniffer/Standards/AbstractPatternSniff.php
@@ -409,7 +409,9 @@ abstract class PHP_CodeSniffer_Standards_AbstractPatternSniff implements PHP_Cod
                             // This may just be an indent that comes after a newline
                             // so check the token before to make sure. If it is a newline, we
                             // can ignore the error here.
-                            if ($tokens[($stackPtr - 1)]['content'] !== $phpcsFile->eolChar) {
+                            if (($tokens[($stackPtr - 1)]['content'] !== $phpcsFile->eolChar)
+                                && ($this->ignoreComments === true && in_array($tokens[($stackPtr - 1)]['code'], PHP_CodeSniffer_Tokens::$commentTokens) === false)
+                            ) {
                                 $hasError = true;
                             } else {
                                 $stackPtr--;


### PR DESCRIPTION
Currently, In AbstractPatternSniff, when checking to see if indents follow a 
newline, even if ignoreComments is true, if the previous token is 
a comment, an error will be reported.

```
if (foo) {
}// This comment will trigger an error
else {
}
```

In this commit, matching against "}EOLelse {EOL" with ignoredComments on, the comment
is ignored and the if block will validate.

This fixes [Bug #19811](http://pear.php.net/bugs/bug.php?id=19811).
