### PR TITLE
Let ComparisonOperatorUsageSniff also check inside 'elseif'

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -101,6 +101,7 @@ class Squiz_Sniffs_Operators_ComparisonOperatorUsageSniff implements PHP_CodeSni
     {
         return array(
                 T_IF,
+                T_ELSEIF,
                 T_INLINE_THEN,
                );
 

--- a/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.inc
@@ -79,3 +79,8 @@ if ($var2 === TRUE) {
 }
 $var1 ? $var2 = 0 : $var2 = 1;
 ?>
+<?php
+if ($value) {
+} elseif (!$value) {
+}
+?>

--- a/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -64,6 +64,8 @@ class Squiz_Tests_Operators_ComparisonOperatorUsageUnitTest extends AbstractSnif
                     75 => 1,
                     78 => 1,
                     80 => 1,
+                    83 => 1,
+                    84 => 1,
                    );
             break;
         case 'ComparisonOperatorUsageUnitTest.js':


### PR DESCRIPTION
Although `ElseIfDeclarationSniff` forbids the usage of `T_ELSEIF`, I think this is a useful addition for those who use `ComparisonOperatorUsageSniff` standalone.
