### PR TITLE
Fix comment for DisallowSpaceIndentSniff

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -15,7 +15,7 @@
 /**
  * Generic_Sniffs_WhiteSpace_DisallowSpaceIndentSniff.
  *
- * Throws errors if tabs are used for indentation.
+ * Throws errors if spaces are used for indentation.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer


### PR DESCRIPTION
This should be referencing spaces are problematic, and not tabs.
