### PR TITLE
Correct docblock short description

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/ClosingPHPTagSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/ClosingPHPTagSniff.php
@@ -13,7 +13,7 @@
  */
 
 /**
- * Checks that the file does not end with a closing tag.
+ * Checks that open PHP tags are paired with closing tags.
  *
  * @category  PHP
  * @package   PHP_CodeSniffer


### PR DESCRIPTION
Another case where a sniff's short description is not accurate.
