### PR TITLE
Fix notice for abstract constructors.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -80,6 +80,11 @@ class Generic_Sniffs_NamingConventions_ConstructorNameSniff extends PHP_CodeSnif
             return;
         }
 
+        // Don't continue if the constructor doesn't have a body, like when it is abstract.
+        if (!array_key_exists('scope_closer', $tokens[$stackPtr])) {
+            return;
+        }
+
         $endFunctionIndex = $tokens[$stackPtr]['scope_closer'];
         $startIndex       = $stackPtr;
         while ($doubleColonIndex = $phpcsFile->findNext(array(T_DOUBLE_COLON), $startIndex, $endFunctionIndex)) {

--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
@@ -36,4 +36,9 @@ class MyClass extends \MyNamespace\SomeClass
     }
 
 }
+
+abstract class MyAbstractClass extends \MyNamespace\SomeClass
+{
+    abstract public function __construct();
+}
 ?>


### PR DESCRIPTION
Abstract methods don't have a method body, so scope_closer is never set.
We still want to verify that the method name is correct, but we don't
want to attempt to look for calls to parent::ClassName() since there is
no code to check.
