### PR TITLE
Use standard name instead of directory name in class names.

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -672,12 +672,7 @@ class PHP_CodeSniffer
                 continue;
             }
 
-            $slashPos = strrpos(substr($file, 0, $sniffPos), DIRECTORY_SEPARATOR);
-            if ($slashPos === false) {
-                continue;
-            }
-
-            $className = substr($file, ($slashPos + 1));
+            $className = $standard.substr($file, $sniffPos);
             $className = substr($className, 0, -4);
             $className = str_replace(DIRECTORY_SEPARATOR, '_', $className);
 


### PR DESCRIPTION
If the standard name in ruleset.xml **is different than** the basename of the directory **and** the standard contains custom sniff classes, a fatal error occurs.

Example `Foo/ruleset.xml` (notice how the directory name is different than the standard name):

```
<?xml version="1.0"?>
<ruleset name="Bar">
    <description>A custom coding standard.</description>
</ruleset>
```

If you run try to run `phpcs` like `phpcs -vvv --standard=ruleset.xml test.php`, you'll get something like this:

```
Registering sniffs in Bar standard...
    Registered Foo_Sniffs_Whitespace_IndentationSniff
PHP Fatal error:  Cannot redeclare class Bar_Sniffs_Examples_ExampleSniff in /path/to/Foo/Sniffs/Examples/ExampleSniff.php on line 3
```

The "Cannot redeclare class" error is because in the `PHP_CodeSniffer->setTokenListeners` method, the file is included but the class name is recorded incorrectly. Then later in the `PHP_CodeSniffer->populateTokenListeners` method, it tries to autoload the incorrect class name, which happens to end up loading the correct file (again), but the class is already declared.
