### PR TITLE
Avoiding PHP-Notice from ConstructorNameSniff::processTokenWithinScope()

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -81,7 +81,7 @@ class Generic_Sniffs_NamingConventions_ConstructorNameSniff extends PHP_CodeSnif
         }
 
         // Stop if the constructor doesn't have a body, like when it is abstract.
-        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+        if (!array_key_exists('scope_closer', $tokens[$stackPtr])) {
             return;
         }
 


### PR DESCRIPTION
When checking for 'scope_closer' within "processTokenWithinScope", do the check by using array_key_exists() instead of isset() to avoid PHP_Notice.
