### PR TITLE
The generator doesn't work with relative paths in the ruleset.xml

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -731,6 +731,10 @@ class PHP_CodeSniffer
         $excludedSniffs = array();
 
         if (is_dir($dir) === true) {
+            if (empty(self::$standardDir)) {
+                self::$standardDir = $dir;
+            }
+
             // Available since PHP 5.2.11 and 5.3.1.
             if (defined('RecursiveDirectoryIterator::FOLLOW_SYMLINKS') === true) {
                 $rdi = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::FOLLOW_SYMLINKS);


### PR DESCRIPTION
If you call the codesniffer with the --generator option the getStandardFiles() function compiles a list of the sniffs via $phpcs->getSniffFiles($standardDir, $standard). As you can see it passes the standard dir and the name of the standard.

But the passed standard folder won't be used inside getSniffFiles(). At the end self::$standardDir in _expandRulesetReference() is empty and can't resolve sniffs which were specified relative in ruleset.xml.
