### PR TITLE
Fixed: Bug #20029, ForbiddenFunction sniff now ignores method renames

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -106,11 +106,26 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
                    T_OBJECT_OPERATOR,
                    T_FUNCTION,
                    T_CONST,
+                   T_PROTECTED,
+                   T_PRIVATE,
+                   T_PUBLIC,
                   );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
             // Not a call to a PHP function.
+            return;
+        }
+
+        $prevPrevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($prevToken - 1), null, true);
+        if ($tokens[$prevToken]['code'] === T_AS && $tokens[$prevPrevToken]['code'] === T_STRING) {
+            //This is a method rename in a use clause.
+            return;
+        }
+
+        $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($tokens[$nextToken]['code'] === T_AS) {
+            //This is a method in a use clause.
             return;
         }
 

--- a/CodeSniffer/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
@@ -19,4 +19,29 @@ function delete() {}
 function unset() {}
 function sizeof() {}
 function count() {}
+
+trait DelProvider {
+	public function delete() {
+		//irrelevant
+	}
+}
+
+class LeftSideTest {
+	use DelProvider {
+		delete as protected unsetter;
+	}
+}
+
+class RightSideTest {
+	use DelProvider {
+		delete as delete;
+	}
+}
+
+class RightSideVisTest {
+	use DelProvider {
+		delete as protected delete;
+	}
+}
+
 ?>


### PR DESCRIPTION
and visibility changes from use clauses.

[Reported Here](https://pear.php.net/bugs/bug.php?id=20029&thanks=3)
