### PR TITLE
make sniff work with different OS and different newlines

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
@@ -72,10 +72,12 @@ class Squiz_Sniffs_WhiteSpace_LogicalOperatorSpacingSniff implements PHP_CodeSni
             $phpcsFile->addError($error, $stackPtr, 'NoSpaceBefore');
         } else {
             $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+            $content = str_replace("\r\n", "\n", $tokens[($stackPtr - 1)]['content']);
+
             if ($tokens[$stackPtr]['line'] === $tokens[$prev]['line']
-                && strlen($tokens[($stackPtr - 1)]['content']) !== 1
+                && strlen($content) !== 1
             ) {
-                $found = strlen($tokens[($stackPtr - 1)]['content']);
+                $found = strlen($content);
                 $error = 'Expected 1 space before logical operator; %s found';
                 $data  = array($found);
                 $phpcsFile->addError($error, $stackPtr, 'TooMuchSpaceBefore', $data);
@@ -88,10 +90,12 @@ class Squiz_Sniffs_WhiteSpace_LogicalOperatorSpacingSniff implements PHP_CodeSni
             $phpcsFile->addError($error, $stackPtr, 'NoSpaceAfter');
         } else {
             $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr - 1), null, true);
+            $content = str_replace("\r\n", "\n", $tokens[($stackPtr + 1)]['content']);
+
             if ($tokens[$stackPtr]['line'] === $tokens[$next]['line']
-                && strlen($tokens[($stackPtr + 1)]['content']) !== 1
+                && strlen($content) !== 1
             ) {
-                $found = strlen($tokens[($stackPtr + 1)]['content']);
+                $found = strlen($content);
                 $error = 'Expected 1 space after logical operator; %s found';
                 $data  = array($found);
                 $phpcsFile->addError($error, $stackPtr, 'TooMuchSpaceAfter', $data);


### PR DESCRIPTION
Fix false reports on windows with \r\n counting as two spaces:

On windows this fixes the false reports like:

```
 2977 | ERROR | Expected 1 space after logical operator; 2 found
      |       | (Sqiz.WhiteSpace.LogicalOperatorSpacing.TooMuchSpaceAfter)
```

The problem is that the error message is not clear - and cloaks the fact that this file would otherwise be fine.

Each sniff should only trigger what it is meant to look for. This sniff is merely there to check on the amount of spaces. If the newlines have to be in the correct (e.g. only unix style) format a different sniff should check on.
