### PR TITLE
Switch patch

### DIFF
--- a/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -67,4 +67,10 @@ switch (0) {
         }
         break;
 }
+
+switch ($foo) {
+    case Foo::ONE:
+    case Foo::TWO:
+        break;
+}
 ?>

--- a/CodeSniffer/Tokenizers/PHP.php
+++ b/CodeSniffer/Tokenizers/PHP.php
@@ -444,6 +444,7 @@ class PHP_CodeSniffer_Tokenizers_PHP
             if ($tokenIsArray === true
                 && $token[0] === T_STRING
                 && $tokens[($stackPtr + 1)] === ':'
+                && $tokens[($stackPtr - 1)][0] !== T_PAAMAYIM_NEKUDOTAYIM
             ) {
                 for ($x = ($newStackPtr - 2); $x > 0; $x--) {
                     if (in_array($finalTokens[$x]['code'], PHP_CodeSniffer_Tokens::$emptyTokens) === false) {


### PR DESCRIPTION
Don't generate T_GOTO_LABEL when encountering `case IDENTIFIER::CONST:`
