### PR TITLE
Removing PHP notice when a sniff was not placed in subfolder

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1034,6 +1034,12 @@ class PHP_CodeSniffer
                 $parts = explode('\\', $listenerClass);
             }
 
+            // fix for "Notice: Undefined offset: 3" which gets thrown if a sniff
+            // is placed in the Sniffs main folder and not a subfolder
+            if (!isset($parts[3])) {
+                $parts[3] = '';
+            }
+
             $code  = $parts[0].'.'.$parts[2].'.'.$parts[3];
             $code  = substr($code, 0, -5);
 


### PR DESCRIPTION
Minor fix to remove a PHP notice when a sniff class was not placed in a subfolder but in the main Sniff directory. This may makes sense if you use just a few sniffs and you do not want to created subdirs with just one file in it.
