### PR TITLE
Allow for coding standards supressions to be included in Doc Block comments

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -408,7 +408,7 @@ class PHP_CodeSniffer_File
         // token, get them to process it.
         foreach ($this->_tokens as $stackPtr => $token) {
             // Check for ignored lines.
-            if ($token['code'] === T_COMMENT) {
+            if ($token['code'] === T_COMMENT || $token['code'] === T_DOC_COMMENT) {
                 if (strpos($token['content'], '@codingStandardsIgnoreStart') !== false) {
                     $ignoring = true;
                 } else if (strpos($token['content'], '@codingStandardsIgnoreEnd') !== false) {

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -176,6 +176,18 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $numWarnings);
         $this->assertEquals(0, count($warnings));
 
+        // Process with a Doc Block suppression.
+        $content = '<?php '.PHP_EOL.'/* @codingStandardsIgnoreFile */'.PHP_EOL.'//TODO: write some code';
+        $phpcs->processFile('suppressionTest.php', $content);
+
+        $files = $phpcs->getFiles();
+        $file  = $files[1];
+
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertEquals(0, count($warnings));
+
     }//end testSuppressFile()
 
 


### PR DESCRIPTION
Seems reasonable to allow for codingStandards tags in doc blocks.

Added code + test.
