### PR TITLE
fixes #19881 and #19899 - added maxlen to file_get_content for JS and CS...

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -614,7 +614,11 @@ class PHP_CodeSniffer_File
         $this->tokenizer = $tokenizer;
 
         if ($contents === null) {
-            $contents = file_get_contents($this->_file);
+            if ($this->tokenizerType === 'JS' || $this->tokenizerType === 'CSS') {
+                $contents = file_get_contents($this->_file, false, null, -1, 100000);
+            } else {
+                $contents = file_get_contents($this->_file);
+            }
         }
 
         $this->_tokens   = self::tokenizeString($contents, $tokenizer, $this->eolChar);


### PR DESCRIPTION
This would fix fixes #19881 (Maximum number of errors) and #19899 (Exclude files like compressed JS based on e.g. size)

file_get_content php function has this parameter which allow us to set a maximum length of data read. We can use this to make phpcs stop when it reaches some limit.

I've found 100000 to be a good value but we can use another one or even create an argument like 
"... --limit=low,normal,high" 
