### PR TITLE
PSR2 Switch declaration

### DIFF
--- a/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -73,4 +73,18 @@ switch ($foo) {
     case Foo::TWO:
         break;
 }
+
+switch (true) {
+    case $value instanceof StdClass:
+        return 1;
+    case strpos('_', get_class($value)) !== false:
+        break;
+}
+
+switch (true) {
+    case $value instanceof StdClass:
+        if ($value) {
+            return null;
+        }
+}
 ?>


### PR DESCRIPTION
The first test case emits false "ERROR | Case statements must not be defined using curly braces".

The second test case emits php notices.

I excluded my current "fix" as it only addresses symptoms.  I suspect the two cases share the same root cause.
