### PR TITLE
Added: -t parameter to allow defining settings for the chosen standard

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -280,7 +280,6 @@ class PHP_CodeSniffer_CLI
             } else {
                 ini_set($ini[0], true);
             }
-
             break;
         case 'n' :
             $values['warningSeverity'] = 0;
@@ -292,7 +291,6 @@ class PHP_CodeSniffer_CLI
             $settingStandard = explode('=', $_SERVER['argv'][($pos + 1)]);
             $_SERVER['argv'][($pos + 1)] = '';
             $values['settingsStandard'][$settingStandard[0]] = $settingStandard[1];
-
             break;
         default:
             $values = $this->processUnknownArgument('-'.$arg, $pos, $values);


### PR DESCRIPTION
Allows specifying specific key-value pair settings for the selected standard, which can then be retrieved by the sniffs.
Use case : in the PHPCompatibility standard, it allows you to specify which PHP version you want to check on
