### PR TITLE
Use correct token to avoid intendation to be lost.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -246,7 +246,7 @@ class Squiz_Sniffs_WhiteSpace_SuperfluousWhitespaceSniff implements PHP_CodeSnif
                                 $i++;
                             }
 
-                            $phpcsFile->fixer->addNewlineBefore($next);
+                            $phpcsFile->fixer->addNewlineBefore($i);
                             $phpcsFile->fixer->endChangeset();
                         }
                     }


### PR DESCRIPTION
With $next, all white-space before (indentation in this case) gets removed, as well.
We need to use $i which points to the beginning of the row.
