### PR TITLE
Address bug #20093 - prevents ternary of being wrongly mangled with

### DIFF
--- a/CodeSniffer/Tokenizers/PHP.php
+++ b/CodeSniffer/Tokenizers/PHP.php
@@ -469,7 +469,7 @@ class PHP_CodeSniffer_Tokenizers_PHP
                     }
                 }
 
-                if ($finalTokens[$x]['code'] !== T_CASE) {
+                if ($finalTokens[$x]['code'] !== T_CASE && $finalTokens[$x + 1]['code'] !== T_INLINE_THEN) {
                     $finalTokens[$newStackPtr] = array(
                                                   'content' => $token[1].':',
                                                   'code'    => T_GOTO_LABEL,


### PR DESCRIPTION
Resolves https://pear.php.net/bugs/bug.php?id=20093

Are there other cases where `:` is a legit PHP character and should also not modify the T_STRING to "T_GOTO_LABEL"s?
