### PR TITLE
Prevent truncating whitespace in the final line of modification.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -92,7 +92,7 @@ class Squiz_Sniffs_WhiteSpace_MemberVarSpacingSniff extends PHP_CodeSniffer_Stan
                     $phpcsFile->fixer->replaceToken($i, '');
                 }
 
-                $phpcsFile->fixer->addNewline($i);
+                $phpcsFile->fixer->addNewline($prevLineToken);
                 $phpcsFile->fixer->endChangeset();
             }
         }//end if


### PR DESCRIPTION
Currently, a line like this would be wrongly truncated:

```
[one tab indentation] /* some inline comment that would be removed */

[one tab indentation]$public var
```

And result in

```
$public var
```

The indentation is lost.
