### PR TITLE
Add auto-fixing for SemicolonSpacingSniff

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -75,7 +75,12 @@ class Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff implements PHP_CodeSniffer_S
                          $expected,
                          $found,
                         );
-            $phpcsFile->addError($error, $stackPtr, 'Incorrect', $data);
+            $phpcsFile->addFixableError($error, $stackPtr, 'Incorrect', $data);
+            if ($phpcsFile->fixer->enabled === true) {
+                for ($i = $stackPtr -1; $i > $nonSpace; $i--) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+            }
         }
 
     }//end process()


### PR DESCRIPTION
This is easily fixable.

See 
[fail](https://github.com/dereuromark/cakephp-codesniffer/blob/master/Vendor/PHP/CodeSniffer/Standards/Squiz/Test/files/semicolon_spacing_fail.php) / [expected](https://github.com/dereuromark/cakephp-codesniffer/blob/master/Vendor/PHP/CodeSniffer/Standards/Squiz/Test/files/semicolon_spacing_expected.php) / [pass](https://github.com/dereuromark/cakephp-codesniffer/blob/master/Vendor/PHP/CodeSniffer/Standards/Squiz/Test/files/semicolon_spacing_pass.php)
