### PR TITLE
Phpcs cast spacing

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/CastSpacingSniff.php
@@ -66,7 +66,10 @@ class Squiz_Sniffs_WhiteSpace_CastSpacingSniff implements PHP_CodeSniffer_Sniff
                       $expected,
                       $content,
                      );
-            $phpcsFile->addError($error, $stackPtr, 'ContainsWhiteSpace', $data);
+            $phpcsFile->addFixableError($error, $stackPtr, 'ContainsWhiteSpace', $data);
+            if ($phpcsFile->fixer->enabled === true) {
+                $phpcsFile->fixer->replaceToken($stackPtr, $expected);
+            }
         }
 
     }//end process()


### PR DESCRIPTION
Also very trivial.

[fail](https://github.com/dereuromark/cakephp-codesniffer/blob/master/Vendor/PHP/CodeSniffer/Standards/Squiz/Test/files/cast_spacing_fail.php) / [expected](https://github.com/dereuromark/cakephp-codesniffer/blob/master/Vendor/PHP/CodeSniffer/Standards/Squiz/Test/files/cast_spacing_expected.php)
