### PR TITLE
Added: parameter to allow defining runtime settings, to be used only once

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -774,7 +774,7 @@ class PHP_CodeSniffer_CLI
      */
     public function printUsage()
     {
-        echo 'Usage: phpcs [-nwlsaepvi] [-d key[=value]] [-t key=value]'.PHP_EOL;
+        echo 'Usage: phpcs [-nwlsaepvi] [-d key[=value]]'.PHP_EOL;
         echo '    [--report=<report>] [--report-file=<reportfile>] [--report-<report>=<reportfile>] ...'.PHP_EOL;
         echo '    [--report-width=<reportWidth>] [--generator=<generator>] [--tab-width=<tabWidth>]'.PHP_EOL;
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;


### PR DESCRIPTION
Allows specifying specific key-value pair settings, which can then be retrieved by the sniffs.
Use case : in the PHPCompatibility standard, it allows you to specify which PHP version you want to check on

See https://github.com/squizlabs/PHP_CodeSniffer/pull/159 for initial discussion

Taking the --config-set functionality in account, I discovered that PHP_CodeSniffer::setConfigData which is being used by --config-set has a 3rd parameter which allows defining that this parameter is not to be written to the config file, but only used during this runtime. This is perfect for what we need.
I created --runtime-set although the name ofcourse can be easily changed (temp-set, run-set, ...)
