### PR TITLE
short ternary operator doesn't need spaces

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -101,6 +101,13 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
             }
         }
 
+        // Skip short ternary such as: $foo = $bar ?: true;
+        if ( ($tokens[$stackPtr]['code'] == T_INLINE_THEN && $tokens[$stackPtr + 1]['code'] == T_INLINE_ELSE)
+            || ($tokens[$stackPtr - 1]['code'] == T_INLINE_THEN && $tokens[$stackPtr]['code'] == T_INLINE_ELSE)
+        ) {
+                return;
+        }
+
         if ($tokens[$stackPtr]['code'] === T_BITWISE_AND) {
             // If it's not a reference, then we expect one space either side of the
             // bitwise operator.

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -106,6 +106,7 @@ function foo($boo = -1) {}
 $foo = array('boo' => -1);
 $x = $test ? -1 : 1;
 $y = $test ? 1 : -1;
+$z = $test ?: false;
 
 $closureWithDefaultParamter = function (array $testArray=array()) {};
 

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -92,7 +92,7 @@ class Squiz_Tests_WhiteSpace_OperatorSpacingUnitTest extends AbstractSniffUnitTe
                     88 => 5,
                     90 => 4,
                     91 => 5,
-                    127 => 4,
+                    128 => 4,
                    );
             break;
         case 'OperatorSpacingUnitTest.js':


### PR DESCRIPTION
The short ternary operator '?:' is an inline if followed by an inline
else and does not have a whitespace:

```
$foo = $bar ?: false;
```
