### PR TITLE
fix preg_splite not in unicode mode may cause some chinese character error

### DIFF
--- a/CodeSniffer/CommentParser/AbstractParser.php
+++ b/CodeSniffer/CommentParser/AbstractParser.php
@@ -239,7 +239,7 @@ abstract class PHP_CodeSniffer_CommentParser_AbstractParser
                 // spaces as well as separate tokens.
                 $flags = (PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
                 $words = preg_split(
-                    '|(\s+)|',
+                    '|(\s+)|u',
                     $line.$this->phpcsFile->eolChar,
                     -1,
                     $flags


### PR DESCRIPTION
if reg_splite not in unicode mode may cause some chinese character split error

example: 

``` php
/**
 * 套装
 * 
 * @param string $name bundleName
 *
 * @return void
 */
```

when reg_splite not in unicode, result is , that not be right:

```
array(3) {
  [0] =>
  string(1) " "
  [1] =>
  string(5) "套�"
  [2] =>
  string(2) "�
"
}
```

but use unicode, result is:

```
array(3) {
  [0] =>
  string(1) " "
  [1] =>
  string(6) "套装"
  [2] =>
  string(1) "
"
}
```
