### PR TITLE
Save values (cli options) passed manually

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -499,6 +499,8 @@ class PHP_CodeSniffer_CLI
     {
         if (empty($values) === true) {
             $values = $this->getCommandLineValues();
+        } else {
+            $this->values = $values;
         }
 
         if ($values['generator'] !== '') {


### PR DESCRIPTION
We need to save manually passed values in order to prevent using default values in `PHP_CodeSniffer::process` (`$cliValues = $this->cli->getCommandLineValues()`)
