### PR TITLE
Save values (cli options) passed manually and merge with defaults

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -499,6 +499,8 @@ class PHP_CodeSniffer_CLI
     {
         if (empty($values) === true) {
             $values = $this->getCommandLineValues();
+        } else {
+            $this->values = $values = array_merge($this->getDefaults(), $values);
         }
 
         if ($values['generator'] !== '') {


### PR DESCRIPTION
We need to save manually passed values in order to prevent using default values in `PHP_CodeSniffer::process` (`$cliValues = $this->cli->getCommandLineValues()`)

I'm not sure if this is acceptable, so I made simple changes in previous PR (https://github.com/squizlabs/PHP_CodeSniffer/pull/172). Choose which one better reflects your vision of doing this.
