### PR TITLE
Add \b to characters that are allowed to use double quotes

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -114,6 +114,7 @@ class Squiz_Sniffs_Strings_DoubleQuoteUsageSniff implements PHP_CodeSniffer_Snif
                          '\t',
                          '\v',
                          '\x',
+                         '\b',
                          '\'',
                         );
 


### PR DESCRIPTION
\b is not properly interpreted with single quotes
