### PR TITLE
SwitchDeclarationSniff cannot handle php 5.5 ::class constant

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -1537,6 +1537,15 @@ class PHP_CodeSniffer_File
                 return $i;
             }
 
+            // handle 5.5 ClassName::class
+            if ($opener === null && $tokenType === T_CLASS && isset($tokens[$i - 1]) && $tokens[$i - 1]['code'] === T_PAAMAYIM_NEKUDOTAYIM) {
+                if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                    echo str_repeat("\t", $depth);
+                    echo "=> Found 5.5 ::class, continuing".PHP_EOL;
+                }
+                continue;
+            }
+
             // Is this an opening condition ?
             if (isset($tokenizer->scopeOpeners[$tokenType]) === true) {
                 if ($opener === null) {

--- a/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -87,4 +87,21 @@ switch (true) {
             return null;
         }
 }
+
+switch (true) {
+    case Foo::class:
+        break;
+}
+
+switch ($foo) {
+    case Foo::class:
+        break;
+case Foo::class:
+}
+
+switch ($foo) {
+    case Foo::class: {
+        break;
+        }
+}
 ?>

--- a/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/CodeSniffer/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -47,6 +47,8 @@ class PSR2_Tests_ControlStructures_SwitchDeclarationUnitTest extends AbstractSni
                 29 => 1,
                 33 => 1,
                 37 => 1,
+                99 => 1,
+                103 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
this patch prevents false positives when a case statement contains a ::class constant
