### PR TITLE
Add NOWDOC tokens to the list of HEREDOC tokens to treat them equally

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -95,8 +95,10 @@ class Generic_Sniffs_Functions_FunctionCallArgumentSpacingSniff implements PHP_C
 
             if ($tokens[$nextSeparator]['code'] === T_COMMA) {
                 if ($tokens[($nextSeparator - 1)]['code'] === T_WHITESPACE) {
-                    $error = 'Space found before comma in function call';
-                    $phpcsFile->addError($error, $stackPtr, 'SpaceBeforeComma');
+                    if (in_array($tokens[($nextSeparator - 2)]['code'], PHP_CodeSniffer_Tokens::$heredocTokens) === false) {
+                        $error = 'Space found before comma in function call';
+                        $phpcsFile->addError($error, $stackPtr, 'SpaceBeforeComma');
+                    }
                 }
 
                 if ($tokens[($nextSeparator + 1)]['code'] !== T_WHITESPACE) {

--- a/CodeSniffer/Tokens.php
+++ b/CodeSniffer/Tokens.php
@@ -444,6 +444,9 @@ final class PHP_CodeSniffer_Tokens
                                     T_START_HEREDOC,
                                     T_END_HEREDOC,
                                     T_HEREDOC,
+                                    T_START_NOWDOC,
+                                    T_END_NOWDOC,
+                                    T_NOWDOC,
                                    );
 
 


### PR DESCRIPTION
NOWDOC and HEREDOC are basically the same but aren't treated like that.

Also, ignore "space before ," when the token before the whitespace is
a HEREDOC or NOWDOC.
