### PR TITLE
allow upper case NULL class constant for PSR-2

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -80,12 +80,17 @@ class Generic_Sniffs_PHP_LowerCaseConstantSniff implements PHP_CodeSniffer_Sniff
             || $tokens[$prevPtr]['code'] === T_EXTENDS
             || $tokens[$prevPtr]['code'] === T_IMPLEMENTS
             || $tokens[$prevPtr]['code'] === T_NEW
+            || $tokens[$prevPtr]['code'] === T_CONST
         ) {
             return;
         }
 
         // Class or namespace?
         if ($tokens[($stackPtr - 1)]['code'] === T_NS_SEPARATOR) {
+            return;
+        }
+
+        if ($tokens[($stackPtr - 1)]['code'] === T_PAAMAYIM_NEKUDOTAYIM) {
             return;
         }
 


### PR DESCRIPTION
PSR-2 states that: 

> The PHP constants true, false, and null MUST be in lower case.

But PSR-1 states:

> Class constants MUST be declared in all upper case with underscore separators.

This PR allows class constants named `NULL` to be uppercase, while still ensuring non-class constant usages of `null` are lower cased:

``` php
class MyClass
{
    const NULL = null;
}

var_dump(MyClass::NULL);
var_dump(null);
```

Current phpcs throws an error on the class constant.
