### PR TITLE
Incorrect docblock comment in Squiz_Sniffs_Files_FileExtensionSniff

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
@@ -16,7 +16,7 @@
 /**
  * Squiz_Sniffs_Files_FileExtensionSniff.
  *
- * Tests that the stars in a doc comment align correctly.
+ * Tests that classes and interfaces are not declared in .php files
  *
  * @category  PHP
  * @package   PHP_CodeSniffer


### PR DESCRIPTION
Looks like a copy/paste from Squiz_Sniffs_Commenting_DocCommentAlignmentSniff - I'm not precious about what it should be changed to, just that it is currently wrong :)
