### PR TITLE
Fix 2.0.0a1 composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
             "CodeSniffer/Sniff.php",
             "CodeSniffer/Tokens.php",
             "CodeSniffer/Reports/",
-            "CodeSniffer/CommentParser/",
             "CodeSniffer/Tokenizers/",
             "CodeSniffer/DocGenerators/",
             "CodeSniffer/Standards/AbstractPatternSniff.php",


### PR DESCRIPTION
Removing a missing namespace from composer classmap as this breaks `composer install`.

Is this the dev-branch for phpcs ~2? There is some confusion on this point as neither composer.json nor README.md seem up-to-date. Maybe you should add a "2.0.x-dev" alias to composer.json
