### PR TITLE
Do not count define as a symbol if used as a method name

### DIFF
--- a/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -158,6 +158,7 @@ class PSR1_Sniffs_Files_SideEffectsSniff implements PHP_CodeSniffer_Sniff
                 continue;
             } else if ($tokens[$i]['code'] === T_STRING
                 && strtolower($tokens[$i]['content']) === 'define'
+                && $phpcsFile->findPrevious(T_OBJECT_OPERATOR, ($i - 1), ($i - 1)) === false
             ) {
                 if ($firstSymbol === null) {
                     $firstSymbol = $i;


### PR DESCRIPTION
`define` is a legal method name to use in a class, so 'define' tokens should not be interpreted as a symbol if it's clear that this is a method call on an object.
