### PR TITLE
don't assume numeric line numbers

### DIFF
--- a/CodeSniffer/Reports/Full.php
+++ b/CodeSniffer/Reports/Full.php
@@ -78,14 +78,7 @@ class PHP_CodeSniffer_Reports_Full implements PHP_CodeSniffer_Report
         echo str_repeat('-', $width).PHP_EOL;
 
         // Work out the max line number for formatting.
-        $maxLine = 0;
-        foreach ($report['messages'] as $line => $lineErrors) {
-            if ($line > $maxLine) {
-                $maxLine = $line;
-            }
-        }
-
-        $maxLineLength = strlen($maxLine);
+        $maxLineLength = max(array_map('strlen', array_keys($report['messages'])));
 
         // The length of the word ERROR or WARNING; used for padding.
         if ($report['warnings'] > 0) {


### PR DESCRIPTION
`PHP_CodeSniffer_Reports_Full` assumes that line numbers in the report are numeric. This isn't always the case. We use this class to display custom reports and that yield line ranges, such as "112 - 118".

So, if a report has two messages, for lines "156 - 172" and "27", the width for the line column is determined as 2, because "27" > "156 - 172".

This PR calculates the actual maximum string length.
