### PR TITLE
Updated docs to install via composer in dev mode

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ Make sure you have `~/.composer/vendor/bin/` in your PATH.
 Or alternatively, include a dependency for `squizlabs/php_codesniffer` in your `composer.json` file. For example:
 
     {
-        "require": {
+        "require-dev": {
             "squizlabs/php_codesniffer": "1.*"
         }
     }


### PR DESCRIPTION
PHPCS is not used in production, so it fits better in the `require-dev`, avoiding the code be deployed to production environment unnecessarily.
