### PR TITLE
Allow relative paths to be used in --config-set installed_paths

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1951,7 +1951,13 @@ class PHP_CodeSniffer
             $installedPaths = array(dirname(__FILE__).'/CodeSniffer/Standards');
             $configPaths    = PHP_CodeSniffer::getConfigData('installed_paths');
             if ($configPaths !== null) {
-                $installedPaths = array_merge($installedPaths, explode(',', $configPaths));
+                $configPaths = explode(',', $configPaths);
+                foreach ( $configPaths as $idx => $configPath ) {
+                    if ( strpos($configPath, '/') !== 0 ) {
+                        $configPaths[$idx] = $installedPaths[0] . '/' . $configPath;
+                    }
+                }
+                $installedPaths = array_merge($installedPaths, $configPaths);
             }
         } else {
             $installedPaths = array($standardsDir);
@@ -2038,7 +2044,13 @@ class PHP_CodeSniffer
         $installedPaths = array(dirname(__FILE__).'/CodeSniffer/Standards');
         $configPaths    = PHP_CodeSniffer::getConfigData('installed_paths');
         if ($configPaths !== null) {
-            $installedPaths = array_merge($installedPaths, explode(',', $configPaths));
+            $configPaths = explode(',', $configPaths);
+            foreach ( $configPaths as $idx => $configPath ) {
+                if ( strpos($configPath, '/') !== 0 ) {
+                    $configPaths[$idx] = $installedPaths[0] . '/' . $configPath;
+                }
+            }
+            $installedPaths = array_merge($installedPaths, $configPaths);
         }
 
         foreach ($installedPaths as $installedPath) {


### PR DESCRIPTION
This patch adds the ability to use relative paths in `installed_paths` directive, to reference _subset_ Standards' packages added inside existing Standards.

This is backward compatible, paths that begins with a slash will still be parsed normally, but those without a preceding slash will be prefixed with the path to Standards directory ( `/path/to/phpcs/CodeSniffer/Standards` ), so using the following:

``` bash
phpcs --config-set installed_paths WordPress/Subsets
```

will cause PHPCS to detect WordPress/Subsets/%subset-name%/ruleset.xml

The use-case for this is discussed at https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/162, and it is clear that changes in this PR would save Standards packages much effort trying to work-around the need to figure out absolute paths, which proves difficult working with multi-environment setup like with VVV.

/cc @westonruter @Rarst @gsherwood, insights are welcome!
