### PR TITLE
Make the tests running under PHPUnit 4.0.x

### DIFF
--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -13,10 +13,6 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHPUnit_Framework_TestSuite', false) === false) {
-    require_once 'PHPUnit/Framework/TestSuite.php';
-}
-
 /**
  * A PHP_CodeSniffer specific test suite for PHPUnit.
  *


### PR DESCRIPTION
Since version 4.0.x PHPUnit will be distributed as a PHAR file via PEAR[1]. This means all the dependencies in form of several files are bundled into one single file. This break any `require` statements. As you can see at [2], PHPUnit comes with an autoloader which make `require` statement obsolete anyway. 

This change fixes the error 

```
Warning: require_once(PHPUnit/Framework/TestSuite.php): failed to open stream: No such file or directory in /Volumes/HDD/Users/sok/Development/PHP/PHP_CodeSniffer/tests/TestSuite.php on line 17
```

[1] https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-4.0.0#obtaining-phpunit-40
[2] https://github.com/sebastianbergmann/phpunit/issues/1173
