### PR TITLE
CLI's report type validation

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -400,23 +400,8 @@ class PHP_CodeSniffer_CLI
                     $output = null;
                 }
 
-                $validReports = array(
-                                 'full',
-                                 'xml',
-                                 'json',
-                                 'checkstyle',
-                                 'junit',
-                                 'csv',
-                                 'emacs',
-                                 'notifysend',
-                                 'source',
-                                 'summary',
-                                 'svnblame',
-                                 'gitblame',
-                                 'hgblame',
-                                );
-
-                if (in_array($report, $validReports) === false) {
+                $reportClassName = 'PHP_CodeSniffer_Reports_'.ucfirst($report);
+                if (class_exists($reportClassName, true) === false) {
                     echo 'ERROR: Report type "'.$report.'" not known.'.PHP_EOL;
                     exit(2);
                 }


### PR DESCRIPTION
The current validation does not allow users to implement their own report types without modifying CLI class.

This suggested change allow usage of any defined PHP_CodeSniffer_Reports_\* class by doing validation like the report factory does it.

https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Reporting.php
Lines: 90-94
