### PR TITLE
Fixed http_response_header not being valid var name

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -69,6 +69,7 @@ class Squiz_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSnif
                             '_COOKIE',
                             '_FILES',
                             'GLOBALS',
+                            'http_response_header'
                            );
 
         // If it's a php reserved var, then its ok.

--- a/CodeSniffer/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/CodeSniffer/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -69,6 +69,7 @@ class Zend_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSniff
                             '_COOKIE',
                             '_FILES',
                             'GLOBALS',
+                            'http_response_header'
                            );
 
         // If it's a php reserved var, then its ok.


### PR DESCRIPTION
While `$http_response_header` is a terrible variable name, it just can't be helped, same as `$_GET` etc.
