### PR TITLE
Subset selection

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1980,10 +1980,12 @@ class PHP_CodeSniffer
                     }
                     // Search for subset rulesets in root, ie: {subset}.ruleset.xml
                     $subsets = glob($file->getPathname().'/*.ruleset.xml');
-                    foreach ( $subsets as $subset ) {
-                        $subset_name = preg_match('#[\\/]([^\\/]*).ruleset.xml$#', $subset, $match) > 0
-                            ? $match[1] : null;
-                        $installedStandards[] = $filename.':'.$subset_name;
+                    if ( ! empty( $subsets ) ) {
+                        foreach ( $subsets as $subset ) {
+                            $subset_name = preg_match('#[\\/]([^\\/]*).ruleset.xml$#', $subset, $match) > 0
+                                ? $match[1] : null;
+                            $installedStandards[] = $filename.':'.$subset_name;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This allows usage of subset rulesets within a Standard directory, so you can add multiple rulesets, like `core.ruleset.xml` in root of your Standard, and pick it up on the command line via something like 

```
phpcs --standard=MyStandard:core
```

This also shows subsets registered in `phpcs -i` so it can be used by PhpStorm and others who query installed standards in their configuration.

Why we did this, is to allow usage of different subset of rules within a single Standard package, not all of people would agree to all rules within a standard package, and this makes it easier to provide pre-selected set of rules to users, usable instantly after installing of a Standard.

We've been struggling with this issue for a while at [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) for a while, with specific two cases in mind:
- Having a VIP set of rules that only applies to WordPress VIP environment
- Having a set of rules that only applies to a WordPress Theme context

This should be 100% backward compatible.

This deprecates work done on https://github.com/x-team/PHP_CodeSniffer/tree/relative-standards-paths / https://github.com/squizlabs/PHP_CodeSniffer/pull/200
