### PR TITLE
[FunctionDeclarationSniff] Ignore also shorthand array notation

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -279,9 +279,9 @@ class PEAR_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffer_
                 $lastLine = $tokens[$i]['line'];
             }//end if
 
-            if ($tokens[$i]['code'] === T_ARRAY) {
+            if ($tokens[$i]['code'] === T_ARRAY || $tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
                 // Skip arrays as they have their own indentation rules.
-                $i        = $tokens[$i]['parenthesis_closer'];
+                $i        = ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) ? $tokens[$i]['bracket_closer'] : $tokens[$i]['parenthesis_closer'];
                 $lastLine = $tokens[$i]['line'];
                 continue;
             }

--- a/CodeSniffer/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/CodeSniffer/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -67,7 +67,19 @@ function validateUrl(
     array $allowedSchemes=array(
                            'http',
                            'https',
-                          )
+                          ),
+    array $notAllowedSchemes=array('ftp', 'sftp')
+) {
+}
+
+function validateUrlShort(
+    $url,
+    $requireScheme=TRUE,
+    array $allowedSchemes=[
+        'http',
+        'https',
+    ],
+    array $notAllowedSchemes=['ftp', 'sftp']
 ) {
 }
 

--- a/CodeSniffer/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/CodeSniffer/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -55,10 +55,10 @@ class PEAR_Tests_Functions_FunctionDeclarationUnitTest extends AbstractSniffUnit
                 44  => 1,
                 51  => 1,
                 61  => 2,
-                86  => 1,
-                98  => 2,
-                108 => 1,
-                109 => 1,
+                98  => 1,
+                110  => 2,
+                120 => 1,
+                121 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Ignore the shorthand array notation as default value for arguments in FunctionDeclarationSniff.
