### PR TITLE
ForbiddenFunctionsSniff will ignore function calls preceded by a T_NS_SEPARATOR

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -117,6 +117,17 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
                   );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+
+        // If function call is directly preceded by a NS_SEPARATOR it points to the
+        // global namespace - so we should still catch it
+        if ($tokens[$prevToken]['code'] == T_NS_SEPARATOR) {
+            $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($prevToken - 1), null, true);
+            if ($tokens[$prevToken]['code'] == T_STRING) {
+                // Not in the global namespace
+                return;
+            }
+        }
+
         if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
             // Not a call to a PHP function.
             return;


### PR DESCRIPTION
The following code will successfully give an error/warning:

```
sizeof('abc');
```

While this will work exactly the same in PHP, but will not give an error/warning:

```
\sizeof('abc');
```

This pull request would fix that, while still not giving an error/warning on the following code:

```
\my\ns\sizeof('abc');
```

Unit tests and code style sniffs all pass.
