### PR TITLE
Fixing namespaces being incorrectly detected as constants

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/LowerCaseConstantSniff.php
@@ -85,7 +85,10 @@ class Generic_Sniffs_PHP_LowerCaseConstantSniff implements PHP_CodeSniffer_Sniff
         }
 
         // Class or namespace?
-        if ($tokens[($stackPtr - 1)]['code'] === T_NS_SEPARATOR) {
+        if ($tokens[($stackPtr - 1)]['code'] === T_NS_SEPARATOR
+            || $tokens[$prevPtr]['code'] === T_USE
+            || $tokens[$prevPtr]['code'] === T_NAMESPACE
+        ) {
             return;
         }
 

--- a/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseConstantUnitTest.inc
@@ -51,10 +51,13 @@ $x = new stdClass();
 $x->NULL = 7;
 
 use Zend\Log\Writer\NULL as NullWriter;
-new \Zend\Log\Writer\NULL()
+new \Zend\Log\Writer\NULL();
+
+namespace False;
 
 class True extends Null implements False {}
 
+use True\Something;
 use Something\True;
 class MyClass
 {


### PR DESCRIPTION
Up to now namespaces starting with `false|true|null` would be incorrectly detected as constants. Those cases are now fixed:

``` php
use True\Something;
namespace False;
```
