### PR TITLE
Use UTF-8 as default encoding

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -123,7 +123,7 @@ class PHP_CodeSniffer_CLI
 
         $encoding = PHP_CodeSniffer::getConfigData('encoding');
         if ($encoding === null) {
-            $defaults['encoding'] = 'iso-8859-1';
+            $defaults['encoding'] = 'utf-8';
         } else {
             $defaults['encoding'] = strtolower($encoding);
         }
@@ -842,7 +842,7 @@ class PHP_CodeSniffer_CLI
         echo '        <extensions>  A comma separated list of file extensions to check'.PHP_EOL;
         echo '                      (only valid if checking a directory)'.PHP_EOL;
         echo '        <patterns>    A comma separated list of patterns to ignore files and directories'.PHP_EOL;
-        echo '        <encoding>    The encoding of the files being checked (default is iso-8859-1)'.PHP_EOL;
+        echo '        <encoding>    The encoding of the files being checked (default is utf-8)'.PHP_EOL;
         echo '        <sniffs>      A comma separated list of sniff codes to limit the check to'.PHP_EOL;
         echo '                      (all sniffs must be part of the specified standard)'.PHP_EOL;
         echo '        <severity>    The minimum severity required to display an error or warning'.PHP_EOL;


### PR DESCRIPTION
Current default (ISO-8859-1) is kind of obsolete - probably most of new code is written using UTF-8 encoding. 

Also the current default can cause false positive CS errors in eg. line length check (line with unicode characters is longer than it actually is when treated as iso-8859-1).
