### PR TITLE
Cover cases when method type hinting is used together with namespaces or use statements.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -126,13 +126,13 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sn
         $this->currentNamespace = '';
         for ($i = ($start + 1); $i <= $end; $i++) {
             switch ($tokens[$i]['code']) {
-                case T_STRING:
-                    if ($i == ($start + 2)) {
-                        $this->currentNamespace .= '\\';
-                    }
-                case T_NS_SEPARATOR:
-                    $this->currentNamespace .= $tokens[$i]['content'];
-                    break;
+            case T_STRING:
+                if ($i == ($start + 2)) {
+                    $this->currentNamespace .= '\\';
+                }
+            case T_NS_SEPARATOR:
+                $this->currentNamespace .= $tokens[$i]['content'];
+                break;
             }
         }
 
@@ -143,17 +143,17 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sn
             $end = $phpcsFile->findNext(T_SEMICOLON, $start+1, null, false, ';');
             for ($i = ($start + 1); $i <= $end; $i++) {
                 switch ($tokens[$i]['code']) {
-                    case T_STRING:
-                        if ($i == ($start + 2)) {
-                            $use .= '\\';
-                        }
-                    case T_NS_SEPARATOR:
-                        $use .= $tokens[$i]['content'];
-                        break;
-                    case T_SEMICOLON:
-                        $this->useStatements[] = $use;
-                        $use = '';
-                        break;
+                case T_STRING:
+                    if ($i == ($start + 2)) {
+                        $use .= '\\';
+                    }
+                case T_NS_SEPARATOR:
+                    $use .= $tokens[$i]['content'];
+                    break;
+                case T_SEMICOLON:
+                    $this->useStatements[] = $use;
+                    $use = '';
+                    break;
                 }
             }
             $start = $end + 1;
@@ -708,8 +708,8 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sn
                                          );
                                 $this->currentFile->addError($error, ($commentEnd + 2), 'TypeHintMissing', $data);
                             } else if ($typeHint !== $suggestedTypeHint
-                                       && $suggestedTypeHint != $this->currentNamespace.'\\'.$typeHint
-                                       && !in_array($suggestedTypeHint, $this->useStatements)
+                                && $suggestedTypeHint != $this->currentNamespace.'\\'.$typeHint
+                                && !in_array($suggestedTypeHint, $this->useStatements)
                             ) {
                                 $error = 'Expected type hint "%s"; found "%s" for %s at position %s';
                                 $data  = array(


### PR DESCRIPTION
This Pull requests fixes errors detected in following code:

```
<?php

namespace Vendor\Package;

use OtherVendor\Package\SomeClass2;

class Foo
{
    /**
     * Some description.
     * @param \Vendor\Package\SomeClass       $someclass  Some class.
     * @param \OtherVendor\Package\SomeClass2 $someclass2 Some class.
     */
    public function setJSModuleLoader(SomeClass $someclass, SomeClass2 $someclass2)
    {
    }
}
```

Code Sniffer output example in such case:

```
Expected type hint "\Vendor\Package\SomeClass";
found "SomeClass" for $someclass
(Squiz.Commenting.FunctionComment.IncorrectTypeHint)
```
