### PR TITLE
Fix for HHVm issue with stream_get_meta_data

### DIFF
--- a/CodeSniffer/Reporting.php
+++ b/CodeSniffer/Reporting.php
@@ -174,7 +174,7 @@ class PHP_CodeSniffer_Reporting
             if ($output === null) {
                 // Using a temp file.
                 if (isset($this->_tmpFiles[$report]) === false) {
-                     $this->_tmpFiles[$report] = fopen(tempnam(sys_get_temp_dir(), 'phpcs'), 'w');
+                    $this->_tmpFiles[$report] = fopen(tempnam(sys_get_temp_dir(), 'phpcs'), 'w');
                 }
 
                 fwrite($this->_tmpFiles[$report], $generatedReport);


### PR DESCRIPTION
This should fix issue when HHVM is used, since HHVM has different implemenation of `tmpfile()` https://github.com/facebook/hhvm/issues/2336 that leads to returning empty `uri` key when `stream_get_meta_data` is used.

```
Warning: Filename cannot be empty in vendor/squizlabs/php_codesniffer/CodeSniffer/Reporting.php on line 237
```

```
array(10) {
  ["wrapper_type"]=>
  string(9) "plainfile"
  ["stream_type"]=>
  string(5) "STDIO"
  ["mode"]=>
  string(0) ""
  ["unread_bytes"]=>
  int(0)
  ["seekable"]=>
  bool(true)
  ["uri"]=>
  string(0) ""
  ["timed_out"]=>
  bool(false)
  ["blocked"]=>
  bool(true)
  ["eof"]=>
  bool(false)
  ["wrapper_data"]=>
  NULL
}
```
