### PR TITLE
Bug #20367 --ignore does not accept pipes in <patterns>

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1282,7 +1282,7 @@ class PHP_CodeSniffer
                 $testPath = $path;
             }
 
-            if (preg_match("|{$pattern}|i", $testPath) === 1) {
+            if (preg_match("`{$pattern}`i", $testPath) === 1) {
                 return true;
             }
         }//end foreach


### PR DESCRIPTION
Backticks (`), in *nix systems, in any case, are not valid filename
or directory name characters. Besides which, I do not believe they have
a special meaning in processing regular expressions.
