### PR TITLE
Call factory method as object method instead of class method

### DIFF
--- a/CodeSniffer/Reporting.php
+++ b/CodeSniffer/Reporting.php
@@ -131,7 +131,7 @@ class PHP_CodeSniffer_Reporting
         $errorsShown = false;
 
         foreach ($cliValues['reports'] as $report => $output) {
-            $reportClass = self::factory($report);
+            $reportClass = $this->factory($report);
 
             ob_start();
             $result = $reportClass->generateFileReport($reportData, $cliValues['showSources'], $cliValues['reportWidth']);
@@ -193,7 +193,7 @@ class PHP_CodeSniffer_Reporting
         $reportFile='',
         $reportWidth=80
     ) {
-        $reportClass = self::factory($report);
+        $reportClass = $this->factory($report);
 
         if ($reportFile !== null) {
             $filename = $reportFile;


### PR DESCRIPTION
In my application particularly, I need to wrap any instance returned by factory method into decorator class which implements some common logic. This seems possible by overriding the `factory()` method of `PHP_CodeSniffer_Reporting` class. However, the fact that factory method is called statically from its own class makes impossible to override it in extended class.

Calling method as `$this->factory()` instead of `self::factory()` would make interpreter using the implementation declared in current class rather than in base one.
