### PR TITLE
Fix to under-reporting of white-space after closing PHP tag

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -142,6 +142,13 @@ class Squiz_Sniffs_WhiteSpace_SuperfluousWhitespaceSniff implements PHP_CodeSnif
             if ($phpcsFile->tokenizerType === 'PHP') {
                 if (isset($tokens[($stackPtr + 1)]) === false) {
                     // The close PHP token is the last in the file.
+                    // However, if it contains a newline character we still need
+                    // to report the error.
+                    $content = $tokens[$stackPtr]['content'];
+                    if ($content != rtrim($content)) {
+                        $phpcsFile->addError('Additional whitespace found at end of file',
+                                             $stackPtr, 'EndFile');
+                    }
                     return;
                 }
 


### PR DESCRIPTION
Proposed fix to bug 20375 (https://pear.php.net/bugs/bug.php?id=20375).

The Sniff does not currently report additional white-space at end of file when closing PHP tag is followed by a single newline.  This is because the newline character is part of the T_CLOSE_TAG token, rather than being part of the T_INLINE_HTML token that follows it.

This update now checks the contents of the T_CLOSE_TAG to check for this situation.

I have not applied a similar fix for T_OPEN_TAG, as I don't think this issue can apply there.
