### PR TITLE
add shellchecker

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -167,6 +167,7 @@ class PHP_CodeSniffer
                                      'inc' => 'PHP',
                                      'js'  => 'JS',
                                      'css' => 'CSS',
+                                     'sh' => 'SH',
                                     );
 
     /**

--- a/CodeSniffer/Standards/Squiz/Sniffs/Debug/ShellCheckerSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Debug/ShellCheckerSniff.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Squiz_Sniffs_Debug_ShellCheckerSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Squiz_Sniffs_Debug_ShellCheckerSniff.
+ *
+ * Runs shellchecker on the file.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Squiz_Sniffs_Debug_ShellCheckerSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array('SH');
+
+    /**
+     * Returns the token types that this sniff is interested in.
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return array(T_OPEN_TAG);
+
+    }//end register()
+
+    /**
+     * Processes the tokens that this sniff is interested in.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
+     * @param int                  $stackPtr  The position in the stack where
+     *                                        the token was found.
+     *
+     * @return void
+     * @throws PHP_CodeSniffer_Exception If shellchecker could not be run
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $fileName = $phpcsFile->getFilename();
+        
+        $shellCheckerPath = PHP_CodeSniffer::getConfigData('shellcheck_path');
+        if ($shellCheckerPath === null) {
+            return;
+        }
+
+        $cmd = "$shellCheckerPath --format=checkstyle $fileName";
+        $output = array();
+        exec($cmd, $output);
+
+        if (empty($output) === true) {
+            return;
+        }
+        
+        $checkstyle = new SimpleXMLElement(implode(PHP_EOL, $output));
+
+        $tokens = $phpcsFile->getTokens();
+
+        foreach ($checkstyle->file as $file) {
+            foreach ($file->error as $error) {
+                $line = $error['line'];
+                $msg = $error['message'];
+                $severity = $error['severity'];
+
+                $lineToken = null;
+                foreach ($tokens as $ptr => $info) {
+                    if ($info['line'] == $line) {
+                        $lineToken = $ptr;
+                        break;
+                    }
+                }
+                if ($severity === 'error') {
+                    $phpcsFile->addError($msg, $lineToken, 'ExternalTool');
+                } else {
+                    $phpcsFile->addWarning($msg, $lineToken, 'ExternalTool');
+                }
+            }
+        }
+    }//end process()
+}//end class
+
+?>

--- a/CodeSniffer/Tokenizers/SH.php
+++ b/CodeSniffer/Tokenizers/SH.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tokenizes SH code.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PHP_CodeSniffer_Tokenizers_SH
+{
+    /**
+     * Creates an array of tokens when given some SH code.
+     *
+     * Uses the PHP tokenizer to do all the tricky work
+     *
+     * @param string $string  The string to tokenize.
+     * @param string $eolChar The EOL character to use for splitting strings.
+     *
+     * @return array
+     */
+    public function tokenizeString($string, $eolChar = '\n')
+    {
+        $tokens[] = array(
+                     'code'    => T_OPEN_TAG,
+                     'type'    => 'T_OPEN_TAG',
+                     'content' => '',
+                    );
+
+        $string = str_replace($eolChar, "\n", $string);
+        $chars    = str_split($string);
+
+        $countValues = array_count_values($chars);
+        $numLines = $countValues["\n"];
+
+        for ($i = 0; $i < $numLines; $i++) {
+            $tokens[] = array(
+                'code'    => T_WHITESPACE,
+                'type'    => 'T_WHITESPACE',
+                'content' => "\n",
+            );
+        }
+
+        $tokens[] = array(
+                     'code'    => T_CLOSE_TAG,
+                     'type'    => 'T_CLOSE_TAG',
+                     'content' => '',
+                    );
+
+        return $tokens;
+    }//end tokenizeString()
+
+
+    /**
+     * Performs additional processing after main tokenizing.
+     *
+     * @param array  &$tokens The array of tokens to process.
+     * @param string $eolChar The EOL character to use for splitting strings.
+     *
+     * @return void
+     */
+    public function processAdditional(&$tokens, $eolChar)
+    {
+    }//end processAdditional()
+
+}//end class
+
+?>


### PR DESCRIPTION
Hi,
It would be nice, (at least for me) if I could use code sniffer to check on my bash scripts.
I use this http://www.shellcheck.net/  tool but I don't have it available on my IDE, SO if we could merge this in CodeSniffer that would be the easier solution for me.

I just made the enough to get it working, so no real Tokenizer as this is not needed since this tool already takes care of that. 

I would like to know what do you think about it. Should CodeSniffer sniff bash scripts also?
I'm open to other solutions or to improve this PR. (I'm also already trying to create a plugin for my IDE).

Thanks 
