### PR TITLE
Fix ignore sniff specific ignore pattern

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1255,7 +1255,7 @@ class PHP_CodeSniffer
         }
 
         foreach ($this->ignorePatterns as $pattern => $type) {
-            if (is_array($pattern) === true) {
+            if (is_array($type) === true) {
                 // A sniff specific ignore pattern.
                 continue;
             }


### PR DESCRIPTION
$pattern must be scalar but $type makes sense here as it could be an array
