### PR TITLE
Error converted to warning lost it's $fixable flag

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -994,7 +994,7 @@ class PHP_CodeSniffer_File
             && $this->ruleset[$sniffCode]['type'] === 'warning'
         ) {
             // Pass this off to the warning handler.
-            return $this->_addWarning($error, $line, $column, $code, $data, $severity);
+            return $this->_addWarning($error, $line, $column, $code, $data, $severity, $fixable);
         } else if ($this->phpcs->cli->errorSeverity === 0) {
             // Don't bother doing any processing as errors are just going to
             // be hidden in the reports anyway.
@@ -1132,7 +1132,7 @@ class PHP_CodeSniffer_File
             && $this->ruleset[$sniffCode]['type'] === 'error'
         ) {
             // Pass this off to the error handler.
-            return $this->_addError($warning, $line, $column, $code, $data, $severity);
+            return $this->_addError($warning, $line, $column, $code, $data, $severity, $fixable);
         } else if ($this->phpcs->cli->warningSeverity === 0) {
             // Don't bother doing any processing as warnings are just going to
             // be hidden in the reports anyway.


### PR DESCRIPTION
Error reported by sniff, that is transformed to warning (according to severity override from ruleset.xml), wasn't retaining it's $fixable flag passed on from sniff itself.

In fact it should have raised Fatal Error:
![phpcs_file_adderror_fatalerror](https://cloud.githubusercontent.com/assets/1277526/4111616/4a27da98-320d-11e4-969c-105db40a62a1.png)

I guess such case isn't covered by any test.
