### PR TITLE
Disable PHP4 style ctor warnings when __construct is present

### DIFF
--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc
@@ -41,4 +41,12 @@ abstract class MyAbstractClass extends \MyNamespace\SomeClass
 {
     abstract public function __construct();
 }
+
+class OldClass
+{
+    function OldClass()
+    {
+
+    }
+}
 ?>

--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.php
@@ -41,10 +41,9 @@ class Generic_Tests_NamingConventions_ConstructorNameUnitTest extends AbstractSn
     public function getErrorList()
     {
         return array(
-                5  => 1,
                 6  => 1,
                 11 => 1,
-                20 => 1,
+                47 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Fix edge-case where classes having both a function with the same name as the class and a __construct function are incorrectly detected as using PHP4 style constructor.

As the PHP5 doc states :

> For backwards compatibility, if PHP 5 cannot find a __construct() function for a given class, and the class did not inherit one from a parent class, it will search for the old-style constructor function, by the name of the class

Meaning that a function named like the class is only considered a constructor if no __construct function is present.

This P/R does not handle cases where __construct is declared in a parent class.
