### PR TITLE
squiz.FunctionDeclarationSniff not working with special words

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -66,3 +66,9 @@ function recurseCreateTree(
 
 
 function test ( ){}
+
+function parent() {}
+function self() {}
+function false() {}
+function true() {}
+function null() {}


### PR DESCRIPTION
Functions which name is one of these:
- parent
- self
- false
- true
- null

trigger the error `Expected "function abc(...)"; found "function abc(...)"`

The error is a little bit misleading, but the cause of the error is that the AbstractPatternSniff expects T_STRING for the function name. In the above cases its T_PARENT, T_SELF, ...

I'm not yet sure how to fix that properly.
This PR is only the failing tests.
