### PR TITLE
Fix bug 20386

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
@@ -115,6 +115,9 @@ class Squiz_Sniffs_Commenting_ClassCommentSniff implements PHP_CodeSniffer_Sniff
                 $prevTokenEnd = $phpcsFile->findPrevious(T_WHITESPACE, ($commentStart - 1), null, true);
                 if ($prevTokenEnd !== false) {
                     $blankLineBefore = 0;
+                    if ($tokens[$prevTokenEnd]['code'] === T_OPEN_TAG) {
+                        $blankLineBefore++;
+                    }
                     for ($i = ($prevTokenEnd + 1); $i < $commentStart; $i++) {
                         if ($tokens[$i]['code'] === T_WHITESPACE && $tokens[$i]['content'] === $phpcsFile->eolChar) {
                             $blankLineBefore++;


### PR DESCRIPTION
Squiz.Commenting.ClassComment.SpacingBefore was being thrown if the class comment is the first comment in the file
and the condition 'There must be exactly one blank line before the class comment' was met

In my case, I've made file-comments optional by assigning Squiz.Commenting.FileComment.Missing a low severity 

FileCommentSniff   looks for zero (0) blank lines between T_OPEN_TAG and the file comment

For consistency, perhaps ClassCommentSniff should also look for zero blank lines if the class comment is first ?
