### PR TITLE
Adding sniff to verify that only one trait is defined per file

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Generic_Sniffs_Files_OneTraitPerFileSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alexander Obuhovich <aik.bold@gmail.com>
+ * @copyright 2010-2014 Alexander Obuhovich
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Checks that only one trait is declared per file.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alexander Obuhovich <aik.bold@gmail.com>
+ * @copyright 2010-2014 Alexander Obuhovich
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_Files_OneTraitPerFileSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_TRAIT);
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $nextClass = $phpcsFile->findNext($this->register(), ($stackPtr + 1));
+        if ($nextClass !== false) {
+            $error = 'Only one trait is allowed in a file';
+            $phpcsFile->addError($error, $nextClass, 'MultipleFound');
+        }
+
+    }//end process()
+
+
+}//end class
+
+?>

--- a/CodeSniffer/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+trait foo {
+
+}
+
+trait bar {
+
+}
+
+trait baz {
+
+}
+?>

--- a/CodeSniffer/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Generic_Tests_Files_OneTraitPerFileUnitTest.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alexander Obuhovich <aik.bold@gmail.com>
+ * @copyright 2010-2014 Alexander Obuhovich
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the OneTraitPerFile sniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alexander Obuhovich <aik.bold@gmail.com>
+ * @copyright 2010-2014 Alexander Obuhovich
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Tests_Files_OneTraitPerFileUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return bool
+     */
+    protected function shouldSkipTest()
+    {
+        return version_compare(PHP_VERSION, '5.4.0', '<');
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getErrorList()
+    {
+        return array(
+                6  => 1,
+                10 => 1,
+               );
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class
+
+?>


### PR DESCRIPTION
I originally created this sniff for https://github.com/aik099/CodingStandard, but thought that it might be of some use also as general sniff.
