### PR TITLE
Show sniff code in error report about failed unit test

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -192,7 +192,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase
 
                 $errorsTemp = array();
                 foreach ($errors as $foundError) {
-                    $errorsTemp[] = $foundError['message'];
+                    $errorsTemp[] = $foundError['message'].' ('.$foundError['source'].')';
                 }
 
                 $allProblems[$line]['found_errors'] = array_merge($foundErrorsTemp, $errorsTemp);
@@ -238,7 +238,7 @@ abstract class AbstractSniffUnitTest extends PHPUnit_Framework_TestCase
 
                 $warningsTemp = array();
                 foreach ($warnings as $warning) {
-                    $warningsTemp[] = $warning['message'];
+                    $warningsTemp[] = $warning['message'].' ('.$warning['source'].')';
                 }
 
                 $allProblems[$line]['found_warnings'] = array_merge($foundWarningsTemp, $warningsTemp);


### PR DESCRIPTION
During sniff development it's important to easily determine what caused test to fail. Unfortunately it's not always possible to do just by reading error message text. Here I've added a sniff code to the error report as well.

Before:

```
[LINE 155] Expected 0 error(s) in FunctionCommentUnitTest.inc but found 2 error(s). The error(s) found were:
 -> Doc comment for var &$str does not match actual variable name $str at position 1
 -> Param comment must end with a full stop
```

After:

```
[LINE 155] Expected 0 error(s) in FunctionCommentUnitTest.inc but found 2 error(s). The error(s) found were:
 -> Doc comment for var &$str does not match actual variable name $str at position 1 (Squiz.Commenting.FunctionComment.ParamNameNoMatch)
 -> Param comment must end with a full stop (Squiz.Commenting.FunctionComment.ParamCommentFullStop)
```
