### PR TITLE
set private variables to protected in order to overload methods

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -52,21 +52,21 @@ class PEAR_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sni
      *
      * @var string
      */
-    private $_methodName = '';
+    protected $_methodName = '';
 
     /**
      * The position in the stack where the function token was found.
      *
      * @var int
      */
-    private $_functionToken = null;
+    protected $_functionToken = null;
 
     /**
      * The position in the stack where the class token was found.
      *
      * @var int
      */
-    private $_classToken = null;
+    protected $_classToken = null;
 
     /**
      * The function comment parser for the current method.


### PR DESCRIPTION
Needed this to overload processParams() in my project. With _functionToken private, this will not work :(
