### PR TITLE
False positives with type hints in ForbiddenFunctionsSniff

### DIFF
--- a/CodeSniffer/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
@@ -51,4 +51,7 @@ namespace Something\sizeof;
 $var = new Sizeof();
 class SizeOf implements Something {}
 
+function mymodule_form_callback(SizeOf $sizeof) {
+}
+
 ?>


### PR DESCRIPTION
Just a test case for now that demonstrates the bug.
