### PR TITLE
Some enhancements re config data commands on command line.

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -304,17 +304,27 @@ class PHP_CodeSniffer_CLI
         case 'config-set':
             $key   = $_SERVER['argv'][($pos + 1)];
             $value = $_SERVER['argv'][($pos + 2)];
-            PHP_CodeSniffer::setConfigData($key, $value);
+            try {
+                PHP_CodeSniffer::setConfigData($key, $value);
+            } catch (Exception $ex) {
+                echo $ex->getMessage() . PHP_EOL;
+                exit(2);
+            }
             exit(0);
             break;
         case 'config-delete':
             $key = $_SERVER['argv'][($pos + 1)];
-            PHP_CodeSniffer::setConfigData($key, null);
+            try {
+                PHP_CodeSniffer::setConfigData($key, null);
+            } catch (Exception $ex) {
+                echo $ex->getMessage() . PHP_EOL;
+                exit(2);
+            }
             exit(0);
             break;
         case 'config-show':
             $data = PHP_CodeSniffer::getAllConfigData();
-            print_r($data);
+            $this->printConfigData($data);
             exit(0);
             break;
         default:
@@ -740,6 +750,33 @@ class PHP_CodeSniffer_CLI
 
     }//end explainStandard()
 
+
+    /**
+     * Prints out the gathered config data
+     *
+     * @param array $data Config data.
+     *
+     * @return void
+     */
+    public function printConfigData($data)
+    {
+        $max = 0;
+        $keys = array_keys($data);
+        foreach ($keys as $key) {
+            $len = strlen($key);
+            if (strlen($key) > $max) {
+                $max = $len;
+            }
+        }
+        if ($max == 0) {
+            return;
+        }
+        $max += 2;
+        asort($data);
+        foreach ($data as $name => $value) {
+            echo str_pad($name . ': ', $max) . $value . PHP_EOL;
+        }
+    }
 
     /**
      * Prints out the usage information for this script.


### PR DESCRIPTION
I've done a little bit of work around displaying, setting and deleting config data on the command line...
1. Display of --config-show now in column format, rather than just using print_r:
   
   $ phpcs --config-show
   jsl_path:    /home/kguest/bin/jsl
   testVersion: 5.3
   $
2. Exceptions when writing to non-writable CodeSniffer.conf caught:
   
   $ phpcs --config-set testVersion 5.5
   Config file /usr/share/php/data/PHP_CodeSniffer/CodeSniffer.conf is not writable
   $
   $ phpcs --config-delete jsl_path
   Config file /usr/share/php/data/PHP_CodeSniffer/CodeSniffer.conf is not writable
   $
