### PR TITLE
Ignore inline "@var" and "@type" DocBlocks in the Generic.DocCommentSniff

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -64,6 +64,15 @@ class Generic_Sniffs_Commenting_DocCommentSniff implements PHP_CodeSniffer_Sniff
         $commentEnd   = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, ($stackPtr + 1));
         $commentStart = $tokens[$commentEnd]['comment_opener'];
 
+        if ($tokens[$commentStart]['line'] === $tokens[$commentEnd]['line']) {
+            $commentText = $phpcsFile->getTokensAsString($commentStart, ($commentEnd - $commentStart + 1));
+
+            if (strpos($commentText, '@var') !== false || strpos($commentText, '@type') !== false) {
+                // Skip inline block comments with variable type definition.
+                return;
+            }
+        }
+
         $empty = array(
                   T_DOC_COMMENT_WHITESPACE,
                   T_DOC_COMMENT_STAR,

--- a/CodeSniffer/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
@@ -166,3 +166,9 @@
 /**
  * @ var Comment
  */
+
+/** @var TheClass $test */
+$test = 'value';
+
+/** @type TheClass $test */
+$test = 'value';


### PR DESCRIPTION
There is special type of DocBlocks, that are written inline and allow to dynamically define type of a variable:

``` php
/** @var ClassName $variableName */
$variableName = new OtherClass();

/** @type ClassName $variableNamePSR5 */
$variableNamePSR5 = new OtherClass();
```

Regardless of fact that they are inline they look like regular malformed DocBlock in the DocCommentSniff. Since all errors, that are reported from DocCommentSniff are designed for multi-line DocBlocks I've simply ignore any inline DocBlock in that sniff.

@gsherwood , since PSR5 isn't approved yet I can remove handling of `@type` if needed.

Closes #258, #275
