### PR TITLE
Ignore inline "@var" and "@type" DocBlocks in the Squiz.InlineCommentSniff

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -124,8 +124,13 @@ class Squiz_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Snif
                 }
 
                 if ($tokens[$stackPtr]['content'] === '/**') {
-                    $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
-                    $phpcsFile->addError($error, $stackPtr, 'DocBlock');
+                    $commentEnd  = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, ($stackPtr + 1));
+                    $commentText = $phpcsFile->getTokensAsString($stackPtr, (($commentEnd - $stackPtr) + 1));
+
+                    if (strpos($commentText, '@var') === false && strpos($commentText, '@type') === false) {
+                        $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
+                        $phpcsFile->addError($error, $stackPtr, 'DocBlock');
+                    }
                 }
             }//end if
         }//end if

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
@@ -117,3 +117,9 @@ echo $foo;
 
 //	Comment here.
 echo $foo;
+
+/** @var TheClass $bar */
+$bar = 5;
+
+/** @type TheClass $bar2 */
+$bar2 = 5;


### PR DESCRIPTION
Inline DocBlock comments are bad and this sniff checks for them, however these is special edge case, which isn't covered:

``` php
/** @var TheClass $bar */
$bar = 5;

/** @type TheClass $bar2 */
$bar2 = 5;
```

With proposed change just skips such comments and doesn't report them as error. If nobody, who uses Squiz standard is using these type of comments, then nothing is changed for them. However anybody using this sniff and using these `@var` comments now will be a bit happier.

Related to #276 
