### PR TITLE
Allow to generate coverage reports using PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /CodeSniffer.conf
 .idea/*
 /vendor/
+/build/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit>
-    <testsuites>
+<phpunit colors="true" verbose="true">
+
+	<testsuites>
         <testsuite name="PHP_CodeSniffer Test Suite">
-            <directory>tests/AllTests.php</directory>
+            <file>tests/AllTests.php</file>
         </testsuite>
-    </testsuites>
+	</testsuites>
+
+	<!--<logging>
+		<log type="coverage-html" target="build/coverage" title="BankAccount"
+			 charset="UTF-8" yui="true" highlight="true"
+			 lowUpperBound="35" highLowerBound="70"/>
+	</logging>-->
+
+	<filter>
+		<whitelist>
+			<directory>CodeSniffer/Standards</directory>
+            <exclude>
+                <directory suffix="UnitTest.php">CodeSniffer/Standards</directory>
+            </exclude>
+		</whitelist>
+	</filter>
 </phpunit>


### PR DESCRIPTION
This PR colors the output of PHPUnit and also allows to generate coverage reports if there will be a need.

![php_codesniffer_coveragereport](https://cloud.githubusercontent.com/assets/1277526/4635150/eeb01c5c-53d6-11e4-9977-9ac2a7dc110c.png)
