### PR TITLE
Update FunctionCallSignatureSniff to allow non-isolated parentheses on multiline calls

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -401,7 +401,7 @@ class PEAR_Sniffs_Functions_FunctionCallSignatureSniff implements PHP_CodeSniffe
                     $foundIndent < $expectedIndent
                     || ($exact === true && $expectedIndent !== $foundIndent)
                 );
-                if ($isNotIndentedCorrectly && !$this->requireIsolatedMultilineCallParentheses && $tokens[$nextCode]['code'] === T_CLOSE_CURLY_BRACKET) {
+                if ($isNotIndentedCorrectly && !$this->requireIsolatedMultilineCallParentheses && in_array($tokens[$nextCode]['code'], array(T_CLOSE_CURLY_BRACKET, T_CLOSE_PARENTHESIS))) {
                     $isNotIndentedCorrectly = false;
                 }
                 if ($isNotIndentedCorrectly) {


### PR DESCRIPTION
This allows the following code block to be valid if the new property `requireIsolatedMultilineCallParentheses` is set to `false` on the `PEAR.Functions.FunctionCallSignature` sniff:

``` php
foreach ( $core_options as $option_name => $real_value ) {
    add_filter( "pre_option_{$option_name}", function( $value ) use ( $real_current_blog_id, $real_value ) {
        if ( get_current_blog_id() == $real_current_blog_id ) {
            return $real_value + 1;
        } else {
            return $value;
        }
    } );
}
```

See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/272
