### PR TITLE
Add support for home dir as tilde

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -2169,6 +2169,12 @@ class PHP_CodeSniffer
      */
     public static function getInstalledStandardPath($standard)
     {
+        if (substr($standard, 0, 2) == '~/' && is_dir($fromHome = getenv('HOME') . substr($standard, 1))) {
+            if (is_file($path = self::realpath($fromHome.DIRECTORY_SEPARATOR.'ruleset.xml'))) {
+                return $path;
+            }
+            $standard = $fromHome;
+        }
         $installedPaths = self::getInstalledStandardPaths();
         foreach ($installedPaths as $installedPath) {
             $standardPath = $installedPath.DIRECTORY_SEPARATOR.$standard;


### PR DESCRIPTION
This is a fix for https://github.com/squizlabs/PHP_CodeSniffer/issues/353, so we can call it this way:

```
phpcs -v --standard=~/.composer/vendor/pragmarx/laravelcs/Standards/Laravel /path/to/folder/or/file
```
