### PR TITLE
Don't interpret "use function" as declaration

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -64,6 +64,13 @@ class PEAR_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffer_
     {
         $tokens = $phpcsFile->getTokens();
 
+        // Ignore 'use function'.
+        for ($i = $stackPtr - 1; $i >= 0 && $tokens[$i]['code'] === T_WHITESPACE; --$i)
+            ;
+        if ($tokens[$i]['code'] === T_USE) {
+            return;
+        }
+
         if ($tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar) {
             $spaces = 'newline';
         } else {

--- a/CodeSniffer/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/CodeSniffer/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -146,3 +146,8 @@ function
 myFunction()
 {
 }
+
+use function foo\bar;
+
+use
+    function bar\baz;


### PR DESCRIPTION
The PEAR FunctionDeclarationSniff produces "Undefined index" errors when it encounters `use function foo\bar` (new in PHP 5.6).
