### PR TITLE
Add configurable PHP namespace prefix for sniffs

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1258,7 +1258,7 @@ class PHP_CodeSniffer
         // For sniff classes using a PHP namespace a prefix can be defined. Example:
         // 'Acme\' for a namespace 'Acme\MyStandard\Sniffs\Commenting'.
         $cliValues = $this->cli->getCommandLineValues();
-        $nsPrefix = isset($cliValues['nsPrefix']) ? $cliValues['nsPrefix'] : '';
+        $nsPrefix  = isset($cliValues['nsPrefix']) === true ? $cliValues['nsPrefix'] : '';
 
         foreach ($files as $file) {
             // Work out where the position of /StandardName/Sniffs/... is

--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1255,6 +1255,11 @@ class PHP_CodeSniffer
     {
         $listeners = array();
 
+        // For sniff classes using a PHP namespace a prefix can be defined. Example:
+        // 'Acme\' for a namespace 'Acme\MyStandard\Sniffs\Commenting'.
+        $cliValues = $this->cli->getCommandLineValues();
+        $nsPrefix = isset($cliValues['nsPrefix']) ? $cliValues['nsPrefix'] : '';
+
         foreach ($files as $file) {
             // Work out where the position of /StandardName/Sniffs/... is
             // so we can determine what the class will be called.
@@ -1285,7 +1290,7 @@ class PHP_CodeSniffer
             // Support the use of PHP namespaces. If the class name we included
             // contains namespace separators instead of underscores, use this as the
             // class name from now on.
-            $classNameNS = str_replace('_', '\\', $className);
+            $classNameNS = $nsPrefix . str_replace('_', '\\', $className);
             if (class_exists($classNameNS, false) === true) {
                 $className = $classNameNS;
             }


### PR DESCRIPTION
I want to use PHP namespaces for the Drupal coding standard to have reliable PSR-4 autoloading during test runs and when the standard is used as library.

PHPCS currently forces me to use the namespace "Drupal\Sniffs\Commenting", but I actually want "Drupal\coder\Drupal\Sniffs\Commenting" because the sniffs live in the coder library on drupal.org.

So I invented a nsPrefix config option so that I can specify "Drupal\coder\" in my ruleset.xml. Otherwise instantiating the sniff classes fails with a fatal error because there is the namespace mismatch. Is this the right approach?