### PR TITLE
[CLEANUP] Remove legacy code for PHP4 constructors

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -137,19 +137,8 @@ class PEAR_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sni
         $tokens = $phpcsFile->getTokens();
 
         // Skip constructor and destructor.
-        $className = '';
-        foreach ($tokens[$stackPtr]['conditions'] as $condPtr => $condition) {
-            if ($condition === T_CLASS || $condition === T_INTERFACE) {
-                $className = $phpcsFile->getDeclarationName($condPtr);
-                $className = strtolower(ltrim($className, '_'));
-            }
-        }
-
         $methodName      = $phpcsFile->getDeclarationName($stackPtr);
         $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
-        if ($methodName !== '_') {
-            $methodName = strtolower(ltrim($methodName, '_'));
-        }
 
         $return = null;
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {

--- a/CodeSniffer/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CodeSniffer/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -273,3 +273,14 @@ public function foo(&$tokens, $tokenizer, $eolChar)
 public function _() {
     return $foo;
 }
+
+class Baz {
+    /**
+     * The PHP5 constructor
+     *
+     * No return tag
+     */
+    public function __construct() {
+
+    }
+}

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -65,19 +65,8 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
         $tokens = $phpcsFile->getTokens();
 
         // Skip constructor and destructor.
-        $className = '';
-        foreach ($tokens[$stackPtr]['conditions'] as $condPtr => $condition) {
-            if ($condition === T_CLASS || $condition === T_INTERFACE) {
-                $className = $phpcsFile->getDeclarationName($condPtr);
-                $className = strtolower(ltrim($className, '_'));
-            }
-        }
-
         $methodName      = $phpcsFile->getDeclarationName($stackPtr);
         $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
-        if ($methodName !== '_') {
-            $methodName = strtolower(ltrim($methodName, '_'));
-        }
 
         $return = null;
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -650,3 +650,14 @@ public function foo(SomeClass $someclass, \OtherVendor\Package\SomeClass2 $somec
 public function _() {
     return $foo;
 }
+
+class Baz {
+    /**
+     * The PHP5 constructor
+     *
+     * No return tag
+     */
+    public function __construct() {
+
+    }
+}


### PR DESCRIPTION
The removed code was used to compare the class name with the method name to skip PHP4 constructors.