### PR TITLE
Replace "%s" in "Squiz.ControlStructures.ForLoopDeclaration.SpacingBeforeClose" error

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -139,7 +139,7 @@ class Squiz_Sniffs_ControlStructures_ForLoopDeclarationSniff implements PHP_Code
                           $this->requiredSpacesBeforeClose,
                           $spaceBeforeClose,
                          );
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeClose');
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeClose', $data);
                 if ($fix === true) {
                     $padding = str_repeat(' ', $this->requiredSpacesBeforeClose);
                     if ($spaceBeforeClose === 0) {


### PR DESCRIPTION
The "SpacingBeforeClose" error in the "Squiz.ControlStructures.ForLoopDeclaration" sniff has non-replaced "%s" in it:
```
Expected %s spaces before closing bracket; %s found 
```
This PR replaces them with actual values.