### PR TITLE
Fixup code for rule: missing tag

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -237,7 +237,7 @@ class PEAR_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
                               $tag,
                               $docBlock,
                              );
-                    $phpcsFile->addError($error, $commentEnd, 'Missing'.ucfirst($tag).'Tag', $data);
+                    $phpcsFile->addError($error, $commentEnd, 'Missing'.ucfirst(substr($tag, 1)).'Tag', $data);
                 }
 
                 continue;


### PR DESCRIPTION
After commit https://github.com/squizlabs/PHP_CodeSniffer/commit/22060b65a3cb54a49011d87fd90cb3dac5388746 rules named **PEAR.Commenting.FileComment.MissingTag** and **PEAR.Commenting.ClassComment.MissingTag** was splitted into many per tag name (category, package, author, license and link).

In version 2.1.0 to exclude requirements for this tags in ruleset.xml is required to write:
```
    <rule ref="PEAR.Commenting.FileComment">
        <exclude name="PEAR.Commenting.FileComment.Missing@categoryTag"/>
        <exclude name="PEAR.Commenting.FileComment.Missing@packageTag"/>
        <exclude name="PEAR.Commenting.FileComment.Missing@authorTag"/>
        <exclude name="PEAR.Commenting.FileComment.Missing@licenseTag"/>
        <exclude name="PEAR.Commenting.FileComment.Missing@linkTag"/>
    </rule>
    <rule ref="PEAR.Commenting.ClassComment">
        <exclude name="PEAR.Commenting.ClassComment.Missing@categoryTag"/>
        <exclude name="PEAR.Commenting.ClassComment.Missing@packageTag"/>
        <exclude name="PEAR.Commenting.ClassComment.Missing@authorTag"/>
        <exclude name="PEAR.Commenting.ClassComment.Missing@licenseTag"/>
        <exclude name="PEAR.Commenting.ClassComment.Missing@linkTag"/>
    </rule>
```
after this change to exclude requirements for this tags in ruleset.xml is required to write:
```
    <rule ref="PEAR.Commenting.FileComment">
        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
        <exclude name="PEAR.Commenting.FileComment.MissingAuthorTag"/>
        <exclude name="PEAR.Commenting.FileComment.MissingLicenseTag"/>
        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
    </rule>
    <rule ref="PEAR.Commenting.ClassComment">
        <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag"/>
        <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag"/>
        <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag"/>
        <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag"/>
        <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag"/>
    </rule>
```
which was intented (usage of ucfirst()).
