### PR TITLE
fix #348 add option to treat newline as whitspace

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -48,6 +48,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
      */
     public $treatNewlineAsWhitespace = false;
 
+
     /**
      * Returns an array of tokens this test wants to listen for.
      *
@@ -142,8 +143,8 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                     $found = $tokens[($stackPtr - 1)]['length'];
                 }
 
-                if ($this->treatNewlineAsWhitespace === false ||
-                    ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+                if ($this->treatNewlineAsWhitespace === false
+                    || ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
                 ) {
                     $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
                     if ($found !== 1) {
@@ -175,8 +176,8 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
 
                 $phpcsFile->recordMetric($stackPtr, 'Space after operator', $found);
                 if ($found !== 1) {
-                    if ($this->treatNewlineAsWhitespace === false ||
-                        ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+                    if ($this->treatNewlineAsWhitespace === false
+                        || ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
                     ) {
                         $error = 'Expected 1 space after "&" operator; %s found';
                         $data  = array($found);
@@ -253,16 +254,16 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $found = $tokens[($stackPtr - 1)]['length'];
             }
 
-            if ($this->treatNewlineAsWhitespace === false ||
-                ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+            if ($this->treatNewlineAsWhitespace === false
+                || ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
             ) {
                 $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
                 if ($found !== 1) {
                     $error = 'Expected 1 space before "%s"; %s found';
                     $data  = array(
-                            $operator,
-                            $found,
-                            );
+                              $operator,
+                              $found,
+                             );
                     $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBefore', $data);
                     if ($fix === true) {
                         $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
@@ -286,16 +287,16 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $found = $tokens[($stackPtr + 1)]['length'];
             }
 
-            if ($this->treatNewlineAsWhitespace === false ||
-                ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+            if ($this->treatNewlineAsWhitespace === false
+                || ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
             ) {
                 $phpcsFile->recordMetric($stackPtr, 'Space after operator', $found);
                 if ($found !== 1) {
                     $error = 'Expected 1 space after "%s"; %s found';
                     $data  = array(
-                            $operator,
-                            $found,
-                            );
+                              $operator,
+                              $found,
+                             );
                     $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
                     if ($fix === true) {
                         $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -40,6 +40,13 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                                    'JS',
                                   );
 
+    /**
+     * Whether a newline should be treated as whitespace for the purpose of
+     * operator spacing.
+     *
+     * @var boolean
+     */
+    public $treatNewlineAsWhitespace = false;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -135,13 +142,17 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                     $found = $tokens[($stackPtr - 1)]['length'];
                 }
 
-                $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
-                if ($found !== 1) {
-                    $error = 'Expected 1 space before "&" operator; %s found';
-                    $data  = array($found);
-                    $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeAmp', $data);
-                    if ($fix === true) {
-                        $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
+                if ($this->treatNewlineAsWhitespace === false ||
+                    ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+                ) {
+                    $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
+                    if ($found !== 1) {
+                        $error = 'Expected 1 space before "&" operator; %s found';
+                        $data  = array($found);
+                        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeAmp', $data);
+                        if ($fix === true) {
+                            $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
+                        }
                     }
                 }
             }//end if
@@ -164,11 +175,15 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
 
                 $phpcsFile->recordMetric($stackPtr, 'Space after operator', $found);
                 if ($found !== 1) {
-                    $error = 'Expected 1 space after "&" operator; %s found';
-                    $data  = array($found);
-                    $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterAmp', $data);
-                    if ($fix === true) {
-                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                    if ($this->treatNewlineAsWhitespace === false ||
+                        ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+                    ) {
+                        $error = 'Expected 1 space after "&" operator; %s found';
+                        $data  = array($found);
+                        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterAmp', $data);
+                        if ($fix === true) {
+                            $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                        }
                     }
                 }
             }//end if
@@ -238,16 +253,20 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $found = $tokens[($stackPtr - 1)]['length'];
             }
 
-            $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
-            if ($found !== 1) {
-                $error = 'Expected 1 space before "%s"; %s found';
-                $data  = array(
-                          $operator,
-                          $found,
-                         );
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBefore', $data);
-                if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
+            if ($this->treatNewlineAsWhitespace === false ||
+                ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+            ) {
+                $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
+                if ($found !== 1) {
+                    $error = 'Expected 1 space before "%s"; %s found';
+                    $data  = array(
+                            $operator,
+                            $found,
+                            );
+                    $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBefore', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
+                    }
                 }
             }
         }//end if
@@ -267,16 +286,20 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $found = $tokens[($stackPtr + 1)]['length'];
             }
 
-            $phpcsFile->recordMetric($stackPtr, 'Space after operator', $found);
-            if ($found !== 1) {
-                $error = 'Expected 1 space after "%s"; %s found';
-                $data  = array(
-                          $operator,
-                          $found,
-                         );
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
-                if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+            if ($this->treatNewlineAsWhitespace === false ||
+                ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
+            ) {
+                $phpcsFile->recordMetric($stackPtr, 'Space after operator', $found);
+                if ($found !== 1) {
+                    $error = 'Expected 1 space after "%s"; %s found';
+                    $data  = array(
+                            $operator,
+                            $found,
+                            );
+                    $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                    }
                 }
             }
         }//end if

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -156,17 +156,17 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 if ($tokens[($stackPtr - 2)]['line'] !== $tokens[$stackPtr]['line']) {
                     $foundToken  = 'newline';
                     $foundLength = 1;
-                    $foundError  = $foundToken;
+                    $foundReport = $foundToken;
                 } else {
                     $foundToken  = 'space';
                     $foundLength = $tokens[($stackPtr - 1)]['length'];
-                    $foundError  = $foundLength;
+                    $foundReport = $foundLength;
                 }
 
                 $phpcsFile->recordMetric(
                     $stackPtr,
                     sprintf('%s before operator', ucfirst($foundToken)),
-                    $foundLength
+                    $foundReport
                 );
 
                 $hasProblem = ($this->treatNewlineAsWhitespace === false && $foundToken === 'newline') ||
@@ -176,7 +176,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                     $error = '%s before "&" operator; %s found';
                     $data  = array(
                               $this->expectedSpaceMessage,
-                              $foundError,
+                              $foundReport,
                              );
                     $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeAmp', $data);
                     if ($fix === true) {
@@ -199,17 +199,17 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 if ($tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']) {
                     $foundToken  = 'newline';
                     $foundLength = 1;
-                    $foundError  = $foundToken;
+                    $foundReport = $foundToken;
                 } else {
                     $foundToken  = 'space';
                     $foundLength = $tokens[($stackPtr + 1)]['length'];
-                    $foundError  = $foundLength;
+                    $foundReport = $foundLength;
                 }
 
                 $phpcsFile->recordMetric(
                     $stackPtr,
-                    sprintf('%s before operator', ucfirst($foundToken)),
-                    $foundLength
+                    sprintf('%s after operator', ucfirst($foundToken)),
+                    $foundReport
                 );
 
                 $hasProblem = ($this->treatNewlineAsWhitespace === false && $foundToken === 'newline') ||
@@ -219,7 +219,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                     $error = '%s after "&" operator; %s found';
                     $data  = array(
                               $this->expectedSpaceMessage,
-                              $foundError,
+                              $foundReport,
                              );
                     $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterAmp', $data);
                     if ($fix === true) {
@@ -290,17 +290,17 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
             if ($tokens[($stackPtr - 2)]['line'] !== $tokens[$stackPtr]['line']) {
                 $foundToken  = 'newline';
                 $foundLength = 1;
-                $foundError  = $foundToken;
+                $foundReport = $foundToken;
             } else {
                 $foundToken  = 'space';
                 $foundLength = $tokens[($stackPtr - 1)]['length'];
-                $foundError  = $foundLength;
+                $foundReport = $foundLength;
             }
 
             $phpcsFile->recordMetric(
                 $stackPtr,
                 sprintf('%s before operator', ucfirst($foundToken)),
-                $foundLength
+                $foundReport
             );
 
             $hasProblem = ($this->treatNewlineAsWhitespace === false && $foundToken === 'newline') ||
@@ -311,7 +311,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $data  = array(
                           $this->expectedSpaceMessage,
                           $operator,
-                          $foundError,
+                          $foundReport,
                          );
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBefore', $data);
                 if ($fix === true) {
@@ -332,17 +332,17 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
             if ($tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']) {
                 $foundToken  = 'newline';
                 $foundLength = 1;
-                $foundError  = $foundToken;
+                $foundReport = $foundToken;
             } else {
                 $foundToken  = 'space';
                 $foundLength = $tokens[($stackPtr + 1)]['length'];
-                $foundError  = $foundLength;
+                $foundReport = $foundLength;
             }
 
             $phpcsFile->recordMetric(
                 $stackPtr,
                 sprintf('%s after operator', ucfirst($foundToken)),
-                $foundLength
+                $foundReport
             );
 
             $hasProblem = ($this->treatNewlineAsWhitespace === false && $foundToken === 'newline') ||
@@ -353,7 +353,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $data  = array(
                           $this->expectedSpaceMessage,
                           $operator,
-                          $foundError,
+                          $foundReport,
                          );
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
                 if ($fix === true) {

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -144,8 +144,9 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
 
             // Check there is one space before the & operator.
             if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
-                $error = sprintf('%s before "&" operator; 0 found', $this->expectedSpaceMessage);
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBeforeAmp');
+                $error ='%s before "&" operator; 0 found';
+                $data  = array($this->expectedSpaceMessage);
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBeforeAmp', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
                 }
@@ -186,8 +187,9 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
 
             // Check there is one space after the & operator.
             if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
-                $error = sprintf('%s after "&" operator; 0 found', $this->expectedSpaceMessage);
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterAmp');
+                $error = '%s after "&" operator; 0 found';
+                $data  = array($this->expectedSpaceMessage);
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterAmp', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->addContent($stackPtr, ' ');
                 }
@@ -275,8 +277,9 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
         $operator = $tokens[$stackPtr]['content'];
 
         if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
-            $error = sprintf("%s before \"$operator\"; 0 found", $this->expectedSpaceMessage);
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBefore');
+            $error = "%s before \"$operator\"; 0 found";
+            $data  = array($this->expectedSpaceMessage);
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBefore', $data);
             if ($fix === true) {
                 $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
             }
@@ -319,8 +322,9 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
         }//end if
 
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
-            $error = sprintf("%s after \"$operator\"; 0 found", $this->expectedSpaceMessage);
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfter');
+            $error = "%s after \"$operator\"; 0 found";
+            $data  = array($this->expectedSpaceMessage);
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfter', $data);
             if ($fix === true) {
                 $phpcsFile->fixer->addContent($stackPtr, ' ');
             }

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -143,10 +143,10 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                     $found = $tokens[($stackPtr - 1)]['length'];
                 }
 
+                $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
                 if ($this->treatNewlineAsWhitespace === false
                     || ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
                 ) {
-                    $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
                     if ($found !== 1) {
                         $error = 'Expected 1 space before "&" operator; %s found';
                         $data  = array($found);
@@ -254,10 +254,10 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $found = $tokens[($stackPtr - 1)]['length'];
             }
 
+            $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
             if ($this->treatNewlineAsWhitespace === false
                 || ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
             ) {
-                $phpcsFile->recordMetric($stackPtr, 'Space before operator', $found);
                 if ($found !== 1) {
                     $error = 'Expected 1 space before "%s"; %s found';
                     $data  = array(
@@ -287,10 +287,10 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                 $found = $tokens[($stackPtr + 1)]['length'];
             }
 
+            $phpcsFile->recordMetric($stackPtr, 'Space after operator', $found);
             if ($this->treatNewlineAsWhitespace === false
                 || ($found !== 'newline' && $this->treatNewlineAsWhitespace === true)
             ) {
-                $phpcsFile->recordMetric($stackPtr, 'Space after operator', $found);
                 if ($found !== 1) {
                     $error = 'Expected 1 space after "%s"; %s found';
                     $data  = array(

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -277,9 +277,8 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
         $operator = $tokens[$stackPtr]['content'];
 
         if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
-            $error = "%s before \"$operator\"; 0 found";
-            $data  = array($this->expectedSpaceMessage);
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBefore', $data);
+            $error = $this->expectedSpaceMessage . " before \"$operator\"; 0 found";
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBefore');
             if ($fix === true) {
                 $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
             }
@@ -322,9 +321,8 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
         }//end if
 
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
-            $error = "%s after \"$operator\"; 0 found";
-            $data  = array($this->expectedSpaceMessage);
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfter', $data);
+            $error = $this->expectedSpaceMessage . " after \"$operator\"; 0 found";
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfter');
             if ($fix === true) {
                 $phpcsFile->fixer->addContent($stackPtr, ' ');
             }


### PR DESCRIPTION
Fixes #348 by adding an option to treat newlines as whitespace.