### PR TITLE
Removing notices for undefined indexes in TODO/FIXME sniffs.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -71,11 +71,16 @@ class Generic_Sniffs_Commenting_FixmeSniff implements PHP_CodeSniffer_Sniff
         if (preg_match('/(?:\A|[^\p{L}]+)fixme([^\p{L}]+(.*)|\Z)/ui', $content, $matches) !== 0) {
             // Clear whitespace and some common characters not required at
             // the end of a fixme message to make the error more informative.
-            $type         = 'CommentFound';
-            $fixmeMessage = trim($matches[1]);
-            $fixmeMessage = trim($fixmeMessage, '-:[](). ');
-            $error        = 'Comment refers to a FIXME task';
-            $data         = array($fixmeMessage);
+            $fixmeMessage = '';
+            if (false === empty($matches)) {
+                $fixmeMessage = trim($matches[1]);
+                $fixmeMessage = trim($fixmeMessage, '-:[](). ');
+            }//end if
+
+            $type  = 'CommentFound';
+            $error = 'Comment refers to a FIXME task';
+            $data  = array($fixmeMessage);
+
             if ($fixmeMessage !== '') {
                 $type   = 'TaskFound';
                 $error .= ' "%s"';

--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -69,11 +69,16 @@ class Generic_Sniffs_Commenting_TodoSniff implements PHP_CodeSniffer_Sniff
         if (preg_match('/(?:\A|[^\p{L}]+)todo([^\p{L}]+(.*)|\Z)/ui', $content, $matches) !== 0) {
             // Clear whitespace and some common characters not required at
             // the end of a to-do message to make the warning more informative.
-            $type        = 'CommentFound';
-            $todoMessage = trim($matches[1]);
-            $todoMessage = trim($todoMessage, '-:[](). ');
-            $error       = 'Comment refers to a TODO task';
-            $data        = array($todoMessage);
+            $todoMessage = '';
+            if (false === empty($matches)) {
+                $todoMessage = trim($matches[1]);
+                $todoMessage = trim($todoMessage, '-:[](). ');
+            }//end if
+
+            $type  = 'CommentFound';
+            $error = 'Comment refers to a TODO task';
+            $data  = array($todoMessage);
+
             if ($todoMessage !== '') {
                 $type   = 'TaskFound';
                 $error .= ' "%s"';

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -184,7 +184,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
             if ($exception === null) {
                 $error = 'Exception type and comment missing for @throws tag in function comment';
                 $phpcsFile->addError($error, $tag, 'InvalidThrows');
-            } else if ($comment === null) {
+            } else if (empty($comment) === true) {
                 $error = 'Comment missing for @throws tag in function comment';
                 $phpcsFile->addError($error, $tag, 'EmptyThrows');
             } else {


### PR DESCRIPTION
When a TODO/FIXME message is empty, the sniff raises a notice when trying to access an undefined index of the array.

And adding a second commit removing a NOTICE send on empty function `@throws` comment. 