### PR TITLE
Fix indentation in PSR2 Ruleset

### DIFF
--- a/CodeSniffer/Standards/PSR2/ruleset.xml
+++ b/CodeSniffer/Standards/PSR2/ruleset.xml
@@ -39,7 +39,7 @@
  <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
   <properties>
    <property name="ignoreBlankLines" value="true"/>
-   </properties>
+  </properties>
  </rule>
  <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
   <severity>0</severity>


### PR DESCRIPTION
Fixing indentation for `<properties>` tag in Squiz.WhiteSpace.SuperfluousWhitespace rule.