### PR TITLE
A better version of https://github.com/squizlabs/PHP_CodeSniffer/pull/440

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -267,6 +267,10 @@ class PEAR_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sni
                         $phpcsFile->addError($error, $tag, 'MissingParamName');
                     }//end if
                 }
+                else {
+                    $error = 'Parameter syntax wrong';
+                    $phpcsFile->addError($error, $tag, 'MissingParamType');
+                }
             } else {
                 $error = 'Missing parameter type';
                 $phpcsFile->addError($error, $tag, 'MissingParamType');

--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -225,47 +225,48 @@ class PEAR_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sni
             $comment   = '';
             if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
                 $matches = array();
-                preg_match('/([^$&]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
-
-                $typeLen   = strlen($matches[1]);
-                $type      = trim($matches[1]);
-                $typeSpace = ($typeLen - strlen($type));
-                $typeLen   = strlen($type);
-                if ($typeLen > $maxType) {
-                    $maxType = $typeLen;
-                }
-
-                if (isset($matches[2]) === true) {
-                    $var    = $matches[2];
-                    $varLen = strlen($var);
-                    if ($varLen > $maxVar) {
-                        $maxVar = $varLen;
+                if (preg_match('/([^$&]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches) ) {
+                    $typeLen = strlen($matches[1]);
+                    $type = trim($matches[1]);
+                    $typeSpace = ($typeLen - strlen($type));
+                    $typeLen = strlen($type);
+                    if ($typeLen > $maxType) {
+                        $maxType = $typeLen;
                     }
 
-                    if (isset($matches[4]) === true) {
-                        $varSpace = strlen($matches[3]);
-                        $comment  = $matches[4];
-
-                        // Any strings until the next tag belong to this comment.
-                        if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
-                            $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
-                        } else {
-                            $end = $tokens[$commentStart]['comment_closer'];
+                    if (isset($matches[2]) === true) {
+                        $var = $matches[2];
+                        $varLen = strlen($var);
+                        if ($varLen > $maxVar) {
+                            $maxVar = $varLen;
                         }
 
-                        for ($i = ($tag + 3); $i < $end; $i++) {
-                            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                                $comment .= ' '.$tokens[$i]['content'];
+                        if (isset($matches[4]) === true) {
+                            $varSpace = strlen($matches[3]);
+                            $comment = $matches[4];
+
+                            // Any strings until the next tag belong to this comment.
+                            if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
+                                $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
+                            } else {
+                                $end = $tokens[$commentStart]['comment_closer'];
                             }
+
+                            for ($i = ($tag + 3); $i < $end; $i++) {
+                                if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                                    $comment .= ' ' . $tokens[$i]['content'];
+                                }
+                            }
+                        } else {
+                            $error = 'Missing parameter comment';
+                            $phpcsFile->addError($error, $tag, 'MissingParamComment');
                         }
+
                     } else {
-                        $error = 'Missing parameter comment';
-                        $phpcsFile->addError($error, $tag, 'MissingParamComment');
-                    }
-                } else {
-                    $error = 'Missing parameter name';
-                    $phpcsFile->addError($error, $tag, 'MissingParamName');
-                }//end if
+                        $error = 'Missing parameter name';
+                        $phpcsFile->addError($error, $tag, 'MissingParamName');
+                    }//end if
+                }
             } else {
                 $error = 'Missing parameter type';
                 $phpcsFile->addError($error, $tag, 'MissingParamType');


### PR DESCRIPTION
A better version of https://github.com/squizlabs/PHP_CodeSniffer/pull/440 

I understand that you may not want to check whether the pattern matches, as in that place it probably should match.

Also, checking if pattern matche will need changes on many other places too (like: 

protected function processThrows(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
    {
        $tokens = $phpcsFile->getTokens();

        $throws = array();
        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
            if ($tokens[$tag]['content'] !== '@throws') {
                continue;
            }

            $exception = null;
            $comment   = null;
            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
                $matches = array();
                preg_match('/([^\s]+)(?:\s+(.*))?/', $tokens[($tag + 2)]['content'], $matches);
                $exception = $matches[1];



