### PR TITLE
Changing the regex check in the FIXME and TODO sniffs.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -68,7 +68,7 @@ class Generic_Sniffs_Commenting_FixmeSniff implements PHP_CodeSniffer_Sniff
 
         $content = $tokens[$stackPtr]['content'];
         $matches = array();
-        if (preg_match('/(?:\A|[^\p{L}]+)fixme([^\p{L}]+(.*)|\Z)/ui', $content, $matches) !== 0) {
+        if (preg_match('/(?:\A|[^\p{L}]+)fixme([^\p{L}]+(.*)|\Z)/ui', $content, $matches) === 1) {
             // Clear whitespace and some common characters not required at
             // the end of a fixme message to make the error more informative.
             $type         = 'CommentFound';

--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -66,7 +66,7 @@ class Generic_Sniffs_Commenting_TodoSniff implements PHP_CodeSniffer_Sniff
 
         $content = $tokens[$stackPtr]['content'];
         $matches = array();
-        if (preg_match('/(?:\A|[^\p{L}]+)todo([^\p{L}]+(.*)|\Z)/ui', $content, $matches) !== 0) {
+        if (preg_match('/(?:\A|[^\p{L}]+)todo([^\p{L}]+(.*)|\Z)/ui', $content, $matches) === 1) {
             // Clear whitespace and some common characters not required at
             // the end of a to-do message to make the warning more informative.
             $type        = 'CommentFound';

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -181,10 +181,10 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                 }
             }
 
-            if ($exception === null) {
+            if (empty($exception) === true) {
                 $error = 'Exception type and comment missing for @throws tag in function comment';
                 $phpcsFile->addError($error, $tag, 'InvalidThrows');
-            } else if ($comment === null) {
+            } else if (empty($comment) === true) {
                 $error = 'Comment missing for @throws tag in function comment';
                 $phpcsFile->addError($error, $tag, 'EmptyThrows');
             } else {


### PR DESCRIPTION
The problem is the use of the preg_match expression. As defined in the official PHP documentation : 

> preg_match() returns 1 if the pattern matches given subject, 0 if it does not, or FALSE if an error occurred.

However the condition used in the sniffs is : 

```
 if (preg_match('/(?:\A|[^\p{L}]+)fixme([^\p{L}]+(.*)|\Z)/ui', $content, $matches) !== 0) {
```

Which will in case of FALSE, enter the block code. Which it should not. This generates a lot of useless PHP notices : 

```
Notice: Undefined offset: 1 in /apps/test/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php on line 73
PHP Notice:  Undefined offset: 1 in /apps/test/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Generic/Sniffs/Commenting/TodoSniff.php on line 73
```
