### PR TITLE
PHP_CodeSniffer should depends on the XMLWriter extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
     },
     "require": {
         "php": ">=5.1.2",
-        "ext-tokenizer": "*"
+        "ext-tokenizer": "*",
+        "ext-xmlwriter": "*"
     },
     "bin": [
         "scripts/phpcs",


### PR DESCRIPTION
As a few reporters uses the XMLWriter extension. I suggest to add this in composer.json to warn users as soon as possible