### PR TITLE
Fix Inspection Error

### DIFF
--- a/CodeSniffer/Reports/Json.php
+++ b/CodeSniffer/Reports/Json.php
@@ -54,7 +54,7 @@ class PHP_CodeSniffer_Reports_Json implements PHP_CodeSniffer_Report
         $filename = str_replace('\\', '\\\\', $report['filename']);
         $filename = str_replace('"', '\"', $filename);
         $filename = str_replace('/', '\/', $filename);
-        echo "\"$filename\":{";
+        echo '"'.$filename.'":{';
         echo '"errors":'.$report['errors'].',"warnings":'.$report['warnings'].',"messages":[';
 
         $messages = '';


### PR DESCRIPTION
The code should follow same syntax in the whole file. You should not use PHP variables inside double quoted string.
Using this syntax  "$param{" causes an inspection error:
Expected: right double quote | Expecting statement

a) Concatenate string
b) Escape bracket: "$param\\{"

I have made a PR for version a