### PR TITLE
[BUGFIX] Fix the aligning of doc comment start after rewrite

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -95,7 +95,10 @@ class Generic_Sniffs_Commenting_DocCommentSniff implements PHP_CodeSniffer_Sniff
             $error = 'The close comment tag must be the only content on the line';
             $fix   = $phpcsFile->addFixableError($error, $commentEnd, 'ContentBeforeClose');
             if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->addContentBefore($commentEnd, ' ');
                 $phpcsFile->fixer->addNewlineBefore($commentEnd);
+                $phpcsFile->fixer->endChangeset();
             }
         }
 


### PR DESCRIPTION
The trailing comment closer will be pushed to the next line but
a whitespace at the beginning is missing.

Current behavior:
```
-/** @var Database $mockedDatabase */
+/**
+ * @var Database $mockedDatabase
+*/
```

New behavior
```
-/** @var Database $mockedDatabase */
+/**
+ * @var Database $mockedDatabase
+ */
```