### PR TITLE
Generic InlineControlStructureSniff can correct with missing semicolon

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -171,6 +171,10 @@ class Generic_Sniffs_ControlStructures_InlineControlStructureSniff implements PH
                 if ($endLine !== $end) {
                     $phpcsFile->fixer->addContent($endLine, '}');
                 } else {
+                    if (in_array($tokens[$end]['code'], array(T_SEMICOLON, T_CLOSE_CURLY_BRACKET)) === false) {
+                        $phpcsFile->fixer->addContent($end, ';');
+                    }
+
                     $phpcsFile->fixer->addContent($end, ' }');
                 }
             } else {

--- a/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.inc.fixed
@@ -76,5 +76,5 @@ if ($a) {
 
 ?>
 <div style="text-align: right;">
-    <?php if ($model->scenario == 'simple') { $widget->renderPager() } ?>
+    <?php if ($model->scenario == 'simple') { $widget->renderPager(); } ?>
 </div>


### PR DESCRIPTION
When using `phpcbf` with `Generic.ControlStructures.InlineControlStructure` on the following code:

```php
<label><input type="radio" <?php if($series) echo 'checked="checked"' ?> > By Series</label>
```

it was transformed into the following which is ***not valid*** PHP

```php
<label><input type="radio" <?php if($series) { echo 'checked="checked"' } ?> > By Series</label>
```

I have altered the correction to include a semicolon if the end is not one.

