### PR TITLE
Use statements don't increase the scope indent

### DIFF
--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
@@ -824,4 +824,13 @@ foo();
         return false;
     }
 
-echo ""
+echo "";
+
+class IndentationResetter {
+}
+
+class Test4 {
+    use TestTrait {
+       testTraitMethod as renamedTraitMethod;
+    }
+}

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
@@ -824,4 +824,13 @@ function foo()
     return false;
 }
 
-echo ""
+echo "";
+
+class IndentationResetter {
+}
+
+class Test4 {
+    use TestTrait {
+        testTraitMethod as renamedTraitMethod;
+    }
+}

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
@@ -824,4 +824,13 @@ foo();
 		return false;
 	}
 
-echo ""
+echo "";
+
+class IndentationResetter {
+}
+
+class Test4 {
+	use TestTrait {
+	testTraitMethod as renamedTraitMethod;
+	}
+}

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
@@ -824,4 +824,13 @@ function foo()
 	return false;
 }
 
-echo ""
+echo "";
+
+class IndentationResetter {
+}
+
+class Test4 {
+	use TestTrait {
+		testTraitMethod as renamedTraitMethod;
+	}
+}

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -134,6 +134,8 @@ class Generic_Tests_WhiteSpace_ScopeIndentUnitTest extends AbstractSniffUnitTest
                 803 => 1,
                 815 => 1,
                 827 => 1,
+                829 => 1,
+                834 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
See http://php.net/manual/en/language.oop5.traits.php#language.oop5.traits.conflict

Only containing a failing test case right now, not sure where the correct place is to fix this.