### PR TITLE
Fix: PSR1_Sniffs_Methods_CamelCapsMethodNameSniff and magic method detections

### DIFF
--- a/CodeSniffer/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -62,11 +62,13 @@ class PSR1_Sniffs_Methods_CamelCapsMethodNameSniff extends Generic_Sniffs_Naming
         }
 
         // Ignore magic methods.
-        $magicPart = strtolower(substr($methodName, 2));
-        if (isset($this->magicMethods[$magicPart]) === true
-            || isset($this->methodsDoubleUnderscore[$magicPart]) === true
-        ) {
-            return;
+        if (preg_match('|^__|', $methodName) !== 0) {
+            $magicPart = strtolower(substr($methodName, 2));
+            if (isset($this->magicMethods[$magicPart]) === true
+                || isset($this->methodsDoubleUnderscore[$magicPart]) === true
+            ) {
+                return;
+            }
         }
 
         $testName = ltrim($methodName, '_');

--- a/CodeSniffer/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.inc
+++ b/CodeSniffer/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.inc
@@ -23,6 +23,7 @@ abstract class My_Class {
     function getSomeValue() {}
     function parseMyDSN() {}
     function get_some_value() {}
+    function o_toString() {}
 
 }//end class
 

--- a/CodeSniffer/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/CodeSniffer/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -49,6 +49,7 @@ class PSR1_Tests_Methods_CamelCapsMethodNameUnitTest extends AbstractSniffUnitTe
                 17 => 1,
                 21 => 1,
                 25 => 1,
+                26 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
This PR

* [x] adds a failing test demonstrating that `PSR1_Sniffs_Methods_CamelCapsMethodNameSniff` incorrectly determines that `o_toString` is a magic method while it shouldn't be
* [x] fixes the determination whether a string is a magic method