### PR TITLE
Fix: Remove duplicate key-value-pair from magic methods array

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -55,7 +55,6 @@ class Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff extends PHP_Co
                                'set_state'  => true,
                                'clone'      => true,
                                'invoke'     => true,
-                               'call'       => true,
                               );
 
     /**

--- a/CodeSniffer/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -55,7 +55,6 @@ class PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff extends PHP_CodeSniff
                                'set_state'  => true,
                                'clone'      => true,
                                'invoke'     => true,
-                               'call'       => true,
                               );
 
     /**


### PR DESCRIPTION
This PR

* [x] removes a duplicate key-value-pair from the array of magic method names