### PR TITLE
Disallow Long Array Syntax Sniff & Disallow Short Array Syntax Sniff 

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Formatting/DisallowLongArraySyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Formatting/DisallowLongArraySyntaxSniff.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Generic_Sniffs_Formatting_DisallowLongArraySyntaxSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2013-2015 Xaver Loppenstedt
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Generic_Sniffs_Formatting_DisallowLongArraySyntaxSniff.
+ *
+ * Disallow long array syntax.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2013-2015 Xaver Loppenstedt
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_Formatting_DisallowLongArraySyntaxSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @return array(int)
+     */
+    public function register()
+    {
+        return array(T_ARRAY);
+
+    }//end register()
+
+
+    /**
+     * Called when one of the token types that this sniff is listening for
+     * is found.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The PHP_CodeSniffer file where the
+     *                                        token was found.
+     * @param int                  $stackPtr  The position in the PHP_CodeSniffer
+     *                                        file's token stack where the token
+     *                                        was found.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $token  = $tokens[$stackPtr];
+        $opener = $token['parenthesis_opener'];
+        $closer = $token['parenthesis_closer'];
+
+        $errorMessage = 'Short array syntax must be used';
+
+        if (($opener !== null) && ($closer !== null)) {
+            $fix = $phpcsFile->addFixableError($errorMessage, $stackPtr);
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($stackPtr, '');
+
+                $phpcsFile->fixer->replaceToken($opener, '[');
+                for ($i = ($stackPtr + 1); $i < $opener; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->replaceToken($closer, ']');
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        } else {
+            // Don't fix erroneous arrays with!
+            $phpcsFile->addError($errorMessage, $stackPtr);
+        }
+
+    }//end process()
+
+
+}//end class

--- a/CodeSniffer/Standards/Generic/Sniffs/Formatting/DisallowShortArraySyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Formatting/DisallowShortArraySyntaxSniff.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Generic_Sniffs_Formatting_DisallowShortArraySyntaxSniff
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2015 Xaver Loppenstedt
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Generic_Sniffs_Formatting_DisallowShortArraySyntaxSniff.
+ *
+ * Disallow short array syntax.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2015 Xaver Loppenstedt, All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_Formatting_DisallowShortArraySyntaxSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * How many spaces should precede the opening parenthesis.
+     *
+     * @var int
+     */
+    public $requiredSpacesBeforeOpen = 0;
+
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @return array(int)
+     */
+    public function register()
+    {
+        return array(T_OPEN_SHORT_ARRAY);
+
+    }//end register()
+
+
+    /**
+     * Called when one of the token types that this sniff is listening for
+     * is found.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The PHP_CodeSniffer file where the
+     *                                        token was found.
+     * @param int                  $stackPtr  The position in the PHP_CodeSniffer
+     *                                        file's token stack where the token
+     *                                        was found.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $fix = $phpcsFile->addFixableError(
+            'Long array syntax must be used',
+            $stackPtr
+        );
+
+        if ($fix === true) {
+            $tokens = $phpcsFile->getTokens();
+            $token  = $tokens[$stackPtr];
+
+            $arrayOpen = 'array'.str_repeat(' ', $this->requiredSpacesBeforeOpen).'(';
+
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($token['bracket_opener'], $arrayOpen);
+            $phpcsFile->fixer->replaceToken($token['bracket_closer'], ')');
+            $phpcsFile->fixer->endChangeset();
+        }
+
+    }//end process()
+
+
+}//end class

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowLongArraySyntaxUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowLongArraySyntaxUnitTest.inc
@@ -1,0 +1,30 @@
+<?php
+// bad
+$a = array(1, 2, 3);
+$b = array(
+    $a,
+    [4, 5, 6],
+);
+$b = array(
+    $a,
+    array(4, 5, 6),
+);
+
+array
+(
+    array/* will be deleted */( ),
+    array (1),  array   (3)
+);
+
+array; // evil syntax error
+
+// good
+/**
+ * do array foo
+ *
+ * @param array $a
+ */
+function foo (array $a)
+{
+    //do stuff
+}

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowLongArraySyntaxUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowLongArraySyntaxUnitTest.inc.fixed
@@ -1,0 +1,29 @@
+<?php
+// bad
+$a = [1, 2, 3];
+$b = [
+    $a,
+    [4, 5, 6],
+];
+$b = [
+    $a,
+    [4, 5, 6],
+];
+
+[
+    [ ],
+    [1],  [3]
+];
+
+array; // evil syntax error
+
+// good
+/**
+ * do array foo
+ *
+ * @param array $a
+ */
+function foo (array $a)
+{
+    //do stuff
+}

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowLongArraySyntaxUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowLongArraySyntaxUnitTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Unit test class for the DisallowLongArraySyntax sniff
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2013-2015 Xaver Loppenstedt
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the DisallowLongArraySyntax sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2013-2015 Xaver Loppenstedt, All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Tests_Formatting_DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @param string $testFile test file
+     *
+     * @return array(int => int)
+     */
+    protected function getErrorList($testFile = '')
+    {
+        return array(
+                3  => 1,
+                4  => 1,
+                8  => 1,
+                10 => 1,
+                13 => 1,
+                15 => 1,
+                16 => 2,
+                19 => 1,
+               );
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    protected function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowShortArraySyntaxUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowShortArraySyntaxUnitTest.inc
@@ -1,0 +1,28 @@
+<?php
+// bad
+$a = [1, 2, 3];
+$b = [
+    $a,
+    array(4, 5, 6),
+];
+$b = [
+    $a,
+    [4, 5, 6],
+];
+
+[
+    [ ],
+    [1],  [3]
+];
+
+[; // evil syntax error
+// good
+/**
+ * do array foo
+ *
+ * @param array $a
+ */
+function foo (array $a)
+{
+    //do stuff
+}

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowShortArraySyntaxUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowShortArraySyntaxUnitTest.inc.fixed
@@ -1,0 +1,28 @@
+<?php
+// bad
+$a = array(1, 2, 3);
+$b = array(
+    $a,
+    array(4, 5, 6),
+);
+$b = array(
+    $a,
+    array(4, 5, 6),
+);
+
+array(
+    array( ),
+    array(1),  array(3)
+);
+
+[; // evil syntax error
+// good
+/**
+ * do array foo
+ *
+ * @param array $a
+ */
+function foo (array $a)
+{
+    //do stuff
+}

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowShortArraySyntaxUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/DisallowShortArraySyntaxUnitTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Unit test class for the DisallowShortArraySyntax sniff
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2015 Xaver Loppenstedt
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the DisallowShortArraySyntax sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Xaver Loppenstedt <xaver@loppenstedt.de>
+ * @copyright 2015 Xaver Loppenstedt
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Tests_Formatting_DisallowShortArraySyntaxUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @param string $testFile test file
+     *
+     * @return array(int => int)
+     */
+    protected function getErrorList($testFile = '')
+    {
+        return array(
+                3  => 1,
+                4  => 1,
+                8  => 1,
+                10 => 1,
+                13 => 1,
+                14 => 1,
+                15 => 2,
+               );
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    protected function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Based on the discussion regarding Short array syntax sniffer #483  this PR adds  
- DisallowLongArraySyntaxSniff
- DisallowShortArraySyntaxSniff

