### PR TITLE
Adding back "branch-alias" setting that points to "master" branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
         "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki",
         "source": "https://github.com/squizlabs/PHP_CodeSniffer"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.x-dev"
+        }
+    },
     "autoload": {
         "classmap": [
             "CodeSniffer.php",


### PR DESCRIPTION
When in 32dd78e5bc2d512e89aaaf1ac0870404df854041 commit the `branch-alias` setting was removed from `composer.json` the versions like `~2.0@dev` stopped working.