### PR TITLE
Add cli-option '--report-relative-path'

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -326,7 +326,7 @@ class PHP_CodeSniffer_CLI
             // Use function defaults.
             $defaults['reportWidth'] = null;
         }
-        
+
         $reportRelativePath = PHP_CodeSniffer::getConfigData('report_relative_path');
         if ($reportRelativePath !== null) {
             $defaults['reportRelativePath'] = $reportRelativePath;
@@ -1168,7 +1168,7 @@ class PHP_CodeSniffer_CLI
     {
         echo 'Usage: phpcs [-nwlsaepvi] [-d key[=value]] [--colors] [--no-colors]'.PHP_EOL;
         echo '    [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>] ...'.PHP_EOL;
-        echo '    [--report-width=<reportWidth>] [--report-relative-path] '.PHP_EOL; 
+        echo '    [--report-width=<reportWidth>] [--report-relative-path] '.PHP_EOL;
         echo '    [--generator=<generator>] [--tab-width=<tabWidth>]'.PHP_EOL;
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
         echo '    [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]'.PHP_EOL;

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -326,6 +326,14 @@ class PHP_CodeSniffer_CLI
             // Use function defaults.
             $defaults['reportWidth'] = null;
         }
+        
+        $reportRelativePath = PHP_CodeSniffer::getConfigData('report_relative_path');
+        if ($reportRelativePath !== null) {
+            $defaults['reportRelativePath'] = $reportRelativePath;
+        } else {
+            // Use function defaults.
+            $defaults['reportRelativePath'] = false;
+        }
 
         $showProgress = PHP_CodeSniffer::getConfigData('show_progress');
         if ($showProgress === null) {
@@ -643,6 +651,8 @@ class PHP_CodeSniffer_CLI
                         $this->values['reportFile'] = $dir.'/'.basename($this->values['reportFile']);
                     }
                 }
+            } else if ($arg === 'report-relative-path') {
+                $this->values['reportRelativePath'] = true;
             } else if (substr($arg, 0, 13) === 'report-width=') {
                 $this->values['reportWidth'] = substr($arg, 13);
             } else if (substr($arg, 0, 7) === 'report='
@@ -1158,7 +1168,8 @@ class PHP_CodeSniffer_CLI
     {
         echo 'Usage: phpcs [-nwlsaepvi] [-d key[=value]] [--colors] [--no-colors]'.PHP_EOL;
         echo '    [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>] ...'.PHP_EOL;
-        echo '    [--report-width=<reportWidth>] [--generator=<generator>] [--tab-width=<tabWidth>]'.PHP_EOL;
+        echo '    [--report-width=<reportWidth>] [--report-relative-path] '.PHP_EOL; 
+        echo '    [--generator=<generator>] [--tab-width=<tabWidth>]'.PHP_EOL;
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
         echo '    [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]'.PHP_EOL;
         echo '    [--standard=<standard>] [--sniffs=<sniffs>] [--encoding=<encoding>]'.PHP_EOL;
@@ -1178,6 +1189,7 @@ class PHP_CodeSniffer_CLI
         echo '        --version     Print version information'.PHP_EOL;
         echo '        --colors      Use colors in output'.PHP_EOL;
         echo '        --no-colors   Do not use colors in output (this is the default)'.PHP_EOL;
+        echo '        --report-relative-path Generate report with relative paths for files'.PHP_EOL;
         echo '        <file>        One or more files and/or directories to check'.PHP_EOL;
         echo '        <encoding>    The encoding of the files being checked (default is iso-8859-1)'.PHP_EOL;
         echo '        <extensions>  A comma separated list of file extensions to check'.PHP_EOL;

--- a/CodeSniffer/Reporting.php
+++ b/CodeSniffer/Reporting.php
@@ -157,7 +157,7 @@ class PHP_CodeSniffer_Reporting
             $report      = get_class($reportClass);
 
             ob_start();
-            $result = $reportClass->generateFileReport($reportData, $phpcsFile, $cliValues['showSources'], $cliValues['reportWidth']);
+            $result = $reportClass->generateFileReport($reportData, $phpcsFile, $cliValues['showSources'], $cliValues['reportWidth'], $cliValues['reportRelativePath']);
             if ($result === true) {
                 $errorsShown = true;
             }

--- a/CodeSniffer/Reports/Checkstyle.php
+++ b/CodeSniffer/Reports/Checkstyle.php
@@ -40,10 +40,11 @@ class PHP_CodeSniffer_Reports_Checkstyle implements PHP_CodeSniffer_Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                $report      Prepared report data.
-     * @param PHP_CodeSniffer_File $phpcsFile   The file being reported on.
-     * @param boolean              $showSources Show sources?
-     * @param int                  $width       Maximum allowed line width.
+     * @param array                $report             Prepared report data.
+     * @param PHP_CodeSniffer_File $phpcsFile          The file being reported on.
+     * @param boolean              $showSources        Show sources?
+     * @param int                  $width              Maximum allowed line width.
+     * @param boolean              $reportRelativePath Output relative path?
      *
      * @return boolean
      */
@@ -64,8 +65,8 @@ class PHP_CodeSniffer_Reports_Checkstyle implements PHP_CodeSniffer_Report
         }
 
         $out->startElement('file');
-        if ($reportRelativePath) {
-            $out->writeAttribute('name', str_replace(getcwd() . '/', '', $report['filename']));
+        if ($reportRelativePath === true) {
+            $out->writeAttribute('name', str_replace(getcwd().'/', '', $report['filename']));
         } else {
             $out->writeAttribute('name', $report['filename']);
         }

--- a/CodeSniffer/Reports/Checkstyle.php
+++ b/CodeSniffer/Reports/Checkstyle.php
@@ -51,7 +51,8 @@ class PHP_CodeSniffer_Reports_Checkstyle implements PHP_CodeSniffer_Report
         $report,
         PHP_CodeSniffer_File $phpcsFile,
         $showSources=false,
-        $width=80
+        $width=80,
+        $reportRelativePath=false
     ) {
         $out = new XMLWriter;
         $out->openMemory();
@@ -63,7 +64,11 @@ class PHP_CodeSniffer_Reports_Checkstyle implements PHP_CodeSniffer_Report
         }
 
         $out->startElement('file');
-        $out->writeAttribute('name', $report['filename']);
+        if ($reportRelativePath) {
+            $out->writeAttribute('name', str_replace(getcwd() . '/', '', $report['filename']));
+        } else {
+            $out->writeAttribute('name', $report['filename']);
+        }
 
         foreach ($report['messages'] as $line => $lineErrors) {
             foreach ($lineErrors as $column => $colErrors) {


### PR DESCRIPTION
This option enables the output of the filenames to be relative to the cwd. Currently this only works for "checkstyle" reports.

fixes squizlabs/PHP_CodeSniffer#470