### PR TITLE
Add support for allowing string concatenation when the concatenated string would result in a line being to long

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -46,6 +46,11 @@ class Generic_Sniffs_Strings_UnnecessaryStringConcatSniff implements PHP_CodeSni
      */
     public $error = true;
 
+    /**
+     * If set do allow string concatenation if
+     * without the line would become too long
+     */
+    public $lineLimit = 0;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -103,6 +108,16 @@ class Generic_Sniffs_Strings_UnnecessaryStringConcatSniff implements PHP_CodeSni
                     $nextChar = $tokens[$next]['content'][1];
                     $combined = $prevChar.$nextChar;
                     if ($combined === '?'.'>' || $combined === '<'.'?') {
+                        return;
+                    }
+                }
+
+                if ($this->lineLimit) {
+                    $end = $tokens[$prev]['column']
+                           + $tokens[$prev]['length']
+                           + $tokens[$next]['length'];
+
+                    if ($end > $this->lineLimit) {
                         return;
                     }
                 }

--- a/CodeSniffer/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -47,10 +47,14 @@ class Generic_Sniffs_Strings_UnnecessaryStringConcatSniff implements PHP_CodeSni
     public $error = true;
 
     /**
-     * If set do allow string concatenation if
-     * without the line would become too long
+     * If true strings concatenated on multiple lines are allowed
+     * default this is disabled, use this feature to prevent clashes
+     * with the LineLengthSniff.
+     *
+     * @var bool
      */
-    public $lineLimit = 0;
+    public $allowMultiline = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -112,14 +116,10 @@ class Generic_Sniffs_Strings_UnnecessaryStringConcatSniff implements PHP_CodeSni
                     }
                 }
 
-                if ($this->lineLimit) {
-                    $end = $tokens[$prev]['column']
-                           + $tokens[$prev]['length']
-                           + $tokens[$next]['length'];
-
-                    if ($end > $this->lineLimit) {
-                        return;
-                    }
+                if ($this->allowMultiline === true
+                    && $tokens[$prev]['line'] !== $tokens[$next]['line']
+                ) {
+                    return;
                 }
 
                 $error = 'String concat is not required here; use a single string instead';
@@ -128,7 +128,7 @@ class Generic_Sniffs_Strings_UnnecessaryStringConcatSniff implements PHP_CodeSni
                 } else {
                     $phpcsFile->addWarning($error, $stackPtr, 'Found');
                 }
-            }
+            }//end if
         }//end if
 
     }//end process()

--- a/CodeSniffer/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.inc
@@ -14,4 +14,8 @@ $code = "$actions = array();"."\n";
 // No errors for these because they are needed in some cases.
 $code = ' ?'.'>';
 $code = '<'.'?php ';
+
+$string = 'This is a really long string. '
+        . 'It is being used for errors. '
+        . 'The message is not translated.';
 ?>

--- a/CodeSniffer/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.js
+++ b/CodeSniffer/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.js
@@ -9,3 +9,7 @@ this.errors['test' + 'blah'] = x;
 this.errors[y] = x;
 this.errors[y + z] = x;
 this.errors[y + z + 'My' + 'String'] = x;
+
+var long = 'This is a really long string. '
+         + 'It is being used for errors. '
+         + 'The message is not translated.';

--- a/CodeSniffer/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Strings/UnnecessaryStringConcatUnitTest.php
@@ -49,6 +49,8 @@ class Generic_Tests_Strings_UnnecessaryStringConcatUnitTest extends AbstractSnif
                     6  => 1,
                     9  => 1,
                     12 => 1,
+                    19 => 1,
+                    20 => 1,
                    );
             break;
         case 'UnnecessaryStringConcatUnitTest.js':
@@ -56,6 +58,8 @@ class Generic_Tests_Strings_UnnecessaryStringConcatUnitTest extends AbstractSnif
                     1  => 1,
                     8  => 1,
                     11 => 1,
+                    14 => 1,
+                    15 => 1,
                    );
             break;
         default:


### PR DESCRIPTION
Default setting is to ignore the limit and always complain, lineLimit is configurable in an AnnotatedRuleset to match the PSR-2 120 chars for example.

Could not write a UnitTest case because I didn't find a way to set the configurable property from the TestSuit, when the default would be set to 80 or 120 I can make a unit-test for that case. Didn't set any default to keep the unconfigured behaviour the same.