### PR TITLE
Automatic discovery of executable paths

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -242,6 +242,13 @@ class Config
      */
     private static $configData = null;
 
+    /**
+     * Automatically discovered executable utility paths.
+     *
+     * @var array<string, string>
+     */
+    private static $executablePaths = array();
+
 
     /**
      * Creates a Config object and populates it with command line values.
@@ -980,6 +987,46 @@ class Config
         return $phpCodeSnifferConfig[$key];
 
     }//end getConfigData()
+
+
+    /**
+     * Get the executable utility path
+     *
+     * @param string $name The name of the executable utility.
+     *
+     * @return string|null
+     * @see    getConfigData()
+     */
+    public static function getExecutablePath($name)
+    {
+        $key = $name . '_path';
+        $data = self::getConfigData($key);
+
+        if ($data !== null) {
+            return $data;
+        }
+
+        if (array_key_exists($name, self::$executablePaths)) {
+            return self::$executablePaths[$name];
+        }
+
+        $isWin = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+        if ($isWin === true) {
+            $cmd = 'where ' . escapeshellarg($name) . ' 2> nul';
+        } else {
+            $cmd = 'which ' . escapeshellarg($name);
+        }
+
+        $result = exec($cmd, $output, $retVal);
+        if ($retVal !== 0) {
+            $result = null;
+        }
+
+        self::$executablePaths[$name] = $result;
+
+        return $result;
+
+    }//end getExecutablePath()
 
 
     /**

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -67,7 +67,7 @@ class Notifysend implements Report
      */
     public function __construct()
     {
-        $path = Config::getConfigData('notifysend_path');
+        $path = Config::getExecutablePath('notifysend');
         if ($path !== null) {
             $this->path = $path;
         }

--- a/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
@@ -66,7 +66,7 @@ class CSSLintSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $csslintPath = Config::getConfigData('csslint_path');
+        $csslintPath = Config::getExecutablePath('csslint');
         if ($csslintPath === null) {
             return;
         }

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -83,7 +83,7 @@ class ClosureLinterSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $lintPath = Config::getConfigData('gjslint_path');
+        $lintPath = Config::getExecutablePath('gjslint');
         if ($lintPath === null) {
             return;
         }

--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -69,8 +69,8 @@ class JSHintSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $rhinoPath  = Config::getConfigData('rhino_path');
-        $jshintPath = Config::getConfigData('jshint_path');
+        $rhinoPath  = Config::getExecutablePath('rhino');
+        $jshintPath = Config::getExecutablePath('jshint');
         if ($rhinoPath === null || $jshintPath === null) {
             return;
         }

--- a/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -61,7 +61,7 @@ class SyntaxSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $phpPath = Config::getConfigData('php_path');
+        $phpPath = Config::getExecutablePath('php');
         if ($phpPath === null) {
             return;
         }

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -44,7 +44,7 @@ class SyntaxUnitTest extends AbstractSniffUnitTest
      */
     protected function shouldSkipTest()
     {
-        $phpPath = Config::getConfigData('php_path');
+        $phpPath = Config::getExecutablePath('php');
         return (is_null($phpPath));
 
     }//end shouldSkipTest()

--- a/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
@@ -67,8 +67,8 @@ class JSLintSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $rhinoPath  = Config::getConfigData('rhino_path');
-        $jslintPath = Config::getConfigData('jslint_path');
+        $rhinoPath  = Config::getExecutablePath('jslint');
+        $jslintPath = Config::getExecutablePath('jslint');
         if ($rhinoPath === null || $jslintPath === null) {
             return;
         }

--- a/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
@@ -67,7 +67,7 @@ class JavaScriptLintSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $jslPath = Config::getConfigData('jsl_path');
+        $jslPath = Config::getExecutablePath('jsl');
         if (is_null($jslPath) === true) {
             return;
         }

--- a/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
@@ -43,7 +43,7 @@ class JSLintUnitTest extends AbstractSniffUnitTest
      */
     protected function shouldSkipTest()
     {
-        $jslPath = Config::getConfigData('jslint_path');
+        $jslPath = Config::getExecutablePath('jslint');
         return (is_null($jslPath));
 
     }//end shouldSkipTest()

--- a/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
@@ -43,7 +43,7 @@ class JavaScriptLintUnitTest extends AbstractSniffUnitTest
      */
     protected function shouldSkipTest()
     {
-        $jslPath = Config::getConfigData('jsl_path');
+        $jslPath = Config::getExecutablePath('jsl');
         return (is_null($jslPath));
 
     }//end shouldSkipTest()

--- a/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
+++ b/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
@@ -62,7 +62,7 @@ class CodeAnalyzerSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $analyzerPath = Config::getConfigData('zend_ca_path');
+        $analyzerPath = Config::getExecutablePath('zend_ca');
         if (is_null($analyzerPath) === true) {
             return;
         }

--- a/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
+++ b/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
@@ -45,7 +45,7 @@ class CodeAnalyzerUnitTest extends AbstractSniffUnitTest
      */
     protected function shouldSkipTest()
     {
-        $analyzerPath = Config::getConfigData('zend_ca_path');
+        $analyzerPath = Config::getExecutablePath('zend_ca');
         return (is_null($analyzerPath));
 
     }//end shouldSkipTest()


### PR DESCRIPTION
See https://github.com/squizlabs/PHP_CodeSniffer/issues/541. Alternatively, the approach used in [symfony/process](https://github.com/symfony/Process/blob/master/ExecutableFinder.php) could be used, however it's much more complex than just calling a shell command.