### PR TITLE
Add warning/error toggle to UnconditionalIfStatementSniff

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/CodeAnalysis/UnconditionalIfStatementSniff.php
@@ -46,6 +46,14 @@ class Generic_Sniffs_CodeAnalysis_UnconditionalIfStatementSniff implements PHP_C
 
 
     /**
+     * Indicates that problems found by this sniff should be treated as errors.
+     *
+     * @var boolean
+     */
+    public $treatAsError = false;
+
+
+    /**
      * Registers the tokens that this sniff wants to listen for.
      *
      * @return int[]
@@ -73,6 +81,7 @@ class Generic_Sniffs_CodeAnalysis_UnconditionalIfStatementSniff implements PHP_C
     {
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];
+        $this->treatAsError = (bool) $this->treatAsError;
 
         // Skip for-loop without body.
         if (isset($token['parenthesis_opener']) === false) {
@@ -95,7 +104,12 @@ class Generic_Sniffs_CodeAnalysis_UnconditionalIfStatementSniff implements PHP_C
 
         if ($goodCondition === false) {
             $error = 'Avoid IF statements that are always true or false';
-            $phpcsFile->addWarning($error, $stackPtr, 'Found');
+
+            if ($this->treatAsError === true) {
+                $phpcsFile->addError($error, $stackPtr, 'Found');
+            } else {
+                $phpcsFile->addWarning($error, $stackPtr, 'Found');
+            }
         }
 
     }//end process()


### PR DESCRIPTION
This pull adds to ability to specify that the `Generic.CodeAnalysis.UnconditionalIfStatement` sniff should trigger an error, rather than a warning (which is its current behavior).

This option can be customized in the phpcs config file by referencing the `treatAsError` property:

```xml
<rule ref="Generic.CodeAnalysis.UnconditionalIfStatement">
   <properties>
      <property name="treatAsError" value="1"/>
   </properties>
</rule>
```