### PR TITLE
Allow DocBlocks on require|include(_once)

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -94,6 +94,10 @@ class Squiz_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Snif
                        T_ABSTRACT,
                        T_CONST,
                        T_PROPERTY,
+                       T_INCLUDE,
+                       T_INCLUDE_ONCE,
+                       T_REQUIRE,
+                       T_REQUIRE_ONCE,
                       );
 
             if (in_array($tokens[$nextToken]['code'], $ignore) === true) {


### PR DESCRIPTION
PSR-5 (draft) [defines](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#3-definitions) `include()`, `include_once()`, `require()` and `require_once()` as Structural Elements which can therefore have DocBlocks.

_Since this was loosening off of a potential false positive, I was unsure if / how unit tests needed to be updated for this._