### PR TITLE
Commented code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributing
 Before you contribute code to PHP\_CodeSniffer, please make sure it conforms to the PHPCS coding standard and that the PHP\_CodeSniffer unit tests still pass. The easiest way to contribute is to work on a checkout of the repository, or your own fork, rather than an installed PEAR version. If you do this, you can run the following commands to check if everything is ready to submit:
 
     cd PHP_CodeSniffer
-    php scripts/phpcs . --standard=PHPCS -np
+    php scripts/phpcs CodeSniffer.php CodeSniffer --standard=PHPCS -np
 
 Which should give you no output, indicating that there are no coding standard errors. And then:
 

--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -47,6 +47,37 @@ class Squiz_Sniffs_PHP_CommentedOutCodeSniff implements PHP_CodeSniffer_Sniff
      */
     public $maxPercentage = 35;
 
+    /**
+     * Returns arbitrary array of protocols that may be misleadingly confused with
+     * T_GOTO_LABEL. It may result in false negative.
+     * See http://en.wikipedia.org/wiki/URI_scheme
+     *
+     * @return array
+     */
+    public $uriScheme = array(
+                         'attachment',
+                         'callto',
+                         'chrome',
+                         'data',
+                         'dns',
+                         'file',
+                         'ftp',
+                         'git',
+                         'http',
+                         'https',
+                         'irc',
+                         'mailto',
+                         'nfs',
+                         'rsync',
+                         'sftp',
+                         'smb',
+                         'ssh',
+                         'svn',
+                         'tcp',
+                         'tel',
+                         'udp',
+                        );
+
 
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -233,6 +233,11 @@ class Squiz_Sniffs_PHP_CommentedOutCodeSniff implements PHP_CodeSniffer_Sniff
                 // Commented out HTML/XML and other docs contain a lot of these
                 // characters, so it is best to not use them directly.
                 $numPossible++;
+            } else if ($stringTokens[$i]['code'] === T_GOTO_LABEL
+                && in_array(rtrim($stringTokens[$i]['content'], ':'), $this->uriScheme) === true
+            ) {
+                // Remove false positive token.
+                $numTokens--;
             } else {
                 // Looks like code.
                 $numCode++;

--- a/CodeSniffer/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
@@ -79,4 +79,6 @@ function myFunction()
 /*
     [^\'"]
 */
+
+// http://www.google.com
 ?>


### PR DESCRIPTION
Right now, when commenting an url, `CommentedOutCode` sniffs will detect a `goto` token.
This pull request is about avoiding that false positive for a list of protocols.