### PR TITLE
Colons in CSS selectors within media queries throw false positives

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css
+++ b/CodeSniffer/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css
@@ -18,3 +18,10 @@
 .HelpWidgetType-list {
     list-style-image: url();
 }
+
+@media (min-width: 320px) and (max-width: 961px) {
+    .tooltipsrt:hover span.tltp,
+    .tooltipstp:hover span.tltp {
+        visibility: hidden;
+    }
+}


### PR DESCRIPTION
Apparently :hover exists in CSS and confuses a couple of CSS sniffs. Test case only for now.