### PR TITLE
Fix division by zero warning in test report

### DIFF
--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -48,9 +48,11 @@ class PHP_CodeSniffer_TestSuite extends PHPUnit_Framework_TestSuite
         $result = parent::run($result, $filter);
         spl_autoload_unregister(array('PHP_CodeSniffer', 'autoload'));
 
-        $codes   = count($GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']);
-        $fixes   = count($GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES']);
-        $percent = round(($fixes / $codes * 100), 2);
+        $codes = count($GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']);
+        $fixes = count($GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES']);
+
+        $divisor = ($codes === 0) ? 1 : $codes;
+        $percent = round(($fixes / $divisor * 100), 2);
 
         echo PHP_EOL.PHP_EOL;
         echo "Tests generated $codes unique error codes; $fixes were fixable ($percent%)";


### PR DESCRIPTION
Running sniff tests that doesn't produce any errors will raise
"Division by zero" PHP warning while calculating fixable percentage.
This can happen if we filter out too much tests, or if sniff adds
warnings only, but not errors.

I've found that this is [addressed in 3.0] by suppressing message. This
fix will still print the message, but with zeros.

[addressed in 3.0]: https://github.com/squizlabs/PHP_CodeSniffer/blob/3.0/tests/TestSuite.php#L56-L60