### PR TITLE
Don't fatal due to Phar::running() on older HHVM versions

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -2300,7 +2300,7 @@ class PHP_CodeSniffer
     {
         if ($temp === false) {
             $path = '';
-            if (class_exists('Phar') === true) {
+            if (is_callable('Phar::running') === true) {
                 $path = Phar::running(false);
             }
 
@@ -2365,7 +2365,7 @@ class PHP_CodeSniffer
         }
 
         $path = '';
-        if (class_exists('Phar') === true) {
+        if (is_callable('Phar::running') === true) {
             $path = Phar::running(false);
         }
 


### PR DESCRIPTION
Until https://github.com/facebook/hhvm/issues/4323 was resolved, older
HHVM versions had the Phar extension installed, but it did not support
the Phar::running() function, causing fatal errors.

For other reasons, Wikimedia's CI installation is still running HHVM
3.3.1, causing fatal errors: https://phabricator.wikimedia.org/T100544.

The code now checks whether the Phar::running() function it plans to
call exists instead of just the class.