### PR TITLE
enforce class naming convention for sniff classes, to …

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1317,6 +1317,11 @@ class PHP_CodeSniffer
 
             include_once $file;
 
+            $elements = explode('_', $className);
+            if (count($elements) <> 4) {
+                throw new Exception('Sniff: class name '.$className.' do not fit to class naming convention. The class name must be with 4 elements separated by underscores.');
+            }
+
             // Support the use of PHP namespaces. If the class name we included
             // contains namespace separators instead of underscores, use this as the
             // class name from now on.


### PR DESCRIPTION
...prevent subsequent E_NOTICE.

There are many places in this project where we access arrays by index without prior checking if the array do have that index key. In many places it is expected to have exact 4 elements in class names.

An E_NOTICE can make you IDE integration fail.

This issue is related to issue #627 .