### PR TITLE
Extended Squiz.Operators.ComparisonOperatorUsage to for, while and do-while

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -106,7 +106,7 @@ class Generic_Sniffs_NamingConventions_ConstructorNameSniff extends PHP_CodeSnif
 
         $endFunctionIndex = $tokens[$stackPtr]['scope_closer'];
         $startIndex       = $stackPtr;
-        while ($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $startIndex, $endFunctionIndex)) {
+        while (($doubleColonIndex = $phpcsFile->findNext(T_DOUBLE_COLON, $startIndex, $endFunctionIndex)) !== false) {
             if ($tokens[($doubleColonIndex + 1)]['code'] === T_STRING
                 && $tokens[($doubleColonIndex + 1)]['content'] === $parentClassName
             ) {

--- a/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -103,6 +103,8 @@ class Squiz_Sniffs_Operators_ComparisonOperatorUsageSniff implements PHP_CodeSni
                 T_IF,
                 T_ELSEIF,
                 T_INLINE_THEN,
+                T_WHILE,
+                T_FOR,
                );
 
     }//end register()
@@ -158,6 +160,16 @@ class Squiz_Sniffs_Operators_ComparisonOperatorUsageSniff implements PHP_CodeSni
 
                 $start = $tokens[$end]['parenthesis_opener'];
             }//end if
+        } else if ($tokens[$stackPtr]['code'] === T_FOR) {
+            if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
+                return;
+            }
+
+            $openingBracket = $tokens[$stackPtr]['parenthesis_opener'];
+            $closingBracket = $tokens[$stackPtr]['parenthesis_closer'];
+
+            $start = $phpcsFile->findNext(T_SEMICOLON, $openingBracket, $closingBracket);
+            $end   = $phpcsFile->findNext(T_SEMICOLON, ($start + 1), $closingBracket);
         } else {
             if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
                 return;

--- a/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.inc
@@ -88,3 +88,26 @@ if (false === ($parent instanceof Foo) && ($parent instanceof Bar) === false) {
 
 if (false === ($parent instanceof Foo) && $foo) {
 }
+
+while ($var1) {
+}
+
+while ($var1 === TRUE) {
+}
+
+do {
+
+} while ($var1);
+
+do {
+
+} while ($var1 === TRUE);
+
+for ($var1 = 10; $var1; $var1--) {
+}
+
+for ($var1 = 10; $var1 !== 0; $var1--) {
+}
+
+for ($var1 = ($var2 === 10); $var1; $var1--) {
+}

--- a/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.js
+++ b/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.js
@@ -36,3 +36,21 @@ if (one === TRUE || two === TRUE || three === FALSE || four === TRUE) {
 
 if (one || two || !three || four) {
 }
+
+while (one == true) {
+}
+
+while (one === true) {
+}
+
+do {
+} while (one == true);
+
+do {
+} while (one === true);
+
+for (one = 10; one != 0; one--) {
+}
+
+for (one = 10; one !== 0; one--) {
+}

--- a/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -67,6 +67,10 @@ class Squiz_Tests_Operators_ComparisonOperatorUsageUnitTest extends AbstractSnif
                     82 => 1,
                     83 => 1,
                     89 => 1,
+                    92 => 1,
+                    100 => 1,
+                    106 => 1,
+                    112 => 1,
                    );
             break;
         case 'ComparisonOperatorUsageUnitTest.js':

--- a/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.php
@@ -80,6 +80,9 @@ class Squiz_Tests_Operators_ComparisonOperatorUsageUnitTest extends AbstractSnif
                     17 => 1,
                     18 => 1,
                     28 => 2,
+                    40 => 1,
+                    47 => 1,
+                    52 => 1,
                    );
             break;
         default:


### PR DESCRIPTION
When enforcing strict and explicit comparison operators for if-statements, I think it would be logical to also enforce these rules for for-statements, while-statements and do-while statements.