### PR TITLE
Add support for braceless do-while loops in Javascript.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -112,16 +112,16 @@ class Generic_Sniffs_ControlStructures_InlineControlStructureSniff implements PH
             // the WHILE. We can detect this by checking only a single semicolon
             // is present between them.
             if ($phpcsFile->tokenizerType === 'JS') {
-                $lastDo = $phpcsFile->findPrevious(T_DO, $stackPtr - 1);
-                $lastSemicolon = $phpcsFile->findPrevious(T_SEMICOLON, $stackPtr - 1);
+                $lastDo        = $phpcsFile->findPrevious(T_DO, ($stackPtr - 1));
+                $lastSemicolon = $phpcsFile->findPrevious(T_SEMICOLON, ($stackPtr - 1));
                 if ($lastDo !== false && $lastSemicolon !== false && $lastDo < $lastSemicolon) {
-                    $precedingSemicolon = $phpcsFile->findPrevious(T_SEMICOLON, $lastSemicolon - 1);
+                    $precedingSemicolon = $phpcsFile->findPrevious(T_SEMICOLON, ($lastSemicolon - 1));
                     if ($precedingSemicolon === false || $precedingSemicolon < $lastDo) {
                         return;
                     }
                 }
             }
-        }
+        }//end if
 
         // This is a control structure without an opening brace,
         // so it is an inline statement.

--- a/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -106,6 +106,21 @@ class Generic_Sniffs_ControlStructures_InlineControlStructureSniff implements PH
                     }
                 }
             }
+
+            // In Javascript DO WHILE loops without curly braces are legal. This
+            // is only valid if a single statement is present between the DO and
+            // the WHILE. We can detect this by checking only a single semicolon
+            // is present between them.
+            if ($phpcsFile->tokenizerType === 'JS') {
+                $lastDo = $phpcsFile->findPrevious(T_DO, $stackPtr - 1);
+                $lastSemicolon = $phpcsFile->findPrevious(T_SEMICOLON, $stackPtr - 1);
+                if ($lastDo !== false && $lastSemicolon !== false && $lastDo < $lastSemicolon) {
+                    $precedingSemicolon = $phpcsFile->findPrevious(T_SEMICOLON, $lastSemicolon - 1);
+                    if ($precedingSemicolon === false || $precedingSemicolon < $lastDo) {
+                        return;
+                    }
+                }
+            }
         }
 
         // This is a control structure without an opening brace,

--- a/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js
+++ b/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js
@@ -17,3 +17,5 @@ while (something) print 'hello';
 do {
     i--;
 } while (something);
+
+do i++; while (i < 5);

--- a/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.js.fixed
@@ -17,3 +17,5 @@ while (something) { print 'hello'; }
 do {
     i--;
 } while (something);
+
+do { i++; } while (i < 5);

--- a/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -71,6 +71,7 @@ class Generic_Tests_ControlStructures_InlineControlStructureUnitTest extends Abs
                     11 => 1,
                     13 => 1,
                     15 => 1,
+                    21 => 1,
                    );
             break;
         default:


### PR DESCRIPTION
In Javascript a do-while loop without curly braces is legal, as long as it only contains a single statement:

```
do i++; while (i < 5);
```

When detecting inline sniffs this is handled incorrectly at the moment, resulting in this:

```
do { i++; } while (i < 5) {}
```

We should add support for this construct.