### PR TITLE
Squiz.Functions.FunctionDeclarationSpacing error for multi-line declarations with required spaces greater than zero

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -321,11 +321,11 @@ class Squiz_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff implements 
                     }
 
                     $spaceAfterOpen = 0;
-                    if ($multiLine === false && $tokens[($bracket + 1)]['code'] === T_WHITESPACE) {
+                    if ($tokens[($bracket + 1)]['code'] === T_WHITESPACE) {
                         $spaceAfterOpen = strlen($tokens[($bracket + 1)]['content']);
                     }
 
-                    if ($spaceAfterOpen !== $this->requiredSpacesAfterOpen) {
+                    if ($multiLine === false && $spaceAfterOpen !== $this->requiredSpacesAfterOpen) {
                         $error = 'Expected %s spaces between opening bracket and type hint "%s"; %s found';
                         $data  = array(
                                   $this->requiredSpacesAfterOpen,

--- a/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
@@ -56,6 +56,14 @@ function myFunc(array $blah ) {}
 function myFunc(  array $blah ) {}
 function myFunc() {}
 function myFunc( ) {}
+
+function multiLineFunction(
+	array $flatList,
+	$markup,
+	array $otherList,
+	$lastOffset=0
+) {
+}
 // @codingStandardsChangeSetting Squiz.Functions.FunctionDeclarationArgumentSpacing requiredSpacesAfterOpen 0
 // @codingStandardsChangeSetting Squiz.Functions.FunctionDeclarationArgumentSpacing requiredSpacesBeforeClose 0
 


### PR DESCRIPTION
This fixes a bug in the `Squiz.Functions.FunctionDeclarationSpacing`
sniff when the `requiredSpacesAfterOpen` option was set to anything
other than 0.

When the first argument in a multiline function declaration had a
type-hint, this error would be given:

> Expected 1 spaces between opening bracket and type hint "array"; 0
found

I don’t think this check was ever intended to affect multiline
functions. The logic was such that it never does when
`requiredSpacesAfterOpen` is 0, and because this is the default, the
bug was never noticed.