### PR TITLE
Syntax checks can fail on Windows with PHP5.6

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -64,7 +64,7 @@ class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
         $output   = shell_exec($cmd);
 
         $matches = array();
-        if (preg_match('/^.*error:(.*) in .* on line ([0-9]+)/', $output, $matches) === 1) {
+        if (preg_match('/^.*error:(.*) in .* on line ([0-9]+)/m', $output, $matches) === 1) {
             $error = trim($matches[1]);
             $line  = (int) $matches[2];
             $phpcsFile->addErrorOnLine("PHP syntax error: $error", $line, 'PHPSyntax');


### PR DESCRIPTION
…PHP5.6

On Windows & PHP5.6, the "php -l" output an empty leading line, and make this sniff down, add flag "m" to make it work again.