### PR TITLE
Add code coverage whitelist filter to phpunit config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,12 @@
             <file>tests/AllTests.php</file>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./CodeSniffer</directory>
+            <exclude>
+                <directory>./CodeSniffer/Standards/*/Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
I would suggest to use code coverage tracking services like [coveralls.io](http://coveralls.io) or [codecov.io](http://codecov.io).
I would also suggest to rename _phpunit.xml_ to _phpunit.xml.dist_, but it will introduce BC break is guess.