### PR TITLE
Implementing git sha related report & fix

### DIFF
--- a/.gitlc.yml
+++ b/.gitlc.yml
@@ -1,2 +1,0 @@
-coding_standards:
-  name: [PHPCS]

--- a/.gitlc.yml
+++ b/.gitlc.yml
@@ -1,0 +1,2 @@
+coding_standards:
+  name: [PHPCS]


### PR DESCRIPTION
Hi. In case if anybody needs it.

This changes allow  phpcs or phpcbf show report and fix file for selected commit.

example: 
SHA=303d632b994cfe2b145554353feebde0655e2ce2 phpcs --standard=**** file
```
FILE: ******
----------------------------------------------------------------------
FOUND 15 ERRORS AFFECTING 5 LINES
----------------------------------------------------------------------
 360 | ERROR | [x] Functions must not contain multiple empty lines in
     |       |     a row; found 2 empty lines
 361 | ERROR | [x] Whitespace found at end of line
 438 | ERROR | [x] Line indented incorrectly; expected 18 spaces,
     |       |     found 19
 438 | ERROR | [x] Closing brace indented incorrectly; expected 18
     |       |     spaces, found 19
 438 | ERROR | [x] Expected newline after closing brace
 438 | ERROR | [x] Expected 1 space after ELSE keyword; 0 found
 441 | ERROR | [x] Line indented incorrectly; expected 16 spaces,
     |       |     found 18
 441 | ERROR | [x] Closing brace indented incorrectly; expected 16
     |       |     spaces, found 18
 441 | ERROR | [x] Expected newline after closing brace
 441 | ERROR | [x] Expected 1 space after ELSE keyword; 0 found
 444 | ERROR | [x] Line indented incorrectly; expected 20 spaces,
     |       |     found 21
 444 | ERROR | [x] Closing brace indented incorrectly; expected 20
     |       |     spaces, found 21
 444 | ERROR | [x] Expected newline after closing brace
 444 | ERROR | [x] Expected 1 space after ELSEIF keyword; 0 found
 444 | ERROR | [x] Expected 1 space after closing parenthesis; found
     |       |     ""
----------------------------------------------------------------------
PHPCBF CAN FIX THE 15 MARKED SNIFF VIOLATIONS AUTOMATICALLY
---------------------------------------------------------------------- 
```