### PR TITLE
Fix endless loop in PRS1 SideEffects sniffer

### DIFF
--- a/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -161,10 +161,14 @@ class PSR1_Sniffs_Files_SideEffectsSniff implements PHP_CodeSniffer_Sniff
                         $firstSymbol = $i;
                     }
 
-                    $i = $phpcsFile->findNext(T_SEMICOLON, ($i + 1));
+                    $semicolon = $phpcsFile->findNext(T_SEMICOLON, ($i + 1));
+                    if ($semicolon !== false) {
+                        $i = $semicolon;
+                    }
+
                     continue;
                 }
-            }
+            }//end if
 
             // Conditional statements are allowed in symbol files as long as the
             // contents is only a symbol definition. So don't count these as effects

--- a/CodeSniffer/Standards/PSR1/Tests/Files/SideEffectsUnitTest.5.inc
+++ b/CodeSniffer/Standards/PSR1/Tests/Files/SideEffectsUnitTest.5.inc
@@ -1,0 +1,2 @@
+<?php
+define('SOME_VERSION', '0.1-foo') ?>

--- a/CodeSniffer/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/CodeSniffer/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -62,6 +62,7 @@ class PSR1_Tests_Files_SideEffectsUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'SideEffectsUnitTest.3.inc':
         case 'SideEffectsUnitTest.4.inc':
+        case 'SideEffectsUnitTest.5.inc':
             return array(
                     1 => 1,
                    );


### PR DESCRIPTION
findNext() might return false, so we have to check for that.
Otherwise we overwrite our loop variable and get stuck.

Detected while playing around with the horde source tree.