### PR TITLE
Allow specified arrays in docblock type hints

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -359,7 +359,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                 } else if (count($typeNames) === 1) {
                     // Check type hint for array and custom type.
                     $suggestedTypeHint = '';
-                    if (strpos($suggestedName, 'array') !== false) {
+                    if (strpos($suggestedName, 'array') !== false || strpos($suggestedName, '[]') !== false) {
                         $suggestedTypeHint = 'array';
                     } else if (strpos($suggestedName, 'callable') !== false) {
                         $suggestedTypeHint = 'callable';


### PR DESCRIPTION
Example:

```php
/**
 * @param Item[] $items
 */
public function foo(array $items)
{
    // do something
}
```

Should be fine but currently returns an error: Expected type hint "Item[]"; found "array" for $items

This fixes #601 and #624 