### PR TITLE
Fix neglect of indentation in JS arrays

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -494,6 +494,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 $condition = 0;
                 if (isset($tokens[$scopeCloser]['conditions']) === true
                     && empty($tokens[$scopeCloser]['conditions']) === false
+
                 ) {
                     end($tokens[$scopeCloser]['conditions']);
                     $condition = key($tokens[$scopeCloser]['conditions']);
@@ -539,9 +540,14 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                     }
 
                     if ($condition > 0) {
-                        $checkIndent   += $this->indent;
-                        $currentIndent += $this->indent;
+                        $nextToken = $tokens[$checkToken+1];
+                        // indent needed except Object close token is glued to Array close token
+                        if ($nextToken['code'] !== T_CLOSE_SHORT_ARRAY) {
+                            $checkIndent   += $this->indent;
+                            $currentIndent += $this->indent;
+                        }
                         $exact          = true;
+
                     }
                 } else {
                     $checkIndent = $currentIndent;
@@ -642,7 +648,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 || ($tokenIndent < $checkIndent && $exact === false))
             ) {
                 $type  = 'IncorrectExact';
-                $error = 'Line indented incorrectly; expected ';
+                $error = 'Line indented incorrectly; expected ' ;
                 if ($exact === false) {
                     $error .= 'at least ';
                     $type   = 'Incorrect';
@@ -868,9 +874,10 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 }
             }//end if
 
+
             // JS objects set the indent level.
             if ($phpcsFile->tokenizerType === 'JS'
-                && $tokens[$i]['code'] === T_OBJECT
+                    && ($tokens[$i]['code'] === T_OBJECT || $tokens[$i]['code'] === T_OPEN_SHORT_ARRAY)
             ) {
                 $closer = $tokens[$i]['bracket_closer'];
                 if ($tokens[$i]['line'] === $tokens[$closer]['line']) {

--- a/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -494,7 +494,6 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 $condition = 0;
                 if (isset($tokens[$scopeCloser]['conditions']) === true
                     && empty($tokens[$scopeCloser]['conditions']) === false
-
                 ) {
                     end($tokens[$scopeCloser]['conditions']);
                     $condition = key($tokens[$scopeCloser]['conditions']);
@@ -648,7 +647,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 || ($tokenIndent < $checkIndent && $exact === false))
             ) {
                 $type  = 'IncorrectExact';
-                $error = 'Line indented incorrectly; expected ' ;
+                $error = 'Line indented incorrectly; expected ';
                 if ($exact === false) {
                     $error .= 'at least ';
                     $type   = 'Incorrect';
@@ -877,7 +876,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
 
             // JS objects set the indent level.
             if ($phpcsFile->tokenizerType === 'JS'
-                    && ($tokens[$i]['code'] === T_OBJECT || $tokens[$i]['code'] === T_OPEN_SHORT_ARRAY)
+                && ($tokens[$i]['code'] === T_OBJECT || $tokens[$i]['code'] === T_OPEN_SHORT_ARRAY)
             ) {
                 $closer = $tokens[$i]['bracket_closer'];
                 if ($tokens[$i]['line'] === $tokens[$closer]['line']) {

--- a/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -546,7 +546,6 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                             $currentIndent += $this->indent;
                         }
                         $exact          = true;
-
                     }
                 } else {
                     $checkIndent = $currentIndent;
@@ -872,7 +871,6 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                     continue;
                 }
             }//end if
-
 
             // JS objects set the indent level.
             if ($phpcsFile->tokenizerType === 'JS'

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.js
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.js
@@ -204,3 +204,23 @@ for (var i = 0; i < 10; i++) {
     var foo = {foo:{'a':'b',
         'c':'d'}};
 }
+
+function arrayobjectmix() {
+    var x = [{
+        "key":"val"
+    }];
+    var y = [
+        'var',
+        {
+            text: "test"
+        },
+        'var2'
+    ];
+    var z = [
+        {
+            text: "test2"
+        }
+    ];
+    call($c[e]);
+}
+

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.js.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.js.fixed
@@ -204,3 +204,23 @@ for (var i = 0; i < 10; i++) {
     var foo = {foo:{'a':'b',
         'c':'d'}};
 }
+
+function arrayobjectmix() {
+    var x = [{
+        "key":"val"
+    }];
+    var y = [
+        'var',
+        {
+            text: "test"
+        },
+        'var2'
+    ];
+    var z = [
+        {
+            text: "test2"
+        }
+    ];
+    call($c[e]);
+}
+

--- a/CodeSniffer/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
+++ b/CodeSniffer/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
@@ -69,7 +69,7 @@ class MySource_Sniffs_Strings_JoinStringsSniff implements PHP_CodeSniffer_Sniff
         }
 
         $prev = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($prev - 1), null, true);
-        if ($tokens[$prev]['code'] === T_CLOSE_SQUARE_BRACKET) {
+        if ($tokens[$prev]['code'] === T_CLOSE_SHORT_ARRAY) {
             $opener = $tokens[$prev]['bracket_opener'];
             if ($tokens[($opener - 1)]['code'] !== T_STRING) {
                 // This means the array is declared inline, like x = [a,b,c].join()


### PR DESCRIPTION
Fix neglect of indentation in arrays typical for ExtJs, like  

Ext.define('AddressBook.view.matrix.base.BaseToolbar', {
    extend: 'Ext.toolbar.Toolbar',

    cls: 'addressbook-matrix-base-toolbar',
    height : 27,

    initComponent: function() {
        var me = this;

        me.items = [
            '->',
            {
                tooltip: me.viewHelpTooltip,
                text: '?',
                cls: 'matrix-viewhelp-button',
                listeners: {
                    click: 'onViewHelpButtonClick'
                }
            }
        ];

        me.callParent();
    }
});