### PR TITLE
Squiz MethodScopeSniff doesn't handle nested functions

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
@@ -72,11 +72,21 @@ class Squiz_Sniffs_Scope_MethodScopeSniff extends PHP_CodeSniffer_Standards_Abst
             }
         }
 
-        if ($modifier === null) {
-            $error = 'Visibility must be declared on method "%s"';
-            $data  = array($methodName);
-            $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
+        if ($modifier) {
+            return;
         }
+
+        // Look for parent function
+        $parent_scope = $phpcsFile->findPrevious(array(T_FUNCTION), $stackPtr-1);
+
+        // Check if function is defined within another functions scope, in which case no visibility required
+        if ($parent_scope && $stackPtr > $tokens[$parent_scope]['scope_opener'] && $stackPtr < $tokens[$parent_scope]['scope_closer']) {
+            return;
+        }
+
+        $error = 'Visibility must be declared on method "%s"';
+        $data  = array($methodName);
+        $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
 
     }//end processTokenWithinScope()
 


### PR DESCRIPTION
Currently, this sniff incorrectly fails for locally scoped named method like:

```php

public function test()
{
    function my_sort()
    {
    // do stuff
    }

    $a = array();
    usort($a, 'my_sort');
}
```

This patch checks if the method is defined within the scope of another method