### PR TITLE
Use Composer's facility of autoloading files

### DIFF
--- a/bin/phpcbf
+++ b/bin/phpcbf
@@ -8,6 +8,6 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-require_once __DIR__.'/../autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';
 $runner = new PHP_CodeSniffer\Runner();
 $runner->runPHPCBF();

--- a/bin/phpcs
+++ b/bin/phpcs
@@ -8,6 +8,6 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-require_once __DIR__.'/../autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';
 $runner = new PHP_CodeSniffer\Runner();
 $runner->runPHPCS();

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "psr-4": {
             "PHP_CodeSniffer\\": "src/",
             "PHP_CodeSniffer\\Tests\\": "tests/"
-        }
+        },
+        "files": ["autoload.php"]
     },
     "require": {
         "php": ">=5.4.0",

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -30,7 +30,7 @@ if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
-require_once __DIR__.'/../autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';
 
 $tokens = new Tokens();
 

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -30,7 +30,7 @@ if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
-require_once __DIR__.'/../../autoload.php';
+require_once __DIR__.'/../../vendor/autoload.php';
 
 $tokens = new Tokens();
 

--- a/tests/Standards/AllSniffs.php
+++ b/tests/Standards/AllSniffs.php
@@ -32,7 +32,7 @@ if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
-require_once __DIR__.'/../../autoload.php';
+require_once __DIR__.'/../../vendor/autoload.php';
 
 $tokens = new Tokens();
 


### PR DESCRIPTION
If PHP_CodeSniffer is a composer dependency of another application, then instead of only requiring `vendor/autoload.php` (which is a common practice when using Composer), it's also needed to require `vendor/squizlabs/php_codesniffer/autoload.php` additionally.

Adding `autoload.php` to composer's autoload.files section eliminates this need.