### PR TITLE
Fixes suppression of errors using docblocks

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -485,7 +485,7 @@ class PHP_CodeSniffer_File
         foreach ($this->_tokens as $stackPtr => $token) {
             // Check for ignored lines.
             if ($token['code'] === T_COMMENT
-                || $token['code'] === T_DOC_COMMENT
+                || $token['code'] === T_DOC_COMMENT_TAG
                 || ($inTests === true && $token['code'] === T_INLINE_HTML)
             ) {
                 if (strpos($token['content'], '@codingStandards') !== false) {
@@ -1603,7 +1603,7 @@ class PHP_CodeSniffer_File
             }
 
             if ($tokens[$i]['code'] === T_COMMENT
-                || $tokens[$i]['code'] === T_DOC_COMMENT
+                || $tokens[$i]['code'] === T_DOC_COMMENT_TAG
                 || ($inTests === true && $tokens[$i]['code'] === T_INLINE_HTML)
             ) {
                 if (strpos($tokens[$i]['content'], '@codingStandards') !== false) {

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -55,6 +55,15 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $numErrors);
         $this->assertEquals(0, count($errors));
 
+        // Process with a PHPDoc block suppression.
+        $content = '<?php '.PHP_EOL.'/** @codingStandardsIgnoreStart */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/** @codingStandardsIgnoreEnd */';
+        $file    = $phpcs->processFile('suppressionTest.php', $content);
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertEquals(0, count($errors));
+
     }//end testSuppressError()
 
 
@@ -79,6 +88,15 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 
         // Process with suppression.
         $content = '<?php '.PHP_EOL.'// @codingStandardsIgnoreStart'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'// @codingStandardsIgnoreEnd'.PHP_EOL.'$var = TRUE;';
+        $file    = $phpcs->processFile('suppressionTest.php', $content);
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(1, $numErrors);
+        $this->assertEquals(1, count($errors));
+
+        // Process with a PHPDoc block suppression.
+        $content = '<?php '.PHP_EOL.'/** @codingStandardsIgnoreStart */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/** @codingStandardsIgnoreEnd */'.PHP_EOL.'$var = TRUE;';
         $file    = $phpcs->processFile('suppressionTest.php', $content);
 
         $errors    = $file->getErrors();
@@ -117,6 +135,15 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $numWarnings);
         $this->assertEquals(0, count($warnings));
 
+        // Process with a PHPDoc block suppression.
+        $content = '<?php '.PHP_EOL.'/** @codingStandardsIgnoreStart */'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'/** @codingStandardsIgnoreEnd */';
+        $file    = $phpcs->processFile('suppressionTest.php', $content);
+
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertEquals(0, count($warnings));
+
     }//end testSuppressWarning()
 
 
@@ -147,7 +174,6 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
         $numErrors = $file->getErrorCount();
         $this->assertEquals(1, $numErrors);
         $this->assertEquals(1, count($errors));
-
     }//end testSuppressLine()
 
 
@@ -220,6 +246,15 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $numErrors);
         $this->assertEquals(0, count($errors));
 
+        // Process with a PhpDoc Block suppression.
+        $content = '<?php '.PHP_EOL.'class MyClass() {'.PHP_EOL.'/** @codingStandardsIgnoreStart */'.PHP_EOL.'function myFunction() {'.PHP_EOL.'/** @codingStandardsIgnoreEnd */'.PHP_EOL.'$this->foo();'.PHP_EOL.'}'.PHP_EOL.'}';
+        $file    = $phpcs->processFile('suppressionTest.php', $content);
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertEquals(0, count($errors));
+
     }//end testSuppressScope()
 
 
@@ -253,6 +288,15 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 
         // Process with a Doc Block suppression.
         $content = '<?php '.PHP_EOL.'/* @codingStandardsIgnoreFile */'.PHP_EOL.'//TODO: write some code';
+        $file    = $phpcs->processFile('suppressionTest.php', $content);
+
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertEquals(0, count($warnings));
+
+        // Process with a PhpDoc Block suppression.
+        $content = '<?php '.PHP_EOL.'/** @codingStandardsIgnoreFile */'.PHP_EOL.'//TODO: write some code';
         $file    = $phpcs->processFile('suppressionTest.php', $content);
 
         $warnings    = $file->getWarnings();


### PR DESCRIPTION
Currently the only acceptable way of suppressing errors is by either using single line comments:
```
// @codeStandardsIgnoreStart
```
Or doc block comments:
```
/*
 * @codeStandardsIgnoreStart
 */
```

This commit makes it possible to suppress errors by using PHPDoc comments:
```
/**
 * @codeStandardsIgnoreStart
 */
```