### PR TITLE
JSON report is invalid when messages contain newlines or tabs

### DIFF
--- a/CodeSniffer/Reports/Json.php
+++ b/CodeSniffer/Reports/Json.php
@@ -65,6 +65,7 @@ class PHP_CodeSniffer_Reports_Json implements PHP_CodeSniffer_Report
                     $error['message'] = str_replace('"', '\"', $error['message']);
                     $error['message'] = str_replace('/', '\/', $error['message']);
                     $error['message'] = str_replace("\n", '\n', $error['message']);
+                    $error['message'] = str_replace("\r", '\r', $error['message']);
                     $error['message'] = str_replace("\t", '\t', $error['message']);
 
                     $fixable = 'false';

--- a/CodeSniffer/Reports/Json.php
+++ b/CodeSniffer/Reports/Json.php
@@ -64,6 +64,8 @@ class PHP_CodeSniffer_Reports_Json implements PHP_CodeSniffer_Report
                     $error['message'] = str_replace('\\', '\\\\', $error['message']);
                     $error['message'] = str_replace('"', '\"', $error['message']);
                     $error['message'] = str_replace('/', '\/', $error['message']);
+                    $error['message'] = str_replace("\n", '\n', $error['message']);
+                    $error['message'] = str_replace("\t", '\t', $error['message']);
 
                     $fixable = 'false';
                     if ($error['fixable'] === true) {
@@ -78,7 +80,7 @@ class PHP_CodeSniffer_Reports_Json implements PHP_CodeSniffer_Report
                     $messages .= '"column":'.$column.',';
                     $messages .= '"fixable":'.$fixable;
                     $messages .= '},';
-                }
+                }//end foreach
             }//end foreach
         }//end foreach
 


### PR DESCRIPTION
When any of the error or warning messages contain tabs or newlines and a JSON report is generated then the resulting JSON will be invalid.

A good solution for this would be to use `json_encode()` to generate the JSON, but since we need to support old PHP versions this is not possible until PHP CodeSniffer 3 (see #449 for more information).

For the moment we can work around the issue by replacing the offending characters before outputting the JSON report.