### PR TITLE
Remove default full report when requiring a single report.

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -663,6 +663,7 @@ class PHP_CodeSniffer_CLI
                     }//end if
                 } else {
                     // This is a single report.
+                    unset($this->values['reports'['full']])
                     $report = substr($arg, 7);
                     $output = null;
                 }//end if

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -663,7 +663,7 @@ class PHP_CodeSniffer_CLI
                     }//end if
                 } else {
                     // This is a single report.
-                    unset($this->values['reports'['full']])
+                    unset($this->values['reports']['full']);
                     $report = substr($arg, 7);
                     $output = null;
                 }//end if


### PR DESCRIPTION
Remove the default full report since it is a single report.