### PR TITLE
ScopeIndent can fail when a short array opening square bracket is on a line by itself

### DIFF
--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
@@ -885,6 +885,12 @@ $a =
     );
 $c = 2;
 
+$a =
+    [
+        $b => 1,
+    ];
+$c = 2;
+
     function foo()
     {
         $foo = array(

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
@@ -885,6 +885,12 @@ $a =
     );
 $c = 2;
 
+$a =
+    [
+        $b => 1,
+    ];
+$c = 2;
+
 function foo()
 {
     $foo = array(

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -144,11 +144,11 @@ class Generic_Tests_WhiteSpace_ScopeIndentUnitTest extends AbstractSniffUnitTest
                 862 => 1,
                 863 => 1,
                 879 => 1,
-                888 => 1,
-                900 => 1,
-                901 => 1,
-                903 => 1,
-                905 => 1,
+                894 => 1,
+                906 => 1,
+                907 => 1,
+                909 => 1,
+                911 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Only a test case for now, not sure about the correct fix.