### PR TITLE
PHP Notice if @package name is made up of all invalid characters

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -347,6 +347,12 @@ class PEAR_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
             $newContent = preg_replace('/[^A-Za-z_]/', '', $newContent);
             $nameBits   = explode('_', $newContent);
             $firstBit   = array_shift($nameBits);
+            
+            if(!isset($firstBit{0})){
+				// Package is empty.
+				continue;
+			}
+            
             $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
             foreach ($nameBits as $bit) {
                 if ($bit !== '') {
@@ -391,6 +397,12 @@ class PEAR_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
             $newContent = str_replace(' ', '_', $content);
             $nameBits   = explode('_', $newContent);
             $firstBit   = array_shift($nameBits);
+            
+            if(!isset($firstBit{0})){
+				// Subpackage is empty.
+				continue;
+			}
+            
             $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
             foreach ($nameBits as $bit) {
                 if ($bit !== '') {

--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -348,10 +348,10 @@ class PEAR_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
             $nameBits   = explode('_', $newContent);
             $firstBit   = array_shift($nameBits);
             
-            if(!isset($firstBit{0})){
-				// Package is empty.
-				continue;
-			}
+            if(isset($firstBit{0}) === false ){
+                // Package is empty.
+                continue;
+            }
             
             $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
             foreach ($nameBits as $bit) {
@@ -398,10 +398,10 @@ class PEAR_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
             $nameBits   = explode('_', $newContent);
             $firstBit   = array_shift($nameBits);
             
-            if(!isset($firstBit{0})){
-				// Subpackage is empty.
-				continue;
-			}
+            if(isset($firstBit{0}) === false ){
+                // Subpackage is empty.
+                continue;
+            }
             
             $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
             foreach ($nameBits as $bit) {


### PR DESCRIPTION
If `@package` name will be empty in comment block, e.g. `@package ''`, then PHP throw notice: 
`PHP Notice:  Uninitialized string offset: 0 in .composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php on line 350`,
because `$firstBit[0]` is not set, but used.