### PR TITLE
More complex switch-return structure (Affiliate to #735)

### DIFF
--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
@@ -403,7 +403,7 @@ class Whatever
     protected $_protectedArray = array(
         'normalString' => 'That email address is already in use!',
         'offendingString' => <<<'STRING'
-Each line of this string is always said to be at column 0, 
+Each line of this string is always said to be at column 0,
     no matter how many spaces are placed
                 at the beginning of each line
 and the ending STRING on the next line is reported as having to be indented.
@@ -914,6 +914,25 @@ switch ($foo) {
         return array();
     case 2:
         return '';
+    case 3:
+        return $function();
+    case 4:
+        return $functionCall($param[0]);
+    case 5:
+        return array() + array(); // Array Merge
+    case 6:
+        // String connect
+        return $functionReturningString('') . $functionReturningString(array());
+    case 7:
+        return functionCall(
+            $withMultiLineParam[0],
+            array(),
+            $functionReturningString(
+                $withMultiLineParam[1]
+            )
+        );
+    case 8:
+        return $param[0][0];
 }
 
     function foo()

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
@@ -403,7 +403,7 @@ class Whatever
     protected $_protectedArray = array(
         'normalString' => 'That email address is already in use!',
         'offendingString' => <<<'STRING'
-Each line of this string is always said to be at column 0, 
+Each line of this string is always said to be at column 0,
     no matter how many spaces are placed
                 at the beginning of each line
 and the ending STRING on the next line is reported as having to be indented.
@@ -914,6 +914,25 @@ switch ($foo) {
         return array();
     case 2:
         return '';
+    case 3:
+        return $function();
+    case 4:
+        return $functionCall($param[0]);
+    case 5:
+        return array() + array(); // Array Merge
+    case 6:
+        // String connect
+        return $functionReturningString('') . $functionReturningString(array());
+    case 7:
+        return functionCall(
+            $withMultiLineParam[0],
+            array(),
+            $functionReturningString(
+                $withMultiLineParam[1]
+            )
+        );
+    case 8:
+        return $param[0][0];
 }
 
 function foo()

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
@@ -403,7 +403,7 @@ class Whatever
 	protected $_protectedArray = array(
 		'normalString' => 'That email address is already in use!',
 		'offendingString' => <<<'STRING'
-Each line of this string is always said to be at column 0, 
+Each line of this string is always said to be at column 0,
     no matter how many spaces are placed
                 at the beginning of each line
 and the ending STRING on the next line is reported as having to be indented.
@@ -914,6 +914,25 @@ switch ($foo) {
 		return array();
 	case 2:
 		return '';
+	case 3:
+		return $function();
+	case 4:
+		return $functionCall($param[0]);
+	case 5:
+		return array() + array(); // Array Merge
+	case 6:
+		// String connect
+		return $functionReturningString('') . $functionReturningString(array());
+	case 7:
+		return functionCall(
+			$withMultiLineParam[0],
+			array(),
+			$functionReturningString(
+				$withMultiLineParam[1]
+			)
+		);
+	case 8:
+		return $param[0][0];
 }
 
 	function foo()

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
@@ -403,7 +403,7 @@ class Whatever
 	protected $_protectedArray = array(
 		'normalString' => 'That email address is already in use!',
 		'offendingString' => <<<'STRING'
-Each line of this string is always said to be at column 0, 
+Each line of this string is always said to be at column 0,
     no matter how many spaces are placed
                 at the beginning of each line
 and the ending STRING on the next line is reported as having to be indented.
@@ -914,6 +914,25 @@ switch ($foo) {
 		return array();
 	case 2:
 		return '';
+	case 3:
+		return $function();
+	case 4:
+		return $functionCall($param[0]);
+	case 5:
+		return array() + array(); // Array Merge
+	case 6:
+		// String connect
+		return $functionReturningString('') . $functionReturningString(array());
+	case 7:
+		return functionCall(
+			$withMultiLineParam[0],
+			array(),
+			$functionReturningString(
+				$withMultiLineParam[1]
+			)
+		);
+	case 8:
+		return $param[0][0];
 }
 
 function foo()

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -144,11 +144,11 @@ class Generic_Tests_WhiteSpace_ScopeIndentUnitTest extends AbstractSniffUnitTest
                 862 => 1,
                 863 => 1,
                 879 => 1,
-                919 => 1,
-                931 => 1,
-                932 => 1,
-                934 => 1,
-                936 => 1,
+                938 => 1,
+                950 => 1,
+                951 => 1,
+                953 => 1,
+                955 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Previously:
https://github.com/squizlabs/PHP_CodeSniffer/issues/735

The commit 9badf27cc7 did fix the most of the problems, but there are still a missed hit.

**I have no idea on how to fix the problem itself**, but I did added the test case for it. In short, it's something like:

	switch ($foo) {
		.....
		case 7:
			return functionCall(
				$withMultiLineParam[0],
				array(),
				$functionReturningString(
					$withMultiLineParam[1]
				)
			);
		.....
	}

It's also effecting something like ...

	switch ($foo) {
		.....
		case 7:
			return functionCall(
				array()
			);
		.....
	}

Or just ...

	switch ($foo) {
		.....
		case 7:
			return array(
				array(),
			);
		.....
	}