### PR TITLE
Check for closing parenthesis - Refs #580

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -80,6 +80,12 @@ class Squiz_Sniffs_ControlStructures_ForEachLoopDeclarationSniff implements PHP_
             return;
         }
 
+        if (array_key_exists('parenthesis_closer', $tokens[$openingBracket]) === false) {
+            $error = 'Possible parse error: FOREACH has no closing parenthesis';
+            $phpcsFile->addWarning($error, $stackPtr, 'MissingParenthesis');
+            return;
+        }
+
         $closingBracket = $tokens[$openingBracket]['parenthesis_closer'];
 
         if ($this->requiredSpacesAfterOpen === 0 && $tokens[($openingBracket + 1)]['code'] === T_WHITESPACE) {


### PR DESCRIPTION
Add guard code for syntax errors to foreach control structure.

Since [this commit](https://github.com/squizlabs/PHP_CodeSniffer/commit/b2050fab7affad74fca0cb7e01193bb4d36aa147) it is already checking for the opening parenthesis, but if the closing parenthesis for a foreach was missing it still resulted in several php notices which are now fixed:

``` bash
PHP Notice:  Undefined index: parenthesis_closer in /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php on line 83
PHP Stack trace:
PHP   1. {main}() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:0
PHP   2. PHP_CodeSniffer_CLI->runphpcs() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:25
PHP   3. PHP_CodeSniffer_CLI->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:95
PHP   4. PHP_CodeSniffer->processFiles() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:855
PHP   5. PHP_CodeSniffer->processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:619
PHP   6. PHP_CodeSniffer->_processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1685
PHP   7. PHP_CodeSniffer_File->start() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1807
PHP   8. Squiz_Sniffs_ControlStructures_ForEachLoopDeclarationSniff->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/File.php:567

Notice: Undefined index: parenthesis_closer in /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php on line 83

Call Stack:
    0.0002     228976   1. {main}() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:0
    0.0081    1552360   2. PHP_CodeSniffer_CLI->runphpcs() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:25
    0.0085    1610808   3. PHP_CodeSniffer_CLI->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:95
    0.0307    3562624   4. PHP_CodeSniffer->processFiles() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:855
    0.0307    3564496   5. PHP_CodeSniffer->processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:619
    0.0308    3565016   6. PHP_CodeSniffer->_processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1685
    0.0314    3605640   7. PHP_CodeSniffer_File->start() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1807
    0.0455    4085872   8. Squiz_Sniffs_ControlStructures_ForEachLoopDeclarationSniff->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/File.php:567

PHP Notice:  Undefined offset: -1 in /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php on line 115
PHP Stack trace:
PHP   1. {main}() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:0
PHP   2. PHP_CodeSniffer_CLI->runphpcs() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:25
PHP   3. PHP_CodeSniffer_CLI->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:95
PHP   4. PHP_CodeSniffer->processFiles() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:855
PHP   5. PHP_CodeSniffer->processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:619
PHP   6. PHP_CodeSniffer->_processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1685
PHP   7. PHP_CodeSniffer_File->start() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1807
PHP   8. Squiz_Sniffs_ControlStructures_ForEachLoopDeclarationSniff->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/File.php:567

Notice: Undefined offset: -1 in /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php on line 115

Call Stack:
    0.0002     228976   1. {main}() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:0
    0.0081    1552360   2. PHP_CodeSniffer_CLI->runphpcs() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:25
    0.0085    1610808   3. PHP_CodeSniffer_CLI->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:95
    0.0307    3562624   4. PHP_CodeSniffer->processFiles() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:855
    0.0307    3564496   5. PHP_CodeSniffer->processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:619
    0.0308    3565016   6. PHP_CodeSniffer->_processFile() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1685
    0.0314    3605640   7. PHP_CodeSniffer_File->start() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1807
    0.0455    4085872   8. Squiz_Sniffs_ControlStructures_ForEachLoopDeclarationSniff->process() /Users/johan/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/File.php:567
```