### PR TITLE
Auto fix for Squiz.Commenting.BlockComment.WrongEnd is incorrect

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -102,7 +102,7 @@ class Squiz_Sniffs_Commenting_BlockCommentSniff implements PHP_CodeSniffer_Sniff
                 $error = 'Block comments must be ended with */';
                 $fix   = $phpcsFile->addFixableError($error, $end, 'WrongEnd');
                 if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken($stackPtr, '*/');
+                    $phpcsFile->fixer->replaceToken($end, '*/');
                 }
             }
 

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -1,0 +1,201 @@
+<?php
+
+/*
+    Comments need to be indented 4 space.
+*/
+
+/*
+    same with multi-line
+    comments.
+*/
+
+/*
+    But they can:
+        - be indented more than 4
+        - but not less than 4
+*/
+
+/*
+    - This is valid:
+   Not indented correctly.
+*/
+
+/*
+   Comments need to be indented 4 space.
+*/
+
+/*
+    Comments need to be indented 4 space.
+     Comments need to be indented 4 space.
+   Comments need to be indented 4 space.
+  Comments need to be indented 4 space.
+
+    Comments need to be indented 4 space.
+   Comments need to be indented 4 space.
+*/
+
+/*
+    Block comments require a blank
+    line after them.
+*/
+$code = 'should not be here';
+
+/*
+    Closing comment not aligned
+    */
+
+/*
+    Closing comment not aligned
+ */
+
+/* Not allowed */
+
+/*  Not allowed
+    either.
+*/
+
+/* */
+
+$code = 'should not be here';
+/*
+
+    Block comments require a blank
+    line before them. */
+
+/*
+*/
+
+/** Not allowed */
+
+/**  Not allowed
+    either.
+**/
+
+/*
+    no capital
+    letter.
+*/
+
+echo 'hi';
+
+function func()
+{
+    echo 1;
+    /**
+       test
+       here
+    **/
+    echo 'test';
+    /**
+        Test
+        here
+       **/
+
+}//end func()
+
+public static function test()
+{
+    /*
+        Block comments do not require a blank line before them
+        if they are after T_OPEN_CURLY_BRACKET.
+    */
+
+    $code = '';
+
+}//end test()
+
+
+public static function test()
+{
+
+    /*
+        Block comments do not require a blank line before them
+        if they are after T_OPEN_CURLY_BRACKET.
+    */
+
+    $code = '';
+
+}//end test()
+
+class MyClass
+{
+
+    /**
+     * Comment should be ignored.
+     *
+     * @var   integer
+     * @since 4.0.0
+     */
+    const LEFT = 1;
+
+}
+
+/**
+ * Comment should be ignored.
+ *
+ */
+final class MyClass
+{
+    /**
+     * Comment should be ignored.
+     *
+     */
+    final public function test() {}
+}
+
+switch ($var) {
+    case 'foo':
+        /*
+            Foo comment.
+            This is a multiple
+            line comment for Foo.
+        */
+
+        echo 'Foo';
+    break;
+
+    default:
+
+        /*
+            Foo comment.
+            This is a multiple
+            line comment for Foo.
+        */
+
+        echo 'Default';
+    break;
+}//end switch
+
+/**
+ * Comment should be ignored in PHP 5.4.
+ *
+ */
+trait MyTrait {
+
+}
+
+/*
+    这是一条测试评论.
+*/
+
+/*Channels::includeSystem('Permission');
+if (Permission::hasPermission($projectid, 'project.metadata.add') === FALSE) {
+    throw new PermissionException(_('You do not have permission to add metadata field'));
+}*/
+
+/*
+    Comment goes here
+*/
+$two = (1 + 1);  // I'm not a comment closer!
+
+class Foo
+{
+
+    /**
+     * Comment here.
+     *
+     * @var array
+     */
+    var $bar = array();
+
+}


### PR DESCRIPTION
The `$stackPtr` was being used instead of `$end`, leading to the
comment opener being replaced with `*/`. This would cause a syntax
error in the “fixed” PHP file.

The sniff did not have a test for the fixing component, which is why
this wasn’t caught sooner. I’ve added the `.fixed` file, but it is just
a copy of the `.inc` file, because I didn’t know for sure whether all
of the fixing behavior is correct. So currently the tests are
intentionally failing.

See
https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/478