### PR TITLE
[WIP] Fix PHP notices with standard PSR-2.

### DIFF
--- a/CodeSniffer/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -142,7 +142,7 @@ class PSR2_Sniffs_Classes_ClassDeclarationSniff extends PEAR_Sniffs_Classes_Clas
         }
 
         // Check after the class/interface name.
-        if ($tokens[($className + 2)]['line'] === $tokens[$className]['line']) {
+        if (isset($tokens[($className + 2)]) === true && $tokens[($className + 2)]['line'] === $tokens[$className]['line']) {
             $gap = $tokens[($className + 1)]['content'];
             if (strlen($gap) !== 1) {
                 $found = strlen($gap);

--- a/CodeSniffer/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/CodeSniffer/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -137,3 +137,5 @@ class C1
 {
 
 } // C1
+
+class Test

--- a/CodeSniffer/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -136,3 +136,7 @@ class C1
 {
 
 } // C1
+
+class Test
+{
+}

--- a/CodeSniffer/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/CodeSniffer/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -79,7 +79,9 @@ class PSR2_Tests_Classes_ClassDeclarationUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return array();
+        return array(
+            141 => 1,
+        );
 
     }//end getWarningList()
 

--- a/CodeSniffer/Tokenizers/PHP.php
+++ b/CodeSniffer/Tokenizers/PHP.php
@@ -620,6 +620,7 @@ class PHP_CodeSniffer_Tokenizers_PHP
 
             if ($tokenIsArray === true
                 && $token[0] === T_STRING
+                && isset($tokens[($stackPtr + 1)])
                 && $tokens[($stackPtr + 1)] === ':'
                 && $tokens[($stackPtr - 1)][0] !== T_PAAMAYIM_NEKUDOTAYIM
             ) {


### PR DESCRIPTION
I get this notice with PHP 5.6.11 and standard PSR-2.

With this code : 

```php
<?php

namespace Foo;

/**
 * TTTTT
 */
class A
```

I have :
```PHP Notice:  Undefined offset: 22 in /usr/share/pear/PHP/CodeSniffer/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php on line 145```
```PHP Notice:  Undefined offset: 12 in /usr/share/pear/PHP/CodeSniffer/Tokenizers/PHP.php on line 601```