### PR TITLE
Ensure $values['standard'] is set when generator is specified on the command line.

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -782,6 +782,9 @@ class PHP_CodeSniffer_CLI
 
         if ($values['generator'] !== '') {
             $phpcs = new PHP_CodeSniffer($values['verbosity']);
+            if (is_null($values['standard'])) {
+                $values['standard'] = $this->validateStandard(null);
+            }
             foreach ($values['standard'] as $standard) {
                 $phpcs->generateDocs(
                     $standard,


### PR DESCRIPTION
This is to fix the following from happening:

    $ phpcs --generator=Markdown .
    PHP Warning:  Invalid argument supplied for foreach() in /usr/share/php/PHP/CodeSniffer/CLI.php on line 789
    PHP Stack trace:
    PHP   1. {main}() /usr/bin/phpcs:0
    PHP   2. PHP_CodeSniffer_CLI->runphpcs() /usr/bin/phpcs:25
    PHP   3. PHP_CodeSniffer_CLI->process() /usr/share/php/PHP/CodeSniffer/CLI.php:95