### PR TITLE
Add PHPUnit dependency to composer manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,6 @@ Before you contribute code to PHP\_CodeSniffer, please make sure it conforms to 
 
 Which should give you no output, indicating that there are no coding standard errors. And then:
 
-    phpunit
+    vendor/bin/phpunit
 
 Which should give you no failures or errors. You can ignore any skipped tests as these are for external tools.

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,9 @@
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*"
     },
+    "require-dev": {
+        "phpunit/PHPUnit": "~4.0"
+    },
     "bin": [
         "scripts/phpcs",
         "scripts/phpcbf"


### PR DESCRIPTION
In order to facilitate running tests I recommend adding an explicit dependency to composer.json.