### PR TITLE
New option to avoid indentation reset on T_OPEN and T_CLOSE tags

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -107,6 +107,18 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
     protected $nonIndentingScopes = array();
 
     /**
+     * Is indentation reset on T_OPEN_TAG and T_CLOSE_TAG?
+     *
+     * If TRUE (default), both T_OPEN_TAG and T_CLOSE_TAG cause
+     * the reset of current indentation (with some exceptions). If FALSE,
+     * current indentation (from previous PHP blocks) isn't affected and
+     * next PHP should observe it.
+     *
+     * @var bool
+     */
+    public $resetIndentationWithOpenClose = true;
+
+    /**
      * Show debug output for this sniff.
      *
      * @var bool
@@ -799,6 +811,15 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                     echo "Open PHP tag found on line $line".PHP_EOL;
                 }
 
+                if ($this->resetIndentationWithOpenClose === false) {
+                    // We don't want any reset to happen, inform and continue.
+                    if ($this->_debug === true) {
+                        echo "Skipping indentation reset, keeping it to $currentIndent".PHP_EOL;
+                    }
+
+                    continue;
+                }
+
                 if ($checkToken === null) {
                     $first         = $phpcsFile->findFirstOnLine(T_WHITESPACE, $i, true);
                     $currentIndent = (strlen($tokens[$first]['content']) - strlen(ltrim($tokens[$first]['content'])));
@@ -828,6 +849,15 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
                 if ($this->_debug === true) {
                     $line = $tokens[$i]['line'];
                     echo "Close PHP tag found on line $line".PHP_EOL;
+                }
+
+                if ($this->resetIndentationWithOpenClose === false) {
+                    // We don't want any reset to happen, inform and continue.
+                    if ($this->_debug === true) {
+                        echo "Skipping indentation reset, keeping it to $currentIndent".PHP_EOL;
+                    }
+
+                    continue;
                 }
 
                 if ($tokens[$lastOpenTag]['line'] !== $tokens[$i]['line']) {


### PR DESCRIPTION
Right now any T_OPEN_TAG/T_OPEN_TAG_WITH_ECHO/T_CLOSE_TAG do lead,
unconditionally, to current indentation being reset. But it may be
desired for some scripts/standards to keep that current indentation to "persist"
over multiple PHP blocks.

This commit adds a new property (resetIndentationWithOpenClose) to
support both behaviors, defaulting to true, aka keeping BC.

Without this property the only solution is to duplicate the whole
process() method just to switch to the alternative behavior.

Some references:

- The issue in our tracker: https://tracker.moodle.org/browse/CONTRIB-5732
- Test file, only reporting line #6 (property set to true, reset, aka, current behavior in non-strict mode), and reporting both #6 and #18 (property set to false, alternative behavior in non-strict mode) so the current indentation (set to 4 by the T_IF in the first PHP block) remains in the 2nd PHP block: https://github.com/stronk7/moodle-local_codechecker/blob/master/moodle/tests/fixtures/moodle_whitespace_scopeindent.php

FYC, ciao :-)