### PR TITLE
Generic.PHP.LowerCaseKeyword ignores "array" hint keyword

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -40,6 +40,7 @@ class Generic_Sniffs_PHP_LowerCaseKeywordSniff implements PHP_CodeSniffer_Sniff
                 T_HALT_COMPILER,
                 T_ABSTRACT,
                 T_ARRAY,
+                T_ARRAY_HINT,
                 T_AS,
                 T_BREAK,
                 T_CALLABLE,

--- a/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
@@ -13,4 +13,5 @@ CONST array()
 For ($var As $var) { Exit; }
 If ($a AND $b OR $c XOR $d) { Die; } ElseIf { } Else
 GOTO a;
+function (Array $a) {}
 ?>

--- a/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
@@ -13,4 +13,5 @@ const array()
 for ($var as $var) { exit; }
 if ($a and $b or $c xor $d) { die; } elseif { } else
 goto a;
+function (array $a) {}
 ?>

--- a/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -47,6 +47,7 @@ class Generic_Tests_PHP_LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
                 13 => 3,
                 14 => 7,
                 15 => 1,
+                16 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
`array` does not seems to be recognized as a keyword when it's not followed by an opening parenthesis. In the [php documentation](http://php.net/manual/en/reserved.keywords.php) it is shown followed by a parenthesis but I think it should be treated as a keyword. 

otherwise, the following statement from the documentation would not make sense for `array` : 

 > You cannot use any of the following words as constants, class names, function or method names