### PR TITLE
Composer autoload include statements to make Composer dependencies work

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -15,9 +15,9 @@
 error_reporting(E_ALL | E_STRICT);
 
 // Installations via Composer: make sure that we autoload all dependencies.
-if (file_exists($a = dirname(__FILE__).'/../../../autoload.php')) {
+if (file_exists($a = dirname(__FILE__).'/../../../autoload.php') === true) {
     include_once $a;
-} else if (file_exists($a = dirname(__FILE__).'/../vendor/autoload.php')) {
+} else if (file_exists($a = dirname(__FILE__).'/../vendor/autoload.php') === true) {
     include_once $a;
 }
 

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -14,6 +14,13 @@
 
 error_reporting(E_ALL | E_STRICT);
 
+// Installations via Composer: make sure that we autoload all dependencies.
+if (file_exists($a = dirname(__FILE__).'/../../../autoload.php')) {
+    include_once $a;
+} else if (file_exists($a = dirname(__FILE__).'/../vendor/autoload.php')) {
+    include_once $a;
+}
+
 if (is_file(dirname(__FILE__).'/../CodeSniffer.php') === true) {
     include_once dirname(__FILE__).'/../CodeSniffer.php';
 } else {


### PR DESCRIPTION
Problem: Drupal's Coder defines a PHPCS standard where one sniff uses the Symfony YAML library. That triggers fatal errors because potential Composer dependencies are never included for auto loading.

Let's do it in CLI.php?
PHP-CS-Fixer does something similar: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/php-cs-fixer