### PR TITLE
CSS indentation fixer changes color codes

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/CSS/IndentationUnitTest.css.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/CSS/IndentationUnitTest.css.fixed
@@ -1,15 +1,12 @@
 body {
-
-        font-family: Arial, Helvetica, sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
     margin: 40px 0 0 0;
-padding: 0;
-  background: #8FB7DB url(diag_lines_bg.gif) top left;
-    
+    padding: 0;
+    background: #8FB7DB url(diag_lines_bg.gif) top left;
 }
 
 td {
     margin: 40px;
-
     padding: 20px;
 }
 
@@ -27,9 +24,9 @@ td {
 @media screen and (max-device-width: 769px) {
 
     header #logo img {
-    max-width: 100%;
+        max-width: 100%;
         padding: 20px;
-         margin: 40px;
+        margin: 40px;
     }
 }
 
@@ -47,10 +44,7 @@ td {
 
 td {
     margin: 40px;
-
     padding: 20px;
-
-
 }
 
 .GUIFileUpload {
@@ -58,10 +52,10 @@ td {
 }
 
 .mortgage-calculator h2 {
-        background: #072237;
-        color: #fff;
-        font-weight: normal;
-        height: 50px;
-        line-height: 50px;
-        padding: 0 0 0 30px;
-    }
+    background: #072237;
+    color: #fff;
+    font-weight: normal;
+    height: 50px;
+    line-height: 50px;
+    padding: 0 0 0 30px;
+}

--- a/CodeSniffer/Standards/Squiz/Tests/CSS/IndentationUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/CSS/IndentationUnitTest.php
@@ -51,6 +51,13 @@ class Squiz_Tests_CSS_IndentationUnitTest extends AbstractSniffUnitTest
                 50 => 1,
                 52 => 1,
                 53 => 1,
+                61 => 1,
+                62 => 1,
+                63 => 1,
+                64 => 1,
+                65 => 1,
+                66 => 1,
+                67 => 1,
                );
 
     }//end getErrorList()

--- a/CodeSniffer/Tokenizers/CSS.php
+++ b/CodeSniffer/Tokenizers/CSS.php
@@ -176,7 +176,7 @@ class PHP_CodeSniffer_Tokenizers_CSS extends PHP_CodeSniffer_Tokenizers_PHP
                 $leadingZero = false;
                 if ($content{0} === '0') {
                     $content     = '1'.$content;
-                    $leadingZero = false;
+                    $leadingZero = true;
                 }
 
                 $commentTokens = parent::tokenizeString('<?php '.$content.'?>', $eolChar);


### PR DESCRIPTION
Here is a test case for demonstration: the line ```background: #072237;``` is changed into ```background: 1072237;```.

Not sure where this should be fixed, so the phpunit tests will fail on this right now.