### PR TITLE
Recognize T_SPACESHIP token as operator token

### DIFF
--- a/CodeSniffer/Tokens.php
+++ b/CodeSniffer/Tokens.php
@@ -130,6 +130,11 @@ if (defined('T_POW') === false) {
     define('T_POW', 'PHPCS_T_POW');
 }
 
+// Some PHP 7 tokens, replicated for lower versions.
+if (defined('T_SPACESHIP') === false) {
+    define('T_SPACESHIP', 'PHPCS_T_SPACESHIP');
+}
+
 // Tokens used for parsing doc blocks.
 define('T_DOC_COMMENT_STAR', 'PHPCS_T_DOC_COMMENT_STAR');
 define('T_DOC_COMMENT_WHITESPACE', 'PHPCS_T_DOC_COMMENT_WHITESPACE');
@@ -203,6 +208,7 @@ final class PHP_CodeSniffer_Tokens
                                  T_MINUS               => 5,
                                  T_MODULUS             => 5,
                                  T_POW                 => 5,
+                                 T_SPACESHIP           => 5,
 
                                  T_SL                  => 5,
                                  T_SR                  => 5,
@@ -361,6 +367,7 @@ final class PHP_CodeSniffer_Tokens
                                    T_MINUS                    => 1,
                                    T_MODULUS                  => 1,
                                    T_POW                      => 2,
+                                   T_SPACESHIP                => 3,
                                    T_BITWISE_AND              => 1,
                                    T_BITWISE_OR               => 1,
                                    T_BITWISE_XOR              => 1,
@@ -548,6 +555,7 @@ final class PHP_CodeSniffer_Tokens
                                 T_DIVIDE      => T_DIVIDE,
                                 T_MODULUS     => T_MODULUS,
                                 T_POW         => T_POW,
+                                T_SPACESHIP   => T_SPACESHIP,
                                 T_BITWISE_AND => T_BITWISE_AND,
                                 T_BITWISE_OR  => T_BITWISE_OR,
                                 T_BITWISE_XOR => T_BITWISE_XOR,


### PR DESCRIPTION
This solves 2 problems:

1. the `<=>` operator added in PHP 7 wasn't interpreted as operator token (the `T_SPACSHIP`) by sniffs that handle operators (e.g. `Squiz.WhiteSpace.OperatorSpacing`)
2. if custom standard referred to this `T_SPACESHIP` token and PHP 7 code was checked on PHP 5 version then `T_SPACSHIP` constant wasn't defined