### PR TITLE
Default to PHP_BINARY for syntax tests

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -56,31 +56,36 @@ class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
     {
         $phpPath = PHP_CodeSniffer::getConfigData('php_path');
         if ($phpPath === null) {
-            // PHP_BINARY is available in PHP 5.4+
-            if (defined('PHP_BINARY')) {
+            // PHP_BINARY is available in PHP 5.4+.
+            if (defined('PHP_BINARY') === true) {
                 $phpPath = PHP_BINARY;
-            }
-            else {
+            } else {
                 // Fallback for old PHP versions that can be removed once PHP
                 // 5.4 is required.
                 $candidates = array(
-                  PHP_BINDIR . '/php',
-                  PHP_BINDIR . '/php.exe',
-                );
+                               PHP_BINDIR.'/php',
+                               PHP_BINDIR.'/php.exe',
+                              );
 
                 foreach ($candidates as $candidate) {
-                    if (file_exists($candidate) && is_executable($candidate)) {
+                    if (file_exists($candidate) === true
+                        && is_executable($candidate) === true
+                    ) {
                         $phpPath = $candidate;
                         break;
                     }
                 }
 
-                if (empty($phpPath)) {
-                    $phpcsFile->addWarning('Unable to check syntax as php_path is not configured', $stackPtr, 'PHPSyntax');
+                if (empty($phpPath) === true) {
+                    $phpcsFile->addWarning(
+                        'Unable to check syntax as php_path is not configured',
+                        $stackPtr,
+                        'PHPSyntax'
+                    );
                     return;
                 }
-            }
-        }
+            }//end if
+        }//end if
 
         $fileName = $phpcsFile->getFilename();
         $cmd      = "$phpPath -l \"$fileName\" 2>&1";

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -56,7 +56,7 @@ class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
     {
         $phpPath = PHP_CodeSniffer::getConfigData('php_path');
         if ($phpPath === null) {
-            return;
+            $phpPath = PHP_BINARY;
         }
 
         $fileName = $phpcsFile->getFilename();

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -60,30 +60,7 @@ class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
             if (defined('PHP_BINARY') === true) {
                 $phpPath = PHP_BINARY;
             } else {
-                // Fallback for old PHP versions that can be removed once PHP
-                // 5.4 is required.
-                $candidates = array(
-                               PHP_BINDIR.'/php',
-                               PHP_BINDIR.'/php.exe',
-                              );
-
-                foreach ($candidates as $candidate) {
-                    if (file_exists($candidate) === true
-                        && is_executable($candidate) === true
-                    ) {
-                        $phpPath = $candidate;
-                        break;
-                    }
-                }
-
-                if (empty($phpPath) === true) {
-                    $phpcsFile->addWarning(
-                        'Unable to check syntax as php_path is not configured',
-                        $stackPtr,
-                        'PHPSyntax'
-                    );
-                    return;
-                }
+                return;
             }//end if
         }//end if
 

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -56,7 +56,30 @@ class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
     {
         $phpPath = PHP_CodeSniffer::getConfigData('php_path');
         if ($phpPath === null) {
-            $phpPath = PHP_BINARY;
+            // PHP_BINARY is available in PHP 5.4+
+            if (defined('PHP_BINARY')) {
+                $phpPath = PHP_BINARY;
+            }
+            else {
+                // Fallback for old PHP versions that can be removed once PHP
+                // 5.4 is required.
+                $candidates = array(
+                  PHP_BINDIR . '/php',
+                  PHP_BINDIR . '/php.exe',
+                );
+
+                foreach ($candidates as $candidate) {
+                    if (file_exists($candidate) && is_executable($candidate)) {
+                        $phpPath = $candidate;
+                        break;
+                    }
+                }
+
+                if (empty($phpPath)) {
+                    $phpcsFile->addWarning('Unable to check syntax as php_path is not configured', $stackPtr, 'PHPSyntax');
+                    return;
+                }
+            }
         }
 
         $fileName = $phpcsFile->getFilename();

--- a/CodeSniffer/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -32,6 +32,23 @@ class Generic_Tests_PHP_SyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**
+     * Should this test be skipped for some reason.
+     *
+     * @return void
+     */
+    protected function shouldSkipTest()
+    {
+        if (defined('PHP_BINARY') === true) {
+            return false;
+        }
+
+        $phpPath = PHP_CodeSniffer::getConfigData('php_path');
+        return (is_null($phpPath));
+
+    }//end shouldSkipTest()
+
+
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value

--- a/CodeSniffer/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -32,19 +32,6 @@ class Generic_Tests_PHP_SyntaxUnitTest extends AbstractSniffUnitTest
 {
 
     /**
-     * Should this test be skipped for some reason.
-     *
-     * @return void
-     */
-    protected function shouldSkipTest()
-    {
-        $phpPath = PHP_CodeSniffer::getConfigData('php_path');
-        return (is_null($phpPath));
-
-    }//end shouldSkipTest()
-
-
-    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value


### PR DESCRIPTION
Without this, you have to manually set php_path in your configuration for this test to work. This also reduces a skipped test in the default testing configuration.