### PR TITLE
Fix comments capital letter detection for multibyte string.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -159,7 +159,7 @@ class Generic_Sniffs_Commenting_DocCommentSniff implements PHP_CodeSniffer_Sniff
             }
         }
 
-        if (preg_match('/\p{Lu}|\P{L}/u', $shortContent[0]) === 0) {
+        if (preg_match('/^(\p{Lu}|\P{L})/u', $shortContent) === 0) {
             $error = 'Doc comment short description must start with a capital letter';
             $phpcsFile->addError($error, $short, 'ShortNotCapital');
         }
@@ -189,7 +189,7 @@ class Generic_Sniffs_Commenting_DocCommentSniff implements PHP_CodeSniffer_Sniff
                 }
             }
 
-            if (preg_match('/\p{Lu}|\P{L}/u', $tokens[$long]['content'][0]) === 0) {
+            if (preg_match('/^(\p{Lu}|\P{L})/u', $tokens[$long]['content']) === 0) {
                 $error = 'Doc comment long description must start with a capital letter';
                 $phpcsFile->addError($error, $long, 'LongNotCapital');
             }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -214,7 +214,7 @@ class Squiz_Sniffs_Commenting_BlockCommentSniff implements PHP_CodeSniffer_Sniff
                 }
             }
 
-            if (preg_match('/\p{Lu}|\P{L}/u', $commentText[0]) === 0) {
+            if (preg_match('/^(\p{Lu}|\P{L})/u', $commentText) === 0) {
                 $error = 'Block comments must start with a capital letter';
                 $phpcsFile->addError($error, $commentLines[1], 'NoCapital');
             }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -526,8 +526,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
             }//end if
 
             // Param comments must start with a capital letter and end with the full stop.
-            $firstChar = $param['comment']{0};
-            if (preg_match('|\p{Lu}|u', $firstChar) === 0) {
+            if (preg_match('/^\p{Lu}/u', $param['comment']) === 0) {
                 $error = 'Parameter comment must start with a capital letter';
                 $phpcsFile->addError($error, $param['tag'], 'ParamCommentNotCapital');
             }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -261,7 +261,7 @@ class Squiz_Sniffs_Commenting_InlineCommentSniff implements PHP_CodeSniffer_Snif
         // a non-letter character, throw an error.
         // \p{Lu} : an uppercase letter that has a lowercase variant.
         // \P{L}  : a non-letter character.
-        if (preg_match('/\p{Lu}|\P{L}/u', $commentText[0]) === 0) {
+        if (preg_match('/^(\p{Lu}|\P{L})/u', $commentText) === 0) {
             $error = 'Inline comments must start with a capital letter';
             $phpcsFile->addError($error, $topComment, 'NotCapital');
         }


### PR DESCRIPTION
Accessing string as array actually cut multibyte characters.

That description would pass the test but it shouldn't.
```
/**
 * étude des ...
 */
```

Rewrite the regexes and compare the entire string.