### PR TITLE
Recognize __debugInfo as a magic method.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -55,6 +55,7 @@ class Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff extends PHP_Co
                                'set_state'  => true,
                                'clone'      => true,
                                'invoke'     => true,
+                               'debuginfo'  => true,
                               );
 
     /**

--- a/CodeSniffer/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -55,6 +55,7 @@ class PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff extends PHP_CodeSniff
                                'set_state'  => true,
                                'clone'      => true,
                                'invoke'     => true,
+                               'debuginfo'  => true,
                               );
 
     /**


### PR DESCRIPTION
PHP 5.6 added the magic method __debugInfo.

http://php.net/manual/en/language.oop5.magic.php#object.debuginfo