### PR TITLE
Add support for a 'rulesetdir' directive in phpcs-ruleset.xml

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -704,6 +704,11 @@ class PHP_CodeSniffer
         $excludedSniffs = array();
         $cliValues      = $this->cli->getCommandLineValues();
 
+        // Populate the list of ruleset directories.
+        foreach ($ruleset->rulesetdir as $dir) {
+            self::$rulesetDirs[] = (string) $dir['dir'];
+        }
+
         $rulesetDir          = dirname($rulesetPath);
         $rulesetName         = basename($rulesetPath);
         self::$rulesetDirs[] = $rulesetDir;


### PR DESCRIPTION
For projects that are using custom standards it would be nice to be able to specify the folder where a custom ruleset is located.

An example use case for this is the Drupal project. The Drupal coding standard is part of a separate library which is not included in the core project. Drupal core supplies an example [phpcs-ruleset.xml.dist](http://cgit.drupalcode.org/drupal/tree/core/phpcs.xml.dist?h=8.1.x) which does not make any assumptions about where the coding standards are installed on a developer's system. Here's an excerpt of the ruleset:

```
<?xml version="1.0" encoding="UTF-8"?>
<ruleset name="drupal_core">
  <rule ref="Drupal">
    <exclude name="Drupal.Commenting.DocComment"/>
    <exclude name="Drupal.Commenting.FunctionComment"/>
    <exclude name="Drupal.Commenting.HookComment"/>
    ...
  </rule>
</ruleset>
```

This won't work out of the box when a developer runs a coding standards check, since the "Drupal" standard is not found:

```
PHP Fatal error:  Uncaught PHP_CodeSniffer_Exception: Referenced sniff "Drupal" does not exist in ./vendor/squizlabs/php_codesniffer/CodeSniffer.php:1132
```

So a developer needs to either symlink the Drupal coding standard into the PHP CodeSniffer standards directory, or hack the original ruleset and hardcode the path to the standard:

```
<?xml version="1.0" encoding="UTF-8"?>
<ruleset name="drupal_core">
  <rule ref="/home/pieter/drupal/vendor/drupal/coder/coder_sniffer/Drupal">
    <exclude name="Drupal.Commenting.DocComment"/>
    <exclude name="Drupal.Commenting.FunctionComment"/>
    <exclude name="Drupal.Commenting.HookComment"/>
    ...
  </rule>
</ruleset>
```

With the `<rulesetdir>` directive that is proposed in this PR a developer can declare the location of the custom coding standard in their own ruleset, and include the original ruleset:

```
<?xml version="1.0" encoding="UTF-8"?>
<ruleset name="drupal_core">
  <rulesetdir dir="/home/pieter/drupal/vendor/drupal/coder/coder_sniffer/Drupal" />
  <rule ref="./phpcs-ruleset.xml.dist" />
</ruleset>
```
