### PR TITLE
'installed_paths' cannot be set for a rule in a custom ruleset

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -717,6 +717,19 @@ class PHP_CodeSniffer
             $ownSniffs = $this->_expandSniffDirectory($rulesetDir.DIRECTORY_SEPARATOR.'Sniffs', $depth);
         }
 
+        // Process custom sniff config settings.
+        foreach ($ruleset->{'config'} as $config) {
+            if ($this->_shouldProcessElement($config) === false) {
+                continue;
+            }
+
+            $this->setConfigData((string) $config['name'], (string) $config['value'], true);
+            if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                echo str_repeat("\t", $depth);
+                echo "\t=> set config value ".(string) $config['name'].': '.(string) $config['value'].PHP_EOL;
+            }
+        }
+
         foreach ($ruleset->rule as $rule) {
             if (isset($rule['ref']) === false
                 || $this->_shouldProcessElement($rule) === false
@@ -838,19 +851,6 @@ class PHP_CodeSniffer
             chdir($rulesetDir);
             $this->cli->setCommandLineValues($cliArgs);
             chdir($currentDir);
-        }
-
-        // Process custom sniff config settings.
-        foreach ($ruleset->{'config'} as $config) {
-            if ($this->_shouldProcessElement($config) === false) {
-                continue;
-            }
-
-            $this->setConfigData((string) $config['name'], (string) $config['value'], true);
-            if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                echo str_repeat("\t", $depth);
-                echo "\t=> set config value ".(string) $config['name'].': '.(string) $config['value'].PHP_EOL;
-            }
         }
 
         // Process custom ignore pattern rules.


### PR DESCRIPTION
When the `installed_paths` configuration option is used to specify the path of a rule that is used in a custom ruleset a fatal error occurs. This happens because the rule is processed before the configuration option is set, which causes the rule not to be found.

An example, if this custom ruleset is used the "Drupal" rule cannot be found even though it is located in the path specified in the config:

```
<?xml version="1.0" encoding="UTF-8"?>
<ruleset name="drupal_core">
  <config name="installed_paths" value="/home/pieter/drupal/vendor/drupal/coder/coder_sniffer/" />
  <rule ref="Drupal" /> 
</ruleset>
```

```
$ ../vendor/bin/phpcs -p
PHP Fatal error:  Uncaught PHP_CodeSniffer_Exception: Referenced sniff "Drupal" does not exist in /home/pieter/drupal/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1127
```

This is especially important when you want to override the path of a standard from a third party ruleset, such as in this case:

```
<?xml version="1.0" encoding="UTF-8"?>
<ruleset name="my_overrides">
  <config name="installed_paths" value="/path/to/my/overridden/standard/" />
  <rule ref="/path/to/original/phpcs.xml.dist" /> 
</ruleset>
```
