### PR TITLE
Require SimpleXML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
     "require": {
         "php": ">=5.1.2",
         "ext-tokenizer": "*",
-        "ext-xmlwriter": "*"
+        "ext-xmlwriter": "*",
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Since the code uses functions from the SimpleXML module
(simplexml_load_string), it should require it. Some distributions split
SimpleXML in a separate package (as Debian recently did), so being
explicit about used modules is helpful.

Bug-Debian: https://bugs.debian.org/816248