### PR TITLE
Preserve indentation from previous PHP block

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -177,7 +177,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
         $openScopes    = array();
         $adjustments   = array();
         $setIndents    = array();
-        $previousPhpBlockIndentation = 0;
+        $previousPhpBlockIndentation = null;
 
         $tokens  = $phpcsFile->getTokens();
         $first   = $phpcsFile->findFirstOnLine(T_INLINE_HTML, $stackPtr);
@@ -872,10 +872,10 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
 
                 // Verify if we must continue matching indentation from previous PHP block.
                 if ($this->observePreviousPhpBlockIndentation === true) {
-                    // Only if it's bigger than current tag indentation.
-                    if ($previousPhpBlockIndentation > $currentIndent) {
+                    // Only if there is any indentation saved from previous PHP block.
+                    if ($previousPhpBlockIndentation !== null) {
                         $currentIndent = $previousPhpBlockIndentation;
-                        $previousPhpBlockIndentation = 0;
+                        $previousPhpBlockIndentation = null;
                         if ($this->_debug === true) {
                             echo "\t=> reusing indentation of $currentIndent from previous PHP block".PHP_EOL;
                         }
@@ -904,7 +904,7 @@ class Generic_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Snif
 
                 // Verify if we must save indentation from current PHP block.
                 if ($this->observePreviousPhpBlockIndentation === true) {
-                    $previousPhpBlockIndentation = 0;
+                    $previousPhpBlockIndentation = null;
                     // Only if there are opened scopes.
                     if (empty($openScopes) === false) {
                         $previousPhpBlockIndentation = $currentIndent;

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc
@@ -1,0 +1,244 @@
+@codingStandardsChangeSetting Generic.WhiteSpace.ScopeIndent exact false
+@codingStandardsChangeSetting Generic.WhiteSpace.ScopeIndent observePreviousPhpBlockIndentation true
+<?php
+$a = 10;
+if ($condition) {
+    $ok = true;
+  $bad = true;
+      $okNonExact = true;
+    // Now we capture current indentation to be used in next php block
+    // (because there are open scopes).
+?>
+<span>here we want some html</span>
+<?php
+    $ok = true;
+  $bad = true;
+      $okNonExact = true;
+}
+// Have closed the scope, next PHP blocks are free to have any indentation.
+?>
+<span>here we want some html</span>
+    <?php require('ok.php'); ?>
+        <?php require('ok.php'); ?>
+            <?php require('ok.php'); ?>
+<?php require('ok.php'); ?>
+    <?php
+    if ($condition) {
+        $ok = true;
+    ?>
+    <span>here we want some html</span>
+    <?php
+    $bad = true;
+      $bad = true;
+        $ok = true;
+        if ($condition) {
+            $ok = true;
+        }
+    }
+    // The close tag must be aligned, hence next one fails.
+  ?>
+
+<?php
+// And, finally, it does not affect normal operations at all,
+// adding some picked from ScopeIndentUnitTest.1.inc to confirm
+// everything continues working ok.
+<?php
+class Test {
+    function __construct()
+    {
+       $this->hello();
+    }
+
+   function hello()
+    {
+        echo 'hello';
+}//end hello()
+
+    function hello2()
+    {
+       if (TRUE) {
+            echo 'hello'; // no error here as its more than 4 spaces.
+        } else {
+        echo 'bye';
+        }
+
+        while (TRUE) {
+           echo 'hello';
+         }
+
+       do {
+         echo 'hello';
+       } while (TRUE);
+   }
+
+    function hello3()
+    {
+        switch ($hello) {
+            case 'hello':
+            break;
+        }
+    }
+
+}
+
+?>
+<pre>
+</head>
+<body>
+<?php
+if ($form->validate()) {
+    $safe = $form->getSubmitValues();
+}
+?>
+</pre>
+<?php
+
+class Test2
+{
+    function __construct()
+    {
+    //    $this->open(); // error here
+    }
+
+    public function open()
+    {
+        // Some inline stuff that shouldn't error
+        if (TRUE) echo 'hello';
+        foreach ($tokens as $token) echo $token;
+    }
+
+    /**
+     * This is a comment 1.
+     * This is a comment 2.
+     * This is a comment 3.
+     * This is a comment 4.
+     */
+    public function close()
+    {
+        // All ok.
+        if (TRUE) {
+            if (TRUE) {
+            } else if (FALSE) {
+                foreach ($tokens as $token) {
+                    switch ($token) {
+                        case '1':
+                        case '2':
+                            if (true) {
+                                if (false) {
+                                    if (false) {
+                                        if (false) {
+                                            echo 'hello';
+                                        }
+                                    }
+                                }
+                            }
+                        break;
+                        case '5':
+                        break;
+                    }
+                    do {
+                        while (true) {
+                            foreach ($tokens as $token) {
+                                for ($i = 0; $i < $token; $i++) {
+                                    echo 'hello';
+                                }
+                            }
+                        }
+                    } while (true);
+                }
+            }
+        }
+    }
+
+    /*
+      This is another c style comment 1.
+      This is another c style comment 2.
+      This is another c style comment 3.
+      This is another c style comment 4.
+      This is another c style comment 5.
+    */
+
+    /* This is a T_COMMENT
+    *
+    *
+    *
+   */
+
+    /** This is a T_DOC_COMMENT
+   */
+
+    /*
+      This T_COMMENT has a newline in it.
+
+    */
+
+    public function read()
+    {
+        echo 'hello';
+
+        // no errors below.
+        $array = array(
+                  'this',
+                  'that' => array(
+                             'hello',
+                             'hello again' => array(
+                                               'hello',
+                                              ),
+                            ),
+                 );
+    }
+}
+
+abstract class Test3
+{
+    public function parse()
+    {
+
+        foreach ($t as $ndx => $token) {
+            if (is_array($token)) {
+                echo 'here';
+            } else {
+                $ts[] = array("token" => $token, "value" => '');
+
+                $last = count($ts) - 1;
+
+                switch ($token) {
+                    case '(':
+
+                        if ($last >= 3 &&
+                            $ts[0]['token'] != T_CLASS &&
+                            $ts[$last - 2]['token'] == T_OBJECT_OPERATOR &&
+                            $ts[$last - 3]['token'] == T_VARIABLE ) {
+
+
+                            if (true) {
+                                echo 'hello';
+                            }
+                        }
+                        array_push($braces, $token);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+public function test()
+{
+    $o = <<<EOF
+this is some text
+this is some text
+this is some text
+this is some text
+this is some text
+this is some text
+EOF;
+
+    return $o;
+}
+
+if ($a === true || $a === true || $a === true || $a === true ||
+    $a === true || $a === true || $a === true || $a === true) {
+
+    echo 'hello';
+}

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc
@@ -39,7 +39,7 @@ if ($condition) {
   ?>
 
 <?php
-// And, finally, it does not affect normal operations at all,
+// And, also, it does not affect normal operations at all,
 // adding some picked from ScopeIndentUnitTest.1.inc to confirm
 // everything continues working ok.
 <?php
@@ -241,4 +241,36 @@ if ($a === true || $a === true || $a === true || $a === true ||
     $a === true || $a === true || $a === true || $a === true) {
 
     echo 'hello';
+}
+// Some example from #907 leading to failures on
+// all the PHP indentations with the setting enabled.
+<?php
+if ($foo) {
+    foreach ($bar as $baz) {
+        if ($baz) {
+            ?>
+            <div>
+                <div>
+                    <div>
+<?php
+                    if ($baz > 1) {
+                        echo '1';
+                    }
+?>
+                    </div>
+        <?php
+                    if ($baz > 1) {
+                        echo '2';
+                    }
+        ?>
+                </div>
+                        <?php
+                if ($baz > 1) {
+                    echo '3';
+                }
+                        ?>
+            </div>
+            <?php
+        }
+    }
 }

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc.fixed
@@ -1,0 +1,244 @@
+@codingStandardsChangeSetting Generic.WhiteSpace.ScopeIndent exact false
+@codingStandardsChangeSetting Generic.WhiteSpace.ScopeIndent observePreviousPhpBlockIndentation true
+<?php
+$a = 10;
+if ($condition) {
+    $ok = true;
+    $bad = true;
+      $okNonExact = true;
+    // Now we capture current indentation to be used in next php block
+    // (because there are open scopes).
+?>
+<span>here we want some html</span>
+<?php
+    $ok = true;
+    $bad = true;
+      $okNonExact = true;
+}
+// Have closed the scope, next PHP blocks are free to have any indentation.
+?>
+<span>here we want some html</span>
+    <?php require('ok.php'); ?>
+        <?php require('ok.php'); ?>
+            <?php require('ok.php'); ?>
+<?php require('ok.php'); ?>
+    <?php
+    if ($condition) {
+        $ok = true;
+    ?>
+    <span>here we want some html</span>
+    <?php
+        $bad = true;
+        $bad = true;
+        $ok = true;
+        if ($condition) {
+            $ok = true;
+        }
+    }
+    // The close tag must be aligned, hence next one fails.
+    ?>
+
+<?php
+// And, finally, it does not affect normal operations at all,
+// adding some picked from ScopeIndentUnitTest.1.inc to confirm
+// everything continues working ok.
+<?php
+class Test {
+    function __construct()
+    {
+        $this->hello();
+    }
+
+    function hello()
+    {
+        echo 'hello';
+    }//end hello()
+
+    function hello2()
+    {
+        if (TRUE) {
+            echo 'hello'; // no error here as its more than 4 spaces.
+        } else {
+            echo 'bye';
+        }
+
+        while (TRUE) {
+            echo 'hello';
+        }
+
+        do {
+            echo 'hello';
+        } while (TRUE);
+    }
+
+    function hello3()
+    {
+        switch ($hello) {
+            case 'hello':
+            break;
+        }
+    }
+
+}
+
+?>
+<pre>
+</head>
+<body>
+<?php
+if ($form->validate()) {
+    $safe = $form->getSubmitValues();
+}
+?>
+</pre>
+<?php
+
+class Test2
+{
+    function __construct()
+    {
+        //    $this->open(); // error here
+    }
+
+    public function open()
+    {
+        // Some inline stuff that shouldn't error
+        if (TRUE) echo 'hello';
+        foreach ($tokens as $token) echo $token;
+    }
+
+    /**
+     * This is a comment 1.
+     * This is a comment 2.
+     * This is a comment 3.
+     * This is a comment 4.
+     */
+    public function close()
+    {
+        // All ok.
+        if (TRUE) {
+            if (TRUE) {
+            } else if (FALSE) {
+                foreach ($tokens as $token) {
+                    switch ($token) {
+                        case '1':
+                        case '2':
+                            if (true) {
+                                if (false) {
+                                    if (false) {
+                                        if (false) {
+                                            echo 'hello';
+                                        }
+                                    }
+                                }
+                            }
+                        break;
+                        case '5':
+                        break;
+                    }
+                    do {
+                        while (true) {
+                            foreach ($tokens as $token) {
+                                for ($i = 0; $i < $token; $i++) {
+                                    echo 'hello';
+                                }
+                            }
+                        }
+                    } while (true);
+                }
+            }
+        }
+    }
+
+    /*
+      This is another c style comment 1.
+      This is another c style comment 2.
+      This is another c style comment 3.
+      This is another c style comment 4.
+      This is another c style comment 5.
+    */
+
+    /* This is a T_COMMENT
+    *
+    *
+    *
+    */
+
+    /** This is a T_DOC_COMMENT
+   */
+
+    /*
+      This T_COMMENT has a newline in it.
+
+    */
+
+    public function read()
+    {
+        echo 'hello';
+
+        // no errors below.
+        $array = array(
+                  'this',
+                  'that' => array(
+                             'hello',
+                             'hello again' => array(
+                                               'hello',
+                                              ),
+                            ),
+                 );
+    }
+}
+
+abstract class Test3
+{
+    public function parse()
+    {
+
+        foreach ($t as $ndx => $token) {
+            if (is_array($token)) {
+                echo 'here';
+            } else {
+                $ts[] = array("token" => $token, "value" => '');
+
+                $last = count($ts) - 1;
+
+                switch ($token) {
+                    case '(':
+
+                        if ($last >= 3 &&
+                            $ts[0]['token'] != T_CLASS &&
+                            $ts[$last - 2]['token'] == T_OBJECT_OPERATOR &&
+                            $ts[$last - 3]['token'] == T_VARIABLE ) {
+
+
+                            if (true) {
+                                echo 'hello';
+                            }
+                        }
+                        array_push($braces, $token);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+public function test()
+{
+    $o = <<<EOF
+this is some text
+this is some text
+this is some text
+this is some text
+this is some text
+this is some text
+EOF;
+
+    return $o;
+}
+
+if ($a === true || $a === true || $a === true || $a === true ||
+    $a === true || $a === true || $a === true || $a === true) {
+
+    echo 'hello';
+}

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.4.inc.fixed
@@ -39,7 +39,7 @@ if ($condition) {
     ?>
 
 <?php
-// And, finally, it does not affect normal operations at all,
+// And, also, it does not affect normal operations at all,
 // adding some picked from ScopeIndentUnitTest.1.inc to confirm
 // everything continues working ok.
 <?php
@@ -241,4 +241,36 @@ if ($a === true || $a === true || $a === true || $a === true ||
     $a === true || $a === true || $a === true || $a === true) {
 
     echo 'hello';
+}
+// Some example from #907 leading to failures on
+// all the PHP indentations with the setting enabled.
+<?php
+if ($foo) {
+    foreach ($bar as $baz) {
+        if ($baz) {
+            ?>
+            <div>
+                <div>
+                    <div>
+<?php
+            if ($baz > 1) {
+                echo '1';
+            }
+?>
+                    </div>
+        <?php
+            if ($baz > 1) {
+                echo '2';
+            }
+        ?>
+                </div>
+                        <?php
+            if ($baz > 1) {
+                echo '3';
+            }
+                        ?>
+            </div>
+            <?php
+        }
+    }
 }

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -98,6 +98,32 @@ class Generic_Tests_WhiteSpace_ScopeIndentUnitTest extends AbstractSniffUnitTest
                    );
         }
 
+        if ($testFile === 'ScopeIndentUnitTest.4.inc') {
+            return array(
+                    7    => 1,
+                    15   => 1,
+                    31   => 1,
+                    32   => 1,
+                    39   => 1,
+                    // These are from ScopeIndentUnitTest.1.inc copy
+                    // to verify they continue behaving the same with
+                    // the setting enabled. (42 lines of displacement).
+                    49   => 1,
+                    52   => 1,
+                    55   => 1,
+                    59   => 1,
+                    62   => 1,
+                    66   => 1,
+                    67   => 1,
+                    69   => 1,
+                    70   => 1,
+                    71   => 1,
+                    72   => 1,
+                    100  => 1,
+                    165  => 1,
+                   );
+        }
+
         return array(
                 7    => 1,
                 10   => 1,

--- a/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -121,6 +121,14 @@ class Generic_Tests_WhiteSpace_ScopeIndentUnitTest extends AbstractSniffUnitTest
                     72   => 1,
                     100  => 1,
                     165  => 1,
+                    // Example showing PHP indentation takes always precedence
+                    // and open/close tags are ignored, not matter how they are incorrect.
+                    256  => 1,
+                    258  => 1,
+                    262  => 1,
+                    264  => 1,
+                    268  => 1,
+                    270  => 1,
                    );
         }
 


### PR DESCRIPTION
Right now all the T_OPEN/T_CLOSE tokens lead, unconditionally,
to the indentation being reset ~~to 0~~ to their level. In general, it works ok, but
there are standards that could prefer to enforce multiple blocks
indentation a bit harder.

There are situations where it may be desired to continue
checking indentation in a PHP block at the same level
the previous PHP block ended with. A classical example is
when you evaluate a condition in PHP, end the block, produce some
conditional output/html, just to continue in the next PHP block,
closing the condition scope or whatever.

This (opt-in) new setting (observePreviousPhpBlockIndentation) tries
to enforce that by looking for the indentation in the leaving block
when there are open scopes and applying it as default indentation in
the next incoming block. When there are not open scopes, there is no
restriction.

Covered with tests, the best I was able to imagine, adding a fraction of
ScopeIndentUnitTest.1.inc fixture to ensure it does not break normal
operations. I was not sure about the best way to cover that.

FYC, Ciao :-)