### PR TITLE
Adding CLI parameter to open files on desired editor 

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -269,10 +269,6 @@ class PHP_CodeSniffer
      */
     public static function autoload($className)
     {
-        if (class_exists($className, false) === true) {
-            return;
-        }
-        
         if (substr($className, 0, 4) === 'PHP_') {
             $newClassName = substr($className, 4);
         } else {

--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -269,6 +269,10 @@ class PHP_CodeSniffer
      */
     public static function autoload($className)
     {
+        if (class_exists($className, false) === true) {
+            return;
+        }
+        
         if (substr($className, 0, 4) === 'PHP_') {
             $newClassName = substr($className, 4);
         } else {
@@ -1796,11 +1800,12 @@ class PHP_CodeSniffer
             $reportData  = $this->reporting->prepareFileReport($phpcsFile);
             $reportClass->generateFileReport($reportData, $phpcsFile, $cliValues['showSources'], $cliValues['reportWidth']);
 
-            if (empty(PHP_CODESNIFFER_EDITOR_PATH)) {
+            if (empty(PHP_CODESNIFFER_EDITOR_PATH) === true) {
                 echo '<ENTER> to recheck, [s] to skip or [q] to quit : ';
             } else {
                 echo '<ENTER> to recheck, [s] to skip, [o] to open in editor or [q] to quit : ';
             }
+
             $input = fgets(STDIN);
             $input = trim($input);
 
@@ -1811,7 +1816,7 @@ class PHP_CodeSniffer
                 exit(0);
                 break;
             case 'o':
-                if (false == empty(PHP_CODESNIFFER_EDITOR_PATH)) {
+                if (false === empty(PHP_CODESNIFFER_EDITOR_PATH)) {
                     exec(PHP_CODESNIFFER_EDITOR_PATH.' '.$file);
                 }
                 break;

--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -135,6 +135,13 @@ class PHP_CodeSniffer
      * @var array
      */
     private $_tokenListeners = array();
+    
+    /**
+     * The editor path / command
+     *
+     * @var string|null
+     */
+    protected $editorPath = null;
 
     /**
      * An array of rules from the ruleset.xml file.
@@ -380,7 +387,18 @@ class PHP_CodeSniffer
 
 
     /**
-     * Sets the interactive flag.
+     * Sets the editor path / command
+     *
+     * @return string|null
+     */
+    public function getEditorPath()
+    {
+        return $this->editorPath;
+    }//end getEditorPath()
+
+
+    /**
+     * Sets the editor path / command
      *
      * @param string $path During interactive session will use this to open invalid files.
      *
@@ -388,11 +406,19 @@ class PHP_CodeSniffer
      */
     public function setEditorPath($path)
     {
-        if (defined('PHP_CODESNIFFER_EDITOR_PATH') === false) {
-            define('PHP_CODESNIFFER_EDITOR_PATH', $path);
-        }
-
+        $this->editorPath = $path;
     }//end setEditorPath()
+
+
+    /**
+     * Returns true if the editor path / command was set
+     *
+     * @return boolean
+     */
+    public function isEditorPathSet()
+    {
+        return false === empty($this->editorPath);
+    }//end isEditorPathSet()
 
 
     /**
@@ -1796,10 +1822,10 @@ class PHP_CodeSniffer
             $reportData  = $this->reporting->prepareFileReport($phpcsFile);
             $reportClass->generateFileReport($reportData, $phpcsFile, $cliValues['showSources'], $cliValues['reportWidth']);
 
-            if (empty(PHP_CODESNIFFER_EDITOR_PATH) === true) {
-                echo '<ENTER> to recheck, [s] to skip or [q] to quit : ';
-            } else {
+            if ($this->isEditorPathSet()) {
                 echo '<ENTER> to recheck, [s] to skip, [o] to open in editor or [q] to quit : ';
+            } else {
+                echo '<ENTER> to recheck, [s] to skip or [q] to quit : ';
             }
 
             $input = fgets(STDIN);
@@ -1812,8 +1838,8 @@ class PHP_CodeSniffer
                 exit(0);
                 break;
             case 'o':
-                if (false === empty(PHP_CODESNIFFER_EDITOR_PATH)) {
-                    exec(PHP_CODESNIFFER_EDITOR_PATH.' '.$file);
+                if ($this->isEditorPathSet()) {
+                    exec($this->getEditorPath().' '.$file);
                 }
                 break;
             default:

--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -380,6 +380,22 @@ class PHP_CodeSniffer
 
 
     /**
+     * Sets the interactive flag.
+     *
+     * @param string $path During interactive session will use this to open invalid files.
+     *
+     * @return void
+     */
+    public function setEditorPath($path)
+    {
+        if (defined('PHP_CODESNIFFER_EDITOR_PATH') === false) {
+            define('PHP_CODESNIFFER_EDITOR_PATH', $path);
+        }
+
+    }//end setEditorPath()
+
+
+    /**
      * Sets an array of file extensions that we will allow checking of.
      *
      * If the extension is one of the defaults, a specific tokenizer
@@ -1780,7 +1796,11 @@ class PHP_CodeSniffer
             $reportData  = $this->reporting->prepareFileReport($phpcsFile);
             $reportClass->generateFileReport($reportData, $phpcsFile, $cliValues['showSources'], $cliValues['reportWidth']);
 
-            echo '<ENTER> to recheck, [s] to skip or [q] to quit : ';
+            if (empty(PHP_CODESNIFFER_EDITOR_PATH)) {
+                echo '<ENTER> to recheck, [s] to skip or [q] to quit : ';
+            } else {
+                echo '<ENTER> to recheck, [s] to skip, [o] to open in editor or [q] to quit : ';
+            }
             $input = fgets(STDIN);
             $input = trim($input);
 
@@ -1789,6 +1809,11 @@ class PHP_CodeSniffer
                 break(2);
             case 'q':
                 exit(0);
+                break;
+            case 'o':
+                if (false == empty(PHP_CODESNIFFER_EDITOR_PATH)) {
+                    exec(PHP_CODESNIFFER_EDITOR_PATH.' '.$file);
+                }
                 break;
             default:
                 // Repopulate the sniffs because some of them save their state

--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -135,7 +135,7 @@ class PHP_CodeSniffer
      * @var array
      */
     private $_tokenListeners = array();
-    
+
     /**
      * The editor path / command
      *
@@ -394,6 +394,7 @@ class PHP_CodeSniffer
     public function getEditorPath()
     {
         return $this->editorPath;
+
     }//end getEditorPath()
 
 
@@ -407,6 +408,7 @@ class PHP_CodeSniffer
     public function setEditorPath($path)
     {
         $this->editorPath = $path;
+
     }//end setEditorPath()
 
 
@@ -418,6 +420,7 @@ class PHP_CodeSniffer
     public function isEditorPathSet()
     {
         return false === empty($this->editorPath);
+
     }//end isEditorPathSet()
 
 
@@ -1822,7 +1825,7 @@ class PHP_CodeSniffer
             $reportData  = $this->reporting->prepareFileReport($phpcsFile);
             $reportClass->generateFileReport($reportData, $phpcsFile, $cliValues['showSources'], $cliValues['reportWidth']);
 
-            if ($this->isEditorPathSet()) {
+            if ($this->isEditorPathSet() === true) {
                 echo '<ENTER> to recheck, [s] to skip, [o] to open in editor or [q] to quit : ';
             } else {
                 echo '<ENTER> to recheck, [s] to skip or [q] to quit : ';
@@ -1838,7 +1841,7 @@ class PHP_CodeSniffer
                 exit(0);
                 break;
             case 'o':
-                if ($this->isEditorPathSet()) {
+                if ($this->isEditorPathSet() === true) {
                     exec($this->getEditorPath().' '.$file);
                 }
                 break;

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -725,14 +725,15 @@ class PHP_CodeSniffer_CLI
                 $this->values['warningSeverity'] = (int) substr($arg, 17);
             } else if (substr($arg, 0, 12) === 'editor-path=') {
                 $value = substr($arg, 12);
-                if (preg_match('/^[\'\"]/', $value, $matches)) {
+                if (1 === preg_match('/^[\'\"]/', $value, $matches)) {
                     while (0 === preg_match("/[{$matches[0]}]$/", $value)) {
                         $value .= ' '.$this->_cliArgs[++$pos];
                         $this->_cliArgs[$pos] = '';
                     }
+
                     $value = substr($value, 1, -1);
                 }
-                
+
                 $this->values['editorPath'] = $value;
             } else if (substr($arg, 0, 7) === 'ignore=') {
                 // Split the ignore string on commas, unless the comma is escaped

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -286,6 +286,7 @@ class PHP_CodeSniffer_CLI
         $defaults['errorSeverity']   = null;
         $defaults['warningSeverity'] = null;
         $defaults['stdin']           = null;
+        $defaults['editorPath']      = null;
 
         $reportFormat = PHP_CodeSniffer::getConfigData('report_format');
         if ($reportFormat !== null) {
@@ -722,6 +723,17 @@ class PHP_CodeSniffer_CLI
                 $this->values['errorSeverity'] = (int) substr($arg, 15);
             } else if (substr($arg, 0, 17) === 'warning-severity=') {
                 $this->values['warningSeverity'] = (int) substr($arg, 17);
+            } else if (substr($arg, 0, 12) === 'editor-path=') {
+                $value = substr($arg, 12);
+                if (preg_match('/^[\'\"]/', $value, $matches)) {
+                    while (0 === preg_match("/[{$matches[0]}]$/", $value)) {
+                        $value .= ' '.$this->_cliArgs[++$pos];
+                        $this->_cliArgs[$pos] = '';
+                    }
+                    $value = substr($value, 1, -1);
+                }
+                
+                $this->values['editorPath'] = $value;
             } else if (substr($arg, 0, 7) === 'ignore=') {
                 // Split the ignore string on commas, unless the comma is escaped
                 // using 1 or 3 slashes (\, or \\\,).
@@ -865,6 +877,7 @@ class PHP_CodeSniffer_CLI
         $phpcs->setTabWidth($values['tabWidth']);
         $phpcs->setEncoding($values['encoding']);
         $phpcs->setInteractive($values['interactive']);
+        $phpcs->setEditorPath($values['editorPath']);
 
         // Set file extensions if they were specified. Otherwise,
         // let PHP_CodeSniffer decide on the defaults.
@@ -1205,7 +1218,7 @@ class PHP_CodeSniffer_CLI
      */
     public function printPHPCSUsage()
     {
-        echo 'Usage: phpcs [-nwlsaepvi] [-d key[=value]] [--colors] [--no-colors]'.PHP_EOL;
+        echo 'Usage: phpcs [-nwlsaepvi] [-d key[=value]] [--colors] [--no-colors] [--editor-path=<path>]'.PHP_EOL;
         echo '    [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>] ...'.PHP_EOL;
         echo '    [--report-width=<reportWidth>] [--generator=<generator>] [--tab-width=<tabWidth>]'.PHP_EOL;
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -726,8 +726,8 @@ class PHP_CodeSniffer_CLI
             } else if (substr($arg, 0, 12) === 'editor-path=') {
                 $value = substr($arg, 12);
                 if (1 === preg_match('/^[\'\"]/', $value, $matches)) {
-                    while (0 === preg_match("/[{$matches[0]}]$/", $value)) {
-                        $value .= ' '.$this->_cliArgs[++$pos];
+                    while ((0 === preg_match("/[{$matches[0]}]$/", $value)) && (isset($this->_cliArgs[++$pos]) === true)) {
+                        $value .= ' '.$this->_cliArgs[$pos];
                         $this->_cliArgs[$pos] = '';
                     }
 


### PR DESCRIPTION
Solution for #925 

One thing: I was unable to run phpunit tests during Composer and Codesinffer autoloader interaction - given the error:
```
PHP Fatal error:  Cannot redeclare class Symfony2_Tests_Formatting_BlankLineBeforeReturnUnitTest in CodeSniffer/Standards/Symfony2DomenyPL/Tests/Formatting/BlankLineBeforeReturnUnitTest.php on line 59
PHP Stack trace:
PHP   1. {main}() vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main($exit = *uninitialized*) vendor/phpunit/phpunit/phpunit:47
PHP   3. PHPUnit_TextUI_Command->run($argv = *uninitialized*, $exit = *uninitialized*) vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_Runner_BaseTestRunner->getTest($suiteClassName = *uninitialized*, $suiteClassFile = *uninitialized*, $suffixes = *uninitialized*) vendor/phpunit/phpunit/src/TextUI/Command.php:123
PHP   5. ReflectionMethod->invoke(*uninitialized*, *uninitialized*) vendor/phpunit/phpunit/src/Runner/BaseTestRunner.php:86
PHP   6. PHP_CodeSniffer_AllTests::suite(*uninitialized*) vendor/phpunit/phpunit/src/Runner/BaseTestRunner.php:86
PHP   7. PHP_CodeSniffer_Standards_AllSniffs::suite() tests/AllTests.php:77
PHP   8. PHPUnit_Framework_TestSuite->addTestSuite($testClass = *uninitialized*) tests/Standards/AllSniffs.php:118
PHP   9. class_exists(*uninitialized*) vendor/phpunit/phpunit/src/Framework/TestSuite.php:264
PHP  10. spl_autoload_call(*uninitialized*) vendor/phpunit/phpunit/src/Framework/TestSuite.php:264
PHP  11. PHP_CodeSniffer::autoload($className = *uninitialized*) vendor/phpunit/phpunit/src/Framework/TestSuite.php:264
```
I believe, that my changes are located in those files not covered by tests and this is tested and used by me in everyday job tasks.