### PR TITLE
Add Composer standards installer plugin.

### DIFF
--- a/CodeSniffer/ComposerInstaller.php
+++ b/CodeSniffer/ComposerInstaller.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Composer installer class to handle installation of additional standards.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+use Composer\Installer\LibraryInstaller;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+
+/**
+ * Composer installer class to handle installation of additional standards.
+ *
+ * This makes sure that Composer packages of type
+ * `phpcs-standard` are installed in the correct subfolder.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Alain Schlesser <alain.schlesser@gmail.com>
+ * @copyright 2006-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PHP_CodeSniffer_ComposerInstaller extends LibraryInstaller
+{
+
+    const EXTRA_KEY      = 'standards';
+    const STANDARDS_PATH = '../php_codesniffer/CodeSniffer/Standards/';
+    const TYPE           = 'phpcs-standard';
+
+
+    /**
+     * Install the package.
+     *
+     * @param InstalledRepositoryInterface $repo    The repository from where the package was fetched.
+     * @param PackageInterface             $package The package to install.
+     *
+     * @return void
+     */
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        $installPath = $this->getInstallPath($package);
+
+        if ($this->io->isVerbose() === true) {
+            $this->io->write(
+                sprintf(
+                    _('Symlinking PHPCS standards package %1$s'),
+                    $installPath
+                ),
+                true
+            );
+        }
+
+        parent::install($repo, $package);
+
+        foreach ($this->getStandards($package) as $standardName => $standardPath) {
+            $this->linkStandard(
+                $standardName,
+                $installPath.DIRECTORY_SEPARATOR.$standardPath
+            );
+        }
+
+    }//end install()
+
+
+    /**
+     * Whether the installer supports a given package type.
+     *
+     * @param string $packageType Type of the package to check support for.
+     *
+     * @return bool Whether the package is supported.
+     */
+    public function supports($packageType)
+    {
+        return self::TYPE === $packageType;
+
+    }//end supports()
+
+
+    /**
+     * Get the list of standards to add.
+     *
+     * @param PackageInterface $package The package for which to retrieve the standards.
+     *
+     * @return array List of standards.
+     */
+    protected function getStandards(PackageInterface $package)
+    {
+        $extraData = $package->getExtra();
+
+        // Bail early if no "extra" key found.
+        if (empty($extraData) === true) {
+            return array();
+        }
+
+        // Bail early if "extra" key does not contain "standards" key.
+        if (array_key_exists(self::EXTRA_KEY, $extraData) === false) {
+            return array();
+        }
+
+        return (array) $extraData[self::EXTRA_KEY];
+
+    }//end getStandards()
+
+
+    /**
+     * Link a standard to the PHPCS installation.
+     *
+     * @param string $name Name of the standard.
+     * @param string $path Relative path of the standard.
+     *
+     * @return void
+     */
+    protected function linkStandard($name, $path)
+    {
+        if ($this->io->isVeryVerbose() === true) {
+            $this->io->write(
+                sprintf(
+                    _('Symlinking standard "%1$s" to path "%2$s"'),
+                    $name,
+                    $path
+                ),
+                true
+            );
+        }
+
+        $linkPath = getcwd().DIRECTORY_SEPARATOR.self::STANDARDS_PATH.$name;
+
+        $this->filesystem->relativeSymlink($path, $linkPath);
+
+    }//end linkStandard()
+
+
+}//end class

--- a/CodeSniffer/ComposerInstaller.php
+++ b/CodeSniffer/ComposerInstaller.php
@@ -34,7 +34,7 @@ use Composer\Repository\InstalledRepositoryInterface;
 class PHP_CodeSniffer_ComposerInstaller extends LibraryInstaller
 {
 
-    const EXTRA_KEY      = 'standards';
+    const EXTRA_KEY      = 'phpcs-standards';
     const STANDARDS_PATH = '../php_codesniffer/CodeSniffer/Standards/';
     const TYPE           = 'phpcs-standard';
 

--- a/CodeSniffer/ComposerPlugin.php
+++ b/CodeSniffer/ComposerPlugin.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Composer plugin class to register the Composer standards installer.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+/**
+ * Composer plugin class to register the Composer standards installer.
+ *
+ * This registers the Composer installer that is responsible for
+ * installing standards into the correct folder.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Alain Schlesser <alain.schlesser@gmail.com>
+ * @copyright 2006-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PHP_CodeSniffer_ComposerPlugin implements PluginInterface
+{
+
+
+    /**
+     * Activate the Composer plugin.
+     *
+     * @param Composer    $composer Reference to the Composer instance.
+     * @param IOInterface $io       Reference to the IO interface.
+     *
+     * @return void
+     */
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $installer = new PHP_CodeSniffer_ComposerInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($installer);
+
+    }//end activate()
+
+
+}//end class

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "squizlabs/php_codesniffer",
     "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-    "type": "library",
+    "type": "composer-plugin",
     "keywords": [
         "phpcs",
         "standards"
@@ -22,12 +22,15 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"
-        }
+        },
+        "class": "PHP_CodeSniffer_ComposerPlugin"
     },
     "autoload": {
         "classmap": [
             "CodeSniffer.php",
             "CodeSniffer/CLI.php",
+            "CodeSniffer/ComposerInstaller.php",
+            "CodeSniffer/ComposerPlugin.php",
             "CodeSniffer/Exception.php",
             "CodeSniffer/File.php",
             "CodeSniffer/Fixer.php",
@@ -55,7 +58,8 @@
         "php": ">=5.1.2",
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*",
-        "ext-simplexml": "*"
+        "ext-simplexml": "*",
+        "composer-plugin-api": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
This turns the Composer package into a plugin that comes with a custom installer that can install packages of type `phpcs-standard`.

A package that is of type `phpcs-standard` will need to have an `extra` key `standards` that contains an array of entries in the following format:

``` JSON
    "extra"      : {
        "standards": {
            "<standard name 1>" : "<standard path 1>",
            "<standard name 2>" : "<standard path 2>"
        }
    }
```

The `<standard path>` is relative to the package root of the standard package.

For each of the standards defined in this way, the installer will create a symlink in `CodeSniffer/Standards/<standard name>` that points back to the corresponding standard.
