### PR TITLE
Shebang can cause PSR1 SideEffects warning

### DIFF
--- a/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -119,6 +119,11 @@ class PSR1_Sniffs_Files_SideEffectsSniff implements PHP_CodeSniffer_Sniff
                 continue;
             }
 
+            // Ignore shebang.
+            if (substr($tokens[$i]['content'], 0, 2) === '#!') {
+                continue;
+            }
+
             // Ignore entire namespace, declare, const and use statements.
             if ($tokens[$i]['code'] === T_NAMESPACE
                 || $tokens[$i]['code'] === T_USE

--- a/CodeSniffer/Standards/PSR1/Tests/Files/SideEffectsUnitTest.7.inc
+++ b/CodeSniffer/Standards/PSR1/Tests/Files/SideEffectsUnitTest.7.inc
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+
+//some code
+function foo()
+{
+    return 'bar';
+}


### PR DESCRIPTION
I found another spot where the [issue 20481 reported through PEAR](https://pear.php.net/bugs/bug.php?id=20481) occurred during a PSR2 sniff. A PHP script beginning with shebang but containing only comments does not trigger it, but a script defining symbols will trigger the `PSR1.Files.SideEffects.FoundWithSymbols` warning.

```
A file should declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it should execute logic with side effects, but should not do both. The first symbol is defined on line 5 and the first side effect is on line 1. (PSR1.Files.SideEffects.FoundWithSymbols)
```

This patch fixes that issue in a similar way to the approach found in the commit addressing issue 20481.