### PR TITLE
Throw tag sniff supporting re-thrown exceptions

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -97,8 +97,15 @@ class Squiz_Sniffs_Commenting_FunctionCommentThrowTagSniff extends PHP_CodeSniff
             while ($currPos < $currScopeEnd && $currPos !== false) {
                 /*
                     If we can't find a NEW, we are probably throwing
-                    a variable, so we ignore it, but they still need to
-                    provide at least one @throws tag, even through we
+                    a variable.
+
+                    If we're throwing the same variable as the exception container
+                    from the nearest 'catch' block, we take that exception, as it is
+                    likely to be a re-throw.
+
+                    If we can't find a matching catch block, or the variable name
+                    is different, it's probably a different variable, so we ignore it,
+                    but they still need to provide at least one @throws tag, even through we
                     don't know the exception class.
                 */
 
@@ -134,6 +141,60 @@ class Squiz_Sniffs_Commenting_FunctionCommentThrowTagSniff extends PHP_CodeSniff
                         } else {
                             $throwTokens[] = $phpcsFile->getTokensAsString($currException, ($endException - $currException));
                         }
+                    }//end if
+                } else if ($tokens[$nextToken]['code'] === T_VARIABLE) {
+                    // Find where the nearest 'catch' block in this scope.
+                    $catch = $phpcsFile->findPrevious(
+                        T_CATCH,
+                        $currPos,
+                        $tokens[$currScope]['scope_opener'],
+                        false,
+                        null,
+                        false
+                    );
+
+                    if ($catch !== false) {
+                        // Get the start of the 'catch' exception.
+                        $currException = $phpcsFile->findNext(
+                            array(
+                             T_NS_SEPARATOR,
+                             T_STRING,
+                            ),
+                            $tokens[$catch]['parenthesis_opener'],
+                            $tokens[$catch]['parenthesis_closer'],
+                            false,
+                            null,
+                            true
+                        );
+
+                        if ($currException !== false) {
+                            // Find the next whitespace (which should be the end of the exception).
+                            $endException = $phpcsFile->findNext(
+                                T_WHITESPACE,
+                                ($currException + 1),
+                                $tokens[$catch]['parenthesis_closer'],
+                                false,
+                                null,
+                                true
+                            );
+
+                            if ($endException !== false) {
+                                // Find the variable that we're catching into.
+                                $thrownVar = $phpcsFile->findNext(
+                                    T_VARIABLE,
+                                    ($endException + 1),
+                                    $tokens[$catch]["parenthesis_closer"],
+                                    false,
+                                    null,
+                                    true
+                                );
+
+                                // Sanity check that the variable that the exception is caught into is the one that's thrown.
+                                if ($tokens[$thrownVar]['content'] === $tokens[$nextToken]['content']) {
+                                    $throwTokens[] = $phpcsFile->getTokensAsString($currException, ($endException - $currException));
+                                }//end if
+                            }//end if
+                        }//end if
                     }//end if
                 }//end if
 

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
@@ -192,7 +192,43 @@ class FunctionCommentThrowTagUnitTest
 
     }//end okFunction
 
+    /**
+     * Needs at throws tag for rethrown exception,
+     * even though we have one throws tag.
+     *
+     * @throws PHP_Exception1
+     */
+    public function notOkVariableRethrown()
+    {
+        throw new PHP_Exception1('Error');
 
+        try {
+            // Do something.
+        } catch (PHP_Exception2 $e) {
+            logError();
+            throw $e;
+        }
+
+    }//end notOkVariableRethrown()
+
+    /**
+     * Has correct throws tags for all exceptions
+     *
+     * @throws PHP_Exception1
+     * @throws PHP_Exception2
+     */
+    public function okVariableRethrown()
+    {
+        throw new PHP_Exception1('Error');
+
+        try {
+            // Do something.
+        } catch (PHP_Exception2 $e) {
+            logError();
+            throw $e;
+        }
+
+    }//end okVariableRethrown()
 }//end class
 
 class NamespacedException {

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -54,7 +54,8 @@ class Squiz_Tests_Commenting_FunctionCommentThrowTagUnitTest extends AbstractSni
                 61  => 2,
                 106 => 1,
                 123 => 1,
-                215 => 1,
+                200 => 1,
+                251 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
This update lets PHPCS detect when an exception is caught and re-thrown as a variable. It requires the re-thrown exception to be explicitly listed in the function comment, and avoids problems where re-thrown exceptions are listed correctly, but show PHPCS errors as excessive `@throws` tags.

For example, this would now be valid:

``` php
/**
 * Calls a function that may raise an exception, or may return false. In either instance, raise an exception
 *
 * @throws NewException When a brand new exception is thrown.
 * @throws OldException When an exception is caught and re-thrown.
 */
function thisThrowsExceptions() {
    try {
        $val = mightThrowExceptions();
    } catch (OldException $e) {
        throw $e;
    }

    if ($val === false) {
        throw new NewException('$val is false');
    }

    // The rest of the code.
}
```
