### PR TITLE
Allow multiple default_standard values in CodeSniffer.conf

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -1079,7 +1079,7 @@ class PHP_CodeSniffer_CLI
                 $standard = 'PEAR';
             }
 
-            return array($standard);
+            return explode(',', $standard);
         }//end if
 
         $cleaned   = array();


### PR DESCRIPTION
This PR fixes the following weird behavior:
```sh
$ phpcs --standard=PSR1,PSR2 src/
$ phpcs --config-set default_standard PSR1,PSR2
Config value "default_standard" added successfully
$ phpcs src/
ERROR: the "PSR1,PSR2" coding standard is not installed. The installed coding standards are PSR2, PHPCS, PEAR, PSR1, MySource, Squiz and Zen
```