### PR TITLE
Distinguish MemberVar reference sniffs from local variable sniffs. (issue 810)

### DIFF
--- a/CodeSniffer/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/CodeSniffer/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -101,11 +101,11 @@ class Zend_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSniff
                     if (PHP_CodeSniffer::isCamelCaps($objVarName, false, true, false) === false) {
                         $error = 'Variable "%s" is not in valid camel caps format';
                         $data  = array($originalVarName);
-                        $phpcsFile->addError($error, $var, 'NotCamelCaps', $data);
+                        $phpcsFile->addError($error, $var, 'MemberVarNotCamelCaps', $data);
                     } else if (preg_match('|\d|', $objVarName) === 1) {
                         $warning = 'Variable "%s" contains numbers but this is discouraged';
                         $data    = array($originalVarName);
-                        $phpcsFile->addWarning($warning, $stackPtr, 'ContainsNumbers', $data);
+                        $phpcsFile->addWarning($warning, $stackPtr, 'MemberVarContainsNumbers', $data);
                     }
                 }//end if
             }//end if


### PR DESCRIPTION
See #810

Update the reported sniff for member variable references to actually claim to be member variable references so that they can be appropriately filtered as such.

The second of the options suggested in https://github.com/squizlabs/PHP_CodeSniffer/issues/810#issuecomment-209101675
