### PR TITLE
Fixed bug #959 : Call-time pass-by-reference false positive if there is a square bracket before the ampersand

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
@@ -140,6 +140,7 @@ class Generic_Sniffs_Functions_CallTimePassByReferenceSniff implements PHP_CodeS
                 $tokenCode = $tokens[$tokenBefore]['code'];
                 if ($tokenCode === T_VARIABLE
                     || $tokenCode === T_CLOSE_PARENTHESIS
+                    || $tokenCode === T_CLOSE_SQUARE_BRACKET
                     || $tokenCode === T_LNUMBER
                     || isset(PHP_CodeSniffer_Tokens::$assignmentTokens[$tokenCode]) === true
                 ) {

--- a/CodeSniffer/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Functions/CallTimePassByReferenceUnitTest.inc
@@ -28,3 +28,6 @@ if (is_array($foo = &$this->bar())) {
 Hooks::run( 'SecondaryDataUpdates', [ $title, $old, $recursive, $parserOutput, &$updates ] );
 
 $foo = Bar(&$fooBar);
+
+myfunc($myvar&$myvar);
+myfunc($myvar[0]&$myvar);


### PR DESCRIPTION
Fixes issue #959 