### PR TITLE
Added ignoreNewlines parameter to Squiz.WhiteSpace.ObjectOperatorSpacing

### DIFF
--- a/CodeSniffer/Standards/Generic/Docs/Formatting/AlphabeticalPropertyNamesStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/Formatting/AlphabeticalPropertyNamesStandard.xml
@@ -1,0 +1,31 @@
+<documentation title="Alphabetical Property Names">
+    <standard>
+    <![CDATA[
+    Property names must be declared in alphabetical order.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Properties are declared in alphabetical order.">
+        <![CDATA[
+class Foo
+{
+    protected $_a = null;
+    protected $a = null;
+    protected $b = null;
+    protected $c = null;
+}
+        ]]>
+        </code>
+        <code title="Invalid: Properties are not declared in alphabetical order.">
+        <![CDATA[
+class Foo
+{
+    protected $c = null;
+    protected $a = null;
+    protected $_a = null;
+    protected $b = null;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/CodeSniffer/Standards/Generic/Sniffs/Formatting/AlphabeticalPropertyNamesSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Formatting/AlphabeticalPropertyNamesSniff.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Generic_Sniffs_Formatting_AlphabeticalPropertyNamesSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alex Howansky <alex.howansky@gmail.com>
+ * @copyright 2016 Alex Howansky (https://github.com/AlexHowansky)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Generic_Sniffs_Formatting_AlphabeticalPropertyNamesSniff.
+ *
+ * Ensures class properties are declared in alphabetical order.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alex Howansky <alex.howansky@gmail.com>
+ * @copyright 2016 Alex Howansky (https://github.com/AlexHowansky)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_Formatting_AlphabeticalPropertyNamesSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * Track the last property name we encountered.
+     *
+     * @var string
+     */
+    protected $lastPropertyName = null;
+
+
+    /**
+     * Register the tokens we're interested in.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_CLASS,
+                T_INTERFACE,
+                T_TRAIT,
+                T_VARIABLE,
+               );
+
+    }//end register()
+
+
+    /**
+     * Process a token.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens()[$stackPtr];
+
+        // In case we have more than one class/interface/trait
+        // per file, we want to reset at the start of each.
+        if ($tokens['code'] !== T_VARIABLE) {
+            $this->lastPropertyName = null;
+            return;
+        }
+
+        // We only care about class properties, so ignore global
+        // variables (level 0) and method variables (level 2).
+        if ($tokens['level'] === 1) {
+            $propertyName = substr($tokens['content'], 1);
+            if ($this->lastPropertyName !== null && $propertyName <= $this->lastPropertyName) {
+                $phpcsFile->addError('Property "%s" is not in alphabetical order.', $stackPtr, 'Found', [$propertyName]);
+            }
+
+            $this->lastPropertyName = $propertyName;
+        }
+
+    }//end process()
+
+
+}//end class

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/AlphabeticalPropertyNamesUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/AlphabeticalPropertyNamesUnitTest.inc
@@ -1,0 +1,63 @@
+<?php
+
+$b = 0;
+$a = 0;
+
+class Foo
+{
+    protected $_a;
+    protected $a;
+    protected $b;
+    public function foo()
+    {
+        $b = 0;
+        $a = 0;
+    }
+    protected $c;
+    public function bar()
+    {
+        $b = 0;
+        $a = 0;
+    }
+    protected $d;
+}
+
+$b = 0;
+$a = 0;
+
+abstract class Bar
+{
+    protected $a;
+    protected $_a;
+    protected $b;
+    protected $e;
+    public function foo()
+    {
+        $b = 0;
+        $a = 0;
+    }
+    protected $d;
+    protected $c;
+}
+
+$b = 0;
+$a = 0;
+
+interface FooInterface
+{
+    public $a;
+    public $c;
+    public $b;
+}
+
+$b = 0;
+$a = 0;
+
+trait FooTrait
+{
+    public $a;
+    public $c;
+    public $b;
+}
+
+?>

--- a/CodeSniffer/Standards/Generic/Tests/Formatting/AlphabeticalPropertyNamesUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Formatting/AlphabeticalPropertyNamesUnitTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Unit test class for the AlphabeticalPropertyNames sniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alex Howansky <alex.howansky@gmail.com>
+ * @copyright 2016 Alex Howansky (https://github.com/AlexHowansky)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the SpaceAfterCast sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Alex Howansky <alex.howansky@gmail.com>
+ * @copyright 2016 Alex Howansky (https://github.com/AlexHowansky)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Tests_Formatting_AlphabeticalPropertyNamesUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array(
+                31 => 1,
+                39 => 1,
+                40 => 1,
+                50 => 1,
+                60 => 1,
+               );
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class
+
+?>

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -30,6 +30,13 @@
 class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSniffer_Sniff
 {
 
+    /**
+     * Allow newlines instead of spaces.
+     *
+     * @var boolean
+     */
+    public $ignoreNewlines = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -78,7 +85,9 @@ class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSnif
         $phpcsFile->recordMetric($stackPtr, 'Spacing before object operator', $before);
         $phpcsFile->recordMetric($stackPtr, 'Spacing after object operator', $after);
 
-        if ($before !== 0) {
+        if ($before !== 0
+            && ($before !== 'newline' || $this->ignoreNewlines === false)
+        ) {
             $error = 'Space found before object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Before');
             if ($fix === true) {
@@ -86,7 +95,9 @@ class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSnif
             }
         }
 
-        if ($after !== 0) {
+        if ($after !== 0
+            && ($after !== 'newline' || $this->ignoreNewlines === false)
+        ) {
             $error = 'Space found after object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'After');
             if ($fix === true) {

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
@@ -8,3 +8,13 @@ $this
     ->testThis();
 $this->
     testThis();
+// @codingStandardsChangeSetting Squiz.WhiteSpace.ObjectOperatorSpacing ignoreNewlines true
+$this->testThis();
+$this-> testThis();
+$this    ->  testThis();
+$this->/* comment here */testThis();
+$this/* comment here */ -> testThis();
+$this
+    ->testThis();
+$this->
+    testThis();

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -48,6 +48,9 @@ class Squiz_Tests_WhiteSpace_ObjectOperatorSpacingUnitTest extends AbstractSniff
                 6 => 2,
                 8 => 1,
                 9 => 1,
+                13 => 1,
+                14 => 2,
+                16 => 2,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Mimics the behavior of the same-named parameter in the Squiz.WhiteSpace.OperatorSpacing sniff.