### PR TITLE
Exception to the newline requirement on the first member var after class opener.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -42,6 +42,7 @@ class Squiz_Sniffs_WhiteSpace_MemberVarSpacingSniff extends PHP_CodeSniffer_Stan
      */
     public $firstVarException = false;
 
+
     /**
      * Processes the function tokens within the class.
      *
@@ -106,8 +107,8 @@ class Squiz_Sniffs_WhiteSpace_MemberVarSpacingSniff extends PHP_CodeSniffer_Stan
         $prev       = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($first - 1), null, true);
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
 
-		// Exception to the newline requirement on the first member var after class opener.
-        if($this->firstVarException) {
+        // Exception to the newline requirement on the first member var after class opener.
+        if ($this->firstVarException === true) {
             if ($foundLines > 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET) {
                 $error = 'Expected 0 blank lines before first member var; %s found';
                 $data  = array($foundLines);
@@ -118,18 +119,21 @@ class Squiz_Sniffs_WhiteSpace_MemberVarSpacingSniff extends PHP_CodeSniffer_Stan
                         if ($tokens[$i]['line'] === $tokens[$prev]['line']) {
                             continue;
                         }
+
                         if ($tokens[$i]['line'] === $tokens[$first]['line']) {
                             break;
                         }
+
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-		}
-		if ($foundLines === 1 || ($this->firstVarException && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
-			return;
-		}
+        }
+
+        if ($foundLines === 1 || ($this->firstVarException === true && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
+            return;
+        }
 
         $error = 'Expected 1 blank line before member var; %s found';
         $data  = array($foundLines);

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -126,10 +126,11 @@ class Squiz_Sniffs_WhiteSpace_MemberVarSpacingSniff extends PHP_CodeSniffer_Stan
 
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
+
                     $phpcsFile->fixer->endChangeset();
-                }
-            }
-        }
+                }//end if
+            }//end if
+        }//end if
 
         if ($foundLines === 1 || ($this->firstVarException === true && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
             return;

--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -107,34 +107,27 @@ class Squiz_Sniffs_WhiteSpace_MemberVarSpacingSniff extends PHP_CodeSniffer_Stan
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
 
 		// Exception to the newline requirement on the first member var after class opener.
-		if($this->firstVarException)
-		{
-    		if ($foundLines > 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)
-    		{
-    			$error = 'Expected 0 blank lines before first member var; %s found';
-    			$data  = array($foundLines);
-    			$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FirstMember', $data);
-    			if ($fix === true)
-    			{
-    				$phpcsFile->fixer->beginChangeset();
-    				for ($i = ($prev + 1); $i < $first; $i++)
-    				{
-    					if ($tokens[$i]['line'] === $tokens[$prev]['line'])
-    					{
-    						continue;
-    					}
-    					if ($tokens[$i]['line'] === $tokens[$first]['line'])
-    					{
-    						break;
-    					}
-    					$phpcsFile->fixer->replaceToken($i, '');
-    				}
-    				$phpcsFile->fixer->endChangeset();
-    			}
-    		}
+        if($this->firstVarException) {
+            if ($foundLines > 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET) {
+                $error = 'Expected 0 blank lines before first member var; %s found';
+                $data  = array($foundLines);
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FirstMember', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($prev + 1); $i < $first; $i++) {
+                        if ($tokens[$i]['line'] === $tokens[$prev]['line']) {
+                            continue;
+                        }
+                        if ($tokens[$i]['line'] === $tokens[$first]['line']) {
+                            break;
+                        }
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
 		}
-		if ($foundLines === 1 || ($this->firstVarException && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET))
-		{
+		if ($foundLines === 1 || ($this->firstVarException && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
 			return;
 		}
 


### PR DESCRIPTION
Based on the draft PHPCS2 Joomla Custom member var sniff https://github.com/photodude/coding-standards/blob/phpcs-2/Joomla/Sniffs/WhiteSpace/MemberVarSpacingSniff.php#L102-L137

Addresses issues #920 and #725
