### PR TITLE
Added ignoreNewlines parameter to Squiz.WhiteSpace.ObjectOperatorSpacing

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -30,6 +30,13 @@
 class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSniffer_Sniff
 {
 
+    /**
+     * Allow newlines instead of spaces.
+     *
+     * @var boolean
+     */
+    public $ignoreNewlines = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -78,7 +85,9 @@ class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSnif
         $phpcsFile->recordMetric($stackPtr, 'Spacing before object operator', $before);
         $phpcsFile->recordMetric($stackPtr, 'Spacing after object operator', $after);
 
-        if ($before !== 0) {
+        if ($before !== 0
+            && ($before !== 'newline' || $this->ignoreNewlines === false)
+        ) {
             $error = 'Space found before object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Before');
             if ($fix === true) {
@@ -86,7 +95,9 @@ class Squiz_Sniffs_WhiteSpace_ObjectOperatorSpacingSniff implements PHP_CodeSnif
             }
         }
 
-        if ($after !== 0) {
+        if ($after !== 0
+            && ($after !== 'newline' || $this->ignoreNewlines === false)
+        ) {
             $error = 'Space found after object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'After');
             if ($fix === true) {

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
@@ -8,3 +8,13 @@ $this
     ->testThis();
 $this->
     testThis();
+// @codingStandardsChangeSetting Squiz.WhiteSpace.ObjectOperatorSpacing ignoreNewlines true
+$this->testThis();
+$this-> testThis();
+$this    ->  testThis();
+$this->/* comment here */testThis();
+$this/* comment here */ -> testThis();
+$this
+    ->testThis();
+$this->
+    testThis();

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -48,6 +48,9 @@ class Squiz_Tests_WhiteSpace_ObjectOperatorSpacingUnitTest extends AbstractSniff
                 6 => 2,
                 8 => 1,
                 9 => 1,
+                13 => 1,
+                14 => 2,
+                16 => 2,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
The Squiz.WhiteSpace.OperatorSpacing sniff has a parameter named ignoreNewlines. Thus, I can disallow:

`$a = $b+$c+$d;`

While allowing:

```
$a =
    $b +
    $c +
    $d;
```

I would like to do the same for object operators, and disallow:

`$foo -> bar() -> baz();`

While allowing:

```
$foo
    ->bar()
    ->baz();
```

However, the Squiz.WhiteSpace.ObjectOperatorSpacing sniff does not have an ignoreNewlines parameter, so the latter is always flagged.

This is an enhancement request to add an ignoreNewlines parameter to the Squiz.WhiteSpace.ObjectOperatorSpacing sniff. Thanks.