### PR TITLE
Allow input paths / files to be passed in a file

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -1254,7 +1254,7 @@ class PHP_CodeSniffer_CLI
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
         echo '    [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]'.PHP_EOL;
         echo '    [--standard=<standard>] [--sniffs=<sniffs>] [--encoding=<encoding>]'.PHP_EOL;
-        echo '    [--extensions=<extensions>] [--ignore=<patterns>] [--bootstrap=<bootstrap>] <file> ...'.PHP_EOL;
+        echo '    [--extensions=<extensions>] [--ignore=<patterns>] [--bootstrap=<bootstrap>] [--file-list=<fileList>] <file> ...'.PHP_EOL;
         echo '                      Set runtime value (see --config-set) '.PHP_EOL;
         echo '        -n            Do not print warnings (shortcut for --warning-severity=0)'.PHP_EOL;
         echo '        -w            Print both warnings and errors (this is the default)'.PHP_EOL;
@@ -1293,6 +1293,8 @@ class PHP_CodeSniffer_CLI
         echo '        <severity>    The minimum severity required to display an error or warning'.PHP_EOL;
         echo '        <standard>    The name or path of the coding standard to use'.PHP_EOL;
         echo '        <tabWidth>    The number of spaces each tab represents'.PHP_EOL;
+        echo '        <fileList>    File containing a list of files to use as input'.PHP_EOL;
+        echo '                      (one file path on each line)'.PHP_EOL;
 
     }//end printPHPCSUsage()
 
@@ -1308,7 +1310,7 @@ class PHP_CodeSniffer_CLI
         echo '    [--standard=<standard>] [--sniffs=<sniffs>] [--suffix=<suffix>]'.PHP_EOL;
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
         echo '    [--tab-width=<tabWidth>] [--encoding=<encoding>]'.PHP_EOL;
-        echo '    [--extensions=<extensions>] [--ignore=<patterns>] [--bootstrap=<bootstrap>] <file> ...'.PHP_EOL;
+        echo '    [--extensions=<extensions>] [--ignore=<patterns>] [--bootstrap=<bootstrap>] [--file-list=<fileList>] <file> ...'.PHP_EOL;
         echo '        -n            Do not fix warnings (shortcut for --warning-severity=0)'.PHP_EOL;
         echo '        -w            Fix both warnings and errors (on by default)'.PHP_EOL;
         echo '        -l            Local directory only, no recursion'.PHP_EOL;
@@ -1333,6 +1335,8 @@ class PHP_CodeSniffer_CLI
         echo '        <suffix>      Write modified files to a filename using this suffix'.PHP_EOL;
         echo '                      ("diff" and "patch" are not used in this mode)'.PHP_EOL;
         echo '        <tabWidth>    The number of spaces each tab represents'.PHP_EOL;
+        echo '        <fileList>    File containing a list of files to use as input'.PHP_EOL;
+        echo '                      (one file path on each line)'.PHP_EOL;
 
     }//end printPHPCBFUsage()
 

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -637,17 +637,19 @@ class PHP_CodeSniffer_CLI
             $files = file($fileList);
             foreach ($files as $inputFile) {
                 $inputFile = trim($inputFile);
-                // skip empty lines
+                // Skip empty lines.
                 if ($inputFile === '') {
                     continue;
                 }
+
                 $realFile = PHP_CodeSniffer::realpath($inputFile);
                 if ($realFile === false) {
                     echo 'ERROR: The specified file "'.$inputFile.'" does not exist'.PHP_EOL.PHP_EOL;
                     $this->printUsage();
                     exit(2);
                 }
-                $this->values['files'][]= $realFile;
+
+                $this->values['files'][] = $realFile;
             }
             break;
         default:

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -626,38 +626,29 @@ class PHP_CodeSniffer_CLI
                 exit(0);
             }
 
-            $file = $this->_cliArgs[($pos + 1)];
+            $fileList = $this->_cliArgs[($pos + 1)];
 
-            if (file_exists($file) === false) {
-                echo 'File list file "'.$file.'" does not exist'.PHP_EOL.PHP_EOL;
+            if (file_exists($fileList) === false) {
+                echo 'File list file "'.$fileList.'" does not exist'.PHP_EOL.PHP_EOL;
                 $this->printUsage();
                 exit(2);
             }
 
-            $fp = fopen($file, 'r');
-            if ($fp === false) {
-                echo 'File "'.$file.'" is not readable'.PHP_EOL.PHP_EOL;
-                $this->printUsage();
-                exit(2);
-            }
-
-            while (!feof($fp)) {
-                $line = trim(fgets($fp));
-                // skip empty lines - if any
-                if ($line === '') {
+            $files = file($fileList);
+            foreach ($files as $inputFile) {
+                $inputFile = trim($inputFile);
+                // skip empty lines
+                if ($inputFile === '') {
                     continue;
                 }
-                $path = PHP_CodeSniffer::realpath($line);
-                if ($path === false) {
-                    fclose($fp);
-                    echo 'ERROR: The specified file "'.$line.'" does not exist'.PHP_EOL.PHP_EOL;
+                $realFile = PHP_CodeSniffer::realpath($inputFile);
+                if ($realFile === false) {
+                    echo 'ERROR: The specified file "'.$inputFile.'" does not exist'.PHP_EOL.PHP_EOL;
                     $this->printUsage();
                     exit(2);
                 }
-                $this->values['files'] []= $path;
+                $this->values['files'][]= $realFile;
             }
-
-            fclose($fp);
             break;
         default:
             if (substr($arg, 0, 7) === 'sniffs=') {

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -619,6 +619,46 @@ class PHP_CodeSniffer_CLI
             $this->_cliArgs[($pos + 2)] = '';
             PHP_CodeSniffer::setConfigData($key, $value, true);
             break;
+        case 'file-list':
+            if (isset($this->_cliArgs[($pos + 1)]) === false) {
+                echo 'ERROR: Specifying a file list requires a value'.PHP_EOL.PHP_EOL;
+                $this->printUsage();
+                exit(0);
+            }
+
+            $file = $this->_cliArgs[($pos + 1)];
+
+            if (file_exists($file) === false) {
+                echo 'File list file "'.$file.'" does not exist'.PHP_EOL.PHP_EOL;
+                $this->printUsage();
+                exit(2);
+            }
+
+            $fp = fopen($file, 'r');
+            if ($fp === false) {
+                echo 'File "'.$file.'" is not readable'.PHP_EOL.PHP_EOL;
+                $this->printUsage();
+                exit(2);
+            }
+
+            while (!feof($fp)) {
+                $line = trim(fgets($fp));
+                // skip empty lines - if any
+                if ($line === '') {
+                    continue;
+                }
+                $path = PHP_CodeSniffer::realpath($line);
+                if ($path === false) {
+                    fclose($fp);
+                    echo 'ERROR: The specified file "'.$line.'" does not exist'.PHP_EOL.PHP_EOL;
+                    $this->printUsage();
+                    exit(2);
+                }
+                $this->values['files'] []= $path;
+            }
+
+            fclose($fp);
+            break;
         default:
             if (substr($arg, 0, 7) === 'sniffs=') {
                 $sniffs = explode(',', substr($arg, 7));


### PR DESCRIPTION
This PR allows running the Code Sniffer on multiple PHP files given as input and output a single report file. This is more convenient than passing the files on the command line(command line limits, simpler handling of input, etc). 

Unix throws an error in case many files(>hundreds) are passed on the command line:
`-bash: <process>: Argument list too long`

This solves the above issue.