### PR TITLE
Refactoring: Remove ELSE block and have just IF condition

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -813,10 +813,12 @@ class PHP_CodeSniffer_File
         $severity=0,
         $fixable=false
     ) {
-        if ($stackPtr === null) {
-            $line   = 1;
-            $column = 1;
-        } else {
+        
+        // Assign defualt values
+        $line   = 1;
+        $column = 1;
+        
+        if ($stackPtr !== null) {
             $line   = $this->_tokens[$stackPtr]['line'];
             $column = $this->_tokens[$stackPtr]['column'];
         }


### PR DESCRIPTION
Either if/else will always get executed, so we can move default values outside conditions. This will reduce the Cyclomatic Complexity.

If you are fine with this change, then I can take care of finding and replacing other such instances where we can remove else part. We would skip this type of refactoring where if-else block has heavy processing.