### PR TITLE
set 'orig_column' when changing tabs to spaces

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -1490,7 +1490,7 @@ class PHP_CodeSniffer_File
         $tokenizerType = get_class($tokenizer);
         $ignoring      = false;
         $inTests       = defined('PHP_CODESNIFFER_IN_TESTS');
-        $tabLines      = [];
+        $tabLines      = array();
 
         $checkEncoding = false;
         if ($encoding !== 'iso-8859-1' && function_exists('iconv_strlen') === true) {

--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -817,7 +817,7 @@ class PHP_CodeSniffer_File
             $line   = 1;
             $column = 1;
         } else {
-            $line   = $this->_tokens[$stackPtr]['line'];
+            $line = $this->_tokens[$stackPtr]['line'];
             if (isset($this->_tokens[$stackPtr]['orig_column']) === true) {
                 $column = $this->_tokens[$stackPtr]['orig_column'];
             } else {
@@ -855,7 +855,7 @@ class PHP_CodeSniffer_File
             $line   = 1;
             $column = 1;
         } else {
-            $line   = $this->_tokens[$stackPtr]['line'];
+            $line = $this->_tokens[$stackPtr]['line'];
             if (isset($this->_tokens[$stackPtr]['orig_column']) === true) {
                 $column = $this->_tokens[$stackPtr]['orig_column'];
             } else {


### PR DESCRIPTION
Set 'orig_column' on tokens when tabs are changed to spaces and use 'orig_column' on errors and warnings for the correct column

fixes #982 