### PR TITLE
Use php's internal defined function list for sniff

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -95,11 +95,10 @@ class Squiz_Sniffs_PHP_LowercasePHPFunctionsSniff implements PHP_CodeSniffer_Sni
         }
 
         // Make sure it is an inbuilt PHP function.
-        // PHP_CodeSniffer doesn't include/require any files, so no
-        // user defined global functions can exist, except for
-        // PHP_CodeSniffer ones.
+        // PHP_CodeSniffer can possibly include user defined functions
+        // through the use of vendor/autoload.php.
         $content = $tokens[$stackPtr]['content'];
-        if (function_exists($content) === false) {
+        if ($this->isBuiltInFunction($content) === false) {
             return;
         }
 
@@ -117,6 +116,24 @@ class Squiz_Sniffs_PHP_LowercasePHPFunctionsSniff implements PHP_CodeSniffer_Sni
         }
 
     }//end process()
+
+
+    /**
+     * Determine whether the functionName in question is a built-in
+     * (or extension-provided) function.
+     *
+     * @param string $functionName Name of the function to check
+     *
+     * @return bool
+     */
+    protected function isBuiltInFunction($functionName)
+    {
+
+        $functions    = get_defined_functions();
+        $functionName = strtolower($functionName);
+        return in_array($functionName, $functions['internal']);
+
+    }//end isBuiltInFunction()
 
 
 }//end class

--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -30,6 +30,25 @@
 class Squiz_Sniffs_PHP_LowercasePHPFunctionsSniff implements PHP_CodeSniffer_Sniff
 {
 
+    /**
+     * String -> int hash map of all php built in function names
+     *
+     * @var array
+     */
+    private $_builtInFunctions;
+
+
+    /**
+     * Construct the LowercasePHPFunctionSniff
+     */
+    public function __construct()
+    {
+
+        $allFunctions            = get_defined_functions();
+        $this->_builtInFunctions = array_flip($allFunctions['internal']);
+
+    }//end __construct()
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -98,7 +117,7 @@ class Squiz_Sniffs_PHP_LowercasePHPFunctionsSniff implements PHP_CodeSniffer_Sni
         // PHP_CodeSniffer can possibly include user defined functions
         // through the use of vendor/autoload.php.
         $content = $tokens[$stackPtr]['content'];
-        if ($this->isBuiltInFunction($content) === false) {
+        if (isset($this->_builtInFunctions[strtolower($content)]) === false) {
             return;
         }
 
@@ -116,24 +135,6 @@ class Squiz_Sniffs_PHP_LowercasePHPFunctionsSniff implements PHP_CodeSniffer_Sni
         }
 
     }//end process()
-
-
-    /**
-     * Determine whether the functionName in question is a built-in
-     * (or extension-provided) function.
-     *
-     * @param string $functionName Name of the function to check
-     *
-     * @return bool
-     */
-    protected function isBuiltInFunction($functionName)
-    {
-
-        $functions    = get_defined_functions();
-        $functionName = strtolower($functionName);
-        return in_array($functionName, $functions['internal']);
-
-    }//end isBuiltInFunction()
 
 
 }//end class


### PR DESCRIPTION
We can no longer rely on calling `function_exists` to determine whether the function token in question is a "PHP internal" function. Mainly because PHP_CodeSniffer now uses the vendor/autoload.php file (if it exists) to load classes. This is a shared autoload system, that could cause many user defined functions to exist in the same memory space under which PHPCS is running.

Since the whole point of the sniff is to check only PHP built in (inbuilt) functions, I've made the change in this PR to check the function using `get_defined_functions`.

I didn't change or add any unit tests, since I couldn't think of any additional use cases needed. I suppose the only risk is if a given function returns `true` for function_exists() but does not exist in get_defined_functions()['internal'].

- phpcs passes
- phpunit passes