### PR TITLE
Fix PHP notices when file extensions defaults are not present

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -722,6 +722,9 @@ class PHP_CodeSniffer_CLI
                     $this->values['standard'] = explode(',', $standards);
                 }
             } else if (substr($arg, 0, 11) === 'extensions=') {
+                if (isset($this->values['extensions']) === false) {
+                    $this->values['extensions'] = array();
+                }
                 $this->values['extensions'] = array_merge($this->values['extensions'], explode(',', substr($arg, 11)));
             } else if (substr($arg, 0, 9) === 'severity=') {
                 $this->values['errorSeverity']   = (int) substr($arg, 9);


### PR DESCRIPTION
Sometimes the internal values of CLI.php are not initialized. This happens on test runs in Drupal's coder. I'm trying to add

```xml
<arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
```
to ruleset.xml to have some extension default values.

The commit is my best guess at fixing the notice, or is there another place where $this->values should be initialized?
