### PR TITLE
Squiz.WhiteSpace.FunctionSpacing - don't check spacing after last block

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -84,10 +84,8 @@ class Squiz_Sniffs_WhiteSpace_FunctionSpacingSniff implements PHP_CodeSniffer_Sn
         }
 
         $foundLines = 0;
-        if ($nextLineToken === ($phpcsFile->numTokens - 1)) {
-            // We are at the end of the file.
-            // Don't check spacing after the function because this
-            // should be done by an EOF sniff.
+        if ($nextLineToken === ($phpcsFile->numTokens - 2)) {
+            // We are at the end of the last block.
             $foundLines = $this->spacing;
         } else {
             $nextContent = $phpcsFile->findNext(T_WHITESPACE, $nextLineToken, null, true);

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -283,6 +283,28 @@ function test() {
 
 
 if ($foo) {
+
+
+    /**
+     * Comment
+     */
+    function foo() {
+        // Code here
+    }
+
+
+    /**
+     * Comment
+     */
+    function bar() {
+        // Code here
+    }
+
+
+}
+
+
+if ($foo) {
     /**
      * Comment
      */

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -324,3 +324,23 @@ if ($foo) {
 
 
 }
+
+
+if ($foo) {
+
+
+    /**
+     * Comment
+     */
+    function foo() {
+        // Code here
+    }
+
+
+    /**
+     * Comment
+     */
+    function bar() {
+        // Code here
+    }
+}

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -65,9 +65,8 @@ class Squiz_Tests_WhiteSpace_FunctionSpacingUnitTest extends AbstractSniffUnitTe
                 252 => 1,
                 275 => 1,
                 276 => 1,
-                289 => 1,
-                291 => 1,
-                297 => 1,
+                311 => 1,
+                313 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
This PR tries to solve the issue reported in #652 by skipping the check after the last block. I'm not sure if that's what everybody wants, but I would be totally happy with this solution. Or it could be a sniff parameter like the spacing itself.
