### PR TITLE
[1.5] [bugfix] `MySource_Sniffs_Objects_CreateWidgetTypeCallbackSniff`

### DIFF
--- a/CodeSniffer/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
+++ b/CodeSniffer/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
@@ -74,7 +74,7 @@ class MySource_Sniffs_Objects_CreateWidgetTypeCallbackSniff implements PHP_CodeS
 
         $function = $phpcsFile->findNext(array(T_WHITESPACE, T_COLON), ($create + 1), null, true);
         if ($tokens[$function]['code'] !== T_FUNCTION) {
-            continue;
+            return;
         }
 
         $start = ($tokens[$function]['scope_opener'] + 1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 1.5
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Fixed `PHP Fatal error:  'continue' not in the 'loop' or 'switch' context`. Replace
`continue` with `return` at `MySource_Sniffs_Objects_CreateWidgetTypeCallbackSniff::process()`.