### PR TITLE
Version control reports can show notices when the report width is very small

### DIFF
--- a/CodeSniffer/Reports/VersionControl.php
+++ b/CodeSniffer/Reports/VersionControl.php
@@ -241,7 +241,7 @@ abstract class PHP_CodeSniffer_Reports_VersionControl implements PHP_CodeSniffer
                     }
 
                     $line = str_repeat(' ', (5 - strlen($count))).$count;
-                    echo '         '.$source.str_repeat(' ', ($width - 14 - strlen($source))).$line.PHP_EOL;
+                    echo '         '.$source.str_repeat(' ', max(0, ($width - 14 - strlen($source)))).$line.PHP_EOL;
                 }
             }
         }//end foreach


### PR DESCRIPTION
The command
```
phpcs --standard=PSR2 --encoding=utf-8 -n -p -s --report=gitblame src/
```
produces warning
```
PHP Warning:  str_repeat(): Second argument has to be greater than or equal to 0 in /home/anton/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Reports/VersionControl.php on line 244
```
if the sniffed code contains a Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose error