### PR TITLE
Read stdin input from the dup()’ed non-blocking handle

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -399,7 +399,7 @@ class PHP_CodeSniffer_CLI
         $handle = fopen('php://stdin', 'r');
         if (stream_set_blocking($handle, false) === true) {
             $fileContents = '';
-            while (($line = fgets(STDIN)) !== false) {
+            while (($line = fgets($handle)) !== false) {
                 $fileContents .= $line;
                 usleep(10);
             }


### PR DESCRIPTION
Read stdin from the handle opened via `fopen('php://stdin')`, not the original `STDIN` handle which may not have been affected by the `stream_set_blocking()` call.

I’d look for confirmation from others but I’m pretty sure this fixes https://github.com/squizlabs/PHP_CodeSniffer/issues/993.