### PR TITLE
Make the `Generic.PHP.DisallowShortOpenTag` sniff fixable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ php:
   - 7.0
   - hhvm
 
+before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-add myconfig.ini; fi
+
 script:
   - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then php scripts/phpcs --config-set php_path php; fi
   - phpunit -d date.timezone=Australia/Sydney tests/AllTests.php

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -63,7 +63,13 @@ class Generic_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
         if ($openTag['content'] === '<?') {
             $error = 'Short PHP opening tag used; expected "<?php" but found "%s"';
             $data  = array($openTag['content']);
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($stackPtr, '<?php');
+                $phpcsFile->fixer->endChangeset();
+            }
+
             $phpcsFile->recordMetric($stackPtr, 'PHP short open tag used', 'yes');
         } else {
             $phpcsFile->recordMetric($stackPtr, 'PHP short open tag used', 'no');
@@ -77,7 +83,12 @@ class Generic_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
                         $openTag['content'],
                         $nextVar['content'],
                        );
-            $phpcsFile->addError($error, $stackPtr, 'EchoFound', $data);
+            $fix     = $phpcsFile->addFixableError($error, $stackPtr, 'EchoFound', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($stackPtr, '<?php echo');
+                $phpcsFile->fixer->endChangeset();
+            }
         }
 
     }//end process()

--- a/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.inc
@@ -1,6 +1,16 @@
 <div>
 <?php echo $var; ?>
 Some content here.
+
 <?= $var; ?>
+Some content <?= $var ?> Some more content
+<?=
+$var;
+?>
+
 <? echo $var; ?>
+Some content <? echo $var ?> Some more content
+<?
+echo $var;
+?>
 </div>

--- a/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.inc.fixed
@@ -1,0 +1,16 @@
+<div>
+<?php echo $var; ?>
+Some content here.
+
+<?php echo $var; ?>
+Some content <?php echo $var ?> Some more content
+<?php echo
+$var;
+?>
+
+<?php echo $var; ?>
+Some content <?php echo $var ?> Some more content
+<?php
+echo $var;
+?>
+</div>

--- a/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -45,14 +45,20 @@ class Generic_Tests_PHP_DisallowShortOpenTagUnitTest extends AbstractSniffUnitTe
         $option = (boolean) ini_get('short_open_tag');
         if ($option === true || defined('HHVM_VERSION') === true) {
             return array(
-                    4 => 1,
                     5 => 1,
+                    6 => 1,
+                    7 => 1,
+                    11 => 1,
+                    12 => 1,
+                    13 => 1,
                    );
         } else if (version_compare(PHP_VERSION, '5.4.0RC1') >= 0) {
             // Shorthand echo is always available from PHP 5.4.0 but needed the
             // short_open_tag ini var to be set for versions before this.
             return array(
-                    4 => 1,
+                    5 => 1,
+                    6 => 1,
+                    7 => 1,
                    );
         }
 

--- a/myconfig.ini
+++ b/myconfig.ini
@@ -1,0 +1,4 @@
+; This directive determines whether or not PHP will recognize code between
+; <? and ?> tags as PHP source which should be processed as such.
+; http://php.net/short-open-tag
+short_open_tag = On

--- a/package.xml
+++ b/package.xml
@@ -689,6 +689,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
          <tasks:replace from="@package_version@" to="version" type="package-info" />
         </file>
         <file baseinstalldir="PHP" name="DisallowShortOpenTagUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP" name="DisallowShortOpenTagUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP" name="DisallowShortOpenTagUnitTest.php" role="test">
          <tasks:replace from="@package_version@" to="version" type="package-info" />
         </file>


### PR DESCRIPTION
This PR makes the `Generic.PHP.DisallowShortOpenTag` sniff fixable.

The `myconfig.ini` file and the adjustment to the `travis` script are needed for the fixer unit tests to pass as when `short_open_tag` is set to `off`, the fixer won't fix it correctly and the tests will fail ;-)