### PR TITLE
Add a sniff to detect the usage of the backtick operator.

### DIFF
--- a/CodeSniffer/Standards/Generic/Docs/PHP/BacktickOperatorStandard.xml
+++ b/CodeSniffer/Standards/Generic/Docs/PHP/BacktickOperatorStandard.xml
@@ -1,0 +1,7 @@
+<documentation title="Backtick Operator">
+    <standard>
+    <![CDATA[
+    Disallow the use of the backtick operator for execution of shell commands.
+    ]]>
+    </standard>
+</documentation>

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/BacktickOperatorSniff.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Generic_Sniffs_PHP_BacktickOperatorSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Generic_Sniffs_PHP_BacktickOperatorSniff.
+ *
+ * Checks for the use of the backtick execution operator.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_PHP_BacktickOperatorSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_BACKTICK);
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $error = 'Use of the backtick operator is strongly discouraged';
+        $phpcsFile->addError($error, $stackPtr, 'Found');
+
+    }//end process()
+
+
+}//end class

--- a/CodeSniffer/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.inc
@@ -1,0 +1,2 @@
+<?php
+$output = `ls -al`;

--- a/CodeSniffer/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Unit test class for the BacktickOperator sniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the BacktickOperator sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Tests_PHP_BacktickOperatorUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return bool
+     */
+    protected function shouldSkipTest()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<') === true && ((bool) ini_get('safe_mode')) === true) {
+            return true;
+        }
+
+        return false;
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array(
+                2 => 2,
+               );
+
+        return $errors;
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Working on a project now which wants to add a sniff like this as part of their security-sniffs and figured it would be re-usable for others as well.