### PR TITLE
Make the LongConditionClosingCommentSniff more flexible.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -59,7 +59,16 @@ class Squiz_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP_Co
      *
      * @var int
      */
-    protected $lineLimit = 20;
+    public $lineLimit = 20;
+
+    /**
+     * The format the end comment should be in.
+     *
+     * The placeholder %s will be replaced with the type of condition opener.
+     *
+     * @var string
+     */
+    public $commentFormat = '//end %s';
 
 
     /**
@@ -102,7 +111,7 @@ class Squiz_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP_Co
         }
 
         if ($startCondition['code'] === T_IF) {
-            // If this is actually and ELSE IF, skip it as the brace
+            // If this is actually an ELSE IF, skip it as the brace
             // will be checked by the original IF.
             $else = $phpcsFile->findPrevious(T_WHITESPACE, ($tokens[$stackPtr]['scope_condition'] - 1), null, true);
             if ($tokens[$else]['code'] === T_ELSE) {
@@ -158,7 +167,7 @@ class Squiz_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP_Co
 
         $lineDifference = ($endBrace['line'] - $startBrace['line']);
 
-        $expected = '//end '.$startCondition['content'];
+        $expected = sprintf($this->commentFormat, $startCondition['content']);
         $comment  = $phpcsFile->findNext(array(T_COMMENT), $stackPtr, null, false);
 
         if (($comment === false) || ($tokens[$comment]['line'] !== $endBrace['line'])) {

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.inc
@@ -763,3 +763,172 @@ switch ($foo) {
         echo $foo;
         break;
 }
+
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment lineLimit 5
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment commentFormat //Dragonbait-%s
+
+function quite_long_function()
+{
+	// Ok - below limit
+    if ($longFunction) {
+        $variable = 'hello';
+	}
+
+	// Ok - correct comment
+    if ($longFunction) {
+        // This is a long
+        // IF statement
+        // that does
+        // not have
+        // an ELSE
+        // block on it
+    }//Dragonbait-if
+
+	// This should be caught - wrong comment
+    if ($longFunction) {
+        // This is a long
+        // IF statement
+        // that does
+        // not have
+        // an ELSE
+        // block on it
+        $variable = 'hello';
+    } else {
+        // Short ELSE
+    }//end if
+
+	// This should be caught - no comment
+    if ($longFunction) {
+        // This is a long
+        // IF statement
+        // that does
+        // not have
+        // an ELSE
+        // block on it
+        $variable = 'hello';
+    } else {
+        // Short ELSE
+    }
+}
+
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment lineLimit 30
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment commentFormat // Bye-Bye %s()
+
+// Ok - below limit
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+}
+
+// Ok - has correct comment
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+    // Line 11
+    // Line 12
+    // Line 13
+    // Line 14
+    // Line 15
+    // Line 16
+    // Line 17
+    // Line 18
+    // Line 19
+    // Line 20
+    // Line 21
+    // Line 22
+    // Line 23
+    // Line 24
+    // Line 25
+    // Line 26
+    // Line 27
+    // Line 28
+    // Line 29
+    // Line 30
+}// Bye-Bye foreach()
+
+// This should be caught - wrong comment
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+    // Line 11
+    // Line 12
+    // Line 13
+    // Line 14
+    // Line 15
+    // Line 16
+    // Line 17
+    // Line 18
+    // Line 19
+    // Line 20
+    // Line 21
+    // Line 22
+    // Line 23
+    // Line 24
+    // Line 25
+    // Line 26
+    // Line 27
+    // Line 28
+    // Line 29
+    // Line 30
+}//end foreach
+
+// This should be caught - no comment
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+    // Line 11
+    // Line 12
+    // Line 13
+    // Line 14
+    // Line 15
+    // Line 16
+    // Line 17
+    // Line 18
+    // Line 19
+    // Line 20
+    // Line 21
+    // Line 22
+    // Line 23
+    // Line 24
+    // Line 25
+    // Line 26
+    // Line 27
+    // Line 28
+    // Line 29
+    // Line 30
+}
+
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment lineLimit 20
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment commentFormat //end %s

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.inc.fixed
@@ -763,3 +763,172 @@ switch ($foo) {
         echo $foo;
         break;
 }//end switch
+
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment lineLimit 5
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment commentFormat //Dragonbait-%s
+
+function quite_long_function()
+{
+	// Ok - below limit
+    if ($longFunction) {
+        $variable = 'hello';
+	}
+
+	// Ok - correct comment
+    if ($longFunction) {
+        // This is a long
+        // IF statement
+        // that does
+        // not have
+        // an ELSE
+        // block on it
+    }//Dragonbait-if
+
+	// This should be caught - wrong comment
+    if ($longFunction) {
+        // This is a long
+        // IF statement
+        // that does
+        // not have
+        // an ELSE
+        // block on it
+        $variable = 'hello';
+    } else {
+        // Short ELSE
+    }//Dragonbait-if
+
+	// This should be caught - no comment
+    if ($longFunction) {
+        // This is a long
+        // IF statement
+        // that does
+        // not have
+        // an ELSE
+        // block on it
+        $variable = 'hello';
+    } else {
+        // Short ELSE
+    }//Dragonbait-if
+}
+
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment lineLimit 30
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment commentFormat // Bye-Bye %s()
+
+// Ok - below limit
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+}
+
+// Ok - has correct comment
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+    // Line 11
+    // Line 12
+    // Line 13
+    // Line 14
+    // Line 15
+    // Line 16
+    // Line 17
+    // Line 18
+    // Line 19
+    // Line 20
+    // Line 21
+    // Line 22
+    // Line 23
+    // Line 24
+    // Line 25
+    // Line 26
+    // Line 27
+    // Line 28
+    // Line 29
+    // Line 30
+}// Bye-Bye foreach()
+
+// This should be caught - wrong comment
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+    // Line 11
+    // Line 12
+    // Line 13
+    // Line 14
+    // Line 15
+    // Line 16
+    // Line 17
+    // Line 18
+    // Line 19
+    // Line 20
+    // Line 21
+    // Line 22
+    // Line 23
+    // Line 24
+    // Line 25
+    // Line 26
+    // Line 27
+    // Line 28
+    // Line 29
+    // Line 30
+}// Bye-Bye foreach()
+
+// This should be caught - no comment
+foreach ($var as $val) {
+    // Line 1
+    // Line 2
+    // Line 3
+    // Line 4
+    // Line 5
+    // Line 6
+    // Line 7
+    // Line 8
+    // Line 9
+    // Line 10
+    // Line 11
+    // Line 12
+    // Line 13
+    // Line 14
+    // Line 15
+    // Line 16
+    // Line 17
+    // Line 18
+    // Line 19
+    // Line 20
+    // Line 21
+    // Line 22
+    // Line 23
+    // Line 24
+    // Line 25
+    // Line 26
+    // Line 27
+    // Line 28
+    // Line 29
+    // Line 30
+}// Bye-Bye foreach()
+
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment lineLimit 20
+// @codingStandardsChangeSetting Squiz.Commenting.LongConditionClosingComment commentFormat //end %s

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.inc.fixed
@@ -46,7 +46,7 @@ function long_function()
             // This is a short ELSE
             // statement
         }
-    }
+    }//end if
 
     if ($longFunction) {
         // This is a long
@@ -96,7 +96,7 @@ function long_function()
         }
     } else {
         // Short ELSE
-    }
+    }//end if
 }
 
 foreach ($var as $val) {
@@ -143,7 +143,7 @@ foreach ($var as $val) {
     // Line 18
     // Line 19
     // Line 20
-}
+}//end foreach
 
 for ($var =1; $var < 20; $var++) {
     // Line 1
@@ -189,7 +189,7 @@ for ($var =1; $var < 20; $var++) {
     // Line 18
     // Line 19
     // Line 20
-}
+}//end for
 
 while ($var < 20) {
     // Line 1
@@ -212,7 +212,7 @@ while ($var < 20) {
     // Line 18
     // Line 19
     // Line 20
-}//end while looping
+}//end while
 
 while ($var < 20) {
     // Line 1
@@ -235,7 +235,7 @@ while ($var < 20) {
     // Line 18
     // Line 19
     // Line 20
-}
+}//end while
 
 if ($longFunction) {
     // This is a long
@@ -375,7 +375,7 @@ while ($var < 20) {
     // Line 18
     // Line 19
     // Line 20
-}//end for
+}//end while
 
 if (true) {
     // Line 1
@@ -490,7 +490,7 @@ if ($something) {
     // Line 18
     // Line 19
     // Line 20
-}
+}//end if
 
 switch ($something) {
     case '1':
@@ -528,12 +528,12 @@ switch ($something) {
     // Line 4
     // Line 5
     break;
-}
+}//end switch
 
 // Wrong comment
 if ($condition) {
     echo "true";
-}//end foreach
+}//end if
 
 if ($condition) {
     echo "true";
@@ -559,7 +559,7 @@ try {
     // some code here.
     // some code here.
     // some code here.
-}
+}//end try
 
 try {
     // some code here.
@@ -598,7 +598,7 @@ try {
     // some code here.
     // some code here.
     // some code here.
-}//end catch
+}//end try
 
 try {
     // some code here.
@@ -626,7 +626,7 @@ try {
     // some code here.
 } catch (Exception $e) {
     // some code here.
-}
+}//end try
 
 switch ($foo) {
     case 'one' : {
@@ -660,7 +660,7 @@ switch ($foo) {
         // some code here.
         // some code here.
         break;
-    }
+    }//end case
     case 'one' :
         // some code here.
         // some code here.
@@ -762,4 +762,4 @@ switch ($foo) {
     case 59:
         echo $foo;
         break;
-}
+}//end switch

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.js
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.js
@@ -5,7 +5,7 @@ function long_function()
         // IF statement
         // that does
         // not have
-        // and ELSE
+        // an ELSE
         // block on it
         variable = 'hello';
 
@@ -28,7 +28,7 @@ function long_function()
         // IF statement
         // that does
         // not have
-        // and ELSE
+        // an ELSE
         // block on it
         variable = 'hello';
 
@@ -51,7 +51,7 @@ function long_function()
         // IF statement
         // that does
         // not have
-        // and ELSE
+        // an ELSE
         // block on it
         variable = 'hello';
 
@@ -76,7 +76,7 @@ function long_function()
         // IF statement
         // that does
         // not have
-        // and ELSE
+        // an ELSE
         // block on it
         variable = 'hello';
 
@@ -194,7 +194,7 @@ if (longFunction) {
     // IF statement
     // that does
     // not have
-    // and ELSE
+    // an ELSE
     // block on it
     variable = 'hello';
 
@@ -217,7 +217,7 @@ if (longFunction) {
     // IF statement
     // that does
     // not have
-    // and ELSE
+    // an ELSE
     // block on it
     variable = 'hello';
 

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/LongConditionClosingCommentUnitTest.php
@@ -68,6 +68,10 @@ class Squiz_Tests_Commenting_LongConditionClosingCommentUnitTest extends Abstrac
                     629 => 1,
                     663 => 1,
                     765 => 1,
+                    798 => 1,
+                    811 => 1,
+                    897 => 1,
+                    931 => 1,
                    );
             break;
         case 'LongConditionClosingCommentUnitTest.js':

--- a/package.xml
+++ b/package.xml
@@ -1802,6 +1802,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
          <tasks:replace from="@package_version@" to="version" type="package-info" />
         </file>
         <file baseinstalldir="PHP" name="LongConditionClosingCommentUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP" name="LongConditionClosingCommentUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP" name="LongConditionClosingCommentUnitTest.js" role="test" />
         <file baseinstalldir="PHP" name="LongConditionClosingCommentUnitTest.php" role="test">
          <tasks:replace from="@package_version@" to="version" type="package-info" />


### PR DESCRIPTION
* Allow for setting a different lineLimit from the config file.
* Allow for a different comment format to be set from the config file.

Also: minor spelling corrections.

Includes unit tests.
Original test files have been renamed to prevent unit tests failing because of property value bleed through.