### PR TITLE
Fix bug where functions in mixed/uppercase would not be recognized.

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -191,7 +191,7 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
             }
         }//end if
 
-        $this->addError($phpcsFile, $stackPtr, $function, $pattern);
+        $this->addError($phpcsFile, $stackPtr, $tokens[$stackPtr]['content'], $pattern);
 
     }//end process()
 
@@ -220,7 +220,7 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
         }
 
         if ($pattern === null) {
-            $pattern = $function;
+            $pattern = strtolower($function);
         }
 
         if ($this->forbiddenFunctions[$pattern] !== null

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -102,6 +102,9 @@ class Generic_Sniffs_PHP_ForbiddenFunctionsSniff implements PHP_CodeSniffer_Snif
             }
         }
 
+        $this->forbiddenFunctionNames = array_map('strtolower', $this->forbiddenFunctionNames);
+        $this->forbiddenFunctions     = array_combine($this->forbiddenFunctionNames, $this->forbiddenFunctions);
+
         return array_unique($register);
 
     }//end register()


### PR DESCRIPTION
The `Generic.PHP.ForbiddenFunctions` sniff can easily be extended to also sniff for other functions.

However, there is a bug which prevents functions in mixed- or uppercase from being recognized.

As functionnames in PHP are case-insensitive both for userland functions as well as build-in functions, the function should always do a case-insensitive function name check.

In the current code the comparison was not consistently done in a case-insensitive manner. This PR fixes that.

No unit tests are provided with the PR as I can't seem to influence the `$forbiddenFunctions` array just and only for the unit test without actually extending the class.

A real world example of the bug can be found here:
https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/WPCS/feature/fix-bug-in-discouraged-functions/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php#L64
With the associated unit test failing: https://travis-ci.org/WordPress-Coding-Standards/WordPress-Coding-Standards/jobs/145281345