### PR TITLE
Allow lower case namespace in constant definitions

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -157,6 +157,13 @@ class Generic_Sniffs_NamingConventions_UpperCaseConstantNameSniff implements PHP
             $constName = substr($constName, ($splitPos + 2));
         }
 
+        // Strip namesspace from constant like /foo/bar/CONSTANT.
+        $splitPos = strrpos($constName, '\\');
+        if ($splitPos !== false) {
+            $prefix    = substr($constName, 0, ($splitPos + 1));
+            $constName = substr($constName, ($splitPos + 1));
+        }
+
         if (strtoupper($constName) !== $constName) {
             if (strtolower($constName) === $constName) {
                 $phpcsFile->recordMetric($stackPtr, 'Constant name case', 'lower');

--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
@@ -8,6 +8,10 @@ define('VALID_NAME', true);
 define('invalidName', true);
 define("VALID_NAME", true);
 define("invalidName", true);
+define('bar\foo\baz\VALID_NAME_WITH_NAMESPACE', true);
+define('bar\foo\baz\invalidNameWithNamespace', true);
+define("bar\foo\baz\VALID_NAME_WITH_NAMESPACE", true);
+define("bar\foo\baz\invalidNameWithNamespace", true);
 
 class TestClass extends MyClass, YourClass
 {
@@ -27,12 +31,26 @@ class TestClass extends MyClass, YourClass
         print invalidName;
         echo(invalidName);
         print(invalidName);
+        echo constant('VALID_NAME_WITH_NAMESPACE');
+        echo VALID_NAME_WITH_NAMESPACE;
+        print VALID_NAME_WITH_NAMESPACE;
+        echo(VALID_NAME_WITH_NAMESPACE);
+        print(VALID_NAME_WITH_NAMESPACE);
+        echo constant('invalidNameWithNamespace');
+        echo invalidNameWithNamespace;
+        print invalidNameWithNamespace;
+        echo(invalidNameWithNamespace);
+        print(invalidNameWithNamespace);
 
         echo constant("VALID_NAME");
         echo constant("invalidName");
+        echo constant("VALID_NAME_WITH_NAMESPACE");
+        echo constant("invalidNameWithNamespace");
 
         echo 'Hello', VALID_NAME;
         echo 'Hello', invalidName;
+        echo 'Hello', VALID_NAME_WITH_NAMESPACE;
+        echo 'Hello', invalidNameWithNamespace;
 
         // These might look like constants to
         // poorly written code.

--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -45,7 +45,9 @@ class Generic_Tests_NamingConventions_UpperCaseConstantNameUnitTest extends Abst
         return array(
                 8   => 1,
                 10  => 1,
-                15  => 1,
+                12  => 1,
+                14  => 1,
+                19  => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
The current version in combination with hhvm raises issues like https://github.com/zircote/swagger-php/pull/319. hhvm interprets the namespaces more strict than php.

This pull request will allow constant definitions with a lower case namespace like `define('bar\foo\baz\VALID_NAME_WITH_NAMESPACE', true)`. Currently it's not allowed and you need to change the code to `define('BAR\FOO\BAZ\VALID_NAME_WITH_NAMESPACE', true);` though the namespace is in lower case like `namespace bar\foo\baz;`.