### PR TITLE
Improve version comparisons by using PHP_VERSION_ID.

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -14,8 +14,15 @@
 
 error_reporting(E_ALL | E_STRICT);
 
+// Make sure version id constant is available.
+if (defined('PHP_VERSION_ID') === false) {
+    $version = explode('.', PHP_VERSION);
+    define('PHP_VERSION_ID', (int) (($version[0] * 10000) + ($version[1] * 100) + $version[2]));
+    unset($version);
+}
+
 // Make sure that we autoload all dependencies if running via Composer.
-if (version_compare(PHP_VERSION, '5.3.2', '>=') === true) {
+if (PHP_VERSION_ID >= 50302) {
     if (file_exists($a = dirname(__FILE__).'/../../../autoload.php') === true) {
         include_once $a;
     } else if (file_exists($a = dirname(__FILE__).'/../vendor/autoload.php') === true) {
@@ -245,7 +252,7 @@ class PHP_CodeSniffer_CLI
     public function checkRequirements()
     {
         // Check the PHP version.
-        if (version_compare(PHP_VERSION, '5.1.2', '<') === true) {
+        if (PHP_VERSION_ID < 50102) {
             echo 'ERROR: PHP_CodeSniffer requires PHP version 5.1.2 or greater.'.PHP_EOL;
             exit(2);
         }

--- a/CodeSniffer/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Files/OneTraitPerFileUnitTest.php
@@ -34,7 +34,7 @@ class Generic_Tests_Files_OneTraitPerFileUnitTest extends AbstractSniffUnitTest
      */
     protected function shouldSkipTest()
     {
-        return version_compare(PHP_VERSION, '5.4.0', '<');
+        return (PHP_VERSION_ID < 50400);
 
     }//end shouldSkipTest()
 

--- a/CodeSniffer/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -39,7 +39,7 @@ class Generic_Tests_PHP_BacktickOperatorUnitTest extends AbstractSniffUnitTest
      */
     protected function shouldSkipTest()
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '<') === true && ((bool) ini_get('safe_mode')) === true) {
+        if (PHP_VERSION_ID < 50400 && ((bool) ini_get('safe_mode')) === true) {
             return true;
         }
 

--- a/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -72,7 +72,7 @@ class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
             $phpcsFile->recordMetric($stackPtr, 'One class per file', 'yes');
         }
 
-        if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+        if (PHP_VERSION_ID >= 50300) {
             $namespace = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
             if ($tokens[$namespace]['code'] !== T_NAMESPACE) {
                 $error = 'Each %s must be in a namespace of at least one level (a top-level vendor name)';

--- a/CodeSniffer/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/CodeSniffer/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.php
@@ -46,7 +46,7 @@ class PSR1_Tests_Classes_ClassDeclarationUnitTest extends AbstractSniffUnitTest
             return array();
         }
 
-        if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+        if (PHP_VERSION_ID >= 50300) {
             return array(
                     2 => 1,
                     3 => 2,

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -382,7 +382,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                         $suggestedTypeHint = 'callable';
                     } else if (in_array($typeName, PHP_CodeSniffer::$allowedTypes) === false) {
                         $suggestedTypeHint = $suggestedName;
-                    } else if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+                    } else if (PHP_VERSION_ID >= 70000) {
                         if ($typeName === 'string') {
                             $suggestedTypeHint = 'string';
                         } else if ($typeName === 'int' || $typeName === 'integer') {

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -120,14 +120,14 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
 
         // The yield tests will only work in PHP versions where yield exists and
         // will throw errors in earlier versions.
-        if (version_compare(PHP_VERSION, '5.5.0') < 0) {
+        if (PHP_VERSION_ID < 50500) {
             $errors[676] = 1;
         } else {
             $errors[688] = 1;
         }
 
         // Scalar type hints only work from PHP 7 onwards.
-        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+        if (PHP_VERSION_ID >= 70000) {
             $errors[17]  = 1;
             $errors[143] = 3;
             $errors[161] = 2;


### PR DESCRIPTION
Inspired by: https://github.com/squizlabs/PHP_CodeSniffer/pull/1084#discussion_r71835858

A PHP version number is build up as `{major}.{minor}.{release}{extra}`.
In 99.9% of cases where a version comparison is needed, the `{extra}` (`alpha/beta/RC`) information can/should be disregarded.
`PHP_VERSION` is a string which contains the complete version number, including `{extra}`.
`PHP_VERSION_ID` is an integer which contains the release version number *without* the `{extra}`

So using `PHP_VERSION_ID` allows to do accurate version comparisons without taking the `{extra}` into account *and* without an extra function call to `version_compare()`.

As `PHP_VERSION_ID` only became available in PHP 5.2.7, it needs to be defined in the application for older PHP versions.

Ref: http://php.net/manual/en/reserved.constants.php#reserved.constants.core