### PR TITLE
Rulesets cannot be loaded if the path contains urlencoded characters

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -711,7 +711,7 @@ class PHP_CodeSniffer
             echo "Processing ruleset $rulesetPath".PHP_EOL;
         }
 
-        $ruleset = simplexml_load_file($rulesetPath);
+        $ruleset = simplexml_load_file(rawurlencode($rulesetPath));
         if ($ruleset === false) {
             throw new PHP_CodeSniffer_Exception("Ruleset $rulesetPath is not valid");
         }


### PR DESCRIPTION
phpcs versions beyond 2.6.1 fail to process xml files in directories containing "%2F". This is because of this change:
https://github.com/squizlabs/PHP_CodeSniffer/commit/322fa248f2c43e6df18f83a8193b42aa37d02c17

We discovered this because we build all our sources via Jenkins which transforms / into %2F so a directory looks like:
/home/jenkins/workspace/project/feature%2Fname

This is needed because in Linux0, / is a directory separator and cannot be used as part of the directory/file name.

phpcs will print an error:
Warning: simplexml_load_file(): I/O warning : failed to load external entity "/home/jenkins/workspace/project/feature%2Fname/phpcs.xml" in /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php on line 715

Fatal error: Uncaught PHP_CodeSniffer_Exception: Ruleset /home/jenkins/workspace/project/feature%2Fname/phpcs.xml is not valid in /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php:717
Stack trace:
#0 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php(562): PHP_CodeSniffer->processRuleset('/home/jenkins/w...')
#1 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php(907): PHP_CodeSniffer->initStandard(Array, Array, Array)
#2 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php(106): PHP_CodeSniffer_CLI->process()
#3 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/scripts/phpcs(25): PHP_CodeSniffer_CLI->ru in /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php on line 717
PHP Warning:  simplexml_load_file(): I/O warning : failed to load external entity "/home/jenkins/workspace/project/feature%2Fname/phpcs.xml" in /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php on line 715
PHP Fatal error:  Uncaught PHP_CodeSniffer_Exception: Ruleset /home/jenkins/workspace/project/feature%2Fname/phpcs.xml is not valid in /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php:717
Stack trace:
#0 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php(562): PHP_CodeSniffer->processRuleset('/home/jenkins/w...')
#1 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php(907): PHP_CodeSniffer->initStandard(Array, Array, Array)
#2 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php(106): PHP_CodeSniffer_CLI->process()
#3 /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/scripts/phpcs(25): PHP_CodeSniffer_CLI->ru in /home/jenkins/workspace/project/feature%2Fname/vendor/squizlabs/php_codesniffer/CodeSniffer.php on line 717

Reference:
https://github.com/doctrine/doctrine2/issues/5705