### PR TITLE
Allow return type hints without space before colon in OpeningFunctionBraceKernighanRitchie sniff

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -153,7 +153,7 @@ class Generic_Sniffs_Functions_OpeningFunctionBraceKernighanRitchieSniff impleme
             return;
         }
 
-        if ($tokens[($closeBracket + 1)]['code'] !== T_WHITESPACE) {
+        if ($tokens[($closeBracket + 1)]['code'] !== T_WHITESPACE && $tokens[($closeBracket + 1)]['code'] !== T_COLON) {
             $length = 0;
         } else if ($tokens[($closeBracket + 1)]['content'] === "\t") {
             $length = '\t';

--- a/CodeSniffer/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc
@@ -138,6 +138,15 @@ $test = function ($param) use ($result) : Something
     return null;
 }
 
+$test = function ($param) use ($result): Something {
+    return null;
+}
+
+$test = function ($param) use ($result): Something
+{
+    return null;
+}
+
 // @codingStandardsChangeSetting Generic.Functions.OpeningFunctionBraceKernighanRitchie checkClosures 0
 
 $closureWithArgs = function ($arg1, $arg2){
@@ -150,6 +159,15 @@ function myFunction() : Something
 }
 
 function myFunction() : Something // Break me
+{
+    return null;
+}
+
+function myFunction(): Something {
+    return null;
+}
+
+function myFunction(): Something
 {
     return null;
 }

--- a/CodeSniffer/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc.fixed
@@ -131,6 +131,14 @@ $test = function ($param) use ($result) : Something {
     return null;
 }
 
+$test = function ($param) use ($result): Something {
+    return null;
+}
+
+$test = function ($param) use ($result): Something {
+    return null;
+}
+
 // @codingStandardsChangeSetting Generic.Functions.OpeningFunctionBraceKernighanRitchie checkClosures 0
 
 $closureWithArgs = function ($arg1, $arg2){
@@ -143,5 +151,13 @@ function myFunction() : Something {
 
 function myFunction() : Something {
  // Break me
+    return null;
+}
+
+function myFunction(): Something {
+    return null;
+}
+
+function myFunction(): Something {
     return null;
 }

--- a/CodeSniffer/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -61,8 +61,10 @@ class Generic_Tests_Functions_OpeningFunctionBraceKernighanRitchieUnitTest exten
                 127 => 1,
                 132 => 1,
                 137 => 1,
-                148 => 1,
-                153 => 1,
+                146 => 1,
+                157 => 1,
+                162 => 1,
+                171 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Currently if you you use return type hints with a space before colon ` : `, f.e.:

```php
<?php

function myFunction() : Something {
    return null;
}
```

everything works fine, but if you prefer not including the space before colon `: `, like this:

```php
<?php

function myFunction(): Something {
    return null;
}
```
then a `SpaceAfterBracket` error is reported.

It is also a problem when defining closures.

This also influences other sniffs, such as `PEAR.Functions.FunctionDeclaration` or inherently `Squiz.Functions.MultiLineFunctionDeclaration` (where I stumbled upon this).

This pull request should allow both syntaxes, see tests, I hope I didn't forget about something.