### PR TITLE
Fix FunctionCallSignatureSniff

### DIFF
--- a/CodeSniffer/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -76,7 +76,7 @@ class PSR2_Sniffs_Methods_FunctionCallSignatureSniff extends PEAR_Sniffs_Functio
 
         // We've reached the last argument, so see if the next content
         // (should be the close bracket) is also on the same line.
-        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), $closeBracket, true);
+        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), $closeBracket + 1, true);
         if ($next !== false && $tokens[$next]['line'] !== $tokens[$end]['line']) {
             return true;
         }


### PR DESCRIPTION
The `findNext` method doesn't return token at the `$end` position. In that case we want the `$end` token to be returned (the close bracket) so there should be `$closeBracket + 1`. At least I think so - it solved my problem. I debugged it couple times and this seems to be the valid and intended `$end`.

The problem was with method `isMultiLineCall` - it didn't detect multi-line call correctly.
```
return [
    'tags'  => array_merge($tags, [
        'service'  => $this->validateService($service),
        'language' => $this->language->getCode(),
    ]),
    'level' => $level,
    'extra' => $extra,
];
```

This is clearly a multi-line call but the method failed to detect that because:

1. `$tags` is on the same line
2. `[ ... ]` doesn't end with comma so the while loop ends
3. Closing brace `)` is not returned as the result of the `findNext` method because the `$end` is not included (and it was set to the closing brace position)

To fix that I simply extended the `$end` by one more token (to include it in the search results).