### PR TITLE
Squiz FunctionDeclarationArgumentSpacing gives incorrect error/fix when variadic operator is followed by a space

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -354,7 +354,9 @@ class Squiz_Sniffs_Functions_FunctionDeclarationArgumentSpacingSniff implements 
                             }
                         }
                     }
-                } else if ($multiLine === false && $gap !== $this->requiredSpacesAfterOpen) {
+                } else if ($multiLine === false && $gap !== $this->requiredSpacesAfterOpen
+                    && ($tokens[$nextToken]['code'] !== T_ELLIPSIS || $nextToken > $whitespace)
+                ) {
                     $error = 'Expected %s spaces between opening bracket and argument "%s"; %s found';
                     $data  = array(
                               $this->requiredSpacesAfterOpen,

--- a/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
@@ -74,3 +74,4 @@ function MissingParamTypeInDocBlock(array$a = null, callable$c, \ArrayObject$o, 
 
 function myFunc(...$args) {}
 function myFunc( ...$args) {}
+function myFunc(... $args) {}

--- a/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc.fixed
@@ -74,3 +74,4 @@ function MissingParamTypeInDocBlock(array $a=null, callable $c, \ArrayObject $o,
 
 function myFunc(...$args) {}
 function myFunc(...$args) {}
+function myFunc(... $args) {}


### PR DESCRIPTION
Before this patch code like:
```function myFunc(... $args) {}```
would become:
```function myFunc($args) {}```
... effectively breaking the code.

I wasn't sure if I also should handle the space removal (between T_ELLIPSIS and the parameter) so I left it like that but if you want I can adjust the code to handle that as well.