### PR TITLE
Add a new utility method to find implemented interface names.

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -3715,4 +3715,56 @@ class PHP_CodeSniffer_File
     }//end findExtendedClassName()
 
 
+    /**
+     * Returns the name(s) of the interface(s) that the specified class implements.
+     *
+     * Returns FALSE on error or if there are no implemented interface names.
+     *
+     * @param int $stackPtr The stack position of the class.
+     *
+     * @return array|false
+     */
+    public function findImplementedInterfaceNames($stackPtr)
+    {
+        // Check for the existence of the token.
+        if (isset($this->_tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($this->_tokens[$stackPtr]['code'] !== T_CLASS) {
+            return false;
+        }
+
+        if (isset($this->_tokens[$stackPtr]['scope_closer']) === false) {
+            return false;
+        }
+
+        $classOpenerIndex = $this->_tokens[$stackPtr]['scope_opener'];
+        $implementsIndex  = $this->findNext(T_IMPLEMENTS, $stackPtr, $classOpenerIndex);
+        if ($implementsIndex === false) {
+            return false;
+        }
+
+        $find = array(
+                 T_NS_SEPARATOR,
+                 T_STRING,
+                 T_WHITESPACE,
+                 T_COMMA,
+                );
+
+        $end  = $this->findNext($find, ($implementsIndex + 1), ($classOpenerIndex + 1), true);
+        $name = $this->getTokensAsString(($implementsIndex + 1), ($end - $implementsIndex - 1));
+        $name = trim($name);
+
+        if ($name === '') {
+            return false;
+        } else {
+            $names = explode(',', $name);
+            $names = array_map('trim', $names);
+            return $names;
+        }
+
+    }//end findImplementedInterfaceNames()
+
+
 }//end class


### PR DESCRIPTION
Based on `findExtendedClassName()`. Allows to retrieve an array with the names of the interfaces a class implements.

Credits go to @westonruter (with a minor fix by me).

This is a method used within the WPCS project, but could possibly be useful for others too.

[Edit] Example use case: check if a method is in an extended class or implements an interface and if so, exempt it from method name convention checks as when overloading a method from the parent/interface complying with the method name conventions may not be possible.