### PR TITLE
add config `php_version` to override PHP_VERSION_ID in sniffs

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -48,7 +48,12 @@ class Generic_Sniffs_PHP_DisallowAlternativePHPTagsSniff implements PHP_CodeSnif
      */
     public function register()
     {
-        if (PHP_VERSION_ID < 70000) {
+        $phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+        if ($phpVersion === null) {
+            $phpVersion = PHP_VERSION_ID;
+        }
+
+        if ($phpVersion < 70000) {
             $this->_aspTags = (boolean) ini_get('asp_tags');
         }
 

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -40,6 +40,13 @@ class Generic_Sniffs_PHP_DisallowAlternativePHPTagsSniff implements PHP_CodeSnif
      */
     private $_aspTags = false;
 
+    /**
+     * The current PHP version.
+     *
+     * @var integer
+     */
+    private $_phpVersion = null;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -48,12 +55,14 @@ class Generic_Sniffs_PHP_DisallowAlternativePHPTagsSniff implements PHP_CodeSnif
      */
     public function register()
     {
-        $phpVersion = PHP_CodeSniffer::getConfigData('php_version');
-        if ($phpVersion === null) {
-            $phpVersion = PHP_VERSION_ID;
+        if ($this->_phpVersion === null) {
+            $this->_phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+            if ($this->_phpVersion === null) {
+                $this->_phpVersion = PHP_VERSION_ID;
+            }
         }
 
-        if ($phpVersion < 70000) {
+        if ($this->_phpVersion < 70000) {
             $this->_aspTags = (boolean) ini_get('asp_tags');
         }
 

--- a/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -56,6 +56,11 @@ class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        $phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+        if ($phpVersion === null) {
+            $phpVersion = PHP_VERSION_ID;
+        }
+
         $tokens = $phpcsFile->getTokens();
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             return;
@@ -72,7 +77,7 @@ class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
             $phpcsFile->recordMetric($stackPtr, 'One class per file', 'yes');
         }
 
-        if (PHP_VERSION_ID >= 50300) {
+        if ($phpVersion >= 50300) {
             $namespace = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
             if ($tokens[$namespace]['code'] !== T_NAMESPACE) {
                 $error = 'Each %s must be in a namespace of at least one level (a top-level vendor name)';

--- a/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -27,6 +27,12 @@
  */
 class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
 {
+    /**
+     * The current PHP version.
+     *
+     * @var integer
+     */
+    private $_phpVersion = null;
 
 
     /**
@@ -56,9 +62,11 @@ class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $phpVersion = PHP_CodeSniffer::getConfigData('php_version');
-        if ($phpVersion === null) {
-            $phpVersion = PHP_VERSION_ID;
+        if ($this->_phpVersion === null) {
+            $this->_phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+            if ($this->_phpVersion === null) {
+                $this->_phpVersion = PHP_VERSION_ID;
+            }
         }
 
         $tokens = $phpcsFile->getTokens();
@@ -77,7 +85,7 @@ class PSR1_Sniffs_Classes_ClassDeclarationSniff implements PHP_CodeSniffer_Sniff
             $phpcsFile->recordMetric($stackPtr, 'One class per file', 'yes');
         }
 
-        if ($phpVersion >= 50300) {
+        if ($this->_phpVersion >= 50300) {
             $namespace = $phpcsFile->findNext(array(T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT), 0);
             if ($tokens[$namespace]['code'] !== T_NAMESPACE) {
                 $error = 'Each %s must be in a namespace of at least one level (a top-level vendor name)';

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -238,6 +238,11 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
      */
     protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
     {
+        $phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+        if ($phpVersion === null) {
+            $phpVersion = PHP_VERSION_ID;
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         $params  = array();
@@ -382,7 +387,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                         $suggestedTypeHint = 'callable';
                     } else if (in_array($typeName, PHP_CodeSniffer::$allowedTypes) === false) {
                         $suggestedTypeHint = $suggestedName;
-                    } else if (PHP_VERSION_ID >= 70000) {
+                    } else if ($phpVersion >= 70000) {
                         if ($typeName === 'string') {
                             $suggestedTypeHint = 'string';
                         } else if ($typeName === 'int' || $typeName === 'integer') {

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -32,6 +32,13 @@ if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false)
 class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting_FunctionCommentSniff
 {
 
+    /**
+     * The current PHP version.
+     *
+     * @var integer
+     */
+    private $_phpVersion = null;
+
 
     /**
      * Process the return comment of this function comment.
@@ -238,9 +245,11 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
      */
     protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
     {
-        $phpVersion = PHP_CodeSniffer::getConfigData('php_version');
-        if ($phpVersion === null) {
-            $phpVersion = PHP_VERSION_ID;
+        if ($this->_phpVersion === null) {
+            $this->_phpVersion = PHP_CodeSniffer::getConfigData('php_version');
+            if ($this->_phpVersion === null) {
+                $this->_phpVersion = PHP_VERSION_ID;
+            }
         }
 
         $tokens = $phpcsFile->getTokens();
@@ -387,7 +396,7 @@ class Squiz_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commentin
                         $suggestedTypeHint = 'callable';
                     } else if (in_array($typeName, PHP_CodeSniffer::$allowedTypes) === false) {
                         $suggestedTypeHint = $suggestedName;
-                    } else if ($phpVersion >= 70000) {
+                    } else if ($this->_phpVersion >= 70000) {
                         if ($typeName === 'string') {
                             $suggestedTypeHint = 'string';
                         } else if ($typeName === 'int' || $typeName === 'integer') {


### PR DESCRIPTION
Provides enhancement requested in #1103, allows your phpcs to target a specific php version since some sniffs (three currently) provide different checks based on php version.

Allows user to specify `--platform=PHP_VERSION_ID` on command line, or `<platform>` in `phpcs.xml`. Can be used for both phpcs and phpcbf. Modified the Squiz Function Comment to use it if present.

Defaults to current PHP_VERSION_ID.

Documentation updates cannot be made in a PR.

This is similar to the composer config setting `platform` https://getcomposer.org/doc/06-config.md#platform but for phpcs.

I almost exclusively live on an intranet with SVN, so this is my first PR, sorry if I did anything wrong.

Ran codestyle and phpunit before submitting. Not sure if I need to also provide a test.