### PR TITLE
Add --force-check to display all errors without ignoring of any files.

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1728,11 +1728,14 @@ class PHP_CodeSniffer
             $filePath = $file;
         }
 
-        // Before we go and spend time tokenizing this file, just check
+        $cliValues = $this->cli->getCommandLineValues();
+
+        // If force check not set,
+        // before we go and spend time tokenizing this file, just check
         // to see if there is a tag up top to indicate that the whole
         // file should be ignored. It must be on one of the first two lines.
         $firstContent = $contents;
-        if ($contents === null && is_readable($filePath) === true) {
+        if (isset($cliValues['forceCheck']) === false && $contents === null && is_readable($filePath) === true) {
             $handle = fopen($filePath, 'r');
             stream_set_blocking($handle, true);
             if ($handle !== false) {
@@ -1786,8 +1789,6 @@ class PHP_CodeSniffer
 
             $phpcsFile->addError($error, null);
         }//end try
-
-        $cliValues = $this->cli->getCommandLineValues();
 
         if (PHP_CODESNIFFER_INTERACTIVE === false) {
             // Cache the report data for this file so we can unset it to save memory.

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -582,6 +582,9 @@ class PHP_CodeSniffer_CLI
         case 'no-colors':
             $this->values['colors'] = false;
             break;
+        case 'force-check':
+            $this->values['forceCheck'] = true;
+            break;
         case 'config-set':
             if (isset($this->_cliArgs[($pos + 1)]) === false
                 || isset($this->_cliArgs[($pos + 2)]) === false
@@ -1293,7 +1296,7 @@ class PHP_CodeSniffer_CLI
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
         echo '    [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]'.PHP_EOL;
         echo '    [--standard=<standard>] [--sniffs=<sniffs>] [--exclude=<sniffs>] [--encoding=<encoding>]'.PHP_EOL;
-        echo '    [--extensions=<extensions>] [--ignore=<patterns>] [--bootstrap=<bootstrap>]'.PHP_EOL;
+        echo '    [--extensions=<extensions>] [--force-check] [--ignore=<patterns>] [--bootstrap=<bootstrap>]'.PHP_EOL;
         echo '    [--file-list=<fileList>] <file> ...'.PHP_EOL;
         echo '                      Set runtime value (see --config-set) '.PHP_EOL;
         echo '        -n            Do not print warnings (shortcut for --warning-severity=0)'.PHP_EOL;
@@ -1311,6 +1314,8 @@ class PHP_CodeSniffer_CLI
         echo '        --version     Print version information'.PHP_EOL;
         echo '        --colors      Use colors in output'.PHP_EOL;
         echo '        --no-colors   Do not use colors in output (this is the default)'.PHP_EOL;
+        echo '        --force-check Disable of ignoring any code'.PHP_EOL;
+        echo '                      and of modification of coding standards via special tags'.PHP_EOL;
         echo '        <file>        One or more files and/or directories to check'.PHP_EOL;
         echo '        <fileList>    A file containing a list of files and/or directories to check (one per line)'.PHP_EOL;
         echo '        <stdinPath>   If processing STDIN, the file path that STDIN will be processed as '.PHP_EOL;

--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -212,6 +212,14 @@ class PHP_CodeSniffer_File
     private $_recordErrors = true;
 
     /**
+     * Force check by disabling of ignoring any code
+     * and of modification of coding standards via special tags.
+     *
+     * @var bool
+     */
+    private static $_forceCheck = false;
+
+    /**
      * An array of lines that are being ignored.
      *
      * @var array()
@@ -330,7 +338,15 @@ class PHP_CodeSniffer_File
 
                 $this->_recordErrors = $recordErrors;
             }
-        }
+
+            if (isset($cliValues['forceCheck']) === true
+                && $cliValues['forceCheck'] === true
+            ) {
+                self::$_forceCheck = true;
+            } else {
+                self::$_forceCheck = false;
+            }
+        }//end if
 
     }//end __construct()
 
@@ -487,9 +503,10 @@ class PHP_CodeSniffer_File
         // token, get them to process it.
         foreach ($this->_tokens as $stackPtr => $token) {
             // Check for ignored lines.
-            if ($token['code'] === T_COMMENT
+            if (self::$_forceCheck === false
+                && ($token['code'] === T_COMMENT
                 || $token['code'] === T_DOC_COMMENT_TAG
-                || ($inTests === true && $token['code'] === T_INLINE_HTML)
+                || ($inTests === true && $token['code'] === T_INLINE_HTML))
             ) {
                 if (strpos($token['content'], '@codingStandards') !== false) {
                     if (strpos($token['content'], '@codingStandardsIgnoreFile') !== false) {
@@ -1611,7 +1628,9 @@ class PHP_CodeSniffer_File
                 $tokens[$i]['length'] += $eolLen;
             }
 
-            if ($tokens[$i]['code'] === T_COMMENT
+            if (self::$_forceCheck === true) {
+                $ignoring = false;
+            } else if ($tokens[$i]['code'] === T_COMMENT
                 || $tokens[$i]['code'] === T_DOC_COMMENT_TAG
                 || ($inTests === true && $tokens[$i]['code'] === T_INLINE_HTML)
             ) {


### PR DESCRIPTION
Provides enhancement requested in #811. Allows your phpcs to prevent of ignoring any @codingStandardsIgnore sections and to ignoring of any modifications of current coding standard via @codingStandardsChangeSetting section.

