### PR TITLE
Add UnusedUseStatementSniff copied from Drupal Coder

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Classes/UnusedUseStatementSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Classes/UnusedUseStatementSniff.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Generic_Sniffs_Classes_UnusedUseStatementSniff.
+ *
+ * PHP versions 5 and 7
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Klaus Purer <klaus.purer@gmail.com>
+ * @author    Alex Pott <alexpott@157725.no-reply.drupal.org>
+ * @copyright 2015-2016 Klaus Purer
+ * @copyright 2015-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+/**
+ * Generic_Sniffs_Classes_UnusedUseStatementSniff
+ *
+ * Checks for "use" statements that are not needed in a file.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Klaus Purer <klaus.purer@gmail.com>
+ * @author    Alex Pott <alexpott@157725.no-reply.drupal.org>
+ * @copyright 2015-2016 Klaus Purer
+ * @copyright 2015-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Sniffs_Classes_UnusedUseStatementSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_USE);
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        // Only check use statements in the global scope.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            return;
+        }
+
+        // Seek to the end of the statement and get the string before the semi colon.
+        $semiColon = $phpcsFile->findEndOfStatement($stackPtr);
+        if ($tokens[$semiColon]['code'] !== T_SEMICOLON) {
+            return;
+        }
+
+        $classPtr = $phpcsFile->findPrevious(
+            PHP_CodeSniffer_Tokens::$emptyTokens,
+            ($semiColon - 1),
+            null,
+            true
+        );
+        if ($tokens[$classPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Search where the class name is used. PHP treats class names case
+        // insensitive, that's why we cannot search for the exact class name string
+        // and need to iterate over all T_STRING tokens in the file.
+        $classUsed      = $phpcsFile->findNext(T_STRING, ($classPtr + 1));
+        $lowerClassName = strtolower($tokens[$classPtr]['content']);
+        // Check if the referenced class is in the same namespace as the current
+        // file. If it is then the use statement is not necessary.
+        $namespacePtr = $phpcsFile->findPrevious([T_NAMESPACE], $stackPtr);
+        // Check if the use statement does aliasing with the "as" keyword. Aliasing
+        // is allowed even in the same namespace.
+        $aliasUsed = $phpcsFile->findPrevious(T_AS, ($classPtr - 1), $stackPtr);
+        if ($namespacePtr !== false && $aliasUsed === false) {
+            $nsEnd           = $phpcsFile->findNext(
+                [
+                 T_NS_SEPARATOR,
+                 T_STRING,
+                 T_WHITESPACE,
+                ],
+                ($namespacePtr + 1),
+                null,
+                true
+            );
+            $namespace       = trim($phpcsFile->getTokensAsString(($namespacePtr + 1), ($nsEnd - $namespacePtr - 1)));
+            $useNamespacePtr = $phpcsFile->findNext([T_STRING], ($stackPtr + 1));
+            $useNamespaceEnd = $phpcsFile->findNext(
+                [
+                 T_NS_SEPARATOR,
+                 T_STRING,
+                ],
+                ($useNamespacePtr + 1),
+                null,
+                true
+            );
+            $use_namespace   = rtrim($phpcsFile->getTokensAsString($useNamespacePtr, ($useNamespaceEnd - $useNamespacePtr - 1)), '\\');
+            if (strcasecmp($namespace, $use_namespace) === 0) {
+                $classUsed = false;
+            }
+        }//end if
+
+        while ($classUsed !== false) {
+            if (strtolower($tokens[$classUsed]['content']) === $lowerClassName) {
+                $beforeUsage = $phpcsFile->findPrevious(
+                    PHP_CodeSniffer_Tokens::$emptyTokens,
+                    ($classUsed - 1),
+                    null,
+                    true
+                );
+                // If a backslash is used before the class name then this is some other
+                // use statement.
+                if ($tokens[$beforeUsage]['code'] !== T_USE && $tokens[$beforeUsage]['code'] !== T_NS_SEPARATOR) {
+                    return;
+                }
+
+                // Trait use statement within a class.
+                if ($tokens[$beforeUsage]['code'] === T_USE && empty($tokens[$beforeUsage]['conditions']) === false) {
+                    return;
+                }
+            }
+
+            $classUsed = $phpcsFile->findNext(T_STRING, ($classUsed + 1));
+        }//end while
+
+        $warning = 'Unused use statement';
+        $fix     = $phpcsFile->addFixableWarning($warning, $stackPtr, 'UnusedUse');
+        if ($fix === true) {
+            // Remove the whole use statement line.
+            $phpcsFile->fixer->beginChangeset();
+            for ($i = $stackPtr; $i <= $semiColon; $i++) {
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+
+            // Also remove whitespace after the semicolon (new lines).
+            while (isset($tokens[$i]) === true && $tokens[$i]['code'] === T_WHITESPACE) {
+                $phpcsFile->fixer->replaceToken($i, '');
+                if (strpos($tokens[$i]['content'], $phpcsFile->eolChar) !== false) {
+                    break;
+                }
+
+                $i++;
+            }
+
+            $phpcsFile->fixer->endChangeset();
+        }
+
+    }//end process()
+
+
+}//end class

--- a/CodeSniffer/Standards/Generic/Tests/Classes/UnusedUseStatementUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Classes/UnusedUseStatementUnitTest.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace MyNamespace\Depth;
+
+use Foo\Bar;
+use Bar\Fail;
+use Test\Bar\Thing;
+use Thing\Fail\ActuallyUsed;
+use Test\TraitTest;
+use Thing\NotUsed;
+use Test\AnotherTrait;
+use Thing\SomeName as OtherName;
+use Thing\DifferentName as UsedOtherName;
+use Another\UnusedUse;
+use Example\MyUrlHelper;
+use MyNamespace\Depth\UnusedSameNamespace;
+use /* I like weird comment placements */ MyNamespace\Depth\AnotherUnusedSameNamespace /* Oh yes I do */;
+use MyNamespace\Depth\SomeClass as CoreSomeClass;
+
+/**
+ * Bla.
+ */
+class Pum {
+  use TraitTest;
+  use Test\AnotherTrait;
+
+  /**
+   * Description.
+   */
+  protected function test(ActuallyUsed $x, UsedOtherName $y) {
+
+  }
+
+  /**
+   * Description.
+   */
+  protected function test2(\Thing\NotUsed $x) {
+
+  }
+
+  /**
+   * PHP is not case sensitive.
+   */
+  protected function test3(MyURLHelper $x) {
+
+  }
+
+  /**
+   * Don't need to use classes in the same namespace.
+   */
+  protected function test4(UnusedSameNamespace $x, AnotherUnusedSameNamespace $y) {
+
+  }
+
+  /**
+   * Renamed class from same namespace.
+   */
+  protected function test5(CoreSomeClass $x) {
+
+  }
+
+}

--- a/CodeSniffer/Standards/Generic/Tests/Classes/UnusedUseStatementUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/Classes/UnusedUseStatementUnitTest.inc.fixed
@@ -1,0 +1,53 @@
+<?php
+
+namespace MyNamespace\Depth;
+
+use Thing\Fail\ActuallyUsed;
+use Test\TraitTest;
+use Thing\DifferentName as UsedOtherName;
+use Example\MyUrlHelper;
+use MyNamespace\Depth\SomeClass as CoreSomeClass;
+
+/**
+ * Bla.
+ */
+class Pum {
+  use TraitTest;
+  use Test\AnotherTrait;
+
+  /**
+   * Description.
+   */
+  protected function test(ActuallyUsed $x, UsedOtherName $y) {
+
+  }
+
+  /**
+   * Description.
+   */
+  protected function test2(\Thing\NotUsed $x) {
+
+  }
+
+  /**
+   * PHP is not case sensitive.
+   */
+  protected function test3(MyURLHelper $x) {
+
+  }
+
+  /**
+   * Don't need to use classes in the same namespace.
+   */
+  protected function test4(UnusedSameNamespace $x, AnotherUnusedSameNamespace $y) {
+
+  }
+
+  /**
+   * Renamed class from same namespace.
+   */
+  protected function test5(CoreSomeClass $x) {
+
+  }
+
+}

--- a/CodeSniffer/Standards/Generic/Tests/Classes/UnusedUseStatementUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Classes/UnusedUseStatementUnitTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Unit test class for the UnusedUseStatement sniff.
+ *
+ * PHP versions 5 and 7
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Klaus Purer <klaus.purer@gmail.com>
+ * @author    Alex Pott <alexpott@157725.no-reply.drupal.org>
+ * @copyright 2015-2016 Klaus Purer
+ * @copyright 2015-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+/**
+ * Unit test class for the UnusedUseStatement sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Klaus Purer <klaus.purer@gmail.com>
+ * @author    Alex Pott <alexpott@157725.no-reply.drupal.org>
+ * @copyright 2015-2016 Klaus Purer
+ * @copyright 2015-2016 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Generic_Tests_Classes_UnusedUseStatementUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array();
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array(
+                5 => 1,
+                6 => 1,
+                7 => 1,
+                10 => 1,
+                11 => 1,
+                12 => 1,
+                14 => 1,
+                16 => 1,
+                17 => 1,
+               );
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Resolves https://github.com/squizlabs/PHP_CodeSniffer/issues/801

- [x] Code conforms to standard
- [x] Has tests
- [x] Unit tests pass.
- [x] Manually tested against a codebase of mine that was rife with unused `use` statements

Nicked from https://github.com/klausi/coder with the gracious permission of its authors.

Changes from the original at https://github.com/klausi/coder were:
- Modified UnusedUseStatementUnitTest.inc.fixed to remove the Thing/NotUsed
  use, instead of modifying the type hint involving it, since this is the
  automatic fix the Sniff would generate and PHPCS's tests require that
  'fixed' files match the output of running the fixer.
- Added file headers in the style of PHPCS's other files
- Modified code formatting to match PHPCS's linting rules

Note that I am not the author of this sniff; @klausi and @alexpott are.

When it comes to crafting the file's PHPDoc header, although I've mostly just imitated the style of existing sniffs, I had to make a few decisions. I'll list them here so that all parties can confirm they're okay with my choices before this gets merged:

- I listed Klaus Purer and Alex Pott as authors, with the email addresses that they used for committing on Drupal Coder.
- Since this is Klaus's work but every single other sniff has Squiz listed as a copyright holder, I listed **both** *Klaus Purer* and *Squiz Pty Ltd (ABN 77 084 670 600)* both as copyright holders, in the same style as e.g. Notifysend.php which lists Christian Weiske and Squiz as copyright holders. I'm no expert either in intellectual property law or PHPDoc, but I think this declares that both parties hold full copyright - i.e. that both parties are free to reproduce the work or to license it to others under any licensing terms that they please. @klausi and @alexpott, are you okay with that line being there?

Also, @klausi and @alexpott - you both agreed to relicensing under MIT in https://github.com/squizlabs/PHP_CodeSniffer/issues/801, which Klausi thought PHPCS was licensed under. However, while writing this I saw that all the files actually declare that they are BSD-licensed, not MIT-licensed. @klausi and @alexpott, could you both confirm that you're happy to relicense under BSD?

Assuming everybody's comfortable with the legal stuff, I think this should be good to go.