### PR TITLE
contributing.md remove args so it uses phpcs.xml.dist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributing
 Before you contribute code to PHP\_CodeSniffer, please make sure it conforms to the PHPCS coding standard and that the PHP\_CodeSniffer unit tests still pass. The easiest way to contribute is to work on a checkout of the repository, or your own fork, rather than an installed PEAR version. If you do this, you can run the following commands to check if everything is ready to submit:
 
     cd PHP_CodeSniffer
-    php scripts/phpcs . --standard=PHPCS -np
+    php scripts/phpcs
 
 Which should give you no output, indicating that there are no coding standard errors. And then:
 


### PR DESCRIPTION
The current `CONTRIBUTING.md` says to run `php scripts/phpcs . --standard=PHPCS -np` which makes it ignore the default `phpcs.xml.dist` and also scans the whole `vendor` directory. 

By removing the arguments it will use the `phpcs.xml.dist` file and not scan the vendor directory, plus keep up to date with whatever defaults you change in the future.

Alternatively it if you want to keep it listing everything, it could be changed to `php scripts/phpcs CodeSniffer.php scripts CodeSniffer --standard=PHPCS -np` so that vendor and tests are ignored.