### PR TITLE
Recognize `self` as type hint in `getMethodParameters()`.

### DIFF
--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -87,6 +87,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => true,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'raw'               => '&$var',
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -117,6 +118,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => 'array',
+                        'raw'               => 'array $var',
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -147,6 +149,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => 'foo',
+                        'raw'               => 'foo $var1',
                        );
 
         $expected[1] = array(
@@ -154,6 +157,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => 'bar',
+                        'raw'               => 'bar $var2',
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -163,6 +167,37 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
             null,
             false,
             '/* testTypeHint */'
+        );
+
+        $found = $this->_phpcsFile->getMethodParameters(($function + 2));
+        $this->assertSame($expected, $found);
+
+    }//end testTypeHint()
+
+
+    /**
+     * Verify self type hint parsing.
+     *
+     * @return void
+     */
+    public function testSelfTypeHint()
+    {
+        $expected    = array();
+        $expected[0] = array(
+                        'name'              => '$var',
+                        'pass_by_reference' => false,
+                        'variable_length'   => false,
+                        'type_hint'         => 'self',
+                        'raw'               => 'self $var',
+                       );
+
+        $start    = ($this->_phpcsFile->numTokens - 1);
+        $function = $this->_phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testSelfTypeHint */'
         );
 
         $found = $this->_phpcsFile->getMethodParameters(($function + 2));
@@ -184,6 +219,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'raw'               => '$var',
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -215,6 +251,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'raw'               => '$var1=self::CONSTANT',
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -246,6 +283,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'raw'               => '$var1=1',
                        );
         $expected[1] = array(
                         'name'              => '$var2',
@@ -253,6 +291,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'raw'               => "\$var2='value'",
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -279,6 +318,9 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
 /* testSingleDefaultValue */ function defaultValue($var1=self::CONSTANT) {}
 /* testDefaultValues */ function defaultValues($var1=1, $var2='value') {}
 /* testTypeHint */ function typeHint(foo $var1, bar $var2) {}
+class MyClass {
+/* testSelfTypeHint */ function typeSelfHint(self $var) {}
+}
 // @codingStandardsIgnoreEnd
 
 ?>


### PR DESCRIPTION
Improve type hint recognition:
- `self` is a valid type hint and was so far not being recognized as such. Ref: http://php.net/functions.arguments#functions.arguments.type-declaration
- `parent` and `static` are _not_ valid type hints, but if they are there, they were probably intended as such.
- For both the above, made sure not to confuse the type hint with the default value.

New array value `raw`:
- Add raw content of the parameter parts to the return array for use in further processing.

Includes adjusted unit tests + added unit test for `self`

P.S.: the alignment of the setting of the `raw` array value is a bit out of sync, but that's due to a bug in another sniff. The PHPCS code style was borking on proper alignment.
