### PR TITLE
Makes Squiz MethodScopeSniff sniff Traits

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
@@ -38,7 +38,7 @@ class Squiz_Sniffs_Scope_MethodScopeSniff extends PHP_CodeSniffer_Standards_Abst
      */
     public function __construct()
     {
-        parent::__construct(array(T_CLASS, T_INTERFACE), array(T_FUNCTION));
+        parent::__construct(array(T_CLASS, T_INTERFACE, T_TRAIT), array(T_FUNCTION));
 
     }//end __construct()
 

--- a/CodeSniffer/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
@@ -25,3 +25,10 @@ class Closure_Test {
 function test() {
     $foo = function() { echo 'foo'; };
 }
+
+trait Trait_Test {
+	function func1() {}
+	public function func1() {}
+	private function func1() {}
+	protected function func1() {}
+}

--- a/CodeSniffer/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -44,6 +44,7 @@ class Squiz_Tests_Scope_MethodScopeUnitTest extends AbstractSniffUnitTest
     {
         return array(
                 6 => 1,
+                30 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
It currently sniffs classes and interfaces, this just adds traits to the list of things sniffed.

Scrutinizer was complaining about one of our traits having a method without visibility defined and I was like "phpcs should have caught this!" huzzah, it was not checking traits.

Easy fix.