### PR TITLE
Bug in Squiz.Operators.ComparisonOperatorUsage

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -154,7 +154,7 @@ class Squiz_Sniffs_Operators_ComparisonOperatorUsageSniff implements PHP_CodeSni
 
                 $start = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($i + 1), null, true);
             } else {
-                if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
+                if (isset($tokens[$end]['parenthesis_opener']) === false) {
                     return;
                 }
 


### PR DESCRIPTION
The sniff which enforces identity operators does not work correctly on inline ifs.
The check for the parenthesis opener uses $stackPtr instead of $end (which is the closer).