### PR TITLE
Improved Squiz.CSS.DuplicateClassDefinitionSniff

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
@@ -69,14 +69,32 @@ class Squiz_Sniffs_CSS_DuplicateClassDefinitionSniff implements PHP_CodeSniffer_
             return;
         }
 
+        // Save the class names in a "scope",
+        // to prevent false positives with @media blocks.
+        $scope = 'main';
+
         $find = array(
                  T_CLOSE_CURLY_BRACKET,
+                 T_OPEN_CURLY_BRACKET,
                  T_COMMENT,
                  T_OPEN_TAG,
                 );
 
+        $exclude = array(
+                    T_WHITESPACE,
+                    T_COMMENT,
+                   );
+
         while ($next !== false) {
             $prev = $phpcsFile->findPrevious($find, ($next - 1));
+
+            // Check if an inner block was closed.
+            $beforePrev = $phpcsFile->findPrevious($exclude, ($prev - 1), null, true);
+            if ($beforePrev !== false
+                && $tokens[$beforePrev]['code'] === T_CLOSE_CURLY_BRACKET
+            ) {
+                $scope = 'main';
+            }
 
             // Create a sorted name for the class so we can compare classes
             // even when the individual names are all over the place.
@@ -94,13 +112,16 @@ class Squiz_Sniffs_CSS_DuplicateClassDefinitionSniff implements PHP_CodeSniffer_
             sort($names);
             $name = implode(',', $names);
 
-            if (isset($classNames[$name]) === true) {
-                $first = $classNames[$name];
+            if ($name{0} === '@') {
+                // Media block has its own "scope".
+                $scope = $name;
+            } else if (isset($classNames[$scope][$name]) === true) {
+                $first = $classNames[$scope][$name];
                 $error = 'Duplicate class definition found; first defined on line %s';
                 $data  = array($tokens[$first]['line']);
                 $phpcsFile->addError($error, $next, 'Found', $data);
             } else {
-                $classNames[$name] = $next;
+                $classNames[$scope][$name] = $next;
             }
 
             $next = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($next + 1));

--- a/CodeSniffer/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.css
+++ b/CodeSniffer/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.css
@@ -31,3 +31,40 @@
 
 .YourClass, .MyClass, .OurClass {
 }
+
+
+.ClassAtTopOfMediaBlock {
+}
+
+@media print {
+    .ClassAtTopOfMediaBlock {
+    }
+
+    .ClassInMultipleMediaBlocks {
+    }
+}
+
+.ClassNotAtTopOfMediaBlock {
+}
+
+@media handheld {
+    .SameClassInMediaBlock {
+    }
+
+    .ClassNotAtTopOfMediaBlock {
+    }
+
+    .SameClassInMediaBlock {
+    }
+}
+
+@media braille {
+    .PlaceholderClass {
+    }
+
+    .ClassNotAtTopOfMediaBlock {
+    }
+
+    .ClassInMultipleMediaBlocks {
+    }
+}

--- a/CodeSniffer/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
@@ -43,6 +43,7 @@ class Squiz_Tests_CSS_DuplicateClassDefinitionUnitTest extends AbstractSniffUnit
         return array(
                 9  => 1,
                 29 => 1,
+                57 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
It now handles a media block as a scope.
This prevents false positives caused by the same class in multiple media queries/blocks.