### PR TITLE
 #1136 - Provide XSL linking first proposition

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -1810,7 +1810,7 @@ class PHP_CodeSniffer
                 continue;
             }
 
-            $reportClass = $this->reporting->factory('full');
+            $reportClass = $this->reporting->factory(PHP_CodeSniffer_Reporting::REPORT_TYPE_FULL);
             $reportData  = $this->reporting->prepareFileReport($phpcsFile);
             $reportClass->generateFileReport($reportData, $phpcsFile, $cliValues['showSources'], $cliValues['reportWidth']);
 

--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -292,6 +292,7 @@ class PHP_CodeSniffer_CLI
         $defaults['reportFile']      = null;
         $defaults['generator']       = '';
         $defaults['reports']         = array();
+        $defaults['with-xsl-path']   = '';
         $defaults['bootstrap']       = array();
         $defaults['errorSeverity']   = null;
         $defaults['warningSeverity'] = null;
@@ -749,6 +750,8 @@ class PHP_CodeSniffer_CLI
                     $this->printUsage();
                     exit(2);
                 }
+            } else if (substr($arg, 0, 14) === 'with-xsl-path=') {
+                $this->values['with-xsl-path'] = substr($arg, 14);
             } else if (substr($arg, 0, 13) === 'report-width=') {
                 $this->values['reportWidth'] = $this->_validateReportWidth(substr($arg, 13));
             } else if (substr($arg, 0, 7) === 'report='
@@ -1047,7 +1050,7 @@ class PHP_CodeSniffer_CLI
         $reportWidth
     ) {
         if (empty($reports) === true) {
-            $reports['full'] = $reportFile;
+            $reports[PHP_CodeSniffer_Reporting::REPORT_TYPE_FULL] = $reportFile;
         }
 
         $errors   = 0;
@@ -1288,7 +1291,7 @@ class PHP_CodeSniffer_CLI
     public function printPHPCSUsage()
     {
         echo 'Usage: phpcs [-nwlsaepqvi] [-d key[=value]] [--colors] [--no-colors] [--stdin-path=<stdinPath>]'.PHP_EOL;
-        echo '    [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>] ...'.PHP_EOL;
+        echo '    [--report=<report>] [--with-xsl-path=<xslFilePath>] [--report-file=<reportFile>] [--report-<report>=<reportFile>] ...'.PHP_EOL;
         echo '    [--report-width=<reportWidth>] [--generator=<generator>] [--tab-width=<tabWidth>]'.PHP_EOL;
         echo '    [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
         echo '    [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]'.PHP_EOL;
@@ -1327,6 +1330,8 @@ class PHP_CodeSniffer_CLI
         echo '                      "json", "emacs", "source", "summary", "diff", "junit"'.PHP_EOL;
         echo '                      "svnblame", "gitblame", "hgblame" or "notifysend" report'.PHP_EOL;
         echo '                      (the "full" report is printed by default)'.PHP_EOL;
+        echo '        <xslFilePath> Include the specified XSL file in the resulting XML. Available only for XML reports'.PHP_EOL;
+        echo '                      This path should be defined relative to the target output .xml file.'.PHP_EOL;
         echo '        <reportFile>  Write the report to the specified file path'.PHP_EOL;
         echo '        <reportWidth> How many columns wide screen reports should be printed'.PHP_EOL;
         echo '                      or set to "auto" to use current screen width, where supported'.PHP_EOL;

--- a/CodeSniffer/Reporting.php
+++ b/CodeSniffer/Reporting.php
@@ -29,6 +29,34 @@
  */
 class PHP_CodeSniffer_Reporting
 {
+    /** @const REPORT_TYPE_FULL - The 'full' report type */
+    const REPORT_TYPE_FULL       = 'full';
+    /** @const REPORT_TYPE_XML - The 'xml' report type */
+    const REPORT_TYPE_XML        = 'xml';
+    /** @const REPORT_TYPE_CHECKSTYLE - The 'checkstyle' report type */
+    const REPORT_TYPE_CHECKSTYLE = 'checkstyle';
+    /** @const REPORT_TYPE_CSV - The 'csv' report type */
+    const REPORT_TYPE_CSV        = 'csv';
+    /** @const REPORT_TYPE_JSON - The 'json' report type */
+    const REPORT_TYPE_JSON       = 'json';
+    /** @const REPORT_TYPE_EMACS - The 'emacs' report type */
+    const REPORT_TYPE_EMACS      = 'emacs';
+    /** @const REPORT_TYPE_SOURCE - The 'source' report type */
+    const REPORT_TYPE_SOURCE     = 'source';
+    /** @const REPORT_TYPE_SUMMARY - The 'summary' report type */
+    const REPORT_TYPE_SUMMARY    = 'summary';
+    /** @const REPORT_TYPE_DIFF - The 'diff' report type */
+    const REPORT_TYPE_DIFF       = 'diff';
+    /** @const REPORT_TYPE_JUNIT - The 'junit' report type */
+    const REPORT_TYPE_JUNIT      = 'junit';
+    /** @const REPORT_TYPE_SVN_BLAME - The 'svnblame' report type */
+    const REPORT_TYPE_SVN_BLAME  = 'svnblame';
+    /** @const REPORT_TYPE_GIT_BLAME - The 'gitblame' report type */
+    const REPORT_TYPE_GIT_BLAME  = 'gitblame';
+    /** @const REPORT_TYPE_HG_BLAME - The 'hgblame' report type */
+    const REPORT_TYPE_HG_BLAME   = 'hgblame';
+    /** @const REPORT_TYPE_NOTIFYSEND - The 'notifysend' report type */
+    const REPORT_TYPE_NOTIFYSEND = 'notifysend';
 
     /**
      * Total number of files that contain errors or warnings.
@@ -223,8 +251,17 @@ class PHP_CodeSniffer_Reporting
         $reportFile='',
         $reportWidth=80
     ) {
+        /** @var bool $callXslSetter */
+        $callXslSetter = false;
+        if ($cliValues['with-xsl-path'] !== '' && $report == self::REPORT_TYPE_XML) {
+            $callXslSetter = true;
+        }
+
         $reportClass = $this->factory($report);
         $report      = get_class($reportClass);
+        if ($callXslSetter === true) {
+            $reportClass->setXslPath($cliValues['with-xsl-path']);
+        }
 
         if ($reportFile !== null) {
             $filename = $reportFile;

--- a/CodeSniffer/Reports/Xml.php
+++ b/CodeSniffer/Reports/Xml.php
@@ -32,7 +32,13 @@
 class PHP_CodeSniffer_Reports_Xml implements PHP_CodeSniffer_Report
 {
 
-
+    /**
+     * Relative path to a XSL stylesheet. 
+     * Added to the resulting XML if set as string.
+     * @var null|string $xslPath 
+     */
+    private $xslPath = null;
+    
     /**
      * Generate a partial report for a single processed file.
      *
@@ -122,11 +128,23 @@ class PHP_CodeSniffer_Reports_Xml implements PHP_CodeSniffer_Report
         $toScreen=true
     ) {
         echo '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL;
+        if (null !== $this->xslPath) {
+            echo '<?xml-stylesheet type="text/xsl" href="'.$this->xslPath.'"?>'.PHP_EOL;
+        }
         echo '<phpcs version="'.PHP_CodeSniffer::VERSION.'">'.PHP_EOL;
         echo $cachedData;
         echo '</phpcs>'.PHP_EOL;
 
     }//end generate()
+
+    /**
+     * Setter for $this->xslPath
+     * @param null|string $xslPath
+     */
+    public function setXslPath($xslPath)
+    {
+        $this->xslPath = (string) $xslPath;
+    }//end setXslPath()
 
 
 }//end class


### PR DESCRIPTION
My changes are working. I don't think it is fully-done as it is almost certain I missed something that the project adheres to. However here is the PR. The XSL is included at the top of the XML file if --with-xsl-file=<xslFilePath> is passed.

The changes Include:
 - new CLI param --with-xsl-path=<xslFilePath>
 - input parsing of the new param
 - docs for the new param
 - Defined report types' constants to match against
 - Reporting modification in printReport()
 - Modification in PHP_CodeSniffer_Reports_Xml