### PR TITLE
Play nice with sniff libraries with alternative unit test setups.

### DIFF
--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -41,6 +41,16 @@ class PHP_CodeSniffer_TestSuite extends PHPUnit_Framework_TestSuite
      */
     public function run(PHPUnit_Framework_TestResult $result=null, $filter=false)
     {
+        // Report on any test files which led to errors including the corresponding sniff file.
+        if (empty(PHP_CodeSniffer_Standards_AllSniffs::$includeFailures) === false) {
+            echo PHP_EOL;
+            echo 'IMPORTANT: No corresponding sniff files were found for the following test files:'.PHP_EOL.PHP_EOL;
+            foreach(PHP_CodeSniffer_Standards_AllSniffs::$includeFailures as $path) {
+                echo "- $path".PHP_EOL;
+            }
+            echo PHP_EOL.PHP_EOL;
+        }
+
         $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']   = array();
         $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'] = array();
 


### PR DESCRIPTION
If there are `installed_paths` set up in the config and one of the standards in the `installed_paths` uses an alternative way to unit test - this applies in particular to the [PHPCompatibility](https://github.com/wimg/PHPCompatibility) sniff library -, running the unit tests for any of the other standards using the normal PHPCS unit test set up will fail as fatal errors will be thrown for (sniff) files which cannot be found.

This minor adjustment prevents these fatal errors while leaving the responsibility for running the tests which are set up differently with the sniff library in question.