### PR TITLE
Allow configuring the number of spaces before colons in alternative control structures

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
@@ -186,6 +186,14 @@ if ($test)    { /*one space after the bracket*/
     echo 'true';
 }
 
+if ($test) /* before */ { /* after */
+    echo 'true';
+}
+
+if ($test) /* before */   { /* after */
+    echo 'true';
+}
+
 ?>
 <?php foreach($formset['Fieldset'] as $fieldset): ?>
     <?php foreach($fieldset['Field'] as $field): ?> 
@@ -196,6 +204,49 @@ if ($test)    { /*one space after the bracket*/
 <?php endforeach; ?>
 
 <?php foreach ($formset['Fieldset'] as $fieldset) :
+    ?>
+    hello
+<?php endforeach; ?>
+
+<?php
+
+// @codingStandardsChangeSetting Squiz.ControlStructures.ControlSignature requiredSpacesBeforeColon 0
+
+if ($a == 5):
+    echo "a equals 5";
+    echo "...";
+elseif ($a == 6):
+    echo "a equals 6";
+    echo "!!!";
+else:
+    echo "a is neither 5 nor 6";
+endif;
+
+switch($foo) {
+
+    case 'bar':
+    break;
+
+}
+
+if ($foo)  :
+endif;
+
+?>
+
+<?php while($row = $data->getRow()) : ?>
+    <p><?= $val ?></p>
+<?php endwhile; ?>
+
+<?php foreach($formset['Fieldset'] as $fieldset) : ?>
+    <?php foreach($fieldset['Field'] as $field) : ?> 
+    <?php endforeach; ?>
+<?php endforeach; ?>
+
+<?php foreach ($formset['Fieldset'] as $fieldset): ?> hello
+<?php endforeach; ?>
+
+<?php foreach ($formset['Fieldset'] as $fieldset):
     ?>
     hello
 <?php endforeach; ?>

--- a/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
@@ -188,6 +188,14 @@ if ($test) { /*one space after the bracket*/
     echo 'true';
 }
 
+if ($test) { /* before */  /* after */
+    echo 'true';
+}
+
+if ($test) { /* before */    /* after */
+    echo 'true';
+}
+
 ?>
 <?php foreach ($formset['Fieldset'] as $fieldset) : ?>
     <?php foreach ($fieldset['Field'] as $field) : ?> 
@@ -199,6 +207,50 @@ if ($test) { /*one space after the bracket*/
 <?php endforeach; ?>
 
 <?php foreach ($formset['Fieldset'] as $fieldset) :
+    ?>
+    hello
+<?php endforeach; ?>
+
+<?php
+
+// @codingStandardsChangeSetting Squiz.ControlStructures.ControlSignature requiredSpacesBeforeColon 0
+
+if ($a == 5):
+    echo "a equals 5";
+    echo "...";
+elseif ($a == 6):
+    echo "a equals 6";
+    echo "!!!";
+else:
+    echo "a is neither 5 nor 6";
+endif;
+
+switch ($foo) {
+
+    case 'bar':
+    break;
+
+}
+
+if ($foo):
+endif;
+
+?>
+
+<?php while ($row = $data->getRow()): ?>
+    <p><?= $val ?></p>
+<?php endwhile; ?>
+
+<?php foreach ($formset['Fieldset'] as $fieldset): ?>
+    <?php foreach ($fieldset['Field'] as $field): ?> 
+    <?php endforeach; ?>
+<?php endforeach; ?>
+
+<?php foreach ($formset['Fieldset'] as $fieldset):
+?> hello
+<?php endforeach; ?>
+
+<?php foreach ($formset['Fieldset'] as $fieldset):
     ?>
     hello
 <?php endforeach; ?>

--- a/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -77,9 +77,17 @@ class Squiz_Tests_ControlStructures_ControlSignatureUnitTest extends AbstractSni
             $errors[165] = 1;
             $errors[170] = 2;
             $errors[185] = 1;
-            $errors[190] = 2;
-            $errors[191] = 2;
-            $errors[195] = 1;
+            $errors[189] = 1;
+            $errors[193] = 1;
+            $errors[198] = 2;
+            $errors[199] = 2;
+            $errors[203] = 1;
+            $errors[225] = 1;
+            $errors[232] = 1;
+            $errors[237] = 2;
+            $errors[241] = 2;
+            $errors[242] = 2;
+            $errors[246] = 1;
         }
 
         return $errors;


### PR DESCRIPTION
This is a follow-up to #1008. I don't think the PSR2 standard should be checking colons at all, but I'm not going to argue about that.

The problem is that if you want to create a standard that expects 0 spaces for colons (since that is how most people write code), you have to copy the entire sniff and modify it, and that sniff needs to handle the normal syntax too, since you have to disable the original sniff.

I made the sniff configurable, so all you need to do is change one setting in your standard.
