### PR TITLE
Remove duplicate code from the Squiz `ArrayDeclaration` sniff.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -344,7 +344,6 @@ class Squiz_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
             }
         }//end if
 
-        $nextToken  = $stackPtr;
         $keyUsed    = false;
         $singleUsed = false;
         $indices    = array();
@@ -367,14 +366,22 @@ class Squiz_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
                 continue;
             }
 
-            if ($tokens[$nextToken]['code'] === T_ARRAY) {
+            if (in_array($tokens[$nextToken]['code'], array(T_ARRAY, T_OPEN_SHORT_ARRAY, T_CLOSURE), true) === true) {
                 // Let subsequent calls of this test handle nested arrays.
                 if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
                     $indices[] = array('value' => $nextToken);
                     $lastToken = $nextToken;
                 }
 
-                $nextToken = $tokens[$tokens[$nextToken]['parenthesis_opener']]['parenthesis_closer'];
+                if ($tokens[$nextToken]['code'] === T_ARRAY) {
+                    $nextToken = $tokens[$tokens[$nextToken]['parenthesis_opener']]['parenthesis_closer'];
+                } else if ($tokens[$nextToken]['code'] === T_OPEN_SHORT_ARRAY) {
+                    $nextToken = $tokens[$nextToken]['bracket_closer'];
+                } else {
+                    // T_CLOSURE.
+                    $nextToken = $tokens[$nextToken]['scope_closer'];
+                }
+
                 $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
                 if ($tokens[$nextToken]['code'] !== T_COMMA) {
                     $nextToken--;
@@ -383,42 +390,7 @@ class Squiz_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
                 }
 
                 continue;
-            }
-
-            if ($tokens[$nextToken]['code'] === T_OPEN_SHORT_ARRAY) {
-                // Let subsequent calls of this test handle nested arrays.
-                if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
-                    $indices[] = array('value' => $nextToken);
-                    $lastToken = $nextToken;
-                }
-
-                $nextToken = $tokens[$nextToken]['bracket_closer'];
-                $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
-                if ($tokens[$nextToken]['code'] !== T_COMMA) {
-                    $nextToken--;
-                } else {
-                    $lastToken = $nextToken;
-                }
-
-                continue;
-            }
-
-            if ($tokens[$nextToken]['code'] === T_CLOSURE) {
-                if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
-                    $indices[] = array('value' => $nextToken);
-                    $lastToken = $nextToken;
-                }
-
-                $nextToken = $tokens[$nextToken]['scope_closer'];
-                $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($nextToken + 1), null, true);
-                if ($tokens[$nextToken]['code'] !== T_COMMA) {
-                    $nextToken--;
-                } else {
-                    $lastToken = $nextToken;
-                }
-
-                continue;
-            }
+            }//end if
 
             if ($tokens[$nextToken]['code'] !== T_DOUBLE_ARROW
                 && $tokens[$nextToken]['code'] !== T_COMMA


### PR DESCRIPTION
The three code blocks for `T_ARRAY`, `T_OPEN_SHORT_ARRAY` and `T_CLOSURE` were nearly the same.
This PR simplifies the code by folding the three blocks into one and only having a small if/else block for the actual difference between the three.