### PR TITLE
Allow for nullable type hints and add a `nullable_type` indicator.

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -2774,6 +2774,7 @@ class PHP_CodeSniffer_File
         $passByReference = false;
         $variableLength  = false;
         $typeHint        = '';
+        $nullableType    = false;
 
         for ($i = ($opener + 1); $i <= $closer; $i++) {
             // Check to see if this token has a parenthesis or bracket opener. If it does
@@ -2806,7 +2807,7 @@ class PHP_CodeSniffer_File
                 break;
             case T_ARRAY_HINT:
             case T_CALLABLE:
-                $typeHint = $this->_tokens[$i]['content'];
+                $typeHint .= $this->_tokens[$i]['content'];
                 break;
             case T_STRING:
                 // This is a string, so it may be a type hint, but it could
@@ -2843,6 +2844,12 @@ class PHP_CodeSniffer_File
                     $typeHint .= $this->_tokens[$i]['content'];
                 }
                 break;
+            case T_INLINE_THEN:
+                if ($defaultStart === null) {
+                    $nullableType = true;
+                    $typeHint    .= $this->_tokens[$i]['content'];
+                }
+                break;
             case T_CLOSE_PARENTHESIS:
             case T_COMMA:
                 // If it's null, then there must be no parameters for this
@@ -2865,12 +2872,14 @@ class PHP_CodeSniffer_File
                 $vars[$paramCount]['pass_by_reference'] = $passByReference;
                 $vars[$paramCount]['variable_length']   = $variableLength;
                 $vars[$paramCount]['type_hint']         = $typeHint;
+                $vars[$paramCount]['nullable_type']     = $nullableType;
 
                 // Reset the vars, as we are about to process the next parameter.
                 $defaultStart    = null;
                 $passByReference = false;
                 $variableLength  = false;
                 $typeHint        = '';
+                $nullableType    = false;
 
                 $paramCount++;
                 break;

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -22,6 +22,8 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
+ *
+ * @group utilityMethods
  */
 class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/Core/File/FindExtendedClassNameTest.inc
+++ b/tests/Core/File/FindExtendedClassNameTest.inc
@@ -1,0 +1,15 @@
+<?php
+
+class testFECNClass {}
+
+/* testExtendedClass */
+class testFECNExtendedClass extends testFECNClass {}
+
+/* testNamespacedClass */
+class testFECNNamespacedClass extends \testFECNClass {}
+
+/* testNonExtendedClass */
+class testFECNNonExtendedClass {}
+
+/* testInterface */
+interface testFECNInterface {}

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -22,12 +22,14 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
+ *
+ * @group utilityMethods
  */
 class Core_File_FindExtendedClassNameTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * The PHP_CodeSniffer_File object containing parsed contents of this file.
+     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
      *
      * @var PHP_CodeSniffer_File
      */
@@ -35,24 +37,25 @@ class Core_File_FindExtendedClassNameTest extends PHPUnit_Framework_TestCase
 
 
     /**
-     * Initialize & tokenize PHP_CodeSniffer_File with code from this file.
+     * Initialize & tokenize PHP_CodeSniffer_File with code from the test case file.
      *
-     * Methods used for these tests can be found at the bottom of
-     * this file.
+     * Methods used for these tests can be found in a test case file in the same
+     * directory and with the same name, using the .inc extension.
      *
      * @return void
      */
     public function setUp()
     {
+        $pathToTestcases  = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.inc';
         $phpcs            = new PHP_CodeSniffer();
         $this->_phpcsFile = new PHP_CodeSniffer_File(
-            __FILE__,
+            $pathToTestcases,
             array(),
             array(),
             $phpcs
         );
 
-        $contents = file_get_contents(__FILE__);
+        $contents = file_get_contents($pathToTestcases);
         $this->_phpcsFile->start($contents);
 
     }//end setUp()
@@ -159,11 +162,3 @@ class Core_File_FindExtendedClassNameTest extends PHPUnit_Framework_TestCase
 
 
 }//end class
-
-// @codingStandardsIgnoreStart
-class testFECNClass {}
-/* testExtendedClass */ class testFECNExtendedClass extends testFECNClass {}
-/* testNamespacedClass */ class testFECNNamespacedClass extends \testFECNClass {}
-/* testNonExtendedClass */ class testFECNNonExtendedClass {}
-/* testInterface */ interface testFECNInterface {}
-// @codingStandardsIgnoreEnd

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.inc
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+interface testFIINInterface2 {}
+
+/* testInterface */
+interface testFIINInterface {}
+
+/* testImplementedClass */
+class testFIINImplementedClass implements testFIINInterface {}
+
+/* testMultiImplementedClass */
+class testFIINMultiImplementedClass implements testFIINInterface, testFIINInterface2 {}
+
+/* testNamespacedClass */
+class testFIINNamespacedClass implements \testFIINInterface {}
+
+/* testNonImplementedClass */
+class testFIINNonImplementedClass {}

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -22,12 +22,14 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
+ *
+ * @group utilityMethods
  */
 class Core_File_FindImplementedInterfaceNamesTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * The PHP_CodeSniffer_File object containing parsed contents of this file.
+     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
      *
      * @var PHP_CodeSniffer_File
      */
@@ -35,24 +37,25 @@ class Core_File_FindImplementedInterfaceNamesTest extends PHPUnit_Framework_Test
 
 
     /**
-     * Initialize & tokenize PHP_CodeSniffer_File with code from this file.
+     * Initialize & tokenize PHP_CodeSniffer_File with code from the test case file.
      *
-     * Methods used for these tests can be found at the bottom of
-     * this file.
+     * Methods used for these tests can be found in a test case file in the same
+     * directory and with the same name, using the .inc extension.
      *
      * @return void
      */
     public function setUp()
     {
+        $pathToTestcases  = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.inc';
         $phpcs            = new PHP_CodeSniffer();
         $this->_phpcsFile = new PHP_CodeSniffer_File(
-            __FILE__,
+            $pathToTestcases,
             array(),
             array(),
             $phpcs
         );
 
-        $contents = file_get_contents(__FILE__);
+        $contents = file_get_contents($pathToTestcases);
         $this->_phpcsFile->start($contents);
 
     }//end setUp()
@@ -181,12 +184,3 @@ class Core_File_FindImplementedInterfaceNamesTest extends PHPUnit_Framework_Test
 
 
 }//end class
-
-// @codingStandardsIgnoreStart
-interface testFIINInterface2 {}
-/* testInterface */ interface testFIINInterface {}
-/* testImplementedClass */ class testFIINImplementedClass implements testFIINInterface {}
-/* testMultiImplementedClass */ class testFIINMultiImplementedClass implements testFIINInterface, testFIINInterface2 {}
-/* testNamespacedClass */ class testFIINNamespacedClass implements \testFIINInterface {}
-/* testNonImplementedClass */ class testFIINNonImplementedClass {}
-// @codingStandardsIgnoreEnd

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -1,0 +1,22 @@
+<?php
+
+/* testPassByReference */
+function passByReference(&$var) {}
+
+/* testArrayHint */
+function arrayHint(array $var) {}
+
+/* testVariable */
+function variable($var) {}
+
+/* testSingleDefaultValue */
+function defaultValue($var1=self::CONSTANT) {}
+
+/* testDefaultValues */
+function defaultValues($var1=1, $var2='value') {}
+
+/* testTypeHint */
+function typeHint(foo $var1, bar $var2) {}
+
+/* testNullableTypeHint */
+function nullableTypeHint(?int $var1, ?\bar $var2) {}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -26,12 +26,14 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
+ *
+ * @group utilityMethods
  */
 class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * The PHP_CodeSniffer_File object containing parsed contents of this file.
+     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
      *
      * @var PHP_CodeSniffer_File
      */
@@ -39,24 +41,25 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
 
 
     /**
-     * Initialize & tokenize PHP_CodeSniffer_File with code from this file.
+     * Initialize & tokenize PHP_CodeSniffer_File with code from the test case file.
      *
-     * Methods used for these tests can be found at the bottom of
-     * this file.
+     * Methods used for these tests can be found in a test case file in the same
+     * directory and with the same name, using the .inc extension.
      *
      * @return void
      */
     public function setUp()
     {
+        $pathToTestcases  = dirname(__FILE__) . '/' . basename(__FILE__, '.php') . '.inc';
         $phpcs            = new PHP_CodeSniffer();
         $this->_phpcsFile = new PHP_CodeSniffer_File(
-            __FILE__,
+            $pathToTestcases,
             array(),
             array(),
             $phpcs
         );
 
-        $contents = file_get_contents(__FILE__);
+        $contents = file_get_contents($pathToTestcases);
         $this->_phpcsFile->start($contents);
 
     }//end setUp()
@@ -318,15 +321,3 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
 
 
 }//end class
-
-// @codingStandardsIgnoreStart
-/* testPassByReference */ function passByReference(&$var) {}
-/* testArrayHint */ function arrayHint(array $var) {}
-/* testVariable */ function variable($var) {}
-/* testSingleDefaultValue */ function defaultValue($var1=self::CONSTANT) {}
-/* testDefaultValues */ function defaultValues($var1=1, $var2='value') {}
-/* testTypeHint */ function typeHint(foo $var1, bar $var2) {}
-/* testNullableTypeHint */ function nullableTypeHint(?int $var1, ?\bar $var2) {}
-// @codingStandardsIgnoreEnd
-
-?>

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -87,6 +87,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => true,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'nullable_type'     => false,
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -117,6 +118,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => 'array',
+                        'nullable_type'     => false,
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -147,6 +149,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => 'foo',
+                        'nullable_type'     => false,
                        );
 
         $expected[1] = array(
@@ -154,6 +157,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => 'bar',
+                        'nullable_type'     => false,
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -163,6 +167,45 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
             null,
             false,
             '/* testTypeHint */'
+        );
+
+        $found = $this->_phpcsFile->getMethodParameters(($function + 2));
+        $this->assertSame($expected, $found);
+
+    }//end testTypeHint()
+
+
+    /**
+     * Verify nullable type hint parsing.
+     *
+     * @return void
+     */
+    public function testNullableTypeHint()
+    {
+        $expected    = array();
+        $expected[0] = array(
+                        'name'              => '$var1',
+                        'pass_by_reference' => false,
+                        'variable_length'   => false,
+                        'type_hint'         => '?int',
+                        'nullable_type'     => true,
+                       );
+
+        $expected[1] = array(
+                        'name'              => '$var2',
+                        'pass_by_reference' => false,
+                        'variable_length'   => false,
+                        'type_hint'         => '?\bar',
+                        'nullable_type'     => true,
+                       );
+
+        $start    = ($this->_phpcsFile->numTokens - 1);
+        $function = $this->_phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testNullableTypeHint */'
         );
 
         $found = $this->_phpcsFile->getMethodParameters(($function + 2));
@@ -184,6 +227,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'nullable_type'     => false,
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -215,6 +259,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'nullable_type'     => false,
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -246,6 +291,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'nullable_type'     => false,
                        );
         $expected[1] = array(
                         'name'              => '$var2',
@@ -253,6 +299,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
                         'pass_by_reference' => false,
                         'variable_length'   => false,
                         'type_hint'         => '',
+                        'nullable_type'     => false,
                        );
 
         $start    = ($this->_phpcsFile->numTokens - 1);
@@ -279,6 +326,7 @@ class Core_File_GetMethodParametersTest extends PHPUnit_Framework_TestCase
 /* testSingleDefaultValue */ function defaultValue($var1=self::CONSTANT) {}
 /* testDefaultValues */ function defaultValues($var1=1, $var2='value') {}
 /* testTypeHint */ function typeHint(foo $var1, bar $var2) {}
+/* testNullableTypeHint */ function nullableTypeHint(?int $var1, ?\bar $var2) {}
 // @codingStandardsIgnoreEnd
 
 ?>

--- a/tests/Core/IsCamelCapsTest.php
+++ b/tests/Core/IsCamelCapsTest.php
@@ -24,6 +24,8 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @version   Release: @package_version@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
+ *
+ * @group utilityMethods
  */
 class Core_IsCamelCapsTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
PHP 7.1 introduces nullable types.

This PR allows for recognizing these in the `getMethodParameters()` method.
The starting `?` will be added to the type hint and a new parameter array key `nullable_type` will be set as well.

Includes additional unit test for this functionality, however the unit test breaks the test suite as the nullable type hint is seen as a parse error in PHP < 7.1. This is due to the test code being contained in the same file as the actual tests.

@gsherwood Any suggestions how I should work around this ? Remove the unit tests ? Move the test code to a separate file ? (but how will the PHPCS test suite handle that ?)

Ref:
- http://php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types
- https://wiki.php.net/rfc/nullable_types
