### PR TITLE
Update ConstructorNameSniff to fix OldStyle methods

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -84,8 +84,11 @@ class Generic_Sniffs_NamingConventions_ConstructorNameSniff extends PHP_CodeSnif
 
         if (strcasecmp($methodName, $className) === 0) {
             if (in_array('__construct', $this->_functionList) === false) {
-                $error = 'PHP4 style constructors are not allowed; use "__construct()" instead';
-                $phpcsFile->addError($error, $stackPtr, 'OldStyle');
+                $error     = 'PHP4 style constructors are not allowed; use "__construct()" instead';
+                $toReplace = $phpcsFile->findNext(T_STRING, $stackPtr);
+                if ($phpcsFile->addFixableError($error, $stackPtr, 'OldStyle') === true) {
+                    $phpcsFile->fixer->replaceToken($toReplace, '__construct');
+                }
             }
         } else if (strcasecmp($methodName, '__construct') !== 0) {
             // Not a constructor.

--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/ConstructorNameUnitTest.inc.fixed
@@ -1,0 +1,52 @@
+<?php
+class TestClass extends MyClass
+{
+
+    function TestClass() {
+        parent::MyClass();
+        parent::__construct();
+    }
+
+    function __construct() {
+        parent::MyClass();
+        parent::__construct();
+    }
+
+}
+
+class MyClass
+{
+
+    function MyClass() {
+        parent::YourClass();
+        parent::__construct();
+    }
+
+    function __construct() {
+        parent::YourClass();
+        parent::__construct();
+    }
+
+}
+
+class MyClass extends \MyNamespace\SomeClass
+{
+    function __construct() {
+        something::MyNamespace();
+    }
+
+}
+
+abstract class MyAbstractClass extends \MyNamespace\SomeClass
+{
+    abstract public function __construct();
+}
+
+class OldClass
+{
+    function __construct()
+    {
+
+    }
+}
+?>


### PR DESCRIPTION
We're about to switch to PHP7 and having this sniff automatically fix things for us would make it a lot easier!
