### PR TITLE
Add rule suppresion for a line or scope

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -1003,7 +1003,8 @@ class PHP_CodeSniffer_File
         }
 
         if (isset($this->_ignoredRulesForLines[$this->_activeListener]) === true) {
-            foreach ($this->_ignoredRulesForLines[$this->_activeListener] as list($lineFrom, $lineTo)) {
+            foreach ($this->_ignoredRulesForLines[$this->_activeListener] as $ignoredLinesRange) {
+                list($lineFrom, $lineTo) = $ignoredLinesRange;
                 if ($line >= $lineFrom && $line <= $lineTo) {
                     return false;
                 }

--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -1159,7 +1159,8 @@ class PHP_CodeSniffer_File
         }
 
         if (isset($this->_ignoredRulesForLines[$this->_activeListener]) === true) {
-            foreach ($this->_ignoredRulesForLines[$this->_activeListener] as list($lineFrom, $lineTo)) {
+            foreach ($this->_ignoredRulesForLines[$this->_activeListener] as $ignoredLinesRange) {
+                list($lineFrom, $lineTo) = $ignoredLinesRange;
                 if ($line >= $lineFrom && $line <= $lineTo) {
                     return false;
                 }

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -315,6 +315,43 @@ class Core_ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 
     }//end testSuppressFile()
 
+    public function testSuppressRule()
+    {
+        $phpcs = new PHP_CodeSniffer();
+        $phpcs->initStandard('Generic', array('Generic.Commenting.Todo'));
+
+        // Process without suppression.
+        $content = '<?php '.PHP_EOL.'class MyClass() {'.PHP_EOL.'function foo() {'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'}'.PHP_EOL.'}';
+        $file    = $phpcs->processFile('ruleNonSuppressionTest.php', $content);
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(1, $numWarnings);
+        $this->assertEquals(1, count($warnings));
+
+        // Process with inline comment suppression
+        $content = '<?php '.PHP_EOL.'class MyClass() {'.PHP_EOL.'// @codingStandardsIgnoreRule(Generic.Commenting.Todo)'.PHP_EOL.'function foo() {'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'}'.PHP_EOL.'}';
+        $file    = $phpcs->processFile('ruleSuppressionTest.php', $content);
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertEquals(0, count($warnings));
+
+        // Process with multiline comment suppression
+        $content = '<?php '.PHP_EOL.'class MyClass() {'.PHP_EOL.'/*'.PHP_EOL.'* @codingStandardsIgnoreRule(Generic.Commenting.Todo)'.PHP_EOL.'*/'.PHP_EOL.'function foo() {'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'}'.PHP_EOL.'}';
+        $file    = $phpcs->processFile('ruleSuppressionTest.php', $content);
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertEquals(0, count($warnings));
+
+        // Process with docblock suppression
+        $content = '<?php '.PHP_EOL.'class MyClass() {'.PHP_EOL.'/**'.PHP_EOL.'* @codingStandardsIgnoreRule(Generic.Commenting.Todo)'.PHP_EOL.'*/'.PHP_EOL.'function foo() {'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'}'.PHP_EOL.'}';
+        $file    = $phpcs->processFile('ruleSuppressionTest.php', $content);
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertEquals(0, count($warnings));
+    }//end testSuppressRule()
 
 }//end class
 


### PR DESCRIPTION
Hey there. How do you feel about adding the functionality to ignore some rules for a given line of code, or block? Right now, you can use the // @codingStandardsIgnoreStart notation, but it has the downside of ignoring all of them. With this feature you can specify exactly which violation you are aware of and should be ignored.

I'm not familiar with the tokenizing process and unaware of the myriad of possibilities, so most likely there's something wrong with how I'm traversing them.

So let this serve as a proof of concept at least. The way it works:
```php
<?php
// @codingStandardsIgnoreRule(Generic.Commenting.Todo)
function foo()
{
    //TODO: blah
    echo 'foo!';
}

/**
 * You can also use multiline or doc comments, and the class name instead of the rule name
 * @codingStandarsIgnoreRule(Generic_Sniffs_Commenting_TodoSniff)
 */
function bar()
{
    //TODO: bleh
    echo 'bar!';
}
```