### PR TITLE
fix(DocCommentAlignment): Check doc block alignment on var key word

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -87,6 +87,7 @@ class Squiz_Sniffs_Commenting_DocCommentAlignmentSniff implements PHP_CodeSniffe
                       T_PROPERTY  => true,
                       T_OBJECT    => true,
                       T_PROTOTYPE => true,
+                      T_VAR       => true,
                      );
 
         if (isset($ignore[$tokens[$nextToken]['code']]) === false) {

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
@@ -68,3 +68,11 @@ function myFunction()
  * @return void
  */
 function myFunction() {}
+
+class MyClass2
+{
+    /**
+       * Some info about the variable here.
+     */
+    var $x;
+}

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
@@ -68,3 +68,11 @@ function myFunction()
  * @return void
  */
 function myFunction() {}
+
+class MyClass2
+{
+    /**
+     * Some info about the variable here.
+     */
+    var $x;
+}

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -38,25 +38,47 @@ class Squiz_Tests_Commenting_DocCommentAlignmentUnitTest extends AbstractSniffUn
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getErrorList()
+    public function getErrorList($testFile='')
     {
-        return array(
-                3  => 1,
-                11 => 1,
-                17 => 1,
-                18 => 1,
-                19 => 1,
-                23 => 2,
-                24 => 1,
-                25 => 2,
-                26 => 1,
-                32 => 1,
-                33 => 1,
-                38 => 1,
-                39 => 1,
-               );
+        switch ($testFile) {
+        case 'DocCommentAlignmentUnitTest.inc':
+            return array(
+                    3  => 1,
+                    11 => 1,
+                    17 => 1,
+                    18 => 1,
+                    19 => 1,
+                    23 => 2,
+                    24 => 1,
+                    25 => 2,
+                    26 => 1,
+                    32 => 1,
+                    33 => 1,
+                    38 => 1,
+                    39 => 1,
+                    75 => 1,
+                  );
+        default:
+            return array(
+                    3  => 1,
+                    11 => 1,
+                    17 => 1,
+                    18 => 1,
+                    19 => 1,
+                    23 => 2,
+                    24 => 1,
+                    25 => 2,
+                    26 => 1,
+                    32 => 1,
+                    33 => 1,
+                    38 => 1,
+                    39 => 1,
+                  );
+        }
 
     }//end getErrorList()
 


### PR DESCRIPTION
Did not have time for a test case yet.