### PR TITLE
Fix "Uninitialized string offset" notice on PHP 5.2

### DIFF
--- a/CodeSniffer/Tokenizers/PHP.php
+++ b/CodeSniffer/Tokenizers/PHP.php
@@ -685,7 +685,7 @@ class PHP_CodeSniffer_Tokenizers_PHP
             */
 
             if ($stackPtr > 1
-                && $tokens[($stackPtr - 1)][0] === T_PAAMAYIM_NEKUDOTAYIM
+                && (isset($tokens[($stackPtr - 1)][0]) === true && $tokens[($stackPtr - 1)][0] === T_PAAMAYIM_NEKUDOTAYIM)
                 && $tokenIsArray === true
                 && $token[0] !== T_STRING
                 && $token[0] !== T_VARIABLE


### PR DESCRIPTION
Quick & dirty fix for the issue reported in #1237. A better fix might still be needed.

Fixes #1237 