### PR TITLE
False positive for function names starting with triple underscore

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -126,7 +126,7 @@ class Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff extends PHP_Co
         $errorData = array($className.'::'.$methodName);
 
         // Is this a magic method. i.e., is prefixed with "__" ?
-        if (preg_match('|^__|', $methodName) !== 0) {
+        if (preg_match('|^__[^_]|', $methodName) !== 0) {
             $magicPart = strtolower(substr($methodName, 2));
             if (isset($this->magicMethods[$magicPart]) === false
                 && isset($this->methodsDoubleUnderscore[$magicPart]) === false
@@ -194,7 +194,7 @@ class Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff extends PHP_Co
         $errorData = array($functionName);
 
         // Is this a magic function. i.e., it is prefixed with "__".
-        if (preg_match('|^__|', $functionName) !== 0) {
+        if (preg_match('|^__[^_]|', $functionName) !== 0) {
             $magicPart = strtolower(substr($functionName, 2));
             if (isset($this->magicFunctions[$magicPart]) === false) {
                  $error = 'Function name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';

--- a/CodeSniffer/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
@@ -119,3 +119,9 @@ function __debugInfo() {}
 class Foo {
     function __debugInfo() {}
 }
+
+function ___tripleUnderscore() {} // Ok.
+
+class triple {
+    public function ___tripleUnderscore() {} // Ok.
+}

--- a/CodeSniffer/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/CodeSniffer/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -52,7 +52,7 @@ class PSR1_Sniffs_Methods_CamelCapsMethodNameSniff extends Generic_Sniffs_Naming
         }
 
         // Ignore magic methods.
-        if (preg_match('|^__|', $methodName) !== 0) {
+        if (preg_match('|^__[^_]|', $methodName) !== 0) {
             $magicPart = strtolower(substr($methodName, 2));
             if (isset($this->magicMethods[$magicPart]) === true
                 || isset($this->methodsDoubleUnderscore[$magicPart]) === true

--- a/CodeSniffer/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.inc
+++ b/CodeSniffer/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.inc
@@ -64,4 +64,10 @@ class Foo extends \SoapClient
 
     function __() {}
 }
+
+function ___tripleUnderscore() {} // Ok.
+
+class triple {
+    public function ___tripleUnderscore() {} // Ok.
+}
 ?>


### PR DESCRIPTION
Function and method names starting with a double underscore are reserved by PHP itself for magic functions/methods.

A triple underscore function name prefix, however, should not trigger this error. (I'm not saying it's a good idea, but it's out there in userland code)

Fixed in the two non-proprietary standards which have checks for double underscored function/method names.
Includes additional unit tests for all four sniffs.

This PR does not cover similar checks in the proprietary PEAR and Squiz standards.

Fixes https://github.com/wimg/PHPCompatibility/issues/297