### PR TITLE
Allow message type changing from the ruleset to work for complete sniffs

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -1020,8 +1020,10 @@ class PHP_CodeSniffer_File
         }
 
         // Make sure this message type has not been set to "warning".
-        if (isset($this->ruleset[$sniffCode]['type']) === true
-            && $this->ruleset[$sniffCode]['type'] === 'warning'
+        if ((isset($this->ruleset[$sniffCode]['type']) === true
+            && $this->ruleset[$sniffCode]['type'] === 'warning')
+            || (isset($sniff, $this->ruleset[$sniff]['type']) === true
+            && $this->ruleset[$sniff]['type'] === 'warning')
         ) {
             // Pass this off to the warning handler.
             return $this->_addWarning($error, $line, $column, $code, $data, $severity, $fixable);
@@ -1167,8 +1169,10 @@ class PHP_CodeSniffer_File
         }
 
         // Make sure this message type has not been set to "error".
-        if (isset($this->ruleset[$sniffCode]['type']) === true
-            && $this->ruleset[$sniffCode]['type'] === 'error'
+        if ((isset($this->ruleset[$sniffCode]['type']) === true
+            && $this->ruleset[$sniffCode]['type'] === 'error')
+            || (isset($sniff, $this->ruleset[$sniff]['type']) === true
+            && $this->ruleset[$sniff]['type'] === 'error')
         ) {
             // Pass this off to the error handler.
             return $this->_addError($warning, $line, $column, $code, $data, $severity, $fixable);


### PR DESCRIPTION
Currently a `<type>` can be set to change the message type of a message from the ruleset.
If the sniff to which the `type` change is applied passes error codes, this only works on error code level, i.e. `Standard.Subset.Sniff.ErrorCode`, however, if the sniff doesn't pass any error codes, it works on sniff level, i.e. `Standard.Subset.Sniff`.

This seemed inconsistent to me and makes the usage unpredictable as that means that the code needed to set this, is dependent on whether error codes are passed or not.

This PR fixes this inconsistency and makes it so the `<type>` parameter can be set both for individual error codes as well as for complete sniffs.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
> ```xml
> <!--
>     You can also change the type of a message from error to
>     warning and vice versa.
>  -->
>  <rule ref="Generic.Commenting.Todo.CommentFound">
>   <type>error</type>
>  </rule>
>  <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
>   <type>warning</type>
>  </rule>

In other words, if this PR would be merged, the following would also become valid:
```xml
<rule ref="Squiz.Strings.DoubleQuoteUsage">
 <type>warning</type>
</rule>
```