### PR TITLE
Syntax errors not being shown when error_prepend_string is set

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -74,11 +74,15 @@ class Generic_Sniffs_PHP_SyntaxSniff implements PHP_CodeSniffer_Sniff
         }
 
         $fileName = $phpcsFile->getFilename();
-        $cmd      = $this->_phpPath." -l \"$fileName\" 2>&1";
-        $output   = shell_exec($cmd);
+        if (defined('HHVM_VERSION') === false) {
+            $cmd = $this->_phpPath." -l -d error_prepend_string='' \"$fileName\" 2>&1";
+        } else {
+            $cmd = $this->_phpPath." -l \"$fileName\" 2>&1";
+        }
 
+        $output  = shell_exec($cmd);
         $matches = array();
-        if (preg_match('/^.*error:(.*) in .* on line ([0-9]+)/', trim($output), $matches) === 1) {
+        if (preg_match('/^.*error:(.*) in .* on line ([0-9]+)/m', trim($output), $matches) === 1) {
             $error = trim($matches[1]);
             $line  = (int) $matches[2];
             $phpcsFile->addErrorOnLine("PHP syntax error: $error", $line, 'PHPSyntax');


### PR DESCRIPTION
Syntax errors were not being matched if the `php.ini` file used contained a value for `error_prepend_string`.

This fix makes double sure that those will now start showing up as it:
* Overloads the ini value specifically for the php process used for the linting.
* Matches the error line pattern per line in the result. The `error_prepend_string` will normally be on its own line in the output, so matching the error pattern for each line should prevent further issues.

Unit testing this would be near impossible as one would need to overload the `php.ini` file used by the linting process.

All the same, the issue can easily be reproduced:
* Edit the `php.ini` file for the PHP version on which PHPCS is running, uncomment it and give it a value. Example often used by people mainly using PHP in the browser: `<span style='color: #ff0000'>` (combined with `error_append_string = "</span>"`).
* Run the sniff on a file with a parse error and see the sniff not throwing any errors.
* Switch to this PR branch and run the sniff again. You should now see the parse error notification.

[Edit]: Recommitted to fix HHVM build failure.