### PR TITLE
Added new token T_NULLABLE

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -2855,7 +2855,7 @@ class PHP_CodeSniffer_File
                     $typeHint .= $this->_tokens[$i]['content'];
                 }
                 break;
-            case T_INLINE_THEN:
+            case T_NULLABLE:
                 if ($defaultStart === null) {
                     $nullableType = true;
                     $typeHint    .= $this->_tokens[$i]['content'];

--- a/CodeSniffer/Tokenizers/PHP.php
+++ b/CodeSniffer/Tokenizers/PHP.php
@@ -679,6 +679,33 @@ class PHP_CodeSniffer_Tokenizers_PHP
             }
 
             /*
+                Convert ? to T_NULLABLE OR T_INLINE_THEN
+            */
+
+            if ($tokenIsArray === false && $token[0] === '?') {
+                $newToken            = array();
+                $newToken['content'] = '?';
+
+                for ($i = ($stackPtr - 1); $i >= 0; $i--) {
+                    if ($tokens[$i][0] === T_FUNCTION) {
+                        $newToken['code'] = T_NULLABLE;
+                        $newToken['type'] = 'T_NULLABLE';
+                        break;
+                    } else if (in_array($tokens[$i][0], array(T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, '{', ';')) === true) {
+                        $newToken['code'] = T_INLINE_THEN;
+                        $newToken['type'] = 'T_INLINE_THEN';
+
+                        $insideInlineIf[] = $stackPtr;
+                        break;
+                    }
+                }
+
+                $finalTokens[$newStackPtr] = $newToken;
+                $newStackPtr++;
+                continue;
+            }//end if
+
+            /*
                 Tokens after a double colon may be look like scope openers,
                 such as when writing code like Foo::NAMESPACE, but they are
                 only ever variables or strings.
@@ -971,9 +998,7 @@ class PHP_CodeSniffer_Tokenizers_PHP
 
                 // Convert colons that are actually the ELSE component of an
                 // inline IF statement.
-                if ($newToken['code'] === T_INLINE_THEN) {
-                    $insideInlineIf[] = $stackPtr;
-                } else if (empty($insideInlineIf) === false && $newToken['code'] === T_COLON) {
+                if (empty($insideInlineIf) === false && $newToken['code'] === T_COLON) {
                     array_pop($insideInlineIf);
                     $newToken['code'] = T_INLINE_ELSE;
                     $newToken['type'] = 'T_INLINE_ELSE';
@@ -1549,9 +1574,6 @@ class PHP_CodeSniffer_Tokenizers_PHP
             break;
         case '.':
             $newToken['type'] = 'T_STRING_CONCAT';
-            break;
-        case '?':
-            $newToken['type'] = 'T_INLINE_THEN';
             break;
         case ';':
             $newToken['type'] = 'T_SEMICOLON';

--- a/CodeSniffer/Tokens.php
+++ b/CodeSniffer/Tokens.php
@@ -22,6 +22,7 @@ define('T_CLOSE_SQUARE_BRACKET', 'PHPCS_T_CLOSE_SQUARE_BRACKET');
 define('T_OPEN_PARENTHESIS', 'PHPCS_T_OPEN_PARENTHESIS');
 define('T_CLOSE_PARENTHESIS', 'PHPCS_T_CLOSE_PARENTHESIS');
 define('T_COLON', 'PHPCS_T_COLON');
+define('T_NULLABLE', 'PHPCS_T_NULLABLE');
 define('T_STRING_CONCAT', 'PHPCS_T_STRING_CONCAT');
 define('T_INLINE_THEN', 'PHPCS_T_INLINE_THEN');
 define('T_INLINE_ELSE', 'PHPCS_T_INLINE_ELSE');
@@ -367,6 +368,7 @@ final class PHP_CodeSniffer_Tokens
                                    T_OPEN_PARENTHESIS         => 1,
                                    T_CLOSE_PARENTHESIS        => 1,
                                    T_COLON                    => 1,
+                                   T_NULLABLE                 => 1,
                                    T_STRING_CONCAT            => 1,
                                    T_INLINE_THEN              => 1,
                                    T_INLINE_ELSE              => 1,


### PR DESCRIPTION
`?` for nullable type hints is tokenized as `T_INLINE_THEN` now and `:` for return type hints is therefore very often tokenized as `T_INLINE_ELSE`. I've added new token `T_NULLABLE` for `?` before type hints to fix this.