### PR TITLE
Fixed bug #1267 : Fixer incorrectly handles filepath

### DIFF
--- a/CodeSniffer/Fixer.php
+++ b/CodeSniffer/Fixer.php
@@ -243,8 +243,13 @@ class PHP_CodeSniffer_Fixer
             $filePath = $this->_currentFile->getFilename();
         }
 
-        $cwd      = getcwd().DIRECTORY_SEPARATOR;
-        $filename = str_replace($cwd, '', $filePath);
+        $cwd = getcwd().DIRECTORY_SEPARATOR;
+        if (strpos($filePath, $cwd) === 0) {
+            $filename = substr($filePath, strlen($cwd));
+        } else {
+            $filename = $filePath;
+        }
+
         $contents = $this->getContents();
 
         if (function_exists('sys_get_temp_dir') === true) {

--- a/package.xml
+++ b/package.xml
@@ -50,6 +50,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
   - Fixed bug #1253 : Generic.ControlStructures.InlineControlStructure fix creates syntax error fixing if-try/catch
   - Fixed bug #1257 : Double dash in CSS class name can lead to "Named colours are forbidden" false positives
   - Fixed bug #1265 : ES6 arrow function raises unexpected operator spacing errors
+  - Fixed bug #1267 : Fixer incorrectly handles filepath
  </notes>
  <contents>
   <dir name="/">


### PR DESCRIPTION
Fixer incorrectly handles filepath, e.g.:

For example, if filePath is `/app/path/app/file.php` and cwd is `/app/`, expected filepath should be `path/app/file.php`
But in fact, filepath became wrong - `pathfile.php`

Because `str_replace` replaces all occurrences in target filepath:
https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Fixer.php#L246
```php
$cwd      = getcwd().DIRECTORY_SEPARATOR;
$filename = str_replace($cwd, '', $filePath);
```
