### PR TITLE
Let's start testing the build on PHP 5.2 to avoid further breaks by PHP notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: php
 
 php:
+  - 5.2
   - 5.3
   - 5.4
   - 5.5
@@ -20,6 +21,6 @@ script:
   - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then php scripts/phpcs --config-set php_path php; fi
   - phpunit tests/AllTests.php
   - php scripts/phpcs CodeSniffer.php CodeSniffer --standard=PHPCS --report=full -np
-  - if [[ $TRAVIS_PHP_VERSION != "hhvm" && ${TRAVIS_PHP_VERSION:0:1} != "7" ]]; then pear package-validate package.xml; fi
-  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then php scripts/build-phar.php; fi
-  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then php phpcs.phar CodeSniffer.php CodeSniffer --standard=PHPCS --report=full -np; fi
+  - if [[ $TRAVIS_PHP_VERSION != "5.2" && $TRAVIS_PHP_VERSION != "hhvm" && ${TRAVIS_PHP_VERSION:0:1} != "7" ]]; then pear package-validate package.xml; fi
+  - if [[ $TRAVIS_PHP_VERSION != "5.2" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then php scripts/build-phar.php; fi
+  - if [[ $TRAVIS_PHP_VERSION != "5.2" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then php phpcs.phar CodeSniffer.php CodeSniffer --standard=PHPCS --report=full -np; fi


### PR DESCRIPTION
And as expected and reported in #1280, the build for PHP 5.2 is currently breaking.

[Edit] Just looked through the details of the breaking build and most of the issues seem to be to do with the `\` `T_NS_SEPARATOR` not being recognized in PHP 5.2, haven't found one demonstrating the current issue yet....

How would you like me to proceed with this ? Exclude namespace related tests for PHP 5.2 ?