### PR TITLE
Squiz: property visibility

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php
@@ -43,25 +43,25 @@ class Squiz_Sniffs_CSS_NamedColoursSniff implements PHP_CodeSniffer_Sniff
      *
      * @var array
      */
-    public $colourNames = array(
-                           'aqua'    => 'aqua',
-                           'black'   => 'black',
-                           'blue'    => 'blue',
-                           'fuchsia' => 'fuchsia',
-                           'gray'    => 'gray',
-                           'green'   => 'green',
-                           'lime'    => 'lime',
-                           'maroon'  => 'maroon',
-                           'navy'    => 'navy',
-                           'olive'   => 'olive',
-                           'orange'  => 'orange',
-                           'purple'  => 'purple',
-                           'red'     => 'red',
-                           'silver'  => 'silver',
-                           'teal'    => 'teal',
-                           'white'   => 'white',
-                           'yellow'  => 'yellow',
-                          );
+    protected $colourNames = array(
+                              'aqua'    => 'aqua',
+                              'black'   => 'black',
+                              'blue'    => 'blue',
+                              'fuchsia' => 'fuchsia',
+                              'gray'    => 'gray',
+                              'green'   => 'green',
+                              'lime'    => 'lime',
+                              'maroon'  => 'maroon',
+                              'navy'    => 'navy',
+                              'olive'   => 'olive',
+                              'orange'  => 'orange',
+                              'purple'  => 'purple',
+                              'red'     => 'red',
+                              'silver'  => 'silver',
+                              'teal'    => 'teal',
+                              'white'   => 'white',
+                              'yellow'  => 'yellow',
+                             );
 
 
     /**

--- a/CodeSniffer/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
@@ -43,13 +43,13 @@ class Squiz_Sniffs_CSS_ShorthandSizeSniff implements PHP_CodeSniffer_Sniff
      *
      * @var array
      */
-    public $excludeStyles = array(
-                             'background-position'      => 'background-position',
-                             'box-shadow'               => 'box-shadow',
-                             'transform-origin'         => 'transform-origin',
-                             '-webkit-transform-origin' => '-webkit-transform-origin',
-                             '-ms-transform-origin'     => '-ms-transform-origin',
-                            );
+    protected $excludeStyles = array(
+                                'background-position'      => 'background-position',
+                                'box-shadow'               => 'box-shadow',
+                                'transform-origin'         => 'transform-origin',
+                                '-webkit-transform-origin' => '-webkit-transform-origin',
+                                '-ms-transform-origin'     => '-ms-transform-origin',
+                               );
 
 
     /**


### PR DESCRIPTION
While working on the list of public properties which can be changed from rulesets (#1278), I came across two properties in the Squiz sniffs for which it seemed unlikely that these were intended to be public.