### PR TITLE
Generic/DuplicateClassName: fix property visibility

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -31,7 +31,7 @@ class Generic_Sniffs_Classes_DuplicateClassNameSniff implements PHP_CodeSniffer_
      *
      * @var array
      */
-    public $foundClasses = array();
+    protected $foundClasses = array();
 
 
     /**


### PR DESCRIPTION
While working on the list of public properties which can be changed from rulesets (#1278), I came across this property for which it seemed unlikely that it was intended to be public.

This is a complex property which expects a multi-level array to be set based on the classes found by the sniff.