### PR TITLE
Generic / ByteOrderMark: property visibility

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Files/ByteOrderMarkSniff.php
@@ -37,11 +37,11 @@ class Generic_Sniffs_Files_ByteOrderMarkSniff implements PHP_CodeSniffer_Sniff
      *
      * @var array
      */
-    public $bomDefinitions = array(
-                              'UTF-8'       => 'efbbbf',
-                              'UTF-16 (BE)' => 'feff',
-                              'UTF-16 (LE)' => 'fffe',
-                             );
+    protected $bomDefinitions = array(
+                                 'UTF-8'       => 'efbbbf',
+                                 'UTF-16 (BE)' => 'feff',
+                                 'UTF-16 (LE)' => 'fffe',
+                                );
 
 
     /**


### PR DESCRIPTION
While working on the list of public properties which can be changed from rulesets (#1278), I came across this property in the `Generic_Sniffs_Files_ByteOrderMarkSniff` for which it seemed unlikely that it was intended to be public.