### PR TITLE
getMethodParameters(): Allow for closures.

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -2742,7 +2742,7 @@ class PHP_CodeSniffer_File
 
 
     /**
-     * Returns the method parameters for the specified T_FUNCTION token.
+     * Returns the method parameters for the specified function token.
      *
      * Each parameter is in the following format:
      *
@@ -2760,17 +2760,19 @@ class PHP_CodeSniffer_File
      * Parameters with default values have an additional array index of
      * 'default' with the value of the default as a string.
      *
-     * @param int $stackPtr The position in the stack of the T_FUNCTION token
+     * @param int $stackPtr The position in the stack of the function token
      *                      to acquire the parameters for.
      *
      * @return array
      * @throws PHP_CodeSniffer_Exception If the specified $stackPtr is not of
-     *                                   type T_FUNCTION.
+     *                                   type T_FUNCTION or T_CLOSURE.
      */
     public function getMethodParameters($stackPtr)
     {
-        if ($this->_tokens[$stackPtr]['code'] !== T_FUNCTION) {
-            throw new PHP_CodeSniffer_Exception('$stackPtr must be of type T_FUNCTION');
+        if ($this->_tokens[$stackPtr]['code'] !== T_FUNCTION
+            && $this->_tokens[$stackPtr]['code'] !== T_CLOSURE
+        ) {
+            throw new PHP_CodeSniffer_Exception('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
         }
 
         $opener = $this->_tokens[$stackPtr]['parenthesis_opener'];

--- a/CodeSniffer/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -42,7 +42,10 @@ class Generic_Sniffs_CodeAnalysis_UnusedFunctionParameterSniff implements PHP_Co
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return array(
+                T_FUNCTION,
+                T_CLOSURE,
+               );
 
     }//end register()
 

--- a/CodeSniffer/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -74,3 +74,7 @@ function bar($x)
 {
     return 2 * ${x};
 }
+
+function ($a, $b) {
+    return $a * 2;
+}

--- a/CodeSniffer/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -57,8 +57,9 @@ class Generic_Tests_CodeAnalysis_UnusedFunctionParameterUnitTest extends Abstrac
     public function getWarningList()
     {
         return array(
-                3 => 1,
-                7 => 1,
+                3  => 1,
+                7  => 1,
+                78 => 1,
                );
 
     }//end getWarningList()

--- a/CodeSniffer/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
@@ -39,7 +39,10 @@ class PEAR_Sniffs_Functions_ValidDefaultValueSniff implements PHP_CodeSniffer_Sn
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return array(
+                T_FUNCTION,
+                T_CLOSURE,
+               );
 
     }//end register()
 

--- a/CodeSniffer/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.inc
+++ b/CodeSniffer/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.inc
@@ -91,3 +91,9 @@ function foo(Foo $foo, $bar) {}
 function foo(Foo $foo = null, $bar = true, $baz) {}
 function foo($baz, Foo $foo = null, $bar = true) {}
 function foo($baz, $bar = true, Foo $foo = null) {}
+
+// Valid closure
+function ($arg1, $arg2='hello') {}
+
+// Invalid closure
+function(array $arg2=array(), array $arg1) {}

--- a/CodeSniffer/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/CodeSniffer/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -50,6 +50,7 @@ class PEAR_Tests_Functions_ValidDefaultValueUnitTest extends AbstractSniffUnitTe
                 76 => 1,
                 81 => 1,
                 91 => 1,
+                99 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
The method itself works perfectly for closures, it just didn't allow itself to be used for them.

Includes allowing for closures in two sniffs which use the `getMethodParameters()` method.
Includes additional unit test(s) for these sniffs.