### PR TITLE
Replace < and > with &t; and &gt; on output

### DIFF
--- a/CodeSniffer/Reports/Full.php
+++ b/CodeSniffer/Reports/Full.php
@@ -178,8 +178,8 @@ class PHP_CodeSniffer_Reports_Full implements PHP_CodeSniffer_Report
 
                         echo '] ';
                     }
-
-                    echo $errorMsg.PHP_EOL;
+                    
+                    echo str_replace( '<', '&lt;', str_replace( '>', '&gt;', $errorMsg ) ).PHP_EOL;
                 }//end foreach
             }//end foreach
         }//end foreach

--- a/CodeSniffer/Reports/Full.php
+++ b/CodeSniffer/Reports/Full.php
@@ -178,8 +178,8 @@ class PHP_CodeSniffer_Reports_Full implements PHP_CodeSniffer_Report
 
                         echo '] ';
                     }
-                    
-                    echo str_replace( '<', '&lt;', str_replace( '>', '&gt;', $errorMsg ) ).PHP_EOL;
+
+                    echo htmlspecialchars($errorMsg, ENT_QUOTES, 'UTF-8', false).PHP_EOL;
                 }//end foreach
             }//end foreach
         }//end foreach


### PR DESCRIPTION
When used in a plugin (https://github.com/ernilambar/ns-theme-check/) if characters are not written as character entities, they will get rendered which breaks the error report looks. This prevents it.