### PR TITLE
Package.xml: Remove reference to non-existent file.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1121,7 +1121,6 @@ http://pear.php.net/dtd/package-2.0.xsd">
          <tasks:replace from="@package_version@" to="version" type="package-info" />
         </file>
         <file baseinstalldir="PHP" name="FunctionCommentUnitTest.inc" role="test" />
-        <file baseinstalldir="PHP" name="FunctionCommentUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP" name="FunctionCommentUnitTest.php" role="test">
          <tasks:replace from="@package_version@" to="version" type="package-info" />
         </file>


### PR DESCRIPTION
Noticed this error in the Travis build.

`Error: File "./CodeSniffer/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc.fixed" in package.xml does not exist`