### PR TITLE
Remove two superfluous checks for fixer->enabled.

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -177,7 +177,7 @@ class PEAR_Sniffs_WhiteSpace_ScopeClosingBraceSniff implements PHP_CodeSniffer_S
             }
         }//end if
 
-        if ($fix === true && $phpcsFile->fixer->enabled === true) {
+        if ($fix === true) {
             $spaces = str_repeat(' ', $expectedIndent);
             if ($braceIndent === 0) {
                 $phpcsFile->fixer->addContentBefore($lineStart, $spaces);

--- a/CodeSniffer/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -267,7 +267,7 @@ class Squiz_Sniffs_Formatting_OperatorBracketSniff implements PHP_CodeSniffer_Sn
         $error = 'Arithmetic operation must be bracketed';
         $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'MissingBrackets');
 
-        if ($fix === false || $phpcsFile->fixer->enabled === false) {
+        if ($fix === false) {
             return;
         }
 


### PR DESCRIPTION
These are no longer needed since commit 5def2acbe3911e2aea08ac8b8eb4e4d64330021f / `addFixableError() and addFixableWarning() now only return true if the fixer is enabled`