### PR TITLE
Squiz / FunctionComment: fix detection of incorrect types when @return tag has description

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.1.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.1.inc
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Issue #1081.
+ */
+
+/**
+ * Return description function + mixed return types.
+ *
+ * @return bool|int This is a description.
+ */
+function returnTypeWithDescriptionA()
+{
+    return 5;
+
+}//end returnTypeWithDescriptionA()
+
+
+/**
+ * Return description function + mixed return types.
+ *
+ * @return real|bool This is a description.
+ */
+function returnTypeWithDescriptionB()
+{
+    return 5;
+
+}//end returnTypeWithDescriptionB()
+
+
+/**
+ * Return description function + lots of different mixed return types.
+ *
+ * @return int|object|string[]|real|double|float|bool|array(int=>MyClass)|callable And here we have a description
+ */
+function returnTypeWithDescriptionC()
+{
+    return 5;
+
+}//end returnTypeWithDescriptionC()
+
+
+/**
+ * Return description function + lots of different mixed return types.
+ *
+ * @return array(int=>bool)|\OtherVendor\Package\SomeClass2|MyClass[]|void And here we have a description
+ */
+function returnTypeWithDescriptionD()
+{
+
+}//end returnTypeWithDescriptionD()

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.1.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.1.inc.fixed
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Issue #1081.
+ */
+
+/**
+ * Return description function + mixed return types.
+ *
+ * @return boolean|integer This is a description.
+ */
+function returnTypeWithDescriptionA()
+{
+    return 5;
+
+}//end returnTypeWithDescriptionA()
+
+
+/**
+ * Return description function + mixed return types.
+ *
+ * @return float|boolean This is a description.
+ */
+function returnTypeWithDescriptionB()
+{
+    return 5;
+
+}//end returnTypeWithDescriptionB()
+
+
+/**
+ * Return description function + lots of different mixed return types.
+ *
+ * @return integer|object|string[]|float|boolean|array(integer => MyClass)|callable And here we have a description
+ */
+function returnTypeWithDescriptionC()
+{
+    return 5;
+
+}//end returnTypeWithDescriptionC()
+
+
+/**
+ * Return description function + lots of different mixed return types.
+ *
+ * @return array(integer => boolean)|\OtherVendor\Package\SomeClass2|MyClass[]|void And here we have a description
+ */
+function returnTypeWithDescriptionD()
+{
+
+}//end returnTypeWithDescriptionD()

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -35,114 +35,131 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getErrorList()
+    public function getErrorList($testFile='FunctionCommentUnitTest.inc')
     {
-        $errors = array(
-                   5   => 1,
-                   10  => 3,
-                   12  => 2,
-                   13  => 2,
-                   14  => 1,
-                   15  => 1,
-                   28  => 1,
-                   43  => 1,
-                   76  => 1,
-                   87  => 1,
-                   103 => 1,
-                   109 => 1,
-                   112 => 1,
-                   122 => 1,
-                   123 => 3,
-                   124 => 2,
-                   125 => 1,
-                   126 => 1,
-                   137 => 4,
-                   138 => 4,
-                   139 => 4,
-                   143 => 2,
-                   152 => 1,
-                   155 => 2,
-                   159 => 1,
-                   166 => 1,
-                   173 => 1,
-                   183 => 1,
-                   190 => 2,
-                   193 => 2,
-                   196 => 1,
-                   199 => 2,
-                   210 => 1,
-                   211 => 1,
-                   222 => 1,
-                   223 => 1,
-                   224 => 1,
-                   225 => 1,
-                   226 => 1,
-                   227 => 1,
-                   230 => 2,
-                   232 => 1,
-                   246 => 1,
-                   248 => 4,
-                   261 => 1,
-                   263 => 1,
-                   276 => 1,
-                   277 => 1,
-                   278 => 1,
-                   279 => 1,
-                   280 => 1,
-                   281 => 1,
-                   284 => 1,
-                   286 => 2,
-                   294 => 1,
-                   302 => 1,
-                   312 => 1,
-                   358 => 1,
-                   359 => 2,
-                   372 => 1,
-                   373 => 1,
-                   387 => 1,
-                   407 => 1,
-                   441 => 1,
-                   500 => 1,
-                   526 => 1,
-                   548 => 1,
-                   641 => 1,
-                   669 => 1,
-                   744 => 1,
-                   748 => 1,
-                   789 => 1,
-                   792 => 1,
-                   794 => 1,
-                   797 => 1,
-                   801 => 1,
-                  );
+        switch ($testFile) {
+        case 'FunctionCommentUnitTest.inc':
+            $errors = array(
+                       5   => 1,
+                       10  => 3,
+                       12  => 2,
+                       13  => 2,
+                       14  => 1,
+                       15  => 1,
+                       28  => 1,
+                       43  => 1,
+                       76  => 1,
+                       87  => 1,
+                       103 => 1,
+                       109 => 1,
+                       112 => 1,
+                       122 => 1,
+                       123 => 3,
+                       124 => 2,
+                       125 => 1,
+                       126 => 1,
+                       137 => 4,
+                       138 => 4,
+                       139 => 4,
+                       143 => 2,
+                       152 => 1,
+                       155 => 2,
+                       159 => 1,
+                       166 => 1,
+                       173 => 1,
+                       183 => 1,
+                       190 => 2,
+                       193 => 2,
+                       196 => 1,
+                       199 => 2,
+                       210 => 1,
+                       211 => 1,
+                       222 => 1,
+                       223 => 1,
+                       224 => 1,
+                       225 => 1,
+                       226 => 1,
+                       227 => 1,
+                       230 => 2,
+                       232 => 1,
+                       246 => 1,
+                       248 => 4,
+                       261 => 1,
+                       263 => 1,
+                       276 => 1,
+                       277 => 1,
+                       278 => 1,
+                       279 => 1,
+                       280 => 1,
+                       281 => 1,
+                       284 => 1,
+                       286 => 2,
+                       294 => 1,
+                       302 => 1,
+                       312 => 1,
+                       358 => 1,
+                       359 => 2,
+                       372 => 1,
+                       373 => 1,
+                       387 => 1,
+                       407 => 1,
+                       441 => 1,
+                       500 => 1,
+                       526 => 1,
+                       548 => 1,
+                       641 => 1,
+                       669 => 1,
+                       744 => 1,
+                       748 => 1,
+                       767 => 1,
+                       789 => 1,
+                       792 => 1,
+                       794 => 1,
+                       797 => 1,
+                       801 => 1,
+                      );
 
-        // The yield tests will only work in PHP versions where yield exists and
-        // will throw errors in earlier versions.
-        if (PHP_VERSION_ID < 50500) {
-            $errors[676] = 1;
-        } else {
-            $errors[688] = 1;
+            // The yield tests will only work in PHP versions where yield exists and
+            // will throw errors in earlier versions.
+            if (PHP_VERSION_ID < 50500) {
+                $errors[676] = 1;
+            } else {
+                $errors[688] = 1;
+            }
+
+            // Scalar type hints only work from PHP 7 onwards.
+            if (PHP_VERSION_ID >= 70000) {
+                $errors[17]  = 1;
+                $errors[143] = 3;
+                $errors[161] = 2;
+                $errors[201] = 1;
+                $errors[363] = 3;
+                $errors[377] = 1;
+                $errors[575] = 2;
+                $errors[627] = 1;
+            } else {
+                $errors[729] = 4;
+                $errors[740] = 2;
+                $errors[752] = 2;
+            }
+
+            return $errors;
+
+        case 'FunctionCommentUnitTest.1.inc':
+            return array(
+                    9  => 1,
+                    21 => 1,
+                    33 => 1,
+                    45 => 1,
+                   );
+
+        default:
+            return array();
         }
-
-        // Scalar type hints only work from PHP 7 onwards.
-        if (PHP_VERSION_ID >= 70000) {
-            $errors[17]  = 1;
-            $errors[143] = 3;
-            $errors[161] = 2;
-            $errors[201] = 1;
-            $errors[363] = 3;
-            $errors[377] = 1;
-            $errors[575] = 2;
-            $errors[627] = 1;
-        } else {
-            $errors[729] = 4;
-            $errors[740] = 2;
-            $errors[752] = 2;
-        }
-
-        return $errors;
 
     }//end getErrorList()
 

--- a/package.xml
+++ b/package.xml
@@ -1837,6 +1837,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
          <tasks:replace from="@package_version@" to="version" type="package-info" />
         </file>
         <file baseinstalldir="PHP" name="FunctionCommentUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP" name="FunctionCommentUnitTest.1.inc" role="test" />
+        <file baseinstalldir="PHP" name="FunctionCommentUnitTest.1.inc.fixed" role="test" />
         <file baseinstalldir="PHP" name="FunctionCommentUnitTest.php" role="test">
          <tasks:replace from="@package_version@" to="version" type="package-info" />
         </file>


### PR DESCRIPTION
Also incidentally fixes a _"Function return type is not void, but function has no return statement"_ error being thrown when it shouldn't be when using multiple types including void, i.e. `array|void`.

Includes unit tests specific to this issue in a separate file + fixed file.

Fixes #1018

Note: the unit tests are in a separate file as the "main" unit test file for this sniff does not have a `.fixed` version and adding that is currently not an option as there are a number of other bugs in the sniff.
Once all the bugs are solved & a `.fixed` file for the main unit test file can be added, the tests for this issue can be added to the main file.