### PR TITLE
Improvements for the Generic.CodeAnalysis.UnusedFunctionParameter sniff

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -58,10 +58,18 @@ class UnusedFunctionParameterSniff implements Sniff
             return;
         }
 
+        $errorCode  = 'Found';
         $implements = false;
+        $extends    = false;
         $classPtr   = $phpcsFile->getCondition($stackPtr, T_CLASS);
         if ($classPtr !== false) {
             $implements = $phpcsFile->findImplementedInterfaceNames($classPtr);
+            $extends    = $phpcsFile->findExtendedClassName($classPtr);
+            if ($extends !== false) {
+                $errorCode .= 'InExtendedClass';
+            } else if ($implements !== false) {
+                $errorCode .= 'InImplementedInterface';
+            }
         }
 
         $params       = [];
@@ -180,7 +188,7 @@ class UnusedFunctionParameterSniff implements Sniff
             foreach ($params as $paramName => $position) {
                 $error = 'The method parameter %s is never used';
                 $data  = [$paramName];
-                $phpcsFile->addWarning($error, $position, 'Found', $data);
+                $phpcsFile->addWarning($error, $position, $errorCode, $data);
             }
         }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -67,6 +67,12 @@ class UnusedFunctionParameterSniff implements Sniff
         $params       = [];
         $methodParams = $phpcsFile->getMethodParameters($stackPtr);
 
+        // Skip when no parameters found.
+        $methodParamsCount = count($methodParams);
+        if ($methodParamsCount === 0) {
+            return;
+        }
+
         foreach ($methodParams as $param) {
             $params[$param['name']] = $stackPtr;
         }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -78,3 +78,8 @@ function bar($x)
 function ($a, $b) {
     return $a * 2;
 }
+
+function foobar() {
+	return;
+}
+

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -20,7 +20,7 @@ function foobar($a, &$b) {
     return (preg_match('/foo/', $a, $b) !== 0);
 }
 
-class Foo {
+class Foo implements Bar {
     function barfoo($a, $b) {
         // Empty body means interface method in many cases.
     }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -107,3 +107,17 @@ class MyExtendedClass implements SomeInterface {
         return $a * 2;
     }
 }
+
+
+/*
+ * Functions may not use all params passed to them.
+ * Report different violations for params *before* and *after* the last param used.
+ */
+
+function something($a) {
+	return 'foobar';
+}
+
+function myCallback($a, $b, $c, $d) {
+    return $a * $c;
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -83,3 +83,27 @@ function foobar() {
 	return;
 }
 
+
+/*
+ * The function signature of methods in extended classes and implemented
+ * interfaces has to mirror the parent class/interface.
+ * The overloaded method may not use all params.
+ */
+
+class MyClass {
+    public function something($a, $b) {
+        return $a * 2;
+    }
+}
+
+class MyExtendedClass extends SomeClass {
+    public function something($a, $b) {
+        return $a * 2;
+    }
+}
+
+class MyExtendedClass implements SomeInterface {
+    public function something($a, $b) {
+        return $a * 2;
+    }
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -41,9 +41,12 @@ class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            3  => 1,
-            7  => 1,
-            78 => 1,
+            3   => 1,
+            7   => 1,
+            78  => 1,
+            94  => 1,
+            100 => 1,
+            106 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -47,6 +47,8 @@ class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
             94  => 1,
             100 => 1,
             106 => 1,
+            117 => 1,
+            121 => 2,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
This PR contains one improvement to the existing code and two enhancements. It also contains two minor efficiency tweaks.

Each change is contained in its own commit.

### Efficiency tweaks
* Don't make a function call in a loop control structure
* Bow out early if the function doesn't have any parameters

### Only allow for empty function bodies if function implements interface

The sniff currently allowed for unused parameters in functions with empty bodies to allow for selective interface implementation.
The sniff, however, did not verify if the function was in a class which implemented an interface.
This has now been fixed.

### Allow for ignoring functions in child classes and classes which implement interfaces.

The function signature of methods in extended classes has to mirror the method as defined in the parent class/interface.
The overloaded method may, however, not use all params.

~~This change introduces a new `$ignore_extended_classes` property which defaults to `false` to retain the original behaviour.
When this property is set to `true`, the sniff will blanket ignore all functions in classes which extend another class and in classes which implement interfaces.~~

This change introduces two new errorcodes which allow a user to ignore these errors by excluding the errorcode from their custom ruleset.

The new errorcodes are:
* `FoundInExtendedClass`
* `FoundInImplementedInterface`


### Allow for unused parameters in functions used as callbacks.

(Callback) functions may not use all parameters passed, but have to allow in their function signature for the ones they do use to be passed to them.

~~This change introduces a new `$allow_for_callbacks` property which defaults to `false` to retain the original behaviour.
When this property is set to `true`, the sniff will only report on unused parameters *after* the last used parameter.~~

This commit introduces additional differentiation in the error codes used based on:
* whether the *only* param was not used (`Found`)
* whether a param was not used, but positioned *before* the last used param (`FoundBeforeLastUsed`)
* whether a param was not used and positioned *after* the last used param (`FoundAfterLastUsed`)

These codes will combine with the `FoundInExtendedClass` and `FoundInImplementedInterface` error codes as introduced in the previous commit.

Unit tests are included for all changes.
