### PR TITLE
Issue #1319: findnext inconsistency, option 2

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -3401,11 +3401,11 @@ class PHP_CodeSniffer_File
     ) {
         $types = (array) $types;
 
-        if ($end === null || $end > $this->numTokens) {
-            $end = $this->numTokens;
+        if ($end === null || $end >= $this->numTokens) {
+            $end = ($this->numTokens - 1);
         }
 
-        for ($i = $start; $i < $end; $i++) {
+        for ($i = $start; $i <= $end; $i++) {
             $found = (bool) $exclude;
             foreach ($types as $type) {
                 if ($this->_tokens[$i]['code'] === $type) {

--- a/CodeSniffer/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -231,7 +231,7 @@ class PEAR_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_CodeS
         // The opening brace needs to be one space away from the closing parenthesis.
         $openBrace = $tokens[$stackPtr]['scope_opener'];
         $next      = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), $openBrace, true);
-        if ($next !== false) {
+        if ($next !== false && $next !== $openBrace) {
             // Probably comments in between tokens, so don't check.
             return;
         }

--- a/CodeSniffer/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
@@ -52,12 +52,13 @@ class PSR2_Sniffs_Files_EndFileNewlineSniff implements PHP_CodeSniffer_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($phpcsFile->findNext(T_INLINE_HTML, ($stackPtr + 1)) !== false) {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[($stackPtr + 1)]) === true && $phpcsFile->findNext(T_INLINE_HTML, ($stackPtr + 1)) !== false) {
             return ($phpcsFile->numTokens + 1);
         }
 
         // Skip to the end of the file.
-        $tokens    = $phpcsFile->getTokens();
         $lastToken = ($phpcsFile->numTokens - 1);
 
         if ($tokens[$lastToken]['content'] === '') {

--- a/CodeSniffer/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -62,7 +62,7 @@ class PSR2_Sniffs_Methods_FunctionCallSignatureSniff extends PEAR_Sniffs_Functio
         while ($tokens[$end]['code'] === T_COMMA) {
             // If the next bit of code is not on the same line, this is a
             // multi-line function call.
-            $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), $closeBracket, true);
+            $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), ($closeBracket - 1), true);
             if ($next === false) {
                 return false;
             }
@@ -76,7 +76,7 @@ class PSR2_Sniffs_Methods_FunctionCallSignatureSniff extends PEAR_Sniffs_Functio
 
         // We've reached the last argument, so see if the next content
         // (should be the close bracket) is also on the same line.
-        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), $closeBracket, true);
+        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), ($closeBracket - 1), true);
         if ($next !== false && $tokens[$next]['line'] !== $tokens[$end]['line']) {
             return true;
         }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -166,7 +166,7 @@ class Squiz_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
                 // Before counting this comma, make sure we are not
                 // at the end of the array.
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), $arrayEnd, true);
-                if ($next !== false) {
+                if ($next !== false && $next !== $arrayEnd) {
                     $valueCount++;
                     $commas[] = $i;
                 } else {
@@ -518,7 +518,7 @@ class Squiz_Sniffs_Arrays_ArrayDeclarationSniff implements PHP_CodeSniffer_Sniff
             $exclude     = PHP_CodeSniffer_Tokens::$emptyTokens;
             $exclude[]   = T_COMMA;
             $nextContent = $phpcsFile->findNext($exclude, ($indices[0]['value'] + 1), $arrayEnd, true);
-            if ($nextContent === false) {
+            if ($nextContent === false || $nextContent === $arrayEnd) {
                 $singleValue = true;
             }
         }

--- a/CodeSniffer/Standards/Squiz/Sniffs/Commenting/EmptyCatchCommentSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Commenting/EmptyCatchCommentSniff.php
@@ -57,7 +57,7 @@ class Squiz_Sniffs_Commenting_EmptyCatchCommentSniff implements PHP_CodeSniffer_
         $tokens = $phpcsFile->getTokens();
 
         $scopeStart   = $tokens[$stackPtr]['scope_opener'];
-        $firstContent = $phpcsFile->findNext(T_WHITESPACE, ($scopeStart + 1), $tokens[$stackPtr]['scope_closer'], true);
+        $firstContent = $phpcsFile->findNext(T_WHITESPACE, ($scopeStart + 1), ($tokens[$stackPtr]['scope_closer'] - 1), true);
 
         if ($firstContent === false) {
             $error = 'Empty CATCH statement must have a comment to explain why the exception is not handled';

--- a/CodeSniffer/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -143,7 +143,7 @@ class Squiz_Sniffs_Operators_IncrementDecrementUsageSniff implements PHP_CodeSni
         $statementEnd = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_PARENTHESIS, T_CLOSE_SQUARE_BRACKET, T_CLOSE_CURLY_BRACKET), $stackPtr);
 
         // If there is anything other than variables, numbers, spaces or operators we need to return.
-        $noiseTokens = $phpcsFile->findNext(array(T_LNUMBER, T_VARIABLE, T_WHITESPACE, T_PLUS, T_MINUS, T_OPEN_PARENTHESIS), ($stackPtr + 1), $statementEnd, true);
+        $noiseTokens = $phpcsFile->findNext(array(T_LNUMBER, T_VARIABLE, T_WHITESPACE, T_PLUS, T_MINUS, T_OPEN_PARENTHESIS), ($stackPtr + 1), ($statementEnd - 1), true);
 
         if ($noiseTokens !== false) {
             return;
@@ -162,7 +162,7 @@ class Squiz_Sniffs_Operators_IncrementDecrementUsageSniff implements PHP_CodeSni
             $nextVar          = ($stackPtr + 1);
             $previousVariable = ($stackPtr + 1);
             $variableCount    = 0;
-            while (($nextVar = $phpcsFile->findNext(T_VARIABLE, ($nextVar + 1), $statementEnd)) !== false) {
+            while (($nextVar = $phpcsFile->findNext(T_VARIABLE, ($nextVar + 1), ($statementEnd - 1))) !== false) {
                 $previousVariable = $nextVar;
                 $variableCount++;
             }


### PR DESCRIPTION
Fixes #1319 with full consistency between behaviour of the `findNext()` and `findPrevious()` methods, but with a larger BC break.