### PR TITLE
Avoid a fatal error when calling a method on bool

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -62,7 +62,11 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
                     && file_exists(__DIR__.'/../../autoload.php') === true
                 ) {
                     self::$composerAutoloader = include_once __DIR__.'/../../autoload.php';
-                    self::$composerAutoloader->unregister();
+                    if (self::$composerAutoloader instanceof Composer\Autoload\ClassLoader) {
+                        self::$composerAutoloader->unregister();
+                    } else {
+                        self::$composerAutoloader = false;
+                    }
                 } else {
                     self::$composerAutoloader = false;
                 }


### PR DESCRIPTION
If the file was already included, `include_once` will return `true` and the function call on  the boolean will throw a fatal error
`PHP Fatal error:  Uncaught Error: Call to a member function unregister() on boolean``