### PR TITLE
Allow failures for PHP nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ php:
   - hhvm
   - nightly
 
+matrix:
+  fast_finish: true
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: nightly
+
 before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:1} != "7" && $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then phpenv config-add php5-testingConfig.ini; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then phpenv config-add php7-testingConfig.ini; fi


### PR DESCRIPTION
Currently PHPUnit is failing on PHP nightly and therefore the build is failing.

This change will prevent complete builds failing for failures which occur only in PHP nightly.

FYI: the underlying issue in PHPUnit / Comparator has already been addressed but is not contained in the version used by Travis yet.
Ref: https://github.com/sebastianbergmann/phpunit/issues/2453
Ref: https://github.com/sebastianbergmann/comparator/pull/30