### PR TITLE
Fixed: comments are no longer removed

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -88,9 +88,14 @@ class Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff implements PHP_CodeSniffer_S
         $fix = $phpcsFile->addFixableError($error, $stackPtr, 'Incorrect', $data);
         if ($fix === true) {
             $phpcsFile->fixer->beginChangeset();
-            for ($i = ($stackPtr - 1); $i > $nonSpace; $i--) {
+            $i = ($stackPtr - 1);
+            while (($tokens[$i]['code'] === T_WHITESPACE) && ($i > $nonSpace)) {
                 $phpcsFile->fixer->replaceToken($i, '');
+                $i--;
             }
+
+            $phpcsFile->fixer->addContent($nonSpace, ';');
+            $phpcsFile->fixer->replaceToken($stackPtr, '');
 
             $phpcsFile->fixer->endChangeset();
         }

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
@@ -10,3 +10,7 @@ $test = $this->testThis()  /* comment here */  ;
 
 $hello ='foo';
 ;
+
+$sum = $a /* + $b */;
+$sum = $a // + $b
+;

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
@@ -1,0 +1,15 @@
+<?php
+$test = $this->testThis();
+$test = $this->testThis();
+$test = $this->testThis();
+for ($var = 1; $var < 10; $var++) {
+    echo $var;
+}
+$test = $this->testThis();  /* comment here */
+$test = $this->testThis();  /* comment here */
+
+$hello ='foo';
+;
+
+$sum = $a; /* + $b */
+$sum = $a; // + $b

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.js
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.js
@@ -15,3 +15,8 @@ for (i=0   ; i<3 ; i++) {
 }
 alert('hi');
 ;
+
+var sum = a /* + b */;
+
+var sum = a // +b
+;

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.js.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.js.fixed
@@ -1,0 +1,21 @@
+var x = {
+    a: function () {
+        alert('thats right');
+        x = (x?a:x);
+    },
+};
+
+id = id.replace(/row\/:;/gi, '');
+
+for (i=0; i<3; i++) {
+   for (j=0; j<5; j++) {
+      if (j==x)
+         break;
+   }
+}
+alert('hi');
+;
+
+var sum = a; /* + b */
+
+var sum = a; // +b

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -53,6 +53,8 @@ class Squiz_Tests_WhiteSpace_SemicolonSpacingUnitTest extends AbstractSniffUnitT
                     6 => 1,
                     8 => 1,
                     9 => 1,
+                    14 => 1,
+                    16 => 1,
                    );
             break;
         case 'SemicolonSpacingUnitTest.js':
@@ -63,6 +65,8 @@ class Squiz_Tests_WhiteSpace_SemicolonSpacingUnitTest extends AbstractSniffUnitT
                     10 => 2,
                     11 => 1,
                     13 => 1,
+                    19 => 1,
+                    22 => 1,
                    );
             break;
         default:


### PR DESCRIPTION
Used to remove everything between a semicolon and a nonempty token. Now it jumps over the comments leaving them as is only removing whitespaces between a comment and a semicolon. For exmple, if we have code like this:
`$test = $a /* + $b */ ;`
Before: the comment would be removed:
`$test = $a;`
Now: the comment remains:
`$test = $a; /* + $b */`