### PR TITLE
Add new sniff MethodPrefixSpacing to Squiz coding standard

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MethodPrefixSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/MethodPrefixSpacingSniff.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Squiz_Sniffs_WhiteSpace_MethodPrefixSpacingSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Squiz_Sniffs_WhiteSpace_MethodPrefixSpacingSniff.
+ *
+ * Ensure there is a single space after the keywords before a method.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Squiz_Sniffs_WhiteSpace_MethodPrefixSpacingSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return PHP_CodeSniffer_Tokens::$methodPrefixes;
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+
+        if ($tokens[$stackPtr]['code'] === T_STATIC
+            && ($tokens[$nextToken]['code'] === T_DOUBLE_COLON
+            || $tokens[$prevToken]['code'] === T_NEW)
+        ) {
+            // Late static binding, e.g., static:: OR new static() usage.
+            return;
+        }
+
+        if ($tokens[$prevToken]['code'] === T_AS) {
+            // Trait visibilty change, e.g., "use HelloWorld { sayHello as private; }".
+            return;
+        }
+
+        $nextToken = $tokens[($stackPtr + 1)];
+        if (strlen($nextToken['content']) !== 1
+            || $nextToken['content'] === $phpcsFile->eolChar
+        ) {
+            $keyword = $tokens[$stackPtr]['content'];
+            if (in_array($tokens[$stackPtr]['code'], PHP_CodeSniffer_Tokens::$scopeModifiers) === true) {
+                $code = 'SpacingAfterVisibility';
+            } else {
+                $code = 'SpacingAfter'.ucfirst($tokens[$stackPtr]['content']);
+            }
+
+            $error = 'Keyword "%s" must be followed by a single space';
+            $data  = array($tokens[$stackPtr]['content']);
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, $code, $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/MethodPrefixSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/MethodPrefixSpacingUnitTest.inc
@@ -1,0 +1,84 @@
+<?php
+class MyClass
+{
+    public static $var = null;
+    protected $var = null;
+
+    public   static  $var = null;
+    protected  $var = null;
+
+    private function myFunction() {}
+    public static function myFunction() {}
+
+    private   function myFunction() {}
+    public  static function myFunction() {}
+    private static   function myFunction() {}
+
+    private  static
+        function myFunction() {}
+
+    public static function output()
+    {
+        // New in PHP 5.3
+        static::bar();
+    }
+}
+
+abstract class Foo
+{
+    public static function getInstance()
+    {
+        return new static();
+    }
+}
+
+if ($geometry instanceof static) {
+    echo 'foo';
+}
+
+class MyClass1 {
+    use HelloWorld { sayHello as private; }
+}
+
+abstract class MyClass
+{
+    abstract protected function myFunction();
+    final public function myFunction() {}
+}
+
+abstract  class MyClass
+{
+    abstract private function myFunction();
+    abstract  protected function myFunction();
+    abstract   public function myFunction();
+    abstract
+    private function myFunction();
+    abstract
+        private function myFunction();
+
+    final public function myFunction() {}
+    final  private function myFunction() {}
+    final   protected function myFunction() {}
+    final
+    public function myFunction() {}
+    final
+        public function myFunction() {}
+    
+    abstract private static function myFunction();
+    abstract  protected static  function myFunction();
+    abstract   public  static  function myFunction();
+    abstract
+    private static  function myFunction();
+    abstract
+        private  static function myFunction();
+
+    final public static function myFunction() {}
+    final  private  static function myFunction() {}
+    final   protected   static   function myFunction() {}
+    final
+    public
+    static function myFunction() {}
+    final
+        public
+            static  function myFunction() {}
+}

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/MethodPrefixSpacingUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/MethodPrefixSpacingUnitTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Unit test class for the MethodPrefixSpacing sniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the MethodPrefixSpacing sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Squiz_Tests_WhiteSpace_MethodPrefixSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array(
+                7  => 2,
+                8  => 1,
+                13 => 1,
+                14 => 1,
+                15 => 1,
+                17 => 2,
+                49 => 1,
+                52 => 1,
+                53 => 1,
+                54 => 1,
+                56 => 1,
+                60 => 1,
+                61 => 1,
+                62 => 1,
+                64 => 1,
+                68 => 2,
+                69 => 3,
+                70 => 1,
+                71 => 1,
+                72 => 1,
+                73 => 1,
+                76 => 2,
+                77 => 3,
+                78 => 1,
+                79 => 1,
+                81 => 1,
+                82 => 1,
+                83 => 1,
+               );
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class
+
+?>


### PR DESCRIPTION
The sniff ensures that there is only a single space after the keywords `static`, `abstract`, `final` and the visibility keywords. I made a new sniff instead of enhancing the existing `ScopeKeywordSpacingSniff`, because the name would be misleading.

This, however, raises a couple of questions:
1. The existing `ScopeKeywordSpacingSniff` is now obsolete and could be removed but I don't know what the procedure is for removing a sniff (users will get an error if they reference this sniff in their ruleset).
2. If it does not get removed, both sniffs will complain, if there is more than one space after a visibility keyword or `static`. I am not sure if this would be considered a problem.

If this is all too much trouble and the misleading name is of no concern, I can also put these changes into the existing sniff.

This PR addresses issue #1312 