### PR TITLE
Remove an unused param inside UselessOverridingMethodSniff

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/CodeAnalysis/UselessOverridingMethodSniff.php
@@ -124,12 +124,6 @@ class Generic_Sniffs_CodeAnalysis_UselessOverridingMethodSniff implements PHP_Co
             return;
         }
 
-        $validParameterTypes = array(
-                                T_VARIABLE,
-                                T_LNUMBER,
-                                T_CONSTANT_ENCAPSED_STRING,
-                               );
-
         $parameters       = array('');
         $parenthesisCount = 1;
         $count            = count($tokens);


### PR DESCRIPTION
Remove an unused variable.
Simple thing.