### PR TITLE
Saving STDIN input to `stdin` CLI value before passing it to `$phpcs-…

### DIFF
--- a/CodeSniffer/CLI.php
+++ b/CodeSniffer/CLI.php
@@ -1013,6 +1013,7 @@ class PHP_CodeSniffer_CLI
                 $this->printUsage();
                 exit(2);
             } else {
+                $this->values['stdin'] = $fileContents;
                 $phpcs->processFile('STDIN', $fileContents);
             }
         }


### PR DESCRIPTION
…>processFile()` method in case the input is obtained during the re-read in `PHP_CodeSniffer_CLI::process` method

fixes #1340