### PR TITLE
PSR2.Methods.FunctionCallSignature strips some comments during fixing

### DIFF
--- a/CodeSniffer/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc
+++ b/CodeSniffer/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc
@@ -116,3 +116,29 @@ $qux = array_filter(
 $this->listeners[] = $events->getSharedManager()->attach(
         'Zend\Mvc\Application', MvcEvent::EVENT_DISPATCH, [$this, 'selectLayout'], 100
 );
+
+// @codingStandardsChangeSetting PSR2.Methods.FunctionCallSignature requiredSpacesBeforeClose 1
+foo('Testing
+    multiline text'
+ );
+
+foo('Testing
+    multiline text: ' // . $text
+ );
+
+foo('Testing
+    multiline text: ' /* . $text */
+ );
+
+foo('Testing
+    multiline text: ' /* . $text */
+    // . $other_text
+ );
+
+foo('Testing
+    multiline text: ' /*
+ . $text
+// . $text2
+ */
+ );
+// @codingStandardsChangeSetting PSR2.Methods.FunctionCallSignature requiredSpacesBeforeClose 0

--- a/CodeSniffer/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc.fixed
@@ -128,3 +128,26 @@ $this->listeners[] = $events->getSharedManager()->attach(
     [$this, 'selectLayout'],
     100
 );
+
+// @codingStandardsChangeSetting PSR2.Methods.FunctionCallSignature requiredSpacesBeforeClose 1
+foo('Testing
+    multiline text' );
+
+foo('Testing
+    multiline text: ' ) // . $text
+;
+
+foo('Testing
+    multiline text: ' /* . $text */ );
+
+foo('Testing
+    multiline text: ' /* . $text */ )
+    // . $other_text
+;
+
+foo('Testing
+    multiline text: ' /*
+ . $text
+// . $text2
+ */ );
+// @codingStandardsChangeSetting PSR2.Methods.FunctionCallSignature requiredSpacesBeforeClose 0

--- a/CodeSniffer/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
+++ b/CodeSniffer/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
@@ -52,6 +52,11 @@ class PSR2_Tests_Methods_FunctionCallSignatureUnitTest extends AbstractSniffUnit
                 103 => 1,
                 111 => 1,
                 117 => 4,
+                121 => 1,
+                125 => 1,
+                129 => 1,
+                133 => 1,
+                138 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
This is a somewhat hard to come by bug, but still... The problem was, when using PSR2.Methods.FunctionCallSignatureSniff with requiredSpacesBeforeClose set to 1 and you had a situation like this:
```
foo('Testing
    multiline text'
 );
```
Notice a space before the closing parenthesis. The sniff would try to fix it but would get stuck, since it was removing a single token before the parenthesis. What I've done is I try to move the closing parenthesis to the end of the function call parameter, while jumping over any inline T_COMMENT and moving it before any /* */ comments or any other token, so for example, if we had a situation like this:
```
foo('Testing
    multiline text: ' // . $text
 );
```
The fixed code would look like this:
```
foo('Testing
    multiline text: ' ) // . $text
;
```

But if we had a situation like this:
```
foo('Testing
    multiline text: ' /* . $text */
 );
```
The fixed code would look like this:
```
foo('Testing
    multiline text: ' /* . $text */ );
```