### PR TITLE
Squiz.Strings.DoubleQuoteUsage.NotRequired message is badly formatted when string contains a CR newline char

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -131,7 +131,7 @@ class Squiz_Sniffs_Strings_DoubleQuoteUsageSniff implements PHP_CodeSniffer_Snif
         }
 
         $error = 'String %s does not require double quotes; use single quotes instead';
-        $data  = array(str_replace("\n", '\n', $workingString));
+        $data  = array(str_replace(array("\r", "\n"), array('\r', '\n'), $workingString));
         $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotRequired', $data);
 
         if ($fix === true) {


### PR DESCRIPTION
On files with CRLF new lines the message would get distorted, since \r chars would not get converted.