### PR TITLE
Add config options to allow short data type aliases.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -867,3 +867,55 @@ function returnTypeWithDescriptionD()
 {
 
 }//end returnTypeWithDescriptionD()
+
+/**
+ * No errors expected here.
+ *
+ * @param integer $someInt  Some int.
+ * @param boolean $someBool Some bool.
+ *
+ * @return integer|boolean
+ */
+public function myFunctionA($someInt, $someBool)
+{
+    return $this->var;
+}
+
+/**
+ * Both int and bool are not allowed.
+ *
+ * @param int  $someInt  Some int.
+ * @param bool $someBool Some bool.
+ *
+ * @return int|bool
+ */
+public function myFunctionB($someInt, $someBool)
+{
+    return $this->var;
+}
+
+/**
+ * int is not allowed, boolean should be fine.
+ *
+ * @param int     $someInt  Some int.
+ * @param boolean $someBool Some bool.
+ *
+ * @return int|boolean
+ */
+public function myFunctionC($someInt, $someBool)
+{
+    return $this->var;
+}
+
+/**
+ * bool is not allowed, integer should be fine.
+ *
+ * @param integer $someInt  Some int.
+ * @param bool    $someBool Some bool.
+ *
+ * @return integer|bool
+ */
+public function myFunctionD($someInt, $someBool)
+{
+    return $this->var;
+}

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -867,3 +867,55 @@ function returnTypeWithDescriptionD()
 {
 
 }//end returnTypeWithDescriptionD()
+
+/**
+ * No errors expected here.
+ *
+ * @param integer $someInt  Some int.
+ * @param boolean $someBool Some bool.
+ *
+ * @return integer|boolean
+ */
+public function myFunctionA($someInt, $someBool)
+{
+    return $this->var;
+}
+
+/**
+ * Both int and bool are not allowed.
+ *
+ * @param integer $someInt  Some int.
+ * @param boolean $someBool Some bool.
+ *
+ * @return integer|boolean
+ */
+public function myFunctionB($someInt, $someBool)
+{
+    return $this->var;
+}
+
+/**
+ * int is not allowed, boolean should be fine.
+ *
+ * @param integer $someInt  Some int.
+ * @param boolean $someBool Some bool.
+ *
+ * @return integer|boolean
+ */
+public function myFunctionC($someInt, $someBool)
+{
+    return $this->var;
+}
+
+/**
+ * bool is not allowed, integer should be fine.
+ *
+ * @param integer $someInt  Some int.
+ * @param boolean $someBool Some bool.
+ *
+ * @return integer|boolean
+ */
+public function myFunctionD($someInt, $someBool)
+{
+    return $this->var;
+}

--- a/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -46,7 +46,6 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
                    13  => 2,
                    14  => 1,
                    15  => 1,
-                   17  => 2,
                    28  => 1,
                    43  => 1,
                    76  => 1,
@@ -59,7 +58,6 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
                    124 => 2,
                    125 => 1,
                    126 => 1,
-                   128 => 1,
                    137 => 4,
                    138 => 4,
                    139 => 4,
@@ -123,6 +121,13 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
                    840 => 1,
                    852 => 1,
                    864 => 1,
+                   887 => 1,
+                   888 => 1,
+                   890 => 1,
+                   900 => 1,
+                   903 => 1,
+                   914 => 1,
+                   916 => 1,
                   );
 
         // The yield tests will only work in PHP versions where yield exists and
@@ -136,6 +141,7 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
         // Scalar type hints only work from PHP 7 onwards.
         if (PHP_VERSION_ID >= 70000) {
             $errors[17]  = 3;
+            $errors[128] = 1;
             $errors[143] = 3;
             $errors[161] = 2;
             $errors[201] = 1;
@@ -143,6 +149,10 @@ class Squiz_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnitTe
             $errors[377] = 1;
             $errors[575] = 2;
             $errors[627] = 1;
+            $errors[879] = 2;
+            $errors[892] = 2;
+            $errors[905] = 2;
+            $errors[918] = 2;
         } else {
             $errors[729] = 4;
             $errors[740] = 2;


### PR DESCRIPTION
There are two new options `useIntDataType` and `useBoolDataType` in Squiz/FunctionCommentSniff which
will allow the usage of `int` instead of `integer` and `bool` instead of `boolean` respectively within doc comments.

Some examples:

```php
// OK with both options set to true, otherwise NOK
/**
 * @param int                $offset The offset.
 * @param int|bool           $value  The mixed value.
 * @param array(int => bool) $map    The fancy mapping.
 */

// OK with both options set to false, otherwise NOK (default & current behaviour)
/**
 * @param integer                   $offset The offset.
 * @param integer|boolean           $value  The mixed value.
 * @param array(integer => boolean) $map    The fancy mapping.
 */
```

This PR is an alternative to #1047 and fixes/answers #1216.