### PR TITLE
Exception to the newline requirement on the first member var after class opener.

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -97,34 +97,27 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
 
 		// Exception to the newline requirement on the first member var after class opener.
-		if($this->firstVarException)
-		{
-    		if ($foundLines > 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)
-    		{
-    			$error = 'Expected 0 blank lines before first member var; %s found';
-    			$data  = array($foundLines);
-    			$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FirstMember', $data);
-    			if ($fix === true)
-    			{
-    				$phpcsFile->fixer->beginChangeset();
-    				for ($i = ($prev + 1); $i < $first; $i++)
-    				{
-    					if ($tokens[$i]['line'] === $tokens[$prev]['line'])
-    					{
-    						continue;
-    					}
-    					if ($tokens[$i]['line'] === $tokens[$first]['line'])
-    					{
-    						break;
-    					}
-    					$phpcsFile->fixer->replaceToken($i, '');
-    				}
-    				$phpcsFile->fixer->endChangeset();
-    			}
-    		}
+        if($this->firstVarException) {
+            if ($foundLines > 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET) {
+                $error = 'Expected 0 blank lines before first member var; %s found';
+                $data  = array($foundLines);
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FirstMember', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($prev + 1); $i < $first; $i++) {
+                        if ($tokens[$i]['line'] === $tokens[$prev]['line']) {
+                            continue;
+                        }
+                        if ($tokens[$i]['line'] === $tokens[$first]['line']) {
+                            break;
+                        }
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
 		}
-		if ($foundLines === 1 || ($this->firstVarException && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET))
-		{
+		if ($foundLines === 1 || ($this->firstVarException && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
 			return;
 		}
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -26,6 +26,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
      */
     public $firstVarException = false;
 
+
     /**
      * Processes the function tokens within the class.
      *
@@ -96,8 +97,8 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         $prev       = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($first - 1), null, true);
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
 
-		// Exception to the newline requirement on the first member var after class opener.
-        if($this->firstVarException) {
+        // Exception to the newline requirement on the first member var after class opener.
+        if ($this->firstVarException === true) {
             if ($foundLines > 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET) {
                 $error = 'Expected 0 blank lines before first member var; %s found';
                 $data  = array($foundLines);
@@ -108,18 +109,21 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
                         if ($tokens[$i]['line'] === $tokens[$prev]['line']) {
                             continue;
                         }
+
                         if ($tokens[$i]['line'] === $tokens[$first]['line']) {
                             break;
                         }
+
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
                     $phpcsFile->fixer->endChangeset();
                 }
             }
-		}
-		if ($foundLines === 1 || ($this->firstVarException && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
-			return;
-		}
+        }
+
+        if ($foundLines === 1 || ($this->firstVarException === true && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
+            return;
+        }
 
         $error = 'Expected 1 blank line before member var; %s found';
         $data  = array($foundLines);

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -116,10 +116,11 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
+
                     $phpcsFile->fixer->endChangeset();
-                }
-            }
-        }
+                }//end if
+            }//end if
+        }//end if
 
         if ($foundLines === 1 || ($this->firstVarException === true && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
             return;

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -20,7 +20,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
     /**
      * The number of blank lines between member vars.
      *
-     * @var int
+     * @var integer
      */
     public $spacing = 1;
 
@@ -28,7 +28,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
     /**
      * The number of blank lines between the class opener and the first member var.
      *
-     * @var int
+     * @var integer
      */
     public $firstMemberSpacing = 1;
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -18,6 +18,15 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
 
     /**
+     * The exception to the newline requirement on the first member var after class opener.
+     * false for newline requirement on the first member var after class opener
+     * true for no newline requirement on the first member var after class opener
+     *
+     * @var bool
+     */
+    public $firstVarException = false;
+
+    /**
      * Processes the function tokens within the class.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
@@ -86,9 +95,38 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         $prev       = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($first - 1), null, true);
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
-        if ($foundLines === 1) {
-            return;
-        }
+
+		// Exception to the newline requirement on the first member var after class opener.
+		if($this->firstVarException)
+		{
+    		if ($foundLines > 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)
+    		{
+    			$error = 'Expected 0 blank lines before first member var; %s found';
+    			$data  = array($foundLines);
+    			$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FirstMember', $data);
+    			if ($fix === true)
+    			{
+    				$phpcsFile->fixer->beginChangeset();
+    				for ($i = ($prev + 1); $i < $first; $i++)
+    				{
+    					if ($tokens[$i]['line'] === $tokens[$prev]['line'])
+    					{
+    						continue;
+    					}
+    					if ($tokens[$i]['line'] === $tokens[$first]['line'])
+    					{
+    						break;
+    					}
+    					$phpcsFile->fixer->replaceToken($i, '');
+    				}
+    				$phpcsFile->fixer->endChangeset();
+    			}
+    		}
+		}
+		if ($foundLines === 1 || ($this->firstVarException && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET))
+		{
+			return;
+		}
 
         $error = 'Expected 1 blank line before member var; %s found';
         $data  = array($foundLines);


### PR DESCRIPTION
Based on the draft PHPCS2 Joomla Custom member var sniff https://github.com/photodude/coding-standards/blob/phpcs-2/Joomla/Sniffs/WhiteSpace/MemberVarSpacingSniff.php#L102-L137

Addresses issues #920 and #725

This is a successor PR to #972 based on the feedback by @gsherwood which @photodude hadn't had time to work on yet