### PR TITLE
PSR2.ControlStructSwitchDeclaration does not handle if branches with returns

### DIFF
--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -154,3 +154,95 @@ switch ($foo) {
     case Foo::ARRAY:
         return self::VALUE;
 }
+
+// OK: Every clause terminates
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } else {
+            return 1;
+        }
+    case 2:
+        return 2;
+}
+
+// ERROR: No else clause
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } elseif ($bar < 0) {
+            return 1;
+        }
+    case 2:
+        return 2;
+}
+
+// OK: No fall-through present
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } elseif ($bar < 0) {
+            return 1;
+        }
+}
+
+// ERROR: No else clause (nested)
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } else {
+            if ($foo > $bar) {
+                continue;
+            }
+        }
+    case 2:
+        return 2;
+}
+
+// OK: Every clause terminates
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } else {
+            if ($foo > $bar) {
+                continue;
+            } else {
+                break;
+            }
+        }
+    case 2:
+        return 2;
+}
+
+// ERROR: Non-termination IF clause
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            $offset = 0;
+        } else {
+            break;
+        }
+    case 2:
+        return 2;
+}
+
+// ERROR: Non-termination IF clause (nested)
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            continue;
+        } else {
+            if ($foo > $bar) {
+                $offset = 0;
+            } else {
+                break;
+            }
+        }
+    case 2:
+        return 2;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -157,3 +157,95 @@ switch ($foo) {
     case Foo::ARRAY:
         return self::VALUE;
 }
+
+// OK: Every clause terminates
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } else {
+            return 1;
+        }
+    case 2:
+        return 2;
+}
+
+// ERROR: No else clause
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } elseif ($bar < 0) {
+            return 1;
+        }
+    case 2:
+        return 2;
+}
+
+// OK: No fall-through present
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } elseif ($bar < 0) {
+            return 1;
+        }
+}
+
+// ERROR: No else clause (nested)
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } else {
+            if ($foo > $bar) {
+                continue;
+            }
+        }
+    case 2:
+        return 2;
+}
+
+// OK: Every clause terminates
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            return 0;
+        } else {
+            if ($foo > $bar) {
+                continue;
+            } else {
+                break;
+            }
+        }
+    case 2:
+        return 2;
+}
+
+// ERROR: Non-termination IF clause
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            $offset = 0;
+        } else {
+            break;
+        }
+    case 2:
+        return 2;
+}
+
+// ERROR: Non-termination IF clause (nested)
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            continue;
+        } else {
+            if ($foo > $bar) {
+                $offset = 0;
+            } else {
+                break;
+            }
+        }
+    case 2:
+        return 2;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -42,6 +42,10 @@ class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
                 114 => 1,
                 128 => 1,
                 141 => 1,
+                172 => 1,
+                194 => 1,
+                224 => 1,
+                236 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
PSR-2 requires a comment when intentionally falling through a `case` within a `switch`.  Before reporting this error, we now check if there is an if/else statement at the end of the `case` block which always terminates. This reduces the number of false positives.

This PR fixes bug #834 .