### PR TITLE
'bool' and 'int' instead of 'boolean' and 'integer'

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -136,7 +136,7 @@ class Config
      * If FALSE, arguments that are not command line options or file/directory paths
      * will be ignored and execution will continue.
      *
-     * @var boolean
+     * @var bool
      */
     public $dieOnUnknownArg;
 

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -81,7 +81,7 @@ class File
      * If TRUE, the file was loaded from a local cache.
      * If FALSE, the file was tokenized and processed fully.
      *
-     * @var boolean
+     * @var bool
      */
     public $fromCache = false;
 
@@ -90,7 +90,7 @@ class File
      *
      * Stored here to save calling count() everywhere.
      *
-     * @var integer
+     * @var int
      */
     public $numTokens = 0;
 
@@ -128,28 +128,28 @@ class File
     /**
      * The total number of errors raised.
      *
-     * @var integer
+     * @var int
      */
     protected $errorCount = 0;
 
     /**
      * The total number of warnings raised.
      *
-     * @var integer
+     * @var int
      */
     protected $warningCount = 0;
 
     /**
      * The total number of errors and warnings that can be fixed.
      *
-     * @var integer
+     * @var int
      */
     protected $fixableCount = 0;
 
     /**
      * The total number of errors and warnings that were fixed.
      *
-     * @var integer
+     * @var int
      */
     protected $fixedCount = 0;
 

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -28,7 +28,7 @@ class FileList implements \Iterator, \Countable
     /**
      * The number of files in the list.
      *
-     * @var integer
+     * @var int
      */
     private $numFiles = 0;
 

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -25,14 +25,14 @@ class Fixer
      * doing extra processing to prepare for a fix when fixing is
      * not required.
      *
-     * @var boolean
+     * @var bool
      */
     public $enabled = false;
 
     /**
      * The number of times we have looped over a file.
      *
-     * @var integer
+     * @var int
      */
     public $loops = 0;
 
@@ -87,21 +87,21 @@ class Fixer
     /**
      * Is there an open changeset.
      *
-     * @var boolean
+     * @var bool
      */
     private $inChangeset = false;
 
     /**
      * Is the current fixing loop in conflict?
      *
-     * @var boolean
+     * @var bool
      */
     private $inConflict = false;
 
     /**
      * The number of fixes that have been performed.
      *
-     * @var integer
+     * @var int
      */
     private $numFixes = 0;
 

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -27,35 +27,35 @@ class Reporter
     /**
      * Total number of files that contain errors or warnings.
      *
-     * @var integer
+     * @var int
      */
     public $totalFiles = 0;
 
     /**
      * Total number of errors found during the run.
      *
-     * @var integer
+     * @var int
      */
     public $totalErrors = 0;
 
     /**
      * Total number of warnings found during the run.
      *
-     * @var integer
+     * @var int
      */
     public $totalWarnings = 0;
 
     /**
      * Total number of errors/warnings that can be fixed.
      *
-     * @var integer
+     * @var int
      */
     public $totalFixable = 0;
 
     /**
      * Total number of errors/warnings that were fixed.
      *
-     * @var integer
+     * @var int
      */
     public $totalFixed = 0;
 

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -25,7 +25,7 @@ class Notifysend implements Report
     /**
      * Notification timeout in milliseconds.
      *
-     * @var integer
+     * @var int
      */
     protected $timeout = 3000;
 
@@ -39,7 +39,7 @@ class Notifysend implements Report
     /**
      * Show "ok, all fine" messages.
      *
-     * @var boolean
+     * @var bool
      */
     protected $showOk = true;
 

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -21,7 +21,7 @@ abstract class AbstractPatternSniff implements Sniff
     /**
      * If true, comments will be ignored if they are found in the code.
      *
-     * @var boolean
+     * @var bool
      */
     public $ignoreComments = false;
 

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -49,7 +49,7 @@ abstract class AbstractScopeSniff implements Sniff
     /**
      * True if this test should fire on tokens outside of the scope.
      *
-     * @var boolean
+     * @var bool
      */
     private $listenOutside = false;
 

--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -24,14 +24,14 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
     /**
      * The end token of the current function that we are in.
      *
-     * @var integer
+     * @var int
      */
     private $endFunction = -1;
 
     /**
      * TRUE if a function is currently open.
      *
-     * @var boolean
+     * @var bool
      */
     private $functionOpen = false;
 

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -29,7 +29,7 @@ class InlineControlStructureSniff implements Sniff
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = true;
 

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -21,14 +21,14 @@ class ClosureLinterSniff implements Sniff
      *
      * All other error codes will show warnings.
      *
-     * @var integer
+     * @var int
      */
     public $errorCodes = array();
 
     /**
      * A list of error codes to ignore.
      *
-     * @var integer
+     * @var int
      */
     public $ignoreCodes = array();
 

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -22,7 +22,7 @@ class LineLengthSniff implements Sniff
     /**
      * The limit that the length of a line should not exceed.
      *
-     * @var integer
+     * @var int
      */
     public $lineLimit = 80;
 
@@ -31,7 +31,7 @@ class LineLengthSniff implements Sniff
      *
      * Set to zero (0) to disable.
      *
-     * @var integer
+     * @var int
      */
     public $absoluteLineLimit = 100;
 

--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -32,7 +32,7 @@ class MultipleStatementAlignmentSniff implements Sniff
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = false;
 
@@ -43,7 +43,7 @@ class MultipleStatementAlignmentSniff implements Sniff
      * surrounding assignments exceeds this number, the assignment will be
      * ignored and no errors or warnings will be thrown.
      *
-     * @var integer
+     * @var int
      */
     public $maxPadding = 1000;
 

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -18,14 +18,14 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
     /**
      * Should this sniff check function braces?
      *
-     * @var boolean
+     * @var bool
      */
     public $checkFunctions = true;
 
     /**
      * Should this sniff check closure braces?
      *
-     * @var boolean
+     * @var bool
      */
     public $checkClosures = false;
 

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -20,14 +20,14 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
     /**
      * Should this sniff check function braces?
      *
-     * @var boolean
+     * @var bool
      */
     public $checkFunctions = true;
 
     /**
      * Should this sniff check closure braces?
      *
-     * @var boolean
+     * @var bool
      */
     public $checkClosures = false;
 

--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -23,14 +23,14 @@ class CyclomaticComplexitySniff implements Sniff
     /**
      * A complexity higher than this value will throw a warning.
      *
-     * @var integer
+     * @var int
      */
     public $complexity = 10;
 
     /**
      * A complexity higher than this value will throw an error.
      *
-     * @var integer
+     * @var int
      */
     public $absoluteComplexity = 20;
 

--- a/src/Standards/Generic/Sniffs/Metrics/NestingLevelSniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/NestingLevelSniff.php
@@ -19,14 +19,14 @@ class NestingLevelSniff implements Sniff
     /**
      * A nesting level higher than this value will throw a warning.
      *
-     * @var integer
+     * @var int
      */
     public $nestingLevel = 5;
 
     /**
      * A nesting level higher than this value will throw an error.
      *
-     * @var integer
+     * @var int
      */
     public $absoluteNestingLevel = 10;
 

--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -70,7 +70,7 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
     /**
      * If TRUE, the string must not have two capital letters next to each other.
      *
-     * @var boolean
+     * @var bool
      */
     public $strict = true;
 

--- a/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -21,14 +21,14 @@ class DisallowAlternativePHPTagsSniff implements Sniff
     /**
      * Whether ASP tags are enabled or not.
      *
-     * @var boolean
+     * @var bool
      */
     private $aspTags = false;
 
     /**
      * The current PHP version.
      *
-     * @var integer
+     * @var int
      */
     private $phpVersion = null;
 

--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -41,14 +41,14 @@ class ForbiddenFunctionsSniff implements Sniff
     /**
      * If true, forbidden functions will be considered regular expressions.
      *
-     * @var boolean
+     * @var bool
      */
     protected $patternMatch = false;
 
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = true;
 

--- a/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -25,7 +25,7 @@ class NoSilencedErrorsSniff implements Sniff
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = false;
 

--- a/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/src/Standards/Generic/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -29,7 +29,7 @@ class UnnecessaryStringConcatSniff implements Sniff
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = true;
 
@@ -39,7 +39,7 @@ class UnnecessaryStringConcatSniff implements Sniff
      * Useful if you break strings over multiple lines to work
      * within a max line length.
      *
-     * @var boolean
+     * @var bool
      */
     public $allowMultiline = false;
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -29,7 +29,7 @@ class DisallowSpaceIndentSniff implements Sniff
     /**
      * The --tab-width CLI value that is being used.
      *
-     * @var integer
+     * @var int
      */
     private $tabWidth = null;
 

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -30,7 +30,7 @@ class ScopeIndentSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 
@@ -40,7 +40,7 @@ class ScopeIndentSniff implements Sniff
      * If TRUE, indent needs to be exactly $indent spaces. If FALSE,
      * indent needs to be at least $indent spaces (but can be more).
      *
-     * @var boolean
+     * @var bool
      */
     public $exact = false;
 
@@ -51,14 +51,14 @@ class ScopeIndentSniff implements Sniff
      * The size of each tab is important, so it should be specified
      * using the --tab-width CLI argument.
      *
-     * @var boolean
+     * @var bool
      */
     public $tabIndent = false;
 
     /**
      * The --tab-width CLI value that is being used.
      *
-     * @var integer
+     * @var int
      */
     private $tabWidth = null;
 
@@ -94,7 +94,7 @@ class ScopeIndentSniff implements Sniff
     /**
      * Show debug output for this sniff.
      *
-     * @var boolean
+     * @var bool
      */
     private $debug = false;
 

--- a/src/Standards/PEAR/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -17,7 +17,7 @@ class ControlSignatureSniff extends AbstractPatternSniff
     /**
      * If true, comments will be ignored if they are found in the code.
      *
-     * @var boolean
+     * @var bool
      */
     public $ignoreComments = true;
 

--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -29,7 +29,7 @@ class MultiLineConditionSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -18,7 +18,7 @@ class MultiLineAssignmentSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -29,28 +29,28 @@ class FunctionCallSignatureSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 
     /**
      * If TRUE, multiple arguments can be defined per line in a multi-line call.
      *
-     * @var boolean
+     * @var bool
      */
     public $allowMultipleArguments = true;
 
     /**
      * How many spaces should follow the opening bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesAfterOpen = 0;
 
     /**
      * How many spaces should precede the closing bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesBeforeClose = 0;
 

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -31,7 +31,7 @@ class FunctionDeclarationSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -18,7 +18,7 @@ class ObjectOperatorIndentSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -19,7 +19,7 @@ class ScopeClosingBraceSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -19,7 +19,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -19,14 +19,14 @@ class ControlStructureSpacingSniff implements Sniff
     /**
      * How many spaces should follow the opening bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesAfterOpen = 0;
 
     /**
      * How many spaces should precede the closing bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesBeforeClose = 0;
 

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -19,7 +19,7 @@ class SwitchDeclarationSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -19,7 +19,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
     /**
      * If TRUE, multiple arguments can be defined per line in a multi-line call.
      *
-     * @var boolean
+     * @var bool
      */
     public $allowMultipleArguments = false;
 

--- a/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
@@ -51,14 +51,14 @@ class ForbiddenStylesSniff implements Sniff
     /**
      * If true, forbidden styles will be considered regular expressions.
      *
-     * @var boolean
+     * @var bool
      */
     protected $patternMatch = false;
 
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = true;
 

--- a/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
@@ -25,7 +25,7 @@ class IndentationSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -19,7 +19,7 @@ class BlockCommentSniff implements Sniff
     /**
      * The --tab-width CLI value that is being used.
      *
-     * @var integer
+     * @var int
      */
     private $tabWidth = null;
 

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -20,7 +20,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
     /**
      * The current PHP version.
      *
-     * @var integer
+     * @var int
      */
     private $phpVersion = null;
 

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -44,7 +44,7 @@ class LongConditionClosingCommentSniff implements Sniff
      * The length that a code block must be before
      * requiring a closing comment.
      *
-     * @var integer
+     * @var int
      */
     public $lineLimit = 20;
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -19,14 +19,14 @@ class ForEachLoopDeclarationSniff implements Sniff
     /**
      * How many spaces should follow the opening bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesAfterOpen = 0;
 
     /**
      * How many spaces should precede the closing bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesBeforeClose = 0;
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -18,14 +18,14 @@ class ForLoopDeclarationSniff implements Sniff
     /**
      * How many spaces should follow the opening bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesAfterOpen = 0;
 
     /**
      * How many spaces should precede the closing bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesBeforeClose = 0;
 

--- a/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -29,7 +29,7 @@ class SwitchDeclarationSniff implements Sniff
     /**
      * The number of spaces code should be indented.
      *
-     * @var integer
+     * @var int
      */
     public $indent = 4;
 

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -18,21 +18,21 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
     /**
      * How many spaces should surround the equals signs.
      *
-     * @var integer
+     * @var int
      */
     public $equalsSpacing = 0;
 
     /**
      * How many spaces should follow the opening bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesAfterOpen = 0;
 
     /**
      * How many spaces should precede the closing bracket.
      *
-     * @var integer
+     * @var int
      */
     public $requiredSpacesBeforeClose = 0;
 

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -30,7 +30,7 @@ class CommentedOutCodeSniff implements Sniff
     /**
      * If a comment is more than $maxPercentage% code, a warning will be shown.
      *
-     * @var integer
+     * @var int
      */
     public $maxPercentage = 35;
 

--- a/src/Standards/Squiz/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -31,7 +31,7 @@ class DiscouragedFunctionsSniff extends GenericForbiddenFunctionsSniff
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = false;
 

--- a/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -18,14 +18,14 @@ class ConcatenationSpacingSniff implements Sniff
     /**
      * The number of spaces before and after a string concat.
      *
-     * @var integer
+     * @var int
      */
     public $spacing = 0;
 
     /**
      * Allow newlines instead of spaces.
      *
-     * @var boolean
+     * @var bool
      */
     public $ignoreNewlines = false;
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -18,7 +18,7 @@ class FunctionSpacingSniff implements Sniff
     /**
      * The number of blank lines between functions.
      *
-     * @var integer
+     * @var int
      */
     public $spacing = 2;
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -18,7 +18,7 @@ class ObjectOperatorSpacingSniff implements Sniff
     /**
      * Allow newlines instead of spaces.
      *
-     * @var boolean
+     * @var bool
      */
     public $ignoreNewlines = false;
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -29,7 +29,7 @@ class OperatorSpacingSniff implements Sniff
     /**
      * Allow newlines instead of spaces.
      *
-     * @var boolean
+     * @var bool
      */
     public $ignoreNewlines = false;
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -35,7 +35,7 @@ class SuperfluousWhitespaceSniff implements Sniff
      *
      * Blank lines are those that contain only whitespace.
      *
-     * @var boolean
+     * @var bool
      */
     public $ignoreBlankLines = false;
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -7,9 +7,9 @@ class PHP_CodeSniffer_File
      *
      * long desc here
      *
-     * @param bool   $stackPtr   The position in @ @unknown the stack of the token
+     * @param boolean   $stackPtr The position in @ @unknown the stack of the token
      *                             that opened the scope
-     * @param int    $detph    How many scope levels down we are.
+     * @param integer $detph    How many scope levels down we are.
      * @param string    $index    The index
      * @return
      * @throws
@@ -120,8 +120,8 @@ class PHP_CodeSniffer_File
      * Param not immediate.
      *
      * @return
-     * @param   int   $threeSpaces
-     * @param integer $superfluous
+     * @param   integer   $threeSpaces
+     * @param int $superfluous
      * @param miss
      * @param
      */

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -121,7 +121,7 @@ class PHP_CodeSniffer_File
      *
      * @return
      * @param   integer   $threeSpaces
-     * @param int $superfluous
+     * @param int     $superfluous
      * @param miss
      * @param
      */
@@ -134,7 +134,7 @@ class PHP_CodeSniffer_File
     /**
      * Comments not capitalised.
      *
-     * @param integer  $one    comment
+     * @param int  $one    comment
      * @param array    $two    -comment
      * @param MyClas   $three  0comment
      *
@@ -190,7 +190,7 @@ public function noReturnOutsideClass()
 /**
  * Missing param comment.
  *
- * @param integer $one comment
+ * @param int $one comment
  *
  * @see     wrong indent
  * @see
@@ -243,7 +243,7 @@ public function caseSensitive($a1, $a2, $a3, arRay $a4, $a5, $a6, myclas $a7)
  * @param MyClass $a3 Comment here.
  * @param MyClass $a4 Comment here.
  *
- * @return array(int => MyClass)
+ * @return array(integer => MyClass)
  */
 public function typeHint(MyClass $a1, $a2, myclass $a3, $a4)
 {
@@ -255,12 +255,12 @@ public function typeHint(MyClass $a1, $a2, myclass $a3, $a4)
 /**
  * Mixed variable type separated by a '|'.
  *
- * @param array|string $a1 Comment here.
- * @param mixed        $a2 Comment here.
- * @param string|array $a3 Comment here.
- * @param MyClass|int  $a4 Comment here.
+ * @param array|string    $a1 Comment here.
+ * @param mixed           $a2 Comment here.
+ * @param string|array    $a3 Comment here.
+ * @param MyClass|integer $a4 Comment here.
  *
- * @return bool
+ * @return boolean
  */
 public function mixedType($a1, $a2, $a3, $a4)
 {
@@ -272,16 +272,16 @@ public function mixedType($a1, $a2, $a3, $a4)
 /**
  * Array type.
  *
- * @param array(MyClass)         $a1 OK.
- * @param array()                $a2 Invalid type.
- * @param array(                 $a3 Typo.
- * @param array(int)             $a4 Use 'array(integer)' instead.
- * @param array(int => integer)  $a5 Use 'array(integer => integer)' instead.
- * @param array(integer => bool) $a6 Use 'array(integer => boolean)' instead.
- * @param aRRay                  $a7 Use 'array' instead.
- * @param string                 $a8 String with unknown type hint.
+ * @param array(MyClass)        $a1 OK.
+ * @param array()               $a2 Invalid type.
+ * @param array(                $a3 Typo.
+ * @param array(integer)        $a4 Use 'array(int)' instead.
+ * @param array(integer => int) $a5 Use 'array(int => int)' instead.
+ * @param array(int => boolean) $a6 Use 'array(int => bool)' instead.
+ * @param aRRay                 $a7 Use 'array' instead.
+ * @param string                $a8 String with unknown type hint.
  *
- * @return int
+ * @return integer
  */
 public function mixedArrayType($a1, $a2, array $a3, $a4, $a5, $a6, $a7, unknownTypeHint $a8)
 {
@@ -316,7 +316,7 @@ function empty3()
 
 
 /**
- * @return boolean
+ * @return bool
  */
 public function missingShortDescriptionInFunctionComment()
 {
@@ -570,7 +570,7 @@ function test($test)
  * @param string $a2     Comment here.
  * @param string $a2,... Comment here.
  *
- * @return boolean
+ * @return bool
  */
 public function variableArgs($a1, $a2)
 {
@@ -673,7 +673,7 @@ function myFunction() {}
 /**
  * Yield test
  *
- * @return integer
+ * @return int
  */
 function yieldTest()
 {
@@ -719,10 +719,10 @@ public function callableCallback(callable $cb) {
 /**
  * PHP7 type hints.
  *
- * @param string  $name1 Comment.
- * @param integer $name2 Comment.
- * @param float   $name3 Comment.
- * @param boolean $name4 Comment.
+ * @param string $name1 Comment.
+ * @param int    $name2 Comment.
+ * @param float  $name3 Comment.
+ * @param bool   $name4 Comment.
  *
  * @return void
  */
@@ -755,7 +755,7 @@ public function myFunction(string $name1, string ...$name2) {
 /**
  * Return description function + correct type.
  *
- * @return integer This is a description.
+ * @return int This is a description.
  */
 public function myFunction() {
     return 5;
@@ -764,7 +764,7 @@ public function myFunction() {
 /**
  * Return description function + incorrect type.
  *
- * @return int This is a description.
+ * @return integer This is a description.
  */
 public function myFunction() {
     return 5;
@@ -825,7 +825,7 @@ public function someFunc(): void
 /**
  * Return description function + mixed return types.
  *
- * @return bool|int This is a description.
+ * @return boolean|integer This is a description.
  */
 function returnTypeWithDescriptionA()
 {

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -7,9 +7,9 @@ class PHP_CodeSniffer_File
      *
      * long desc here
      *
-     * @param boolean $stackPtr The position in @ @unknown the stack of the token
+     * @param bool $stackPtr The position in @ @unknown the stack of the token
      *                            that opened the scope
-     * @param integer $detph    How many scope levels down we are.
+     * @param int $detph    How many scope levels down we are.
      * @param string  $index    The index
      * @return
      * @throws
@@ -120,8 +120,8 @@ class PHP_CodeSniffer_File
      * Param not immediate.
      *
      * @return
-     * @param   integer $threeSpaces
-     * @param integer $superfluous
+     * @param   int $threeSpaces
+     * @param int $superfluous
      * @param miss
      * @param
      */

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -7,10 +7,10 @@ class PHP_CodeSniffer_File
      *
      * long desc here
      *
-     * @param bool $stackPtr The position in @ @unknown the stack of the token
-     *                            that opened the scope
-     * @param int $detph    How many scope levels down we are.
-     * @param string  $index    The index
+     * @param bool   $stackPtr The position in @ @unknown the stack of the token
+     *                          that opened the scope
+     * @param int    $detph    How many scope levels down we are.
+     * @param string $index    The index
      * @return
      * @throws
      */
@@ -120,8 +120,8 @@ class PHP_CodeSniffer_File
      * Param not immediate.
      *
      * @return
-     * @param   int $threeSpaces
-     * @param int $superfluous
+     * @param   int  $threeSpaces
+     * @param int  $superfluous
      * @param miss
      * @param
      */
@@ -134,9 +134,9 @@ class PHP_CodeSniffer_File
     /**
      * Comments not capitalised.
      *
-     * @param integer $one   comment
-     * @param array   $two   -comment
-     * @param MyClas  $three 0comment
+     * @param int    $one   comment
+     * @param array  $two   -comment
+     * @param MyClas $three 0comment
      *
      * @return void
      */
@@ -190,7 +190,7 @@ public function noReturnOutsideClass()
 /**
  * Missing param comment.
  *
- * @param integer $one comment
+ * @param int $one comment
  *
  * @see     wrong indent
  * @see
@@ -220,14 +220,14 @@ public function missingReturnType()
  * Case-sensitive var type check with multiple return type.
  *
  * @param string  $a1 Comment here.
- * @param boolean $a2 Comment here.
- * @param integer $a3 Comment here.
+ * @param bool    $a2 Comment here.
+ * @param int     $a3 Comment here.
  * @param array   $a4 Comment here.
  * @param float   $a5 Comment here.
  * @param float   $a6 Comment here.
  * @param Myclass $a7 Comment here.
  *
- * @return integer|object|float|array(integer => MyClass)
+ * @return int|object|float|array(int => MyClass)
  */
 public function caseSensitive($a1, $a2, $a3, arRay $a4, $a5, $a6, myclas $a7)
 {
@@ -243,7 +243,7 @@ public function caseSensitive($a1, $a2, $a3, arRay $a4, $a5, $a6, myclas $a7)
  * @param MyClass $a3 Comment here.
  * @param MyClass $a4 Comment here.
  *
- * @return array(integer => MyClass)
+ * @return array(int => MyClass)
  */
 public function typeHint(MyClass $a1, $a2, myclass $a3, $a4)
 {
@@ -255,12 +255,12 @@ public function typeHint(MyClass $a1, $a2, myclass $a3, $a4)
 /**
  * Mixed variable type separated by a '|'.
  *
- * @param array|string    $a1 Comment here.
- * @param mixed           $a2 Comment here.
- * @param string|array    $a3 Comment here.
- * @param MyClass|integer $a4 Comment here.
+ * @param array|string $a1 Comment here.
+ * @param mixed        $a2 Comment here.
+ * @param string|array $a3 Comment here.
+ * @param MyClass|int  $a4 Comment here.
  *
- * @return boolean
+ * @return bool
  */
 public function mixedType($a1, $a2, $a3, $a4)
 {
@@ -272,16 +272,16 @@ public function mixedType($a1, $a2, $a3, $a4)
 /**
  * Array type.
  *
- * @param array(MyClass)            $a1 OK.
- * @param array                     $a2 Invalid type.
- * @param array                     $a3 Typo.
- * @param array(integer)            $a4 Use 'array(integer)' instead.
- * @param array(integer => integer) $a5 Use 'array(integer => integer)' instead.
- * @param array(integer => boolean) $a6 Use 'array(integer => boolean)' instead.
- * @param array                     $a7 Use 'array' instead.
- * @param string                    $a8 String with unknown type hint.
+ * @param array(MyClass)     $a1 OK.
+ * @param array              $a2 Invalid type.
+ * @param array              $a3 Typo.
+ * @param array(int)         $a4 Use 'array(int)' instead.
+ * @param array(int => int)  $a5 Use 'array(int => int)' instead.
+ * @param array(int => bool) $a6 Use 'array(int => bool)' instead.
+ * @param array              $a7 Use 'array' instead.
+ * @param string             $a8 String with unknown type hint.
  *
- * @return integer
+ * @return int
  */
 public function mixedArrayType($a1, $a2, array $a3, $a4, $a5, $a6, $a7, unknownTypeHint $a8)
 {
@@ -316,7 +316,7 @@ function empty3()
 
 
 /**
- * @return boolean
+ * @return bool
  */
 public function missingShortDescriptionInFunctionComment()
 {
@@ -570,7 +570,7 @@ function test($test)
  * @param string $a2     Comment here.
  * @param string $a2,... Comment here.
  *
- * @return boolean
+ * @return bool
  */
 public function variableArgs($a1, $a2)
 {
@@ -673,7 +673,7 @@ function myFunction() {}
 /**
  * Yield test
  *
- * @return integer
+ * @return int
  */
 function yieldTest()
 {
@@ -719,10 +719,10 @@ public function callableCallback(callable $cb) {
 /**
  * PHP7 type hints.
  *
- * @param string  $name1 Comment.
- * @param integer $name2 Comment.
- * @param float   $name3 Comment.
- * @param boolean $name4 Comment.
+ * @param string $name1 Comment.
+ * @param int    $name2 Comment.
+ * @param float  $name3 Comment.
+ * @param bool   $name4 Comment.
  *
  * @return void
  */
@@ -755,7 +755,7 @@ public function myFunction(string $name1, string ...$name2) {
 /**
  * Return description function + correct type.
  *
- * @return integer This is a description.
+ * @return int This is a description.
  */
 public function myFunction() {
     return 5;
@@ -764,7 +764,7 @@ public function myFunction() {
 /**
  * Return description function + incorrect type.
  *
- * @return integer This is a description.
+ * @return int This is a description.
  */
 public function myFunction() {
     return 5;
@@ -825,7 +825,7 @@ public function someFunc(): void
 /**
  * Return description function + mixed return types.
  *
- * @return boolean|integer This is a description.
+ * @return bool|int This is a description.
  */
 function returnTypeWithDescriptionA()
 {
@@ -837,7 +837,7 @@ function returnTypeWithDescriptionA()
 /**
  * Return description function + mixed return types.
  *
- * @return float|boolean This is a description.
+ * @return float|bool This is a description.
  */
 function returnTypeWithDescriptionB()
 {
@@ -849,7 +849,7 @@ function returnTypeWithDescriptionB()
 /**
  * Return description function + lots of different mixed return types.
  *
- * @return integer|object|string[]|float|boolean|array(integer => MyClass)|callable And here we have a description
+ * @return int|object|string[]|float|bool|array(int => MyClass)|callable And here we have a description
  */
 function returnTypeWithDescriptionC()
 {
@@ -861,7 +861,7 @@ function returnTypeWithDescriptionC()
 /**
  * Return description function + lots of different mixed return types.
  *
- * @return array(integer => boolean)|\OtherVendor\Package\SomeClass2|MyClass[]|void And here we have a description
+ * @return array(int => bool)|\OtherVendor\Package\SomeClass2|MyClass[]|void And here we have a description
  */
 function returnTypeWithDescriptionD()
 {

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -139,25 +139,25 @@ class VariableCommentUnitTest
 
 
      /**
-     * Var type checking (array(int => string) v.s. array(int => string)).
+     * Var type checking (array(integer => string) v.s. array(integer => string)).
      *
-     * @var array(int => string)
+     * @var array(integer => string)
      */
      private $_varArrayTypeCheck;
 
 
     /**
-     * Boolean @var tag Capitalized
+     * Bool @var tag Capitalized
      *
-     * @var Boolean
+     * @var Bool
      */
      public $CapBoolTag = true;
 
 
     /**
-     * Boolean @var tag Capitalized
+     * Bool @var tag Capitalized
      *
-     * @var BOOLEAN
+     * @var BOOL
      */
      public $CapBoolTag2 = true;
 
@@ -283,7 +283,7 @@ class VariableCommentUnitTest
 
 
     /**
-     * @var integer
+     * @var int
      */
      private $_varWithNoShortComment;
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -131,9 +131,9 @@ class VariableCommentUnitTest
      $emptyVarDoc = '';
 
      /**
-     * Var type checking (int v.s. integer).
+     * Var type checking (integer v.s. int).
      *
-     * @var int
+     * @var integer
      */
      private $_varSimpleTypeCheck;
 

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -131,33 +131,33 @@ class VariableCommentUnitTest
      $emptyVarDoc = '';
 
      /**
-     * Var type checking (int v.s. integer).
+     * Var type checking (integer v.s. int).
      *
-     * @var integer
+     * @var int
      */
      private $_varSimpleTypeCheck;
 
 
      /**
-     * Var type checking (array(int => string) v.s. array(int => string)).
+     * Var type checking (array(integer => string) v.s. array(integer => string)).
      *
-     * @var array(integer => string)
+     * @var array(int => string)
      */
      private $_varArrayTypeCheck;
 
 
     /**
-     * Boolean @var tag Capitalized
+     * Bool @var tag Capitalized
      *
-     * @var boolean
+     * @var bool
      */
      public $CapBoolTag = true;
 
 
     /**
-     * Boolean @var tag Capitalized
+     * Bool @var tag Capitalized
      *
-     * @var boolean
+     * @var bool
      */
      public $CapBoolTag2 = true;
 
@@ -213,7 +213,7 @@ class VariableCommentUnitTest
     /**
      * Int @var tag Capitalized
      *
-     * @var integer
+     * @var int
      */
      public $CapIntTag = 1;
 
@@ -221,7 +221,7 @@ class VariableCommentUnitTest
     /**
      * Int @var tag Capitalized
      *
-     * @var integer
+     * @var int
      */
      public $CapIntTag2 = 1;
 
@@ -229,7 +229,7 @@ class VariableCommentUnitTest
     /**
      * Integer @var tag Capitalized
      *
-     * @var integer
+     * @var int
      */
      public $CapIntTag3 = 1;
 
@@ -237,7 +237,7 @@ class VariableCommentUnitTest
     /**
      * Integer @var tag Capitalized
      *
-     * @var integer
+     * @var int
      */
      public $CapIntTag4 = 1;
 
@@ -283,7 +283,7 @@ class VariableCommentUnitTest
 
 
     /**
-     * @var integer
+     * @var int
      */
      private $_varWithNoShortComment;
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -22,9 +22,9 @@ class Common
      */
     public static $allowedTypes = array(
                                    'array',
-                                   'boolean',
+                                   'bool',
                                    'float',
-                                   'integer',
+                                   'int',
                                    'mixed',
                                    'object',
                                    'string',
@@ -345,14 +345,14 @@ class Common
             switch ($lowerVarType) {
             case 'bool':
             case 'boolean':
-                return 'boolean';
+                return 'bool';
             case 'double':
             case 'real':
             case 'float':
                 return 'float';
             case 'int':
             case 'integer':
-                return 'integer';
+                return 'int';
             case 'array()':
             case 'array':
                 return 'array';

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -22,7 +22,7 @@ class Timing
     /**
      * Used to make sure we only print the run time once per run.
      *
-     * @var boolean
+     * @var bool
      */
     private static $printed = false;
 

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -28,7 +28,7 @@ abstract class AbstractSniffUnitTest extends \PHPUnit_Framework_TestCase
      * Overwrite this attribute in a child class of TestCase.
      * Setting this attribute in setUp() has no effect!
      *
-     * @var boolean
+     * @var bool
      */
     protected $backupGlobals = false;
 


### PR DESCRIPTION
- Replace boolean and integer with bool and int 
- Update tests and doc blocks 

This PR is related to:
- #1047
- #1195

We're very interested to have this change in the 3.0 version of CodeSniffer because currently we modified in our local CI server the library in order to allows bool and int types. 

@gsherwood, any feedback is appreciated.