### PR TITLE
Make the unit test suite compatible with PHPUnit v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,20 @@ matrix:
     - php: nightly
     - php: hhvm
 
+before_install:
+  # Circumvent a bug in the travis HHVM image - ships with incompatible PHPUnit.
+  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer self-update; fi
+  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:~4.0; fi
+  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer install; fi
+
 before_script:
   - if [[ $CUSTOM_INI == "1" && ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then phpenv config-add php5-testingConfig.ini; fi
   - if [[ $CUSTOM_INI == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then phpenv config-add php7-testingConfig.ini; fi
 
 script:
-  - composer install
   - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then php bin/phpcs --config-set php_path php; fi
-  - vendor/bin/phpunit tests/AllTests.php
+  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then phpunit tests/AllTests.php; fi
+  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then vendor/bin/phpunit tests/AllTests.php; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
   - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* && $TRAVIS_PHP_VERSION != "nightly" ]]; then pear package-validate package.xml; fi
   - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* ]]; then php scripts/build-phar.php; fi

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-simplexml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
     },
     "bin": [
         "bin/phpcs",

--- a/package.xml
+++ b/package.xml
@@ -82,6 +82,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
      <file baseinstalldir="" name="AbstractSniffUnitTest.php" role="test" />
      <file baseinstalldir="" name="AllSniffs.php" role="test" />
     </dir>
+    <file baseinstalldir="" name="bootstrap.php" role="test" />
     <file baseinstalldir="" name="AllTests.php" role="test" />
     <file baseinstalldir="" name="TestSuite.php" role="test" />
    </dir>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit>
+<phpunit backupGlobals="true" bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="PHP_CodeSniffer Test Suite">
             <file>tests/AllTests.php</file>

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -9,33 +9,18 @@
 
 namespace PHP_CodeSniffer\Tests;
 
-use PHP_CodeSniffer\Util\Tokens;
-
-if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
-    define('PHP_CODESNIFFER_IN_TESTS', true);
-}
-
-if (defined('PHP_CODESNIFFER_CBF') === false) {
-    define('PHP_CODESNIFFER_CBF', false);
-}
-
-if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
-    define('PHP_CODESNIFFER_VERBOSITY', 0);
-}
+use PHP_CodeSniffer\Tests\TestSuite;
+use PHPUnit\TextUI\TestRunner;
 
 if (is_file(__DIR__.'/../autoload.php') === true) {
-    include_once __DIR__.'/../autoload.php';
     include_once 'Core/AllTests.php';
     include_once 'Standards/AllSniffs.php';
 } else {
-    include_once 'PHP/CodeSniffer/autoload.php';
     include_once 'CodeSniffer/Core/AllTests.php';
     include_once 'CodeSniffer/Standards/AllSniffs.php';
 }
 
 require_once 'TestSuite.php';
-
-$tokens = new Tokens();
 
 class PHP_CodeSniffer_AllTests
 {
@@ -48,7 +33,7 @@ class PHP_CodeSniffer_AllTests
      */
     public static function main()
     {
-        \PHPUnit_TextUI_TestRunner::run(self::suite());
+        TestRunner::run(self::suite());
 
     }//end main()
 
@@ -56,7 +41,7 @@ class PHP_CodeSniffer_AllTests
     /**
      * Add all PHP_CodeSniffer test suites into a single test suite.
      *
-     * @return \PHPUnit_Framework_TestSuite
+     * @return \PHPUnit\Framework\TestSuite
      */
     public static function suite()
     {

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -9,27 +9,8 @@
 
 namespace PHP_CodeSniffer\Tests\Core;
 
-use PHP_CodeSniffer\Util\Tokens;
-
-if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
-    define('PHP_CODESNIFFER_IN_TESTS', true);
-}
-
-if (defined('PHP_CODESNIFFER_CBF') === false) {
-    define('PHP_CODESNIFFER_CBF', false);
-}
-
-if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
-    define('PHP_CODESNIFFER_VERBOSITY', 0);
-}
-
-if (is_file(__DIR__.'/../../autoload.php') === true) {
-    include_once __DIR__.'/../../autoload.php';
-} else {
-    include_once 'PHP/CodeSniffer/autoload.php';
-}
-
-$tokens = new Tokens();
+use PHPUnit\TextUI\TestRunner;
+use PHPUnit\Framework\TestSuite;
 
 require_once 'IsCamelCapsTest.php';
 require_once 'ErrorSuppressionTest.php';
@@ -48,7 +29,7 @@ class AllTests
      */
     public static function main()
     {
-        \PHPUnit2_TextUI_TestRunner::run(self::suite());
+        TestRunner::run(self::suite());
 
     }//end main()
 
@@ -56,11 +37,11 @@ class AllTests
     /**
      * Add all core unit tests into a test suite.
      *
-     * @return \PHPUnit_Framework_TestSuite
+     * @return \PHPUnit\Framework\TestSuite
      */
     public static function suite()
     {
-        $suite = new \PHPUnit_Framework_TestSuite('PHP CodeSniffer Core');
+        $suite = new TestSuite('PHP CodeSniffer Core');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\IsCamelCapsTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\ErrorSuppressionTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodParametersTest');

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -12,8 +12,9 @@ namespace PHP_CodeSniffer\Tests\Core;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHPUnit\Framework\TestCase;
 
-class ErrorSuppressionTest extends \PHPUnit_Framework_TestCase
+class ErrorSuppressionTest extends TestCase
 {
 
 

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -12,8 +12,9 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHPUnit\Framework\TestCase;
 
-class FindExtendedClassNameTest extends \PHPUnit_Framework_TestCase
+class FindExtendedClassNameTest extends TestCase
 {
 
     /**

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -12,8 +12,9 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHPUnit\Framework\TestCase;
 
-class FindImplementedInterfaceNamesTest extends \PHPUnit_Framework_TestCase
+class FindImplementedInterfaceNamesTest extends TestCase
 {
 
     /**

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -12,8 +12,9 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
+use PHPUnit\Framework\TestCase;
 
-class GetMethodParametersTest extends \PHPUnit_Framework_TestCase
+class GetMethodParametersTest extends TestCase
 {
 
     /**

--- a/tests/Core/IsCamelCapsTest.php
+++ b/tests/Core/IsCamelCapsTest.php
@@ -10,8 +10,9 @@
 namespace PHP_CodeSniffer\Tests\Core;
 
 use PHP_CodeSniffer\Util\Common;
+use PHPUnit\Framework\TestCase;
 
-class IsCamelCapsTest extends \PHPUnit_Framework_TestCase
+class IsCamelCapsTest extends TestCase
 {
 
 

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -18,8 +18,9 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Util\Common;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractSniffUnitTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractSniffUnitTest extends TestCase
 {
 
     /**
@@ -110,7 +111,7 @@ abstract class AbstractSniffUnitTest extends \PHPUnit_Framework_TestCase
      * Tests the extending classes Sniff class.
      *
      * @return void
-     * @throws \PHPUnit_Framework_Error
+     * @throws \PHPUnit\Framework\Exception
      */
     final public function testSniff()
     {

--- a/tests/Standards/AllSniffs.php
+++ b/tests/Standards/AllSniffs.php
@@ -9,30 +9,11 @@
 
 namespace PHP_CodeSniffer\Tests\Standards;
 
-use PHP_CodeSniffer\Util\Tokens;
 use PHP_CodeSniffer\Util\Standards;
 use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
-
-if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
-    define('PHP_CODESNIFFER_IN_TESTS', true);
-}
-
-if (defined('PHP_CODESNIFFER_CBF') === false) {
-    define('PHP_CODESNIFFER_CBF', false);
-}
-
-if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
-    define('PHP_CODESNIFFER_VERBOSITY', 0);
-}
-
-if (is_file(__DIR__.'/../../autoload.php') === true) {
-    include_once __DIR__.'/../../autoload.php';
-} else {
-    include_once 'PHP/CodeSniffer/autoload.php';
-}
-
-$tokens = new Tokens();
+use PHPUnit\TextUI\TestRunner;
+use PHPUnit\Framework\TestSuite;
 
 class AllSniffs
 {
@@ -45,7 +26,7 @@ class AllSniffs
      */
     public static function main()
     {
-        \PHPUnit_TextUI_TestRunner::run(self::suite());
+        TestRunner::run(self::suite());
 
     }//end main()
 
@@ -56,14 +37,14 @@ class AllSniffs
      * Sniff unit tests are found by recursing through the 'Tests' directory
      * of each installed coding standard.
      *
-     * @return \PHPUnit_Framework_TestSuite
+     * @return \PHPUnit\Framework\TestSuite
      */
     public static function suite()
     {
         $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']   = array();
         $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'] = array();
 
-        $suite = new \PHPUnit_Framework_TestSuite('PHP CodeSniffer Standards');
+        $suite = new TestSuite('PHP CodeSniffer Standards');
 
         $isInstalled = !is_file(__DIR__.'/../../autoload.php');
 

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -9,19 +9,22 @@
 
 namespace PHP_CodeSniffer\Tests;
 
-class TestSuite extends \PHPUnit_Framework_TestSuite
+use PHPUnit\Framework\TestSuite as PHPUnit_TestSuite;
+use PHPUnit\Framework\TestResult;
+
+class TestSuite extends PHPUnit_TestSuite
 {
 
 
     /**
      * Runs the tests and collects their result in a TestResult.
      *
-     * @param \PHPUnit_Framework_TestResult $result A test result.
+     * @param \PHPUnit\Framework\TestResult $result A test result.
      * @param mixed                         $filter The filter passed to each test.
      *
-     * @return \PHPUnit_Framework_TestResult
+     * @return \PHPUnit\Framework\TestResult
      */
-    public function run(\PHPUnit_Framework_TestResult $result=null, $filter=false)
+    public function run(TestResult $result=null, $filter=false)
     {
         $result = parent::run($result, $filter);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Bootstrap file for PHP_CodeSniffer unit tests.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
+    define('PHP_CODESNIFFER_IN_TESTS', true);
+}
+
+if (defined('PHP_CODESNIFFER_CBF') === false) {
+    define('PHP_CODESNIFFER_CBF', false);
+}
+
+if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
+    define('PHP_CODESNIFFER_VERBOSITY', 0);
+}
+
+if (is_file(__DIR__.'/../autoload.php') === true) {
+    include_once __DIR__.'/../autoload.php';
+} else {
+    include_once 'PHP/CodeSniffer/autoload.php';
+}
+
+$tokens = new \PHP_CodeSniffer\Util\Tokens();
+
+
+// Compatibility for PHPUnit < 6 and PHPUnit 6+.
+if (class_exists('PHPUnit_Framework_TestSuite') === true && class_exists('PHPUnit\Framework\TestSuite') === false) {
+    class_alias('PHPUnit_Framework_TestSuite', 'PHPUnit\Framework\TestSuite');
+}
+
+if (class_exists('PHPUnit_Framework_TestCase') === true && class_exists('PHPUnit\Framework\TestCase') === false) {
+    class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
+}
+
+if (class_exists('PHPUnit_TextUI_TestRunner') === true && class_exists('PHPUnit\TextUI\TestRunner') === false) {
+    class_alias('PHPUnit_TextUI_TestRunner', 'PHPUnit\TextUI\TestRunner');
+}
+
+if (class_exists('PHPUnit_Framework_TestResult') === true && class_exists('PHPUnit\Framework\TestResult') === false) {
+    class_alias('PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult');
+}


### PR DESCRIPTION
Since today Travis uses PHPUnit 6.x for PHP 7+. The unit tests were not compatible with this and failing because of it.

These relatively minor changes fix that and make the testsuite compatible with both PHPUnit < 6 as well as 6+.

Ref: https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0

I've also run a test with an external standard using the PHPCS test suite to confirm that this will fix it for them too without any effort on their side and have confirmed it will.
See: https://travis-ci.org/jrfnl/WordPress-Coding-Standards/builds/209592330 - the PHP 7+ builds fail when using PHPCS `master`, but pass when using the branch contained in this PR.

Fixes #1383