### PR TITLE
DisallowMultipleAssignments sniff: fix false positive for PHP4 compatible code

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -124,7 +124,9 @@ class Squiz_Sniffs_PHP_DisallowMultipleAssignmentsSniff implements PHP_CodeSniff
 
         // Ignore member var definitions.
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($varToken - 1), null, true);
-        if (isset(PHP_CodeSniffer_Tokens::$scopeModifiers[$tokens[$prev]['code']]) === true) {
+        if (isset(PHP_CodeSniffer_Tokens::$scopeModifiers[$tokens[$prev]['code']]) === true
+            || $tokens[$prev]['code'] === T_VAR
+        ) {
             return;
         }
 

--- a/CodeSniffer/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
@@ -30,6 +30,7 @@ class myClass
     private static $_dbh = NULL;
     public $dbh = NULL;
     protected $dbh = NULL;
+    var $dbh = NULL; // Old PHP4 compatible code.
 }
 
 $var = $var2;


### PR DESCRIPTION
While PHP4 code shouldn't be used anymore, there are other sniffs which deal with that.
This sniff should in that regard be version agnostic.