### PR TITLE
Tokens: Move `T_COALESCE_EQUAL` from `$operators` to `$assignmentTokens`

### DIFF
--- a/CodeSniffer/Tokens.php
+++ b/CodeSniffer/Tokens.php
@@ -422,20 +422,21 @@ final class PHP_CodeSniffer_Tokens
      * @var array(int)
      */
     public static $assignmentTokens = array(
-                                       T_EQUAL        => T_EQUAL,
-                                       T_AND_EQUAL    => T_AND_EQUAL,
-                                       T_OR_EQUAL     => T_OR_EQUAL,
-                                       T_CONCAT_EQUAL => T_CONCAT_EQUAL,
-                                       T_DIV_EQUAL    => T_DIV_EQUAL,
-                                       T_MINUS_EQUAL  => T_MINUS_EQUAL,
-                                       T_POW_EQUAL    => T_POW_EQUAL,
-                                       T_MOD_EQUAL    => T_MOD_EQUAL,
-                                       T_MUL_EQUAL    => T_MUL_EQUAL,
-                                       T_PLUS_EQUAL   => T_PLUS_EQUAL,
-                                       T_XOR_EQUAL    => T_XOR_EQUAL,
-                                       T_DOUBLE_ARROW => T_DOUBLE_ARROW,
-                                       T_SL_EQUAL     => T_SL_EQUAL,
-                                       T_SR_EQUAL     => T_SR_EQUAL,
+                                       T_EQUAL          => T_EQUAL,
+                                       T_AND_EQUAL      => T_AND_EQUAL,
+                                       T_OR_EQUAL       => T_OR_EQUAL,
+                                       T_CONCAT_EQUAL   => T_CONCAT_EQUAL,
+                                       T_DIV_EQUAL      => T_DIV_EQUAL,
+                                       T_MINUS_EQUAL    => T_MINUS_EQUAL,
+                                       T_POW_EQUAL      => T_POW_EQUAL,
+                                       T_MOD_EQUAL      => T_MOD_EQUAL,
+                                       T_MUL_EQUAL      => T_MUL_EQUAL,
+                                       T_PLUS_EQUAL     => T_PLUS_EQUAL,
+                                       T_XOR_EQUAL      => T_XOR_EQUAL,
+                                       T_DOUBLE_ARROW   => T_DOUBLE_ARROW,
+                                       T_SL_EQUAL       => T_SL_EQUAL,
+                                       T_SR_EQUAL       => T_SR_EQUAL,
+                                       T_COALESCE_EQUAL => T_COALESCE_EQUAL,
                                       );
 
     /**
@@ -582,20 +583,19 @@ final class PHP_CodeSniffer_Tokens
      * @var array(int)
      */
     public static $operators = array(
-                                T_MINUS          => T_MINUS,
-                                T_PLUS           => T_PLUS,
-                                T_MULTIPLY       => T_MULTIPLY,
-                                T_DIVIDE         => T_DIVIDE,
-                                T_MODULUS        => T_MODULUS,
-                                T_POW            => T_POW,
-                                T_SPACESHIP      => T_SPACESHIP,
-                                T_COALESCE       => T_COALESCE,
-                                T_COALESCE_EQUAL => T_COALESCE_EQUAL,
-                                T_BITWISE_AND    => T_BITWISE_AND,
-                                T_BITWISE_OR     => T_BITWISE_OR,
-                                T_BITWISE_XOR    => T_BITWISE_XOR,
-                                T_SL             => T_SL,
-                                T_SR             => T_SR,
+                                T_MINUS       => T_MINUS,
+                                T_PLUS        => T_PLUS,
+                                T_MULTIPLY    => T_MULTIPLY,
+                                T_DIVIDE      => T_DIVIDE,
+                                T_MODULUS     => T_MODULUS,
+                                T_POW         => T_POW,
+                                T_SPACESHIP   => T_SPACESHIP,
+                                T_COALESCE    => T_COALESCE,
+                                T_BITWISE_AND => T_BITWISE_AND,
+                                T_BITWISE_OR  => T_BITWISE_OR,
+                                T_BITWISE_XOR => T_BITWISE_XOR,
+                                T_SL          => T_SL,
+                                T_SR          => T_SR,
                                );
 
     /**


### PR DESCRIPTION
The `T_COALESCE_EQUAL` operator compares and assigns to a variable:
```php
$a ??= $b; // When $a is set, use $a, otherwise assign $b to $a.
```

Looking at the token arrays, I believe was incorrectly placed with `$operators` and should be in `$assignmentTokens` instead.

Having it in `$operators` could cause issues with sniffs like `Squiz.Formatting.OperatorBracket`.