### PR TITLE
Tokens: Add new `$textStringTokens` property representing all tokens which typically contain text strings

### DIFF
--- a/CodeSniffer/Tokens.php
+++ b/CodeSniffer/Tokens.php
@@ -669,6 +669,19 @@ final class PHP_CodeSniffer_Tokens
                                   );
 
     /**
+     * Tokens that represent text strings.
+     *
+     * @var array(int)
+     */
+    public static $textStringTokens = array(
+                                       T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+                                       T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
+                                       T_INLINE_HTML              => T_INLINE_HTML,
+                                       T_HEREDOC                  => T_HEREDOC,
+                                       T_NOWDOC                   => T_NOWDOC,
+                                      );
+
+    /**
      * Tokens that represent brackets and parenthesis.
      *
      * @var array(int)


### PR DESCRIPTION
The `PHP_CodeSniffer_Tokens` class currently contains a `$stringTokens` property which contains the tokens for the typical single/quoted text string variable type.

However, when the intention is examining the _content_ of textual tokens, there are three more tokens which need to be taken into account: `T_INLINE_HTML`, `T_HEREDOC` and `T_NOWDOC`.

I was a bit wary of changing the `$stringTokens` array as it feels like the intention of that array is different than what I described above, so I have opted for adding a new `$textStringTokens` property.