### PR TITLE
Squiz/OperatorSpacing: Ignore operators in declare statements.

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -84,6 +84,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
         $tokens = $phpcsFile->getTokens();
 
         // Skip default values in function declarations.
+        // Skip declare statements.
         if ($tokens[$stackPtr]['code'] === T_EQUAL
             || $tokens[$stackPtr]['code'] === T_MINUS
         ) {
@@ -94,6 +95,7 @@ class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_Sn
                     $function = $tokens[$bracket]['parenthesis_owner'];
                     if ($tokens[$function]['code'] === T_FUNCTION
                         || $tokens[$function]['code'] === T_CLOSURE
+                        || $tokens[$function]['code'] === T_DECLARE
                     ) {
                         return;
                     }

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -185,3 +185,6 @@ function bar($boo = +1) {}
 $username = $_GET['user']??'nobody';
 
 function foo(string $bar, array $baz, ?MyClass $object) : MyClass {}
+
+// Issue 1163
+declare(strict_types=1);

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -179,3 +179,6 @@ function bar($boo = +1) {}
 $username = $_GET['user'] ?? 'nobody';
 
 function foo(string $bar, array $baz, ?MyClass $object) : MyClass {}
+
+// Issue 1163
+declare(strict_types=1);


### PR DESCRIPTION
Fixes #1163