### PR TITLE
Tokens: Add new `$ooScopeTokens` property.

### DIFF
--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -16,6 +16,8 @@
 namespace PHP_CodeSniffer\Sniffs;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 
 abstract class AbstractVariableSniff extends AbstractScopeSniff
 {
@@ -47,12 +49,7 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        $scopes = array(
-                   T_CLASS,
-                   T_ANON_CLASS,
-                   T_TRAIT,
-                   T_INTERFACE,
-                  );
+        $scopes = Tokens::$ooScopeTokens;
 
         $listen = array(
                    T_FUNCTION,

--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 use PHP_CodeSniffer\Files\File;
 
 class CamelCapsFunctionNameSniff extends AbstractScopeSniff
@@ -80,7 +81,7 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct(array(T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT), array(T_FUNCTION), true);
+        parent::__construct(Tokens::$ooScopeTokens, array(T_FUNCTION), true);
 
     }//end __construct()
 

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 use PHP_CodeSniffer\Files\File;
 
 class ValidFunctionNameSniff extends AbstractScopeSniff
@@ -52,7 +53,7 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct(array(T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT), array(T_FUNCTION), true);
+        parent::__construct(Tokens::$ooScopeTokens, array(T_FUNCTION), true);
 
     }//end __construct()
 

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -531,6 +531,18 @@ final class Tokens
                                          T_EMPTY        => T_EMPTY,
                                         );
 
+    /**
+     * Tokens that are open class and object scopes.
+     *
+     * @var array<int, int>
+     */
+    public static $ooScopeTokens = array(
+                                    T_CLASS      => T_CLASS,
+                                    T_ANON_CLASS => T_ANON_CLASS,
+                                    T_INTERFACE  => T_INTERFACE,
+                                    T_TRAIT      => T_TRAIT,
+                                   );
+
 
     /**
      * Given a token, returns the name of the token.


### PR DESCRIPTION
Add new `$ooScopeTokens` property representing all tokens which typically open class-like constructs.

This is particularly useful if a sniff needs to behave differently when it encounters a token within one of those scopes, like in the case of NamingConvention sniffs.

Applied the use of the property in a few places in existing sniffs.