### PR TITLE
Minor doc fix `PHP_CodeSniffer_File::getMethodParameters()`

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -2750,6 +2750,7 @@ class PHP_CodeSniffer_File
      *         'name'              => '$var',  // The variable name.
      *         'content'           => string,  // The full content of the variable definition.
      *         'pass_by_reference' => boolean, // Is the variable passed by reference?
+     *         'variable_length'   => boolean, // Is the param of variable length through use of `...` ?
      *         'type_hint'         => string,  // The type hint for the variable.
      *         'nullable_type'     => boolean, // Is the variable using a nullable type?
      *        )


### PR DESCRIPTION
Add information about the `variable_length` index in the returned array.