### PR TITLE
PEAR/ClassComment: Apply the class comment rules to traits as well.

### DIFF
--- a/CodeSniffer/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
+++ b/CodeSniffer/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
@@ -39,6 +39,7 @@ class PEAR_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_Fi
         return array(
                 T_CLASS,
                 T_INTERFACE,
+                T_TRAIT,
                );
 
     }//end register()

--- a/CodeSniffer/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.inc
+++ b/CodeSniffer/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.inc
@@ -108,4 +108,13 @@ interface Empty_Interface_Doc
 {
 
 }//end interface
-?>
+
+
+/**
+ *
+ *
+ */
+trait Empty_Trait_Doc
+{
+
+}//end trait

--- a/CodeSniffer/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/CodeSniffer/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -57,6 +57,7 @@ class PEAR_Tests_Commenting_ClassCommentUnitTest extends AbstractSniffUnitTest
                 85  => 1,
                 96  => 5,
                 106 => 5,
+                116 => 5,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Under the "PEAR rules were created before traits existed" principle, I figured traits should comply with the class comment rules as well.

I've not added anonymous classes as to add that, some token walking would be needed allow for the anonymous class to be assigned to a variable. Let me know if you'd like me to change/add that anyway.