### PR TITLE
PHPCBF can't fix short open tags when they are not followed by a space

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -73,10 +73,11 @@ class Generic_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
             if ($fix === true) {
                 $correctOpening = '<?php';
-                if (isset($tokens[$stackPtr + 1]) === true && $tokens[$stackPtr + 1]['code'] !== T_WHITESPACE) {
-                    // Avoid creation of invalid open tags like <?phpecho if the original was <?echo
+                if (isset($tokens[($stackPtr + 1)]) === true && $tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+                    // Avoid creation of invalid open tags like <?phpecho if the original was <?echo .
                     $correctOpening .= ' ';
                 }
+
                 $phpcsFile->fixer->replaceToken($stackPtr, $correctOpening);
             }
 

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -72,7 +72,12 @@ class Generic_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
             $data  = array($token['content']);
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
             if ($fix === true) {
-                $phpcsFile->fixer->replaceToken($stackPtr, '<?php');
+                $correctOpening = '<?php';
+                if (isset($tokens[$stackPtr + 1]) && $tokens[$stackPtr + 1]['code'] !== T_WHITESPACE) {
+                    // Avoid creation of invalid open tags like <?phpecho if the original was <?echo
+                    $correctOpening .= ' ';
+                }
+                $phpcsFile->fixer->replaceToken($stackPtr, $correctOpening);
             }
 
             $phpcsFile->recordMetric($stackPtr, 'PHP short open tag used', 'yes');

--- a/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -73,7 +73,7 @@ class Generic_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
             if ($fix === true) {
                 $correctOpening = '<?php';
-                if (isset($tokens[$stackPtr + 1]) && $tokens[$stackPtr + 1]['code'] !== T_WHITESPACE) {
+                if (isset($tokens[$stackPtr + 1]) === true && $tokens[$stackPtr + 1]['code'] !== T_WHITESPACE) {
                     // Avoid creation of invalid open tags like <?phpecho if the original was <?echo
                     $correctOpening .= ' ';
                 }

--- a/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.2.inc
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.2.inc
@@ -4,4 +4,5 @@ Some content <? echo $var ?> Some more content
 <?
 echo $var;
 ?>
+<?echo $var; ?>
 </div>

--- a/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.2.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.2.inc.fixed
@@ -4,4 +4,5 @@ Some content <?php echo $var ?> Some more content
 <?php
 echo $var;
 ?>
+<?php echo $var; ?>
 </div>

--- a/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -92,6 +92,7 @@ class Generic_Tests_PHP_DisallowShortOpenTagUnitTest extends AbstractSniffUnitTe
                     2 => 1,
                     3 => 1,
                     4 => 1,
+                    7 => 1
                    );
         default:
             return array();


### PR DESCRIPTION
I was using `phpcbf` to fix some legacy files that contained short opening tags without an empty space between them and the content: `<?echo` (this is valid to the PHP engine)
The problem is that `phpcbf` was replacing the short opening tag with a huge string like `<?phpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpphpecho`

I've added a test that shows the failure + the fix that I found for the problem.
Keep up the good work.
Cheers