### PR TITLE
White space rules

### DIFF
--- a/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/AssignmentSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/AssignmentSniff.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ *
+ * Ensures the assignment operators are surrounded with whitespace.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Diogo Alexsander Cavilha <diogocavilha@gmail.com>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PSR2_Sniffs_WhiteSpaces_AssignmentSniff
+    implements PHP_CodeSniffer_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return PHP_CodeSniffer_Tokens::$assignmentTokens;
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenBefore = $tokens[$stackPtr -1]['code'];
+        $tokenAfter = $tokens[$stackPtr +1]['code'];
+
+        if (T_WHITESPACE !== $tokenBefore || T_WHITESPACE !== $tokenAfter) {
+            $phpcsFile->addError(
+                'A space was expected around the assignment operator. 0 found.',
+                $stackPtr,
+                'Invalid'
+            );
+        }
+    }
+}

--- a/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/AssignmentSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/AssignmentSniff.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ * PSR2_Sniffs_WhiteSpaces_AssignmentSpacingSniff.
  *
  * PHP version 5
  *
@@ -14,7 +14,7 @@
  */
 
 /**
- * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ * PSR2_Sniffs_WhiteSpaces_AssignmentSpacingSniff.
  *
  * Ensures the assignment operators are surrounded with whitespace.
  *

--- a/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/TypeCastSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/TypeCastSniff.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ *
+ * Ensures the assignment operators are surrounded with whitespace.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Diogo Alexsander Cavilha <diogocavilha@gmail.com>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PSR2_Sniffs_WhiteSpaces_TypeCastSniff
+    implements PHP_CodeSniffer_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_ARRAY_CAST,
+            T_BOOL_CAST,
+            T_DOUBLE_CAST,
+            T_INT_CAST,
+            T_OBJECT_CAST,
+            T_STRING_CAST,
+            T_UNSET_CAST
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenBefore = $tokens[$stackPtr -1]['code'];
+        $tokenAfter = $tokens[$stackPtr +1]['code'];
+
+        if (T_WHITESPACE !== $tokenBefore || T_WHITESPACE !== $tokenAfter) {
+            $phpcsFile->addError(
+                'A space was expected between type cast and variable. 0 found.',
+                $stackPtr,
+                'Invalid'
+            );
+        }
+    }
+}

--- a/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/TypeCastSniff.php
+++ b/CodeSniffer/Standards/PSR2/Sniffs/WhiteSpaces/TypeCastSniff.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ * PSR2_Sniffs_WhiteSpaces_AssignmentSpacingSniff.
  *
  * PHP version 5
  *
@@ -14,7 +14,7 @@
  */
 
 /**
- * PSR2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ * PSR2_Sniffs_WhiteSpaces_AssignmentSpacingSniff.
  *
  * Ensures the assignment operators are surrounded with whitespace.
  *

--- a/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/AssignmentUnitTest.inc
+++ b/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/AssignmentUnitTest.inc
@@ -1,0 +1,10 @@
+<?php
+
+$foo='bar';
+
+$bar = array(
+    'foo'=>$foo,
+    'bar' => 'bar',
+    'foobar'=> 'foobar',
+    'barfoo' =>'barfoo',
+);

--- a/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/AssignmentUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/AssignmentUnitTest.inc.fixed
@@ -1,0 +1,10 @@
+<?php
+
+$foo = 'bar';
+
+$bar = array(
+    'foo' => $foo,
+    'bar' => 'bar',
+    'foobar' => 'foobar',
+    'barfoo' => 'barfoo',
+);

--- a/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/AssignmentUnitTest.php
+++ b/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/AssignmentUnitTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Unit test class for the Assignment sniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the Assignment sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Diogo Alexsander Cavilha <diogocavilha@gmail.com>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PSR2_Tests_WhiteSpaces_AssignmentUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList($testFile = '')
+    {
+        if ('AssignmentUnitTest.inc' == $testFile) {
+            return array(
+                3 => 1,
+                6 => 1,
+                8 => 1,
+                9 => 1,
+            );
+        }
+
+        return array();
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class
+
+?>

--- a/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/TypeCastUnitTest.inc
+++ b/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/TypeCastUnitTest.inc
@@ -1,0 +1,10 @@
+<?php
+
+$foo = null;
+
+(array) $foo;
+(int) $foo;
+(float)$foo;
+(double) $foo;
+(object)$foo;
+(unset) $foo;

--- a/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/TypeCastUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/TypeCastUnitTest.inc.fixed
@@ -1,0 +1,10 @@
+<?php
+
+$foo = null;
+
+(array) $foo;
+(int) $foo;
+(float) $foo;
+(double) $foo;
+(object) $foo;
+(unset) $foo;

--- a/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/TypeCastUnitTest.php
+++ b/CodeSniffer/Standards/PSR2/Tests/WhiteSpaces/TypeCastUnitTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Unit test class for the Assignment sniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Unit test class for the Assignment sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Diogo Alexsander Cavilha <diogocavilha@gmail.com>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PSR2_Tests_WhiteSpaces_TypeCastUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList($testFile = '')
+    {
+        if ('TypeCastUnitTest.inc' == $testFile) {
+            return array(
+                7 => 1,
+                9 => 1,
+            );
+        }
+
+        return array();
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array();
+
+    }//end getWarningList()
+
+
+}//end class
+
+?>


### PR DESCRIPTION
- Spaces arround the assignment symbols.
- Single space between type cast and variable