### PR TITLE
T_NULLABLE detection not working for nullable parameters and return type hints in some cases

### DIFF
--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -189,3 +189,5 @@ function foo(string $bar, array $baz, ?MyClass $object) : MyClass {}
 declare(strict_types=1);
 
 function foo($c = ((BAR)?10:100)) {}
+
+function foo(string $a = '', ?string $b = ''): ?string {}

--- a/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -183,3 +183,5 @@ function foo(string $bar, array $baz, ?MyClass $object) : MyClass {}
 declare(strict_types=1);
 
 function foo($c = ((BAR) ? 10 : 100)) {}
+
+function foo(string $a = '', ?string $b = ''): ?string {}


### PR DESCRIPTION
The commit https://github.com/squizlabs/PHP_CodeSniffer/commit/46983c79ac8456c3a15fc32f63c5ddfb4a10430d broke T_NULLABLE detection. This should fix it and https://github.com/squizlabs/PHP_CodeSniffer/issues/1421 should still be fixed too.

The pull request is based on 2.9 branch however it's very easy to port this bugfix to 3.0 branch. You just have to change `PHP_CodeSniffer_Tokens::$emptyTokens` to `Utils\Tokens::$emptyTokens`.

It would be very nice if you could release versions 2.9.1 and 3.0.1 very quickly. Actually both versions are unusable for users that use nullable parameter and return type hints.