### PR TITLE
Generic.Classes.OpeningBraceSameLine doesn't detect comment before opening brace

### DIFF
--- a/CodeSniffer/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
+++ b/CodeSniffer/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
@@ -74,7 +74,7 @@ class Generic_Sniffs_Classes_OpeningBraceSameLineSniff implements PHP_CodeSniffe
         $openingBrace = $tokens[$stackPtr]['scope_opener'];
 
         // Is the brace on the same line as the class/interface/trait declaration ?
-        $lastClassLineToken = $phpcsFile->findPrevious(T_STRING, ($openingBrace - 1), $stackPtr);
+        $lastClassLineToken = $phpcsFile->findPrevious(T_WHITESPACE, ($openingBrace - 1), $stackPtr, true);
         $lastClassLine      = $tokens[$lastClassLineToken]['line'];
         $braceLine          = $tokens[$openingBrace]['line'];
         $lineDifference     = ($braceLine - $lastClassLine);

--- a/CodeSniffer/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc
+++ b/CodeSniffer/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc
@@ -79,3 +79,13 @@ class A_Class_With_Really_Long_Name_4
 {
 
 }
+
+// While this is ok again.
+class Test_Class_Bad_G /*some comment*/ {
+}
+
+// And this is not.
+class Test_Class_Bad_G
+    /*some comment*/
+{
+}

--- a/CodeSniffer/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc.fixed
@@ -79,3 +79,13 @@ class A_Class_With_Really_Long_Name_4
 
 
 }
+
+// While this is ok again.
+class Test_Class_Bad_G /*some comment*/ {
+}
+
+// And this is not.
+class Test_Class_Bad_G
+    /*some comment*/ {
+
+}

--- a/CodeSniffer/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
+++ b/CodeSniffer/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
@@ -54,6 +54,7 @@ class Generic_Tests_Classes_OpeningBraceSameLineUnitTest extends AbstractSniffUn
                 47 => 1,
                 70 => 1,
                 79 => 1,
+                90 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
There might be a comment between the opening brace and the last part of the class declaration.
The sniff currently did not take that into account.

Fixed including unit test demonstrating the issue.