### PR TITLE
Coding standard located under an installed_path with the same directory name throws an error

### DIFF
--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -164,10 +164,9 @@ class Standards
     {
         $installedPaths = self::getInstalledStandardPaths();
         foreach ($installedPaths as $installedPath) {
-            if (basename($installedPath) === $standard) {
+            $standardPath = $installedPath.DIRECTORY_SEPARATOR.$standard;
+            if (file_exists($standardPath) === false && basename($installedPath) === $standard) {
                 $standardPath = $installedPath;
-            } else {
-                $standardPath = $installedPath.DIRECTORY_SEPARATOR.$standard;
             }
 
             $path = Common::realpath($standardPath.DIRECTORY_SEPARATOR.'ruleset.xml');


### PR DESCRIPTION
If a "Standards" directory is called the same as one of the standards it contains and that standard is requested, an _"ERROR: the ... coding standard is not installed."_ error will be thrown and the sniffs will not run.

While I suppose this change in behaviour between PHPCS 3.x and PHPCS 2.x is intended to add support for "one standard" type of libraries, it breaks support for multi-standard libraries where one of the standards has the same name as the repository.

The change I'm proposing in this PR will maintain support for the PHPCS 2.x behaviour - thus not breaking existing registered standards - while at the same time supporting the new feature.