### PR TITLE
Sniff exclusions/restrictions dont work with custom sniffs unless they use the PHP_CodeSniffer NS

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -115,6 +115,21 @@ class Ruleset
      */
     private $config = null;
 
+    /**
+     * PHPCS native standards.
+     *
+     * @var array<string, bool>
+     */
+    private $nativeStandards = array(
+                                'generic'  => true,
+                                'mysource' => true,
+                                'pear'     => true,
+                                'psr1'     => true,
+                                'psr2'     => true,
+                                'squiz'    => true,
+                                'zend'     => true,
+                               );
+
 
     /**
      * Initialise the ruleset that the run will use.
@@ -186,14 +201,22 @@ class Ruleset
         $sniffRestrictions = array();
         foreach ($restrictions as $sniffCode) {
             $parts     = explode('.', strtolower($sniffCode));
-            $sniffName = 'php_codesniffer\standards\\'.$parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
+            $sniffName = $parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
+            if (isset($this->nativeStandards[$parts[0]]) === true) {
+                $sniffName = 'php_codesniffer\standards\\'.$sniffName;
+            }
+
             $sniffRestrictions[$sniffName] = true;
         }
 
         $sniffExclusions = array();
         foreach ($exclusions as $sniffCode) {
             $parts     = explode('.', strtolower($sniffCode));
-            $sniffName = 'php_codesniffer\standards\\'.$parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
+            $sniffName = $parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
+            if (isset($this->nativeStandards[$parts[0]]) === true) {
+                $sniffName = 'php_codesniffer\standards\\'.$sniffName;
+            }
+
             $sniffExclusions[$sniffName] = true;
         }
 

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -115,21 +115,6 @@ class Ruleset
      */
     private $config = null;
 
-    /**
-     * PHPCS native standards.
-     *
-     * @var array<string, bool>
-     */
-    private $nativeStandards = array(
-                                'generic'  => true,
-                                'mysource' => true,
-                                'pear'     => true,
-                                'psr1'     => true,
-                                'psr2'     => true,
-                                'squiz'    => true,
-                                'zend'     => true,
-                               );
-
 
     /**
      * Initialise the ruleset that the run will use.
@@ -202,7 +187,7 @@ class Ruleset
         foreach ($restrictions as $sniffCode) {
             $parts     = explode('.', strtolower($sniffCode));
             $sniffName = $parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
-            if (isset($this->nativeStandards[$parts[0]]) === true) {
+            if ($this->isNativeStandard($parts[0]) === true) {
                 $sniffName = 'php_codesniffer\standards\\'.$sniffName;
             }
 
@@ -213,7 +198,7 @@ class Ruleset
         foreach ($exclusions as $sniffCode) {
             $parts     = explode('.', strtolower($sniffCode));
             $sniffName = $parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
-            if (isset($this->nativeStandards[$parts[0]]) === true) {
+            if ($this->isNativeStandard($parts[0]) === true) {
                 $sniffName = 'php_codesniffer\standards\\'.$sniffName;
             }
 
@@ -1284,6 +1269,29 @@ class Ruleset
         return array();
 
     }//end getIncludePatterns()
+
+
+    /**
+     * Verify whether a standard is native to PHP_Codesniffer or a custom standard.
+     *
+     * @param string $name The lowercase name of a standard.
+     *
+     * @return bool
+     */
+    public function isNativeStandard($name)
+    {
+        static $nativeStandards;
+
+        if (isset($nativeStandards) === false) {
+            $nativeStandards = glob(__DIR__.'/Standards/*', GLOB_ONLYDIR);
+            $nativeStandards = array_map('basename', $nativeStandards);
+            $nativeStandards = array_map('strtolower', $nativeStandards);
+            $nativeStandards = array_flip($nativeStandards);
+        }
+
+        return isset($nativeStandards[$name]);
+
+    }//end isNativeStandard()
 
 
 }//end class


### PR DESCRIPTION
When running PHPCS with a custom standard, the command-line `--sniffs` and `--exclude` options no longer work.

This is caused by the sniffNames being prefixed with PHPCS's own `php_codesniffer\standards\` namespace which custom standard should not use in the first place.

This PR fixes this by only prefixing the sniffname with the PHPCS native namespace when it is a sniff from one of the build-in standards.