### PR TITLE
:fire: Fix PHPCS native autoloader & class recognition in PHPCS 3.x.

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -156,7 +156,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
             include $path;
 
             $className  = null;
-            $newClasses = array_diff(get_declared_classes(), $classes);
+            $newClasses = array_reverse(array_diff(get_declared_classes(), $classes));
             foreach ($newClasses as $name) {
                 if (isset(self::$loadedFiles[$name]) === false) {
                     $className = $name;
@@ -165,8 +165,8 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
             }
 
             if ($className === null) {
-                $newClasses = array_reverse(array_diff(get_declared_traits(), $classes));
-                foreach ($newClasses as $name) {
+                $newTraits = array_reverse(array_diff(get_declared_traits(), $traits));
+                foreach ($newTraits as $name) {
                     if (isset(self::$loadedFiles[$name]) === false) {
                         $className = $name;
                         break;
@@ -175,8 +175,8 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
             }
 
             if ($className === null) {
-                $newClasses = array_reverse(array_diff(get_declared_interfaces(), $classes));
-                foreach ($newClasses as $name) {
+                $newInterfaces = array_reverse(array_diff(get_declared_interfaces(), $interfaces));
+                foreach ($newInterfaces as $name) {
                     if (isset(self::$loadedFiles[$name]) === false) {
                         $className = $name;
                         break;


### PR DESCRIPTION
While working on making a custom standard compatible with PHPCS 3.x using `class_alias()`-es, a number of sniff files were getting misidentified by the autoloader causing PHPCS to choke.

This change fixes the issue I was encountering by using the the `$newClasses` diff in reverse.

While debugging this I noticed copy/paste artifacts in the subsequent checks for new interfaces and traits. Both of which were - incorrectly - being compared against the `$classes` variable.
I've taken the liberty to rename the local variables related to this as well to make the distinction clearer.