### PR TITLE
Squiz.WhiteSpace.OperatorSpacing is not checking spacing on either side of a short ternary operator

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -218,8 +218,8 @@ class OperatorSpacingSniff implements Sniff
         $operator = $tokens[$stackPtr]['content'];
 
         if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE
-            && (($tokens[$stackPtr - 1]['code'] === T_INLINE_THEN && $tokens[($stackPtr )]['code'] === T_INLINE_ELSE) === false)
-            ) {
+            && (($tokens[($stackPtr - 1)]['code'] === T_INLINE_THEN && $tokens[($stackPtr )]['code'] === T_INLINE_ELSE) === false)
+        ) {
             $error = "Expected 1 space before \"$operator\"; 0 found";
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBefore');
             if ($fix === true) {
@@ -269,7 +269,8 @@ class OperatorSpacingSniff implements Sniff
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
             // Skip short ternary such as: "$foo = $bar ?: true;".
             if (($tokens[$stackPtr]['code'] === T_INLINE_THEN
-                && $tokens[($stackPtr + 1)]['code'] === T_INLINE_ELSE)) {
+                && $tokens[($stackPtr + 1)]['code'] === T_INLINE_ELSE)
+            ) {
                 return;
             }
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -98,15 +98,6 @@ class OperatorSpacingSniff implements Sniff
             }
         }
 
-        // Skip short ternary such as: "$foo = $bar ?: true;".
-        if (($tokens[$stackPtr]['code'] === T_INLINE_THEN
-            && $tokens[($stackPtr + 1)]['code'] === T_INLINE_ELSE)
-            || ($tokens[($stackPtr - 1)]['code'] === T_INLINE_THEN
-            && $tokens[$stackPtr]['code'] === T_INLINE_ELSE)
-        ) {
-                return;
-        }
-
         if ($tokens[$stackPtr]['code'] === T_BITWISE_AND) {
             // If it's not a reference, then we expect one space either side of the
             // bitwise operator.
@@ -226,7 +217,9 @@ class OperatorSpacingSniff implements Sniff
 
         $operator = $tokens[$stackPtr]['content'];
 
-        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
+        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE
+            && (($tokens[$stackPtr - 1]['code'] === T_INLINE_THEN && $tokens[($stackPtr )]['code'] === T_INLINE_ELSE) === false)
+            ) {
             $error = "Expected 1 space before \"$operator\"; 0 found";
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceBefore');
             if ($fix === true) {
@@ -274,6 +267,12 @@ class OperatorSpacingSniff implements Sniff
         }
 
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+            // Skip short ternary such as: "$foo = $bar ?: true;".
+            if (($tokens[$stackPtr]['code'] === T_INLINE_THEN
+                && $tokens[($stackPtr + 1)]['code'] === T_INLINE_ELSE)) {
+                return;
+            }
+
             $error = "Expected 1 space after \"$operator\"; 0 found";
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfter');
             if ($fix === true) {

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -192,8 +192,10 @@ function foo($c = ((BAR)?10:100)) {}
 
 $res = $a ?: $b;
 $res = $a ?:  $b;
-$res = $a  ? : $b;
-$res = $a  ? :  $b;
+$res = $a  ?: $b;
+$res = $a  ?:  $b;
+
 $res = $a ? : $b;
+$res = $a ? :  $b;
 $res = $a  ? : $b;
 $res = $a  ? :  $b;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -189,3 +189,11 @@ function foo(string $bar, array $baz, ?MyClass $object) : MyClass {}
 declare(strict_types=1);
 
 function foo($c = ((BAR)?10:100)) {}
+
+$res = $a ?: $b;
+$res = $a ?:  $b;
+$res = $a  ? : $b;
+$res = $a  ? :  $b;
+$res = $a ? : $b;
+$res = $a  ? : $b;
+$res = $a  ? :  $b;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -183,3 +183,8 @@ function foo(string $bar, array $baz, ?MyClass $object) : MyClass {}
 declare(strict_types=1);
 
 function foo($c = ((BAR) ? 10 : 100)) {}
+
+$res = $a ?: $b;
+$res = $a ?: $b;
+$res = $a ? : $b;
+$res = $a ? : $b;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -186,5 +186,10 @@ function foo($c = ((BAR) ? 10 : 100)) {}
 
 $res = $a ?: $b;
 $res = $a ?: $b;
+$res = $a ?: $b;
+$res = $a ?: $b;
+
+$res = $a ? : $b;
+$res = $a ? : $b;
 $res = $a ? : $b;
 $res = $a ? : $b;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -88,6 +88,12 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                     179 => 1,
                     185 => 2,
                     191 => 4,
+                    194 => 1,
+                    195 => 1,
+                    196 => 2,
+                    199 => 1,
+                    200 => 1,
+                    201 => 2,
                    );
             break;
         case 'OperatorSpacingUnitTest.js':


### PR DESCRIPTION
If the sniff has found a ternary statement it would return to quickly and so it would avoid doing some checks.

You can check the tests to see what I am talking about.