### PR TITLE
Fix exceptions uses in version 3.x

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1101,9 +1101,9 @@ class File
      *
      * @return string|null The name of the class, interface, trait, or function;
      *                     or NULL if the function or class is anonymous.
-     * @throws PHP_CodeSniffer_Exception If the specified token is not of type
-     *                                   T_FUNCTION, T_CLASS, T_ANON_CLASS,
-     *                                   T_CLOSURE, T_TRAIT, or T_INTERFACE.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
+     *                                                      T_FUNCTION, T_CLASS, T_ANON_CLASS,
+     *                                                      T_CLOSURE, T_TRAIT, or T_INTERFACE.
      */
     public function getDeclarationName($stackPtr)
     {
@@ -1165,8 +1165,8 @@ class File
      *                      to acquire the parameters for.
      *
      * @return array
-     * @throws PHP_CodeSniffer_Exception If the specified $stackPtr is not of
-     *                                   type T_FUNCTION or T_CLOSURE.
+     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the specified $stackPtr is not of
+     *                                                        type T_FUNCTION or T_CLOSURE.
      */
     public function getMethodParameters($stackPtr)
     {
@@ -1332,8 +1332,8 @@ class File
      *                      acquire the properties for.
      *
      * @return array
-     * @throws PHP_CodeSniffer_Exception If the specified position is not a
-     *                                   T_FUNCTION token.
+     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the specified position is not a
+     *                                                        T_FUNCTION token.
      */
     public function getMethodProperties($stackPtr)
     {
@@ -1428,9 +1428,9 @@ class File
      *                      acquire the properties for.
      *
      * @return array
-     * @throws PHP_CodeSniffer_Exception If the specified position is not a
-     *                                   T_VARIABLE token, or if the position is not
-     *                                   a class member variable.
+     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the specified position is not a
+     *                                                        T_VARIABLE token, or if the position is not
+     *                                                        a class member variable.
      */
     public function getMemberProperties($stackPtr)
     {
@@ -1528,8 +1528,8 @@ class File
      *                      acquire the properties for.
      *
      * @return array
-     * @throws PHP_CodeSniffer_Exception If the specified position is not a
-     *                                   T_CLASS token.
+     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the specified position is not a
+     *                                                        T_CLASS token.
      */
     public function getClassProperties($stackPtr)
     {

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -66,7 +66,7 @@ abstract class AbstractScopeSniff implements Sniff
      *                               processTokenOutsideScope method.
      *
      * @see    PHP_CodeSniffer.getValidScopeTokeners()
-     * @throws PHP_CodeSniffer_Exception If the specified tokens array is empty.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified tokens array is empty.
      */
     public function __construct(
         array $scopeTokens,

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -60,7 +60,7 @@ class ClosureLinterSniff implements Sniff
      *                                               the token was found.
      *
      * @return void
-     * @throws PHP_CodeSniffer_Exception If jslint.js could not be run
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jslint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
@@ -52,7 +52,7 @@ class ESLintSniff implements Sniff
      *                                               the token was found.
      *
      * @return void
-     * @throws PHP_CodeSniffer_Exception If jshint.js could not be run
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jshint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -45,7 +45,7 @@ class JSHintSniff implements Sniff
      *                                               the token was found.
      *
      * @return void
-     * @throws PHP_CodeSniffer_Exception If jshint.js could not be run
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jshint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\VersionControl;
 
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -119,8 +120,8 @@ class SubversionPropertiesSniff implements Sniff
      * @param string $path The path to return Subversion properties on.
      *
      * @return array
-     * @throws PHP_CodeSniffer_Exception If Subversion properties file could
-     *                                   not be opened.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If Subversion properties file could
+     *                                                      not be opened.
      */
     protected function getProperties($path)
     {
@@ -138,7 +139,7 @@ class SubversionPropertiesSniff implements Sniff
                 $handle = fopen($path, 'r');
                 if ($handle === false) {
                     $error = 'Error opening file; could not get Subversion properties';
-                    throw new PHP_CodeSniffer_Exception($error);
+                    throw new RuntimeException($error);
                 }
 
                 while (feof($handle) === false) {

--- a/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
@@ -44,7 +44,7 @@ class JSLintSniff implements Sniff
      *                                               the token was found.
      *
      * @return void
-     * @throws PHP_CodeSniffer_Exception If jslint.js could not be run
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jslint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -14,11 +14,10 @@
 namespace PHP_CodeSniffer\Tests\Standards;
 
 use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\LocalFile;
-use PHP_CodeSniffer\RuntimeException;
 use PHP_CodeSniffer\Util\Common;
-use PHP_CodeSniffer\Autoload;
 
 abstract class AbstractSniffUnitTest extends \PHPUnit_Framework_TestCase
 {
@@ -206,10 +205,10 @@ abstract class AbstractSniffUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * Generate a list of test failures for a given sniffed file.
      *
-     * @param PHP_CodeSniffer_File $file The file being tested.
+     * @param \PHP_CodeSniffer\Files\LocalFile $file The file being tested.
      *
      * @return array
-     * @throws PHP_CodeSniffer_Exception
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
      */
     public function generateFailureMessages(LocalFile $file)
     {


### PR DESCRIPTION
Fixed various places where the old exception of PHP_Codesniffer_Exception was used either as docblock either as an actual exception (found only one place... so it's mainly docblocks)