### PR TITLE
Added scripts in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,10 @@
     "bin": [
         "bin/phpcs",
         "bin/phpcbf"
-    ]
+    ],
+    "scripts": {
+        "tests": "php vendor/bin/phpunit tests/AllTests.php",
+        "phpcs": "php bin/phpcs --no-cache --parallel=1",
+        "phpcbf": "php bin/phpcbf --no-cache --parallel=1"
+    }
 }


### PR DESCRIPTION
Before each push I had to go and find the command to run the `tests`, the `phpcs` and if I had errors for codestyle the command to fix them.

Most of the times I used to open `travis.yml` in order to find them but again I had to remember them or press CTRL+R on my command line in order to search them back.

I believe this adds simplicity. It's easy to remember and write the quickly.

So now you can execute the tests running: `composer tests`