### PR TITLE
Allowing no space before first variable declaration

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -86,7 +86,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         $prev       = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($first - 1), null, true);
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
-        if ($foundLines === 1) {
+        if ($foundLines === 1 || ($foundLines === 0 && $tokens[$prev]['code'] === T_OPEN_CURLY_BRACKET)) {
             return;
         }
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -1,7 +1,6 @@
 <?php
 class MyClass
 {
-
     public $var1 = 'value';
 
     public $var2 = 'value';
@@ -38,14 +37,12 @@ class MyClass
 
 class MyClass
 {
-
     public $var1 = 'value';
 }//end class
 
 
 interface MyInterface
 {
-
     public $var1 = 'value';
     function myFunction();
 }//end interface
@@ -75,7 +72,6 @@ class MyClass
 
 class MyClass
 {
-
     /**
      * The actions that this wizard step requires.
      *

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -26,15 +26,11 @@ class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return array(
-                4   => 1,
                 7   => 1,
                 20  => 1,
                 30  => 1,
                 35  => 1,
-                44  => 1,
-                50  => 1,
                 73  => 1,
-                86  => 1,
                 106 => 1,
                 115 => 1,
                 150 => 1,


### PR DESCRIPTION
Allows first variable to be declared on a class without forcing an empty line before it