### PR TITLE
PHP_CodeSniffer_File::findExtendedClassName() works with extended interfaces

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2120,6 +2120,7 @@ class File
 
     /**
      * Returns the name of the class that the specified class extends.
+     * (works for classes, anonymous classes and interfaces)
      *
      * Returns FALSE on error or if there is no extended class name.
      *
@@ -2136,6 +2137,7 @@ class File
 
         if ($this->tokens[$stackPtr]['code'] !== T_CLASS
             && $this->tokens[$stackPtr]['code'] !== T_ANON_CLASS
+            && $this->tokens[$stackPtr]['code'] !== T_INTERFACE
         ) {
             return false;
         }

--- a/tests/Core/File/FindExtendedClassNameTest.inc
+++ b/tests/Core/File/FindExtendedClassNameTest.inc
@@ -16,3 +16,9 @@ class testFECNNonExtendedClass {}
 
 /* testInterface */
 interface testFECNInterface {}
+
+/* testInterfaceThatExtendsInterface */
+interface testInterfaceThatExtendsInterface extends testFECNInterface{}
+
+/* testInterfaceThatExtendsFQCNInterface */
+interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\Core\File\testFECNInterface{}

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -146,4 +146,48 @@ class FindExtendedClassNameTest extends \PHPUnit_Framework_TestCase
     }//end testInterface()
 
 
+    /**
+     * Test an interface that extends another.
+     *
+     * @return void
+     */
+    public function testExtendedInterface()
+    {
+        $start = ($this->phpcsFile->numTokens - 1);
+        $class = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testInterfaceThatExtendsInterface */'
+        );
+
+        $found = $this->phpcsFile->findExtendedClassName(($class + 2));
+        $this->assertSame('testFECNInterface', $found);
+
+    }//end testExtendedInterface()
+
+
+    /**
+     * Test an interface that extends another, using namespaces.
+     *
+     * @return void
+     */
+    public function testExtendedNamespacedInterface()
+    {
+        $start = ($this->phpcsFile->numTokens - 1);
+        $class = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testInterfaceThatExtendsFQCNInterface */'
+        );
+
+        $found = $this->phpcsFile->findExtendedClassName(($class + 2));
+        $this->assertSame('\PHP_CodeSniffer\Tests\Core\File\testFECNInterface', $found);
+
+    }//end testExtendedNamespacedInterface()
+
+
 }//end class


### PR DESCRIPTION
I've changed `PHP_CodeSniffer_File::findExtendedClassName()` behaviour so it also works with extended interfaces