### PR TITLE
Fix slow input on stdin / require `-` for stdin

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -6,7 +6,7 @@
  * and provides functions to access data stored in config files.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
@@ -318,11 +318,9 @@ class Config
             $this->dieOnUnknownArg = $dieOnUnknownArg;
         }
 
-        $checkStdin = false;
         if (empty($cliArgs) === true) {
             $cliArgs = $_SERVER['argv'];
             array_shift($cliArgs);
-            $checkStdin = true;
         }
 
         $this->restoreDefaults();
@@ -354,23 +352,13 @@ class Config
         }//end if
 
         // Check for content on STDIN.
-        if ($checkStdin === true) {
-            $handle = fopen('php://stdin', 'r');
-            if (stream_set_blocking($handle, false) === true) {
-                $fileContents = '';
-                while (($line = fgets($handle)) !== false) {
-                    $fileContents .= $line;
-                    usleep(10);
-                }
+        if ($this->stdin === true) {
+            $handle       = fopen('php://stdin', 'r');
+            $fileContents = stream_get_contents($handle);
 
-                stream_set_blocking($handle, true);
-                fclose($handle);
-                if (trim($fileContents) !== '') {
-                    $this->stdin        = true;
-                    $this->stdinContent = $fileContents;
-                    $this->overriddenDefaults['stdin']        = true;
-                    $this->overriddenDefaults['stdinContent'] = true;
-                }
+            fclose($handle);
+            if (trim($fileContents) !== '') {
+                $this->stdinContent = $fileContents;
             }
         }
 


### PR DESCRIPTION
Make it required to explicitly use `-` for reading from stdin.

Making it explicitly required to use will simplify the code by not needing a lot of edge cases.

Non-blocking reading from stdin was introduced in 80b156de8d440b6245e6b1dd7f8df777d99064fa because we had problems with auto detecting whether we should read from stdin or not. This is avoided by requiring `-`.

By going back to blocking read from stdin we can avoid the extra check introduced in 23bd0235c5c4ebed5d5605844335c73530028e43 for Windows.

We can also avoid the "read by line" and "usleep" introduced 8d669c50e4122c592a634580d9ea8b30c4edd0e1 and 63fafe07d6cb8588b787475a3cc041f52b05a4ac. They where introduced trying to solve what is possible the same problem still reported in #1472.

Fixes #1472.

I think this also fixes #993 and fixes #1417.