### PR TITLE
Do not check the existence of stdin-path when processing data from STDIN 

### DIFF
--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -81,7 +81,7 @@ class Filter extends \RecursiveFilterIterator
      */
     public function accept()
     {
-        $filePath = Util\Common::realpath($this->current());
+        $filePath = Util\Common::realpath($this->current(), $this->config->stdin);
         if ($filePath === false) {
             return false;
         }


### PR DESCRIPTION
#1488 

[realpath](http://php.net/manual/en/function.realpath.php) is  used to get canonicalized absolute pathname, whether to specify the file directly or to use STDIN with --stdin-path specified, and it will check the existence of the file.

In my opinion, it is not necessary to check the existence of stdin-path when processing data from STDIN. If you want, just specify the file instead of using STDIN.

This PR provides a new function to get canonicalized absolute pathname and not check existence. When processing data from STDIN with --stdin-path specified, use the new function.
