### PR TITLE
Squiz.Strings.DoubleQuoteUsage not unescaping dollar sign when fixing

### DIFF
--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -123,6 +123,7 @@ class DoubleQuoteUsageSniff implements Sniff
             $phpcsFile->fixer->beginChangeset();
             $innerContent = substr($workingString, 1, -1);
             $innerContent = str_replace('\"', '"', $innerContent);
+            $innerContent = str_replace('\\$', '$', $innerContent);
             $phpcsFile->fixer->replaceToken($stackPtr, "'$innerContent'");
             while ($lastStringToken !== $stackPtr) {
                 $phpcsFile->fixer->replaceToken($lastStringToken, '');

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
@@ -14,6 +14,7 @@ $string = 'Hello '.$there.' Greg';
 $string = "<div class='$class'>";
 $string = "Value: $var[test]";
 $string = "\0";
+$string = "\$var";
 
 $x = "bar = '$z',
 baz = '" . $a . "'...$x";

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
@@ -14,6 +14,7 @@ $string = 'Hello '.$there.' Greg';
 $string = "<div class='$class'>";
 $string = "Value: $var[test]";
 $string = "\0";
+$string = '$var';
 
 $x = "bar = '$z',
 baz = '" . $a . "'...$x";

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
@@ -32,11 +32,12 @@ class DoubleQuoteUsageUnitTest extends AbstractSniffUnitTest
                 8  => 2,
                 14 => 1,
                 15 => 1,
-                18 => 1,
+                17 => 1,
                 19 => 1,
-                21 => 1,
-                28 => 1,
+                20 => 1,
+                22 => 1,
                 29 => 1,
+                30 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
When double quotes are changed to single in content character escaped
dolar sign (`\$`) should be replaced to dolar sign (`$`) only.

Let me know if you need separate PR with this fix for v2.