### PR TITLE
Sniff variables of nested anonymous classes

### DIFF
--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -41,6 +41,12 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      */
     protected $currentFile = null;
 
+    /**
+     * The current scope that we are processing.
+     *
+     * @var int
+     */
+    protected $currentScope;
 
     /**
      * Constructs an AbstractVariableTest.
@@ -78,8 +84,11 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      */
     final protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
-        if ($this->currentFile !== $phpcsFile) {
+        if ($this->currentFile !== $phpcsFile
+            || $this->currentScope !== $currScope
+        ) {
             $this->currentFile  = $phpcsFile;
+            $this->currentScope = $currScope;
             $this->functionOpen = false;
             $this->endFunction  = -1;
         }

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
@@ -9,11 +9,29 @@ class MyClass
     public function method()
     {
         $anon = new class() {
-            public $p1;
-            protected $p2;
-            private $p3;
-            $p0 = null;
+            $p1 = null;
+            public $p2;
+            protected $p3;
+            private $p4;
+            $p5 = null;
+
+            public function m($x)
+            {
+                $y = $x + 1;
+
+                $xAnon = new class() {
+                    $g1;
+                    public $g2;
+                    $g3 = null;
+                };
+
+                $z = 2 * $y;
+
+                return $y ?: $z;
+            }
         };
+
+        $var = null;
     }
 }
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
@@ -5,6 +5,16 @@ class MyClass
     protected $var2 = null;
     public $var3 = null;
     $var4 = null;
+
+    public function method()
+    {
+        $anon = new class() {
+            public $p1;
+            protected $p2;
+            private $p3;
+            $p0 = null;
+        };
+    }
 }
 
 class foo

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -26,9 +26,12 @@ class MemberVarScopeUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return array(
-            7 => 1,
-            15 => 1,
-        );
+                7  => 1,
+                12 => 1,
+                16 => 1,
+                23 => 1,
+                25 => 1,
+               );
 
     }//end getErrorList()
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -25,7 +25,10 @@ class MemberVarScopeUnitTest extends AbstractSniffUnitTest
      */
     public function getErrorList()
     {
-        return array(7 => 1);
+        return array(
+            7 => 1,
+            15 => 1,
+        );
 
     }//end getErrorList()
 


### PR DESCRIPTION
Member vars of nested classes (anonymous class in normal class) should be also sniffed.

Something is wrong with my changes, because now the error is reported twice in this line, but without my change the error is not reported at all. If I change order of the properties in anonymous class (first will be property without visibility) then all seems to be fine. Any ideas?