### PR TITLE
Fix XMLReport not able to write filename with non-latin characters

### DIFF
--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -16,6 +16,23 @@ class Xml implements Report
 {
 
 
+	/**
+	 * Checks that the string is UTF-8 encoded, and converts it to UTF-8 if it isn't.
+	 *
+	 * @param string $string String to check and convert
+	 *
+	 * @return string
+	 */
+	private function makeSureStringIsUTF8($string)
+	{
+		if(mb_detect_encoding($string, 'UTF-8', true) === false)
+		{
+			$string	= utf8_encode($string);
+		}
+
+		return $string;
+	}
+
     /**
      * Generate a partial report for a single processed file.
      *
@@ -42,7 +59,7 @@ class Xml implements Report
         }
 
         $out->startElement('file');
-        $out->writeAttribute('name', utf8_encode($report['filename']));
+        $out->writeAttribute('name', $this->makeSureStringIsUTF8($report['filename']));
         $out->writeAttribute('errors', $report['errors']);
         $out->writeAttribute('warnings', $report['warnings']);
         $out->writeAttribute('fixable', $report['fixable']);

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -42,7 +42,7 @@ class Xml implements Report
         }
 
         $out->startElement('file');
-        $out->writeAttribute('name', $report['filename']);
+        $out->writeAttribute('name', utf8_encode($report['filename']));
         $out->writeAttribute('errors', $report['errors']);
         $out->writeAttribute('warnings', $report['warnings']);
         $out->writeAttribute('fixable', $report['fixable']);

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -16,22 +16,22 @@ class Xml implements Report
 {
 
 
-	/**
-	 * Checks that the string is UTF-8 encoded, and converts it to UTF-8 if it isn't.
-	 *
-	 * @param string $string String to check and convert
-	 *
-	 * @return string
-	 */
-	private function makeSureStringIsUTF8($string)
-	{
-		if(mb_detect_encoding($string, 'UTF-8', true) === false)
-		{
-			$string	= utf8_encode($string);
-		}
+    /**
+     * Checks that the string is UTF-8 encoded, and converts it to UTF-8 if it isn't.
+     *
+     * @param string $string String to check and convert
+     *
+     * @return string
+     */
+    private function makeSureStringIsUTF8($string)
+    {
+        if (mb_detect_encoding($string, 'UTF-8', true) === false) {
+            $string = utf8_encode($string);
+        }
 
-		return $string;
-	}
+        return $string;
+    }//end makeSureStringIsUTF8()
+
 
     /**
      * Generate a partial report for a single processed file.

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -30,6 +30,7 @@ class Xml implements Report
         }
 
         return $string;
+
     }//end makeSureStringIsUTF8()
 
 


### PR DESCRIPTION
This fixes #1189, where it wasn't possible to use PHP_CodeSniffer when the user's path (at least on Windows) included non-latin characters.
XMLWriter would fail with 
`phpcs: PHP Warning:  XMLWriter::writeAttribute(): invalid character value in vendor\squizlabs\php_codesniffer\CodeSniffer\Reports\Xml.php on line 66`

By doing utf8_encode, we make sure XMLWriter allows non-latin characters