### PR TITLE
Fix for not saving cache

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -815,7 +815,7 @@ class Config
             } else if (defined('PHP_CODESNIFFER_IN_TESTS') === false
                 && substr($arg, 0, 6) === 'cache='
             ) {
-                if ($this->cache === false || isset($this->overriddenDefaults['cacheFile']) === true) {
+                if (isset($this->overriddenDefaults['cacheFile']) === true) {
                     break;
                 }
 


### PR DESCRIPTION
After releasing `3.0.1` passing cache in command line is not working.

Reproducing:
```bash
git clone --depth=1 https://github.com/squizlabs/PHP_CodeSniffer.git
cd PHP_CodeSniffer/
composer install
bin/phpcs --cache=test.cache src/
```

No file `test.cache` will be written.