### PR TITLE
Add autoload.php to Composer autoloaded files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,11 @@
     ],
     "homepage": "http://www.squizlabs.com/php-codesniffer",
     "license": "BSD-3-Clause",
+    "autoload": {
+        "files": [
+            "autoload.php"
+        ]
+    },
     "authors": [
         {
             "name": "Greg Sherwood",


### PR DESCRIPTION
This makes autoloading classes work when using CodeSniffer programmatically.