### PR TITLE
[2.x] Fix auto-fixer conflict between Squiz/ControlSignature and Generic/InlineControlStructure

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -89,7 +89,7 @@ class Squiz_Sniffs_ControlStructures_ControlSignatureSniff implements PHP_CodeSn
             }
         }
 
-        if ($found !== 1) {
+        if ($found !== 1 && (isset($tokens[$stackPtr]['scope_opener']) === true || $found !== 'newline')) {
             $error = 'Expected 1 space after %s keyword; %s found';
             $data  = array(
                       strtoupper($tokens[$stackPtr]['content']),

--- a/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
@@ -211,3 +211,20 @@ if (1 === $a) :
 else :
     echo 'not 1';
 endif;
+
+// Prevent whitespace after keyword fixes for inline control structures.
+if ( 'message' == $severity )
+	$messages .= '	' . $error_message . "<br />\n";
+else
+	$errors .= '	' . $error_message . "<br />\n";
+
+if ( ! is_subdomain_install() )
+	echo '<label for="blogname">' . __( 'Site Name:' ) . '</label>';
+elseif ( $a === $b )
+	echo '<label for="blogname">' . __( 'Site Domain:' ) . '</label>';
+else
+	echo '<label for="blogname">' . __( 'Site Domain:' ) . '</label>';
+
+do
+	$a = $b;
+while ( $a !== $b );

--- a/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
@@ -214,3 +214,20 @@ if (1 === $a) :
 else :
     echo 'not 1';
 endif;
+
+// Prevent whitespace after keyword fixes for inline control structures.
+if ( 'message' == $severity )
+	$messages .= '	' . $error_message . "<br />\n";
+else
+	$errors .= '	' . $error_message . "<br />\n";
+
+if ( ! is_subdomain_install() )
+	echo '<label for="blogname">' . __( 'Site Name:' ) . '</label>';
+elseif ( $a === $b )
+	echo '<label for="blogname">' . __( 'Site Domain:' ) . '</label>';
+else
+	echo '<label for="blogname">' . __( 'Site Domain:' ) . '</label>';
+
+do
+	$a = $b;
+while ( $a !== $b );


### PR DESCRIPTION
The WordPress project has (finally) decided to fix the remaining code style issues in the code base according to their own standard. See https://core.trac.wordpress.org/ticket/41057

An initial run of the auto-fixer yielded a number of bugs in the auto-fixers however. This PR is part of an effort to fix these issues.

As the WordPress Coding Standards are currently not (yet) compatible with PHPCS 3.x, it would be very much appreciated if this fix could (also) be merged into PHPCS 2.x.

This PR is the version for PHPCS 2.x. I'll be opening a sister-PR for the PHPCS 3.x/master branch.

----

#### Issue summary:
The autofixer for `else` / `do ... while` control structure signatures removes a new line which should be there when these control structures are used without braces.

#### Cause:
Conflict between the `Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword` - _"Expected 1 space after ELSE keyword; newline found"_ - and the `Generic.ControlStructures.InlineControlStructure.NotAllowed` - _"Inline control structures are not allowed"_ - sniffs.
Basically, the Squiz sniff kicks in too early, removing the new line before the Generic sniff has had a chance to add the braces.

#### Fix:
I've fixed this by setting the `Squiz.ControlStructures.ControlSignature` sniff to ignore the "Expected 1 space after keyword" violation for inline control structures in combination with a new line.
This allows the `Generic.ControlStructures.InlineControlStructure` sniff to kick in in an early auto-fix pass to add the necessary braces.
In the next auto-fix pass, the `Squiz.ControlStructures.ControlSignature` will kick in (if still needed) as now the braces are in place.

#### Example code:
```php
if ( 'message' == $severity )
	$messages .= '	' . $error_message . "<br />\n";
else
	$errors .= '	' . $error_message . "<br />\n";
```

#### Was being fixed as:
```php
if ( 'message' == $severity ) {
	$messages .= '	' . $error_message . "<br />\n";
} else {       $errors .= '	' . $error_message . "<br />\n";
}
```

#### Expected fix /fix after this PR would be merged:
```php
if ( 'message' == $severity ) {
	$messages .= '	' . $error_message . "<br />\n";
} else {
	$errors .= '	' . $error_message . "<br />\n";
}
```

Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/971