### PR TITLE
Fatal error when using the --suffix argument

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1093,7 +1093,7 @@ class Config
                     break;
                 }
 
-                $this->suffix = explode(',', substr($arg, 7));
+                $this->suffix = substr($arg, 7);
                 $this->overriddenDefaults['suffix'] = true;
             } else if (substr($arg, 0, 9) === 'parallel=') {
                 if (isset($this->overriddenDefaults['parallel']) === true) {


### PR DESCRIPTION
Running `phpcbf` with the `--sufffix` argument caused a fatal `array to string conversion` error.

The `suffix` argument is expected to be a `string`, but was being converted to an array with the `explode` in the `Config::processLongArgument()` method.

```
Fatal error: Uncaught exception 'PHP_CodeSniffer\Exceptions\RuntimeException' with message 'Array to  string conversion in PHP_CodeSniffer\src\Reports\Cbf.php on line 81' in PHP_CodeSniffer\src\Runner.php on line 557

PHP_CodeSniffer\Exceptions\RuntimeException: Array to string conversion in PHP_CodeSniffer\src\Reports\Cbf.php on line 81 in PHP_CodeSniffer\src\Runner.php on line 557

Call Stack:
    0.0000     124152   1. {main}() PHP_CodeSniffer\bin\phpcbf:0
    0.0070     298216   2. PHP_CodeSniffer\Runner->runPHPCBF() PHP_CodeSniffer\bin\phpcbf:18
    1.6141    6325976   3. PHP_CodeSniffer\Runner->run() PHP_CodeSniffer\src\Runner.php:193
    1.6831    6985456   4. PHP_CodeSniffer\Runner->processFile() PHP_CodeSniffer\src\Runner.php:397
    2.0111    7070176   5. PHP_CodeSniffer\Reporter->cacheFileReport() PHP_CodeSniffer\src\Runner.php:606
    2.0111    7089040   6. PHP_CodeSniffer\Reports\Cbf->generateFileReport() PHP_CodeSniffer\src\Reporter.php:262
    2.5131    7094152   7. PHP_CodeSniffer\Runner->handleErrors() PHP_CodeSniffer\src\Reporter.php:81

```