### PR TITLE
Tokenize `yield` keyword as `T_YIELD` on PHP 5.4, and `yield from` as `T_YIELD_FROM` on PHP < 7.0

### DIFF
--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -95,6 +95,7 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
                    548 => 1,
                    641 => 1,
                    669 => 1,
+                   688 => 1,
                    744 => 1,
                    748 => 1,
                    767 => 1,
@@ -108,15 +109,6 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
                    852 => 1,
                    864 => 1,
                   );
-
-        // The yield tests will only work in PHP versions where yield exists and
-        // will throw errors in earlier versions.
-        if (PHP_VERSION_ID < 50500) {
-            $errors[676] = 1;
-            $errors[874] = 1;
-        } else {
-            $errors[688] = 1;
-        }
 
         // Scalar type hints only work from PHP 7 onwards.
         if (PHP_VERSION_ID >= 70000) {

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -722,6 +722,27 @@ class PHP extends Tokenizer
             }//end if
 
             /*
+                Before PHP 5.5, the yield keyword was tokenized as
+                T_STRING. So look for and change this token in
+                earlier versions.
+            */
+
+            if (PHP_VERSION_ID < 50500
+                && $tokenIsArray === true
+                && $token[0] === T_STRING
+                && strtolower($token[1]) === 'yield'
+            ) {
+                $newToken            = array();
+                $newToken['code']    = T_YIELD;
+                $newToken['type']    = 'T_YIELD';
+                $newToken['content'] = $token[1];
+                $finalTokens[$newStackPtr] = $newToken;
+
+                $newStackPtr++;
+                continue;
+            }//end if
+
+            /*
                 Before PHP 5.6, the ... operator was tokenized as three
                 T_STRING_CONCAT tokens in a row. So look for and combine
                 these tokens in earlier versions.

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -722,9 +722,37 @@ class PHP extends Tokenizer
             }//end if
 
             /*
+                Before PHP 7.0, the "yield from" was tokenized as
+                T_YIELD, T_WHITESPACE and T_STRING. So look for
+                and change this token in earlier versions.
+            */
+
+            if (PHP_VERSION_ID < 70000
+                && PHP_VERSION_ID >= 50500
+                && $tokenIsArray === true
+                && $token[0] === T_YIELD
+                && isset($tokens[($stackPtr + 1)]) === true
+                && isset($tokens[($stackPtr + 2)]) === true
+                && $tokens[($stackPtr + 1)][0] === T_WHITESPACE
+                && $tokens[($stackPtr + 2)][0] === T_STRING
+                && strtolower($tokens[($stackPtr + 2)][1]) === 'from'
+            ) {
+                $newToken            = array();
+                $newToken['code']    = T_YIELD_FROM;
+                $newToken['type']    = 'T_YIELD_FROM';
+                $newToken['content'] = $token[1].$tokens[($stackPtr + 1)][1].$tokens[($stackPtr + 2)][1];
+                $finalTokens[$newStackPtr] = $newToken;
+
+                $newStackPtr++;
+                $stackPtr += 2;
+                continue;
+            }
+
+            /*
                 Before PHP 5.5, the yield keyword was tokenized as
                 T_STRING. So look for and change this token in
                 earlier versions.
+                Checks also if it is just "yield" or "yield from".
             */
 
             if (PHP_VERSION_ID < 50500
@@ -732,6 +760,23 @@ class PHP extends Tokenizer
                 && $token[0] === T_STRING
                 && strtolower($token[1]) === 'yield'
             ) {
+                if (isset($tokens[($stackPtr + 1)]) === true
+                    && isset($tokens[($stackPtr + 2)]) === true
+                    && $tokens[($stackPtr + 1)][0] === T_WHITESPACE
+                    && $tokens[($stackPtr + 2)][0] === T_STRING
+                    && strtolower($tokens[($stackPtr + 2)][1]) === 'from'
+                ) {
+                    $newToken            = array();
+                    $newToken['code']    = T_YIELD_FROM;
+                    $newToken['type']    = 'T_YIELD_FROM';
+                    $newToken['content'] = $token[1].$tokens[($stackPtr + 1)][1].$tokens[($stackPtr + 2)][1];
+                    $finalTokens[$newStackPtr] = $newToken;
+
+                    $newStackPtr++;
+                    $stackPtr += 2;
+                    continue;
+                }
+
                 $newToken            = array();
                 $newToken['code']    = T_YIELD;
                 $newToken['type']    = 'T_YIELD';


### PR DESCRIPTION
Resolves #1513 

With these changes PR #1492 is not gonna fail.