### PR TITLE
Tokenize comments starting from '/**' as doc-block comments

### DIFF
--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
@@ -190,3 +190,5 @@
 /**
  * étude des ...
  */
+
+/**doc comment */

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js
@@ -190,3 +190,5 @@
 /**
  * étude des ...
  */
+
+/**doc comment */

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -58,6 +58,7 @@ class DocCommentUnitTest extends AbstractSniffUnitTest
                 186 => 1,
                 187 => 2,
                 191 => 1,
+                194 => 4,
                );
 
     }//end getErrorList()

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -536,7 +536,10 @@ class PHP extends Tokenizer
                 Parse doc blocks into something that can be easily iterated over.
             */
 
-            if ($tokenIsArray === true && $token[0] === T_DOC_COMMENT) {
+            if ($tokenIsArray === true
+                && ($token[0] === T_DOC_COMMENT
+                || ($token[0] === T_COMMENT && strpos($token[1], '/**') === 0))
+            ) {
                 $commentTokens = $commentTokenizer->tokenizeString($token[1], $this->eolChar, $newStackPtr);
                 foreach ($commentTokens as $commentToken) {
                     $finalTokens[$newStackPtr] = $commentToken;


### PR DESCRIPTION
Currently comments starting form /** but without space after that
were not tokenized as doc-block comments.

For example:
```php
/**@var string */
```
was not recognized as doc-block comment.
