### PR TITLE
Hotfix #1550 - Squiz.Commenting.FunctionComment - return type in doc-block

### DIFF
--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -931,3 +931,42 @@ function returnArrayWithAnonymousClass()
 
     return [];
 }
+
+/**
+ * @return void
+ */
+function returnVoidWithClosure()
+{
+    function () {
+        return 1;
+    };
+}
+
+/**
+ * @return void
+ */
+function returnVoidWithAnonymousClass()
+{
+    new class {
+        /**
+         * @return integer
+         */
+        public function test()
+        {
+            return 1;
+        }
+    };
+}
+
+class TestReturnVoid
+{
+    /**
+     * @return void
+     */
+    public function test()
+    {
+        function () {
+            return 4;
+        };
+    }
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -898,3 +898,36 @@ function audio(
 {
     return 'test';
 }
+
+/**
+ * Test function
+ *
+ * @return array
+ */
+function returnArrayWithClosure()
+{
+    function () {
+        return;
+    };
+
+    return [];
+}
+
+/**
+ * Test function
+ *
+ * @return array
+ */
+function returnArrayWithAnonymousClass()
+{
+    new class {
+        /**
+         * @return void
+         */
+        public function test() {
+            return;
+        }
+    };
+
+    return [];
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -931,3 +931,42 @@ function returnArrayWithAnonymousClass()
 
     return [];
 }
+
+/**
+ * @return void
+ */
+function returnVoidWithClosure()
+{
+    function () {
+        return 1;
+    };
+}
+
+/**
+ * @return void
+ */
+function returnVoidWithAnonymousClass()
+{
+    new class {
+        /**
+         * @return integer
+         */
+        public function test()
+        {
+            return 1;
+        }
+    };
+}
+
+class TestReturnVoid
+{
+    /**
+     * @return void
+     */
+    public function test()
+    {
+        function () {
+            return 4;
+        };
+    }
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -898,3 +898,36 @@ function audio(
 {
     return 'test';
 }
+
+/**
+ * Test function
+ *
+ * @return array
+ */
+function returnArrayWithClosure()
+{
+    function () {
+        return;
+    };
+
+    return [];
+}
+
+/**
+ * Test function
+ *
+ * @return array
+ */
+function returnArrayWithAnonymousClass()
+{
+    new class {
+        /**
+         * @return void
+         */
+        public function test() {
+            return;
+        }
+    };
+
+    return [];
+}


### PR DESCRIPTION
Please see #1550 for more information and see tests.