### PR TITLE
Improve compatibility of Windows BAT files

### DIFF
--- a/bin/phpcbf.bat
+++ b/bin/phpcbf.bat
@@ -5,10 +5,8 @@ REM @author    Greg Sherwood <gsherwood@squiz.net>
 REM @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
 REM @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
 
-if "%PHPBIN%" == "" set PHPBIN=@php_bin@
-if not exist "%PHPBIN%" if "%PHP_PEAR_PHP_BIN%" neq "" goto USE_PEAR_PATH
-GOTO RUN
-:USE_PEAR_PATH
-set PHPBIN=%PHP_PEAR_PHP_BIN%
-:RUN
-"%PHPBIN%" "@bin_dir@\phpcbf" %*
+if "%PHP_PEAR_PHP_BIN%" neq "" (
+    set PHPBIN=%PHP_PEAR_PHP_BIN%
+) else set PHPBIN=php
+
+"%PHPBIN%" "%~dp0\phpcbf" %*

--- a/bin/phpcs.bat
+++ b/bin/phpcs.bat
@@ -5,10 +5,8 @@ REM @author    Greg Sherwood <gsherwood@squiz.net>
 REM @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
 REM @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
 
-if "%PHPBIN%" == "" set PHPBIN=@php_bin@
-if not exist "%PHPBIN%" if "%PHP_PEAR_PHP_BIN%" neq "" goto USE_PEAR_PATH
-GOTO RUN
-:USE_PEAR_PATH
-set PHPBIN=%PHP_PEAR_PHP_BIN%
-:RUN
-"%PHPBIN%" "@bin_dir@\phpcs" %*
+if "%PHP_PEAR_PHP_BIN%" neq "" (
+    set PHPBIN=%PHP_PEAR_PHP_BIN%
+) else set PHPBIN=php
+
+"%PHPBIN%" "%~dp0\phpcs" %*


### PR DESCRIPTION
The batch files didn't work for me because neither of those `@var_names@` existed (frankly I don't even know that syntax). I found several blog posts online about how to "fix" this by editing the bat file, but I figured it would be nice if this was simply included in this repository. Better out-of-the-box compatibility, yay!

So I extended the .bat files to support both the original logic, and the situation where "php" is available in the Environment Variables in Windows, which I believe is usually recommended to do. 

(Further, I think `@bin_dir@` is actually never required because we can use %~dp0, but I decided not to touch the orginal logic more than needed)