### PR TITLE
2.x: Squiz/EmbeddedPHP sniff - prevent fixer conflict

### DIFF
--- a/CodeSniffer/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/CodeSniffer/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -384,6 +384,10 @@ class Squiz_Sniffs_PHP_EmbeddedPhpSniff implements PHP_CodeSniffer_Sniff
         $trailingSpace = 0;
         if ($tokens[($closeTag - 1)]['code'] === T_WHITESPACE) {
             $trailingSpace = strlen($tokens[($closeTag - 1)]['content']);
+        } else if ($tokens[($closeTag - 1)]['code'] === T_COMMENT
+            && substr($tokens[($closeTag - 1)]['content'], -1) === ' '
+        ) {
+            $trailingSpace = (strlen($tokens[($closeTag - 1)]['content']) - strlen(rtrim($tokens[($closeTag - 1)]['content'])));
         }
 
         if ($trailingSpace !== 1) {
@@ -393,6 +397,8 @@ class Squiz_Sniffs_PHP_EmbeddedPhpSniff implements PHP_CodeSniffer_Sniff
             if ($fix === true) {
                 if ($trailingSpace === 0) {
                     $phpcsFile->fixer->addContentBefore($closeTag, ' ');
+                } else if ($tokens[($closeTag - 1)]['code'] === T_COMMENT) {
+                    $phpcsFile->fixer->replaceToken(($closeTag - 1), rtrim($tokens[($closeTag - 1)]['content']).' ');
                 } else {
                     $phpcsFile->fixer->replaceToken(($closeTag - 1), ' ');
                 }

--- a/CodeSniffer/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
+++ b/CodeSniffer/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
@@ -107,3 +107,7 @@ function foo()
 
 <?php if ($foo) { ?>
 <?php } ?>
+
+<?php echo 'oops'; // Something. ?>
+<?php echo 'oops'; // Something.      ?>
+<?php echo 'oops'; // Something.?>

--- a/CodeSniffer/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
+++ b/CodeSniffer/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
@@ -107,3 +107,7 @@ function foo()
 
 <?php if ($foo) { ?>
 <?php } ?>
+
+<?php echo 'oops'; // Something. ?>
+<?php echo 'oops'; // Something. ?>
+<?php echo 'oops'; // Something. ?>

--- a/CodeSniffer/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/CodeSniffer/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -68,6 +68,8 @@ class Squiz_Tests_PHP_EmbeddedPhpUnitTest extends AbstractSniffUnitTest
                 94  => 2,
                 100 => 1,
                 102 => 1,
+                112 => 1,
+                113 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
The `Squiz.PHP.EmbeddedPhp` sniff will create a fixer conflict with itself when it encounters a `//` comment just before the PHP close tag.

The tokenizer will tokenize whitespace at the end of a `//` comment as part of the `T_COMMENT` token, so the fixer just keeps adding more spaces between the `T_COMMENT` and the `T_CLOSE_TAG` which in the next fixer round is then tokenized again as being part of the `T_COMMENT` resulting in the loop.