### PR TITLE
Patch/fix config exception handling

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -12,6 +12,7 @@
 
 namespace PHP_CodeSniffer;
 
+use Exception;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 
@@ -1556,7 +1557,8 @@ class Config
             $output .= "\n?".'>';
 
             if (file_put_contents($configFile, $output) === false) {
-                return false;
+                $error = 'Failed to write to config file '.$configFile;
+                throw new RuntimeException($error);
             }
         }
 
@@ -1601,6 +1603,10 @@ class Config
         }
 
         include $configFile;
+        if (false === isset($phpCodeSnifferConfig)) {
+            $phpCodeSnifferConfig = null;
+        }
+
         self::$configData = $phpCodeSnifferConfig;
         return self::$configData;
 

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -32,6 +32,7 @@ if (is_file(__DIR__.'/../../autoload.php') === true) {
 $tokens = new Tokens();
 
 require_once 'IsCamelCapsTest.php';
+require_once 'ConfigTest.php';
 require_once 'ErrorSuppressionTest.php';
 require_once 'File/GetMethodParametersTest.php';
 require_once 'File/FindExtendedClassNameTest.php';
@@ -62,6 +63,7 @@ class AllTests
     {
         $suite = new \PHPUnit_Framework_TestSuite('PHP CodeSniffer Core');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\IsCamelCapsTest');
+        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\ConfigTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\ErrorSuppressionTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodParametersTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindExtendedClassNameTest');

--- a/tests/Core/ConfigTest.php
+++ b/tests/Core/ConfigTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Tests for \PHP_CodeSniffer\Config
+ *
+ * @author    Tom Klingenberg <ktomk@users.github.com>
+ * @copyright 2017 Contributors
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core;
+
+use PHP_CodeSniffer\Config;
+
+class ConfigTest extends \PHPUnit_Framework_TestCase
+{
+
+
+    /**
+     * Flag config-file existence
+     *
+     * @var boolean
+     */
+    private $configExisted;
+
+
+    /**
+     * Configuration file path
+     *
+     * @var string
+     */
+    private $configFile;
+
+    /**
+     * Configuration file permissions
+     *
+     * @var null|int
+     */
+    private $configPerms;
+
+
+    /**
+     * Test set up
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->configFile    = $this->getConfigPath();
+        $this->configExisted = file_exists($this->configFile);
+        if (true === $this->configExisted) {
+            $this->configPerms = fileperms($this->configFile);
+        }
+
+        parent::setUp();
+
+    }//end setUp()
+
+
+    /**
+     * Test tear down
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+
+        $fileExists = file_exists($this->configFile);
+        if (true === $fileExists && null !== $this->configPerms) {
+            chmod($this->configFile, ($this->configPerms & 0777));
+        }
+
+        if (false === $this->configExisted && true === $fileExists) {
+            unlink($this->configFile);
+        }
+
+        parent::tearDown();
+
+    }//end tearDown()
+
+
+    /**
+     * Test read-only config file throws a RuntimeException
+     *
+     * @return void
+     */
+    public function testReadonlyConfigThrowsPhpCodeSnifferRuntimeException()
+    {
+        $exception = $this->readonlyConfig(
+            function () {
+                Config::setConfigData('foo', 'bar');
+            }
+        );
+
+        $this->assertInstanceOf(
+            'PHP_CodeSniffer\Exceptions\RuntimeException',
+            $exception,
+            'Expected exception class'
+        );
+
+    }//end testReadonlyConfigThrowsPhpCodeSnifferRuntimeException()
+
+
+    /**
+     * Test read-only config file throws a RuntimeException
+     *
+     * @return void
+     */
+    public function testReadonlyConfigSettingValue()
+    {
+        $exception = $this->readonlyConfig(
+            function () {
+                $args = array(
+                         '--config-set',
+                         'foo',
+                         'bar',
+                        );
+                new Config($args);
+            }
+        );
+
+        $this->assertNotNull(
+            $exception,
+            'An expected exception was not thrown'
+        );
+
+        $this->assertInstanceOf(
+            'PHP_CodeSniffer\Exceptions\DeepExitException',
+            $exception
+        );
+
+    }//end testReadonlyConfigSettingValue()
+
+
+    /**
+     * Make callback operate on a read-only config file, helper function
+     * for tests.
+     *
+     * @param callable $callback to be run with a readonly config
+     *
+     * @return NULL|\Exception
+     */
+    private function readonlyConfig($callback)
+    {
+        if (true === defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Test not valid for windows');
+        }
+
+        $file = $this->getConfigPath();
+
+        if (false === file_exists($this->configFile)) {
+            touch($file);
+        }
+
+        $this->assertFileExists(
+            $this->configFile,
+            'precondition: config file exists'
+        );
+        $this->assertTrue(
+            is_writable($this->configFile),
+            'precondition: config file is writable'
+        );
+
+        $result = fileperms($this->configFile);
+
+        $savedPermission = ($result & 0777);
+
+        $this->assertInternalType(
+            'int',
+            $result,
+            'precondition: fileperms available'
+        );
+
+        $this->assertTrue(
+            chmod($this->configFile, 0444),
+            'precondition: read-only config file'
+        );
+
+        $exception = null;
+        try {
+            call_user_func($callback);
+        } catch (\Exception $exception) {
+            // Fall-through intended.
+        }
+
+        chmod($this->configFile, $savedPermission);
+
+        return $exception;
+
+    }//end readonlyConfig()
+
+
+    /**
+     * Get path of the configuration file.
+     *
+     * @return string
+     */
+    private function getConfigPath()
+    {
+        return __DIR__.'/../../CodeSniffer.conf';
+
+    }//end getConfigPath()
+
+
+}//end class


### PR DESCRIPTION
While getting my own hands dirty with PHP Code Sniffer after a longer period of time, I stumbled over some things I'd like to address in this PR.

Please see the individual commit messages for a description of each, the commits are isolated by topic, but each commit should work clean on itself on top of master.

- fix config exception handling - little bug not importing the \Exception class
- add bootstrap file to phpunit configuration (extracted from the existing test-code)
- update on the contribution guide while I stumbled over it
- a single minor docblock class typehint while I stumbled over it in step-debugging within Phpstorm

