### PR TITLE
Only include the custom autoload file once.

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -341,7 +341,7 @@ class Ruleset
                 throw new RuntimeException('The specified autoload file "'.$autoload.'" does not exist');
             }
 
-            include $autoloadPath;
+            include_once $autoloadPath;
 
             if (PHP_CODESNIFFER_VERBOSITY > 1) {
                 echo str_repeat("\t", $depth);


### PR DESCRIPTION
I was running into trouble with a library containing several standards which all use the same custom autoload file, resulting in fatal `class already declared` errors for the autoloader class.

This simple change fixes that.