### PR TITLE
Patch Wrong sniff codes with "special namespace"

### DIFF
--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -444,6 +444,19 @@ class Common
             return $newName;
         }
 
+        // Handle special namespace.
+        $namespace = substr($newName, 0, $sniffPos);
+        $standard  = strtolower(Standards::getStandardOfNamespace($namespace));
+        $newName   = str_replace($namespace, $standard, $newName);
+
+        // Sniff-Pos might have changed.
+        $sniffPos = strrpos($newName, '\sniffs\\');
+        if ($sniffPos === false) {
+            // Nothing we can do as it isn't in a known format.
+            return $newName;
+        }
+
+        // Handle long namespace.
         $end   = (strlen($newName) - $sniffPos + 1);
         $start = strrpos($newName, '\\', ($end * -1));
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Util;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Util\Standards;
 
 class Common
 {
@@ -416,10 +417,11 @@ class Common
             $sniff = substr($sniff, 0, -8);
         }
 
-        $category = array_pop($parts);
-        $sniffDir = array_pop($parts);
-        $standard = array_pop($parts);
-        $code     = $standard.'.'.$category.'.'.$sniff;
+        $category  = array_pop($parts);
+        $sniffDir  = array_pop($parts);
+        $namespace = implode('\\', $parts);
+        $standard  = Standards::getStandardOfNamespace($namespace);
+        $code      = $standard.'.'.$category.'.'.$sniff;
         return $code;
 
     }//end getSniffCode()

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -332,13 +332,14 @@ class Standards
         if (self::$namespaceStandardArray === null) {
             $standardDetails = self::getInstalledStandardDetails(true);
             foreach ($standardDetails as $standardName => $details) {
-                $standardNamespace = $details['namespace'];
+                $standardNamespace = strtolower($details['namespace']);
                 self::$namespaceStandardArray[$standardNamespace] = $standardName;
             }
         }
 
-        if (isset(self::$namespaceStandardArray[$namespace]) === true) {
-            return self::$namespaceStandardArray[$namespace];
+        $lowerNamespace = strtolower($namespace);
+        if (isset(self::$namespaceStandardArray[$lowerNamespace]) === true) {
+            return self::$namespaceStandardArray[$lowerNamespace];
         } else {
             $parts = explode('\\', $namespace);
             return array_pop($parts);

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -16,6 +16,15 @@ class Standards
 
 
     /**
+     * Saves the namespaces of the found standards and their short names.
+     * ['Generic' => 'Generic', 'Rhorber\PHPCS\Standard' => 'Rhorber', ...]
+     *
+     * @var array
+     */
+    private static $namespaceStandardArray = null;
+
+
+    /**
      * Get a list paths where standards are installed.
      *
      * @return array
@@ -309,6 +318,33 @@ class Standards
         }
 
     }//end printInstalledStandards()
+
+
+    /**
+     * Returns a standard's name for the given namespace.
+     *
+     * @param string $namespace The namespace to search the standard name for.
+     *
+     * @return string
+     */
+    public static function getStandardOfNamespace($namespace)
+    {
+        if (self::$namespaceStandardArray === null) {
+            $standardDetails = self::getInstalledStandardDetails(true);
+            foreach ($standardDetails as $standardName => $details) {
+                $standardNamespace = $details['namespace'];
+                self::$namespaceStandardArray[$standardNamespace] = $standardName;
+            }
+        }
+
+        if (isset(self::$namespaceStandardArray[$namespace]) === true) {
+            return self::$namespaceStandardArray[$namespace];
+        } else {
+            $parts = explode('\\', $namespace);
+            return array_pop($parts);
+        }
+
+    }//end getStandardOfNamespace()
 
 
 }//end class


### PR DESCRIPTION
It is possible to use a namespace other than `StandardName\Sniffs`, i.e. `MyProject\PHPCS\Standard\Sniffs`. But then the sniff codes look like `Standard.Category.Code`, which imho is wrong.
This PR takes care of this situation. The gathered namespaces are saved with their standard name. When a sniff code is requested, it will be looked up with the namespace and then this name will be returned (not just a namespace level).

Edit/Addendum:
Probably its not the best solution with a static property, but I do not know the internas very well ;)
So feel free to adjust/correct things, as you like.