### PR TITLE
Squiz.WhiteSpace.LanguageConstructSpacing does not properly check for tabs and newlines

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -51,6 +51,11 @@ class LanguageConstructSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        if (isset($tokens[($stackPtr + 1)]) === false) {
+            // Skip if there is no next token.
+            return;
+        }
+
         if ($tokens[($stackPtr + 1)]['code'] === T_SEMICOLON) {
             // No content for this language construct.
             return;

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -65,7 +65,7 @@ class LanguageConstructSpacingSniff implements Sniff
             $content = $tokens[($stackPtr + 1)]['content'];
             if ($content !== ' ') {
                 $error = 'Language constructs must be followed by a single space; expected 1 space but found "%s"';
-                $data  = array($tokenContent = Util\Common::prepareForOutput($content));
+                $data  = array(Util\Common::prepareForOutput($content));
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'IncorrectSingle', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util;
 
 class LanguageConstructSpacingSniff implements Sniff
 {
@@ -56,11 +57,10 @@ class LanguageConstructSpacingSniff implements Sniff
         }
 
         if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-            $content       = $tokens[($stackPtr + 1)]['content'];
-            $contentLength = strlen($content);
-            if ($contentLength !== 1) {
-                $error = 'Language constructs must be followed by a single space; expected 1 space but found %s';
-                $data  = array($contentLength);
+            $content = $tokens[($stackPtr + 1)]['content'];
+            if ($content !== ' ') {
+                $error = 'Language constructs must be followed by a single space; expected 1 space but found "%s"';
+                $data  = array($tokenContent = Util\Common::prepareForOutput($content));
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'IncorrectSingle', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
@@ -30,3 +30,7 @@ return;
 return $blah;
 return   $blah;
 return($blah);
+
+return	$tab;
+return
+$newLine;

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
@@ -34,3 +34,6 @@ return($blah);
 return	$tab;
 return
 $newLine;
+
+// The following line must be the last line in the file
+return

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
@@ -35,5 +35,9 @@ return	$tab;
 return
 $newLine;
 
+// The following line must have a single space at the end (after return)
+return 
+$spaceAndNewLine;
+
 // The following line must be the last line in the file
 return

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
@@ -30,3 +30,6 @@ return;
 return $blah;
 return $blah;
 return($blah);
+
+return $tab;
+return $newLine;

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
@@ -34,5 +34,8 @@ return($blah);
 return $tab;
 return $newLine;
 
+// The following line must have a single space at the end (after return)
+return $spaceAndNewLine;
+
 // The following line must be the last line in the file
 return

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
@@ -33,3 +33,6 @@ return($blah);
 
 return $tab;
 return $newLine;
+
+// The following line must be the last line in the file
+return

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -34,6 +34,8 @@ class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
                 23 => 1,
                 27 => 1,
                 31 => 1,
+                34 => 1,
+                35 => 1,
                );
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -36,6 +36,7 @@ class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
                 31 => 1,
                 34 => 1,
                 35 => 1,
+                39 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
As we discussed in https://github.com/squizlabs/PHP_CodeSniffer/pull/1337#discussion_r129082516 I've created this PR to issues noted in PR #1337 