### PR TITLE
Sniffs not loaded when one-standard directories are being registered in `installed_paths`

### DIFF
--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -255,16 +255,26 @@ class Standards
      * CodeSniffer/Standards directory. Valid coding standards
      * include a ruleset.xml file.
      *
-     * @param string $standard The name of the coding standard.
+     * @param string|\SimpleXMLElement $standard The name of the coding standard.
      *
      * @return string|null
      */
     public static function getInstalledStandardPath($standard)
     {
         $installedPaths = self::getInstalledStandardPaths();
+        $standard       = (string) $standard;
+
+        if (strpos($standard, '.') !== false) {
+            return null;
+        }
+
         foreach ($installedPaths as $installedPath) {
             $standardPath = $installedPath.DIRECTORY_SEPARATOR.$standard;
-            if (file_exists($standardPath) === false && basename($installedPath) === $standard) {
+            if (file_exists($standardPath) === false) {
+                if (basename($installedPath) !== (string) $standard) {
+                    continue;
+                }
+
                 $standardPath = $installedPath;
             }
 
@@ -278,7 +288,7 @@ class Standards
                     return $path;
                 }
             }
-        }
+        }//end foreach
 
         return null;
 


### PR DESCRIPTION
If any external standard or a custom ruleset refers to a complete standard and this standard is registered in the `installed_paths` config as a one-standard directory, a `Reference sniff ...  does not exist` error will be thrown and no sniffs will be run.

Bug introduced in #1450 (by me, sorry!).

The reason for this is that the `getInstalledStandardPath()` method expects a string, but will in actual fact receive a `SimpleXMLElement` object when a complete standard is included by  another standard. This was previously not documented in the function doc block as a possibility.

While in the original code, the `$standards` name was only used as a concatenated string - which  triggered the `SimpleXML.toString()` method -, the fix in #1450 introduced a strict comparison  without the `toString()` conversion, causing the bug.

Installed_paths | string `$standards` | SimpleXMLElement `$standards`
--------------- | ------------------- | ----------------------
"Standards" directory | :white_check_mark: | :white_check_mark:
one-standard directory | :white_check_mark: | :x: <= This is what this fixes.

While debugging this, I also noticed that this method is called for every single ref in the  ruleset and would go through the whole loop before returning `null`, while for `refs` which  refer to a custom xml ruleset or to a sniff or sniff category, `null` can be returned a lot  earlier and for paths which don't resolve to a ruleset, part of the loop can be skipped.

-------
### Testing the fix:

Using the [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/) as an example to demonstrate what I mean, set `installed_paths` like so:
`phpcs --config-set installed_paths /path/to/WordPressCS/WordPress,/path/to/WordPressCS/WordPress-Core,/path/to/WordPressCS/WordPress-Docs,/path/to/WordPressCS/WordPress-Extra,/path/to/WordPressCS/WordPress-VIP`

Custom ruleset `test.xml`:
```xml
<?xml version="1.0"?>
<ruleset name="Test">
	<rule ref="WordPress-Core"/>
</ruleset>
```

Then run PHPCS against any file:
`phpcs ./test-file.php --standard=test.xml` 