### PR TITLE
Fixes the return codes for PHPCBF.

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -149,7 +149,7 @@ class Runner
     /**
      * Run the PHPCBF script.
      *
-     * @return array
+     * @return int
      */
     public function runPHPCBF()
     {
@@ -200,25 +200,18 @@ class Runner
             return $e->getCode();
         }//end try
 
-        if ($this->reporter->totalFixed === 0) {
-            // Nothing was fixed by PHPCBF.
-            if ($this->reporter->totalFixable === 0) {
-                // Nothing found that could be fixed.
-                return 0;
-            } else {
-                // Something failed to fix.
-                return 2;
-            }
+        if ($this->reporter->totalFixable === 0) {
+            // Nothing found that could be fixed.
+            return 0;
         }
 
-        if ($this->reporter->totalFixable === 0) {
+        if ($this->reporter->totalFixed === $this->reporter->totalFixable) {
             // PHPCBF fixed all fixable errors.
             return 1;
         }
 
-        // PHPCBF fixed some fixable errors, but others failed to fix.
+        // Something failed to fix.
         return 2;
-
     }//end runPHPCBF()
 
 


### PR DESCRIPTION
At the moment the logic for the return code is a bit confusing and there is a logical mistake in the `if`s:
```
/** line 203 **/ if ($this->reporter->totalFixed === 0) {
```
If this is `false`, meaning that the total fixed are greater than `0` there is no chance at all that  that this can be `true`:

```
/**line 214 **/ if ($this->reporter->totalFixable === 0) {
```
as of `$this->reporter->totalFixable >= $this->reporter->totalFixed` by definition.

Ping @gsherwood @jrfnl