### PR TITLE
Fix `<exclude-pattern>` in PHPCS native ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,7 +7,7 @@
  <file>src</file>
  <file>tests</file>
 
- <exclude-pattern>*/Standards/*/Tests/*.(inc|css|js)</exclude-pattern>
+ <exclude-pattern>*/Standards/*/Tests/*\.(inc|css|js)</exclude-pattern>
 
  <arg name="basepath" value="."/>
  <arg name="colors" />

--- a/src/Standards/MySource/Tests/Channels/IncludeSystemUnitTest.php
+++ b/src/Standards/MySource/Tests/Channels/IncludeSystemUnitTest.php
@@ -58,5 +58,3 @@ class IncludeSystemUnitTest extends AbstractSniffUnitTest
 
 
 }//end class
-
-?>

--- a/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
+++ b/src/Standards/PEAR/Tests/Files/IncludingFileUnitTest.php
@@ -65,5 +65,3 @@ class IncludingFileUnitTest extends AbstractSniffUnitTest
 
 
 }//end class
-
-?>

--- a/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
@@ -63,5 +63,3 @@ class JSLintUnitTest extends AbstractSniffUnitTest
 
 
 }//end class
-
-?>

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -56,5 +56,3 @@ class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
 
 
 }//end class
-
-?>


### PR DESCRIPTION
See issue #1592 for the rationale.

And apparently the file I was testing wasn't the only one being accidentally excluded, so fixed the minor code style issues being thrown up for previously excluded files in a separate commit.