### PR TITLE
Add new `AssignmentInCondition` sniff to `Generic`

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -167,6 +167,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureStandard.xml" role="php" />
        </dir>
        <dir name="CodeAnalysis">
+        <file baseinstalldir="PHP/CodeSniffer" name="AssignmentInConditionStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStatementStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopShouldBeWhileLoopStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopWithTestFunctionCallStandard.xml" role="php" />
@@ -242,6 +243,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="OpeningBraceSameLineSniff.php" role="php" />
        </dir>
        <dir name="CodeAnalysis">
+        <file baseinstalldir="PHP/CodeSniffer" name="AssignmentInConditionSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStatementSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopShouldBeWhileLoopSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopWithTestFunctionCallSniff.php" role="php" />
@@ -348,6 +350,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="OpeningBraceSameLineUnitTest.php" role="test" />
        </dir>
        <dir name="CodeAnalysis">
+        <file baseinstalldir="PHP/CodeSniffer" name="AssignmentInConditionUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="AssignmentInConditionUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStatementUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStatementUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopShouldBeWhileLoopUnitTest.inc" role="test" />

--- a/src/Standards/Generic/Docs/CodeAnalysis/AssignmentInConditionStandard.xml
+++ b/src/Standards/Generic/Docs/CodeAnalysis/AssignmentInConditionStandard.xml
@@ -1,0 +1,23 @@
+<documentation title="Assignment In Condition">
+    <standard>
+    <![CDATA[
+    Variable assignments should not be made within conditions.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: A variable comparison being executed within a condition.">
+        <![CDATA[
+if (<em>$test === 'abc'</em>) {
+    // Code.
+}
+        ]]>
+        </code>
+        <code title="Invalid: A variable assignment being made within a condition.">
+        <![CDATA[
+if (<em>$test = 'abc'</em>) {
+    // Code.
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Detects variable assignments being made within conditions.
+ *
+ * This is a typical code smell and more often than not a comparison was intended.
+ *
+ * Note: this sniff does not detect variable assignments in the conditional part of ternaries!
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class AssignmentInConditionSniff implements Sniff
+{
+
+
+    /**
+     * Assignment tokens to trigger on.
+     *
+     * Set in the register() method.
+     *
+     * @var array
+     */
+    protected $assignmentTokens = array();
+
+    /**
+     * The tokens that indicate the start of a condition.
+     *
+     * @var array
+     */
+    protected $conditionStartTokens = array();
+
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        $this->assignmentTokens = Tokens::$assignmentTokens;
+        unset($this->assignmentTokens[T_DOUBLE_ARROW]);
+
+        $starters = Tokens::$booleanOperators;
+        $starters[T_SEMICOLON]        = T_SEMICOLON;
+        $starters[T_OPEN_PARENTHESIS] = T_OPEN_PARENTHESIS;
+
+        $this->conditionStartTokens = $starters;
+
+        return array(
+                T_IF,
+                T_ELSEIF,
+                T_FOR,
+                T_SWITCH,
+                T_CASE,
+                T_WHILE,
+               );
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $token  = $tokens[$stackPtr];
+
+        // Find the condition opener/closer.
+        if ($token['code'] === T_FOR) {
+            if (isset($token['parenthesis_opener'], $token['parenthesis_closer']) === false) {
+                return;
+            }
+
+            $semicolon = $phpcsFile->findNext(T_SEMICOLON, ($token['parenthesis_opener'] + 1), ($token['parenthesis_closer']));
+            if ($semicolon === false) {
+                return;
+            }
+
+            $opener = $semicolon;
+
+            $semicolon = $phpcsFile->findNext(T_SEMICOLON, ($opener + 1), ($token['parenthesis_closer']));
+            if ($semicolon === false) {
+                return;
+            }
+
+            $closer = $semicolon;
+            unset($semicolon);
+        } else if ($token['code'] === T_CASE) {
+            if (isset($token['scope_opener']) === false) {
+                return;
+            }
+
+            $opener = $stackPtr;
+            $closer = $token['scope_opener'];
+        } else {
+            if (isset($token['parenthesis_opener'], $token['parenthesis_closer']) === false) {
+                return;
+            }
+
+            $opener = $token['parenthesis_opener'];
+            $closer = $token['parenthesis_closer'];
+        }//end if
+
+        $startPos = $opener;
+
+        do {
+            $hasAssignment = $phpcsFile->findNext($this->assignmentTokens, ($startPos + 1), $closer);
+            if ($hasAssignment === false) {
+                return;
+            }
+
+            // Examine whether the left side is a variable.
+            $hasVariable       = false;
+            $conditionStart    = $startPos;
+            $altConditionStart = $phpcsFile->findPrevious($this->conditionStartTokens, ($hasAssignment - 1), $startPos);
+            if ($altConditionStart !== false) {
+                $conditionStart = $altConditionStart;
+            }
+
+            for ($i = $hasAssignment; $i > $conditionStart; $i--) {
+                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                    continue;
+                }
+
+                // If this is a variable or array, we've seen all we need to see.
+                if ($tokens[$i]['code'] === T_VARIABLE || $tokens[$i]['code'] === T_CLOSE_SQUARE_BRACKET) {
+                    $hasVariable = true;
+                    break;
+                }
+
+                // If this is a function call or something, we are OK.
+                if ($tokens[$i]['code'] === T_CLOSE_PARENTHESIS) {
+                    break;
+                }
+            }
+
+            if ($hasVariable === true) {
+                $phpcsFile->addWarning(
+                    'Variable assignment found within a condition. Did you mean to do a comparison ?',
+                    $hasAssignment,
+                    'Found'
+                );
+            }
+
+            $startPos = $hasAssignment;
+        } while ($startPos < $closer);
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
@@ -1,0 +1,93 @@
+<?php
+
+// OK.
+if ($a === 123) {
+} elseif ($a == 123) {
+} elseif ($a !== 123) {
+} elseif ($a != 123) {}
+
+function abc( $a = 'default' ) {}
+if (in_array( $a, array( 1 => 'a', 2 => 'b' ) ) ) {}
+
+switch ( $a === $b ) {}
+switch ( true ) {
+	case $sample == 'something':
+		break;
+}
+
+for ( $i = 0; $i == 100; $i++ ) {}
+for ( $i = 0; $i >= 100; $i++ ) {}
+for ( $i = 0; ; $i++ ) {}
+for (;;) {}
+
+do {
+} while ( $sample == false );
+
+while ( $sample === false ) {}
+
+ // Silly, but not an assignment.
+if (123 = $a) {}
+if (strtolower($b) = $b) {}
+if (array( 1 => 'a', 2 => 'b' ) = $b) {}
+
+if (SOME_CONSTANT = 123) {
+} else if(self::SOME_CONSTANT -= 10) {}
+
+if ( $a() = 123 ) {
+} else if ( $b->something() = 123 ) {
+} elseif ( $c::something() = 123 ) {}
+
+switch ( true ) {
+	case 'something' = $sample:
+		break;
+}
+
+// Assignments in condition.
+if ($a = 123) {
+} elseif ($a = 'abc') {
+} else if( $a += 10 ) {
+} else if($a -= 10) {
+} else if($a *= 10) {
+} else if($a **= 10) {
+} else if($a /= 10) {
+} else if($a .= strtolower($b)) {
+} else if($a %= SOME_CONSTANT) {
+} else if($a &= 2) {
+} else if($a |= 2) {
+} else if($a ^= 2) {
+} else if($a <<= 2) {
+} else if($a >>= 2) {
+} else if($a ??= $b) {
+} elseif( $a = 'abc' && $b = 'def' ) {
+} elseif(
+    $a = 'abc'
+	&& $a .= 'def'
+) {}
+
+if ($a[] = 123) {
+} elseif ($a['something'] = 123) {
+} elseif (self::$a = 123) {
+} elseif (parent::$a *= 123) {
+} elseif (static::$a = 123) {
+} elseif (MyClass::$a .= 'abc') {
+} else if( $this->something += 10 ) {}
+
+switch ( $a = $b ) {}
+switch ( true ) {
+	case $sample = 'something':
+		break;
+
+	case $sample = 'something' && $a = $b:
+		break;
+}
+
+for ( $i = 0; $i = 100; $i++ ) {}
+for ( $i = 0; $i = 100 && $b = false; $i++ ) {}
+
+do {
+} while ( $sample = false );
+
+while ( $sample = false ) {}
+
+if ($a = 123) :
+endif;

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Unit test class for the AssignmentInCondition sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class AssignmentInConditionUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array();
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array(
+                46 => 1,
+                47 => 1,
+                48 => 1,
+                49 => 1,
+                50 => 1,
+                51 => 1,
+                52 => 1,
+                53 => 1,
+                54 => 1,
+                55 => 1,
+                56 => 1,
+                57 => 1,
+                58 => 1,
+                59 => 1,
+                60 => 1,
+                61 => 2,
+                63 => 1,
+                64 => 1,
+                67 => 1,
+                68 => 1,
+                69 => 1,
+                70 => 1,
+                71 => 1,
+                72 => 1,
+                73 => 1,
+                75 => 1,
+                77 => 1,
+                80 => 2,
+                84 => 1,
+                85 => 2,
+                88 => 1,
+                90 => 1,
+                92 => 1,
+               );
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Most of the time variable assignments being made in conditions are unintentional and are in actual fact typos which were intended as a comparison.

This sniff will warn when any such a variable assignment is found in a condition.

Note: the sniff does currently **not** detect variable assignments in the conditional part of ternaries.

Includes extensive unit tests.

Inspired by [this twitter thread](https://twitter.com/jrf_nl/status/893891839903838209), or rather: the responses I received to my tweet.