### PR TITLE
Squiz/OperatorSpacing: fix false positive on unary minus after comment.

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -169,7 +169,7 @@ class OperatorSpacingSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_MINUS || $tokens[$stackPtr]['code'] === T_PLUS) {
             // Check minus spacing, but make sure we aren't just assigning
             // a minus value or returning one.
-            $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if ($tokens[$prev]['code'] === T_RETURN) {
                 // Just returning a negative value; eg. (return -1).
                 return;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -201,3 +201,12 @@ $res = $a  ? : $b;
 $res = $a  ? :  $b;
 
 function foo(string $a = '', ?string $b = ''): ?string {}
+
+// Issue #1605.
+$text = preg_replace_callback(
+		self::CHAR_REFS_REGEX,
+		[ 'Sanitizer', 'decodeCharReferencesCallback' ],
+		$text, /* limit */ -1, $count );
+
+if (true || /* test */ -1 == $b) {}
+$y = 10 + /* test */ -2;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -195,3 +195,12 @@ $res = $a ? : $b;
 $res = $a ? : $b;
 
 function foo(string $a = '', ?string $b = ''): ?string {}
+
+// Issue #1605.
+$text = preg_replace_callback(
+		self::CHAR_REFS_REGEX,
+		[ 'Sanitizer', 'decodeCharReferencesCallback' ],
+		$text, /* limit */ -1, $count );
+
+if (true || /* test */ -1 == $b) {}
+$y = 10 + /* test */ -2;


### PR DESCRIPTION
Changes (just and only) the code block which determines whether a minus sign is used as an operator or a unary, to use `$emptyTokens` instead of `T_WHITESPACE` for improved accuracy.

Includes unit tests.

Fixes #1605