### PR TITLE
Fix `File::isReference()` method

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -92,6 +92,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="FindImplementedInterfaceNamesTest.php" role="test" />
       <file baseinstalldir="" name="GetMethodParametersTest.inc" role="test" />
       <file baseinstalldir="" name="GetMethodParametersTest.php" role="test" />
+      <file baseinstalldir="" name="IsReference.inc" role="test" />
+      <file baseinstalldir="" name="IsReferenceTest.php" role="test" />
      </dir>
      <file baseinstalldir="" name="AllTests.php" role="test" />
      <file baseinstalldir="" name="ErrorSuppressionTest.php" role="test" />
@@ -1541,6 +1543,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/FindImplementedInterfaceNamesTest.inc" name="tests/Core/File/FindImplementedInterfaceNamesTest.inc" />
    <install as="CodeSniffer/Core/File/GetMethodParametersTest.php" name="tests/Core/File/GetMethodParametersTest.php" />
    <install as="CodeSniffer/Core/File/GetMethodParametersTest.inc" name="tests/Core/File/GetMethodParametersTest.inc" />
+   <install as="CodeSniffer/Core/File/IsReferenceTest.php" name="tests/Core/File/IsReferenceTest.php" />
+   <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
   </filelist>
@@ -1563,6 +1567,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/FindImplementedInterfaceNamesTest.inc" name="tests/Core/File/FindImplementedInterfaceNamesTest.inc" />
    <install as="CodeSniffer/Core/File/GetMethodParametersTest.php" name="tests/Core/File/GetMethodParametersTest.php" />
    <install as="CodeSniffer/Core/File/GetMethodParametersTest.inc" name="tests/Core/File/GetMethodParametersTest.inc" />
+   <install as="CodeSniffer/Core/File/IsReferenceTest.php" name="tests/Core/File/IsReferenceTest.php" />
+   <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
    <ignore name="bin/phpcs.bat" />

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1158,6 +1158,7 @@ class File
      * <code>
      *   0 => array(
      *         'name'              => '$var',  // The variable name.
+     *         'token'             => integer, // The stack pointer to the variable name.
      *         'content'           => string,  // The full content of the variable definition.
      *         'pass_by_reference' => boolean, // Is the variable passed by reference?
      *         'variable_length'   => boolean, // Is the param of variable length through use of `...` ?
@@ -1218,7 +1219,9 @@ class File
 
             switch ($this->tokens[$i]['code']) {
             case T_BITWISE_AND:
-                $passByReference = true;
+                if ($defaultStart === null) {
+                    $passByReference = true;
+                }
                 break;
             case T_VARIABLE:
                 $currVar = $i;

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1612,7 +1612,7 @@ class File
         }
 
         if ($this->tokens[$tokenBefore]['code'] === T_DOUBLE_ARROW) {
-            // Inside a foreach loop, this is a reference.
+            // Inside a foreach loop or array assignment, this is a reference.
             return true;
         }
 
@@ -1621,14 +1621,20 @@ class File
             return true;
         }
 
-        if ($this->tokens[$tokenBefore]['code'] === T_OPEN_SHORT_ARRAY) {
-            // Inside an array declaration, this is a reference.
-            return true;
-        }
-
         if (isset(Util\Tokens::$assignmentTokens[$this->tokens[$tokenBefore]['code']]) === true) {
             // This is directly after an assignment. It's a reference. Even if
             // it is part of an operation, the other tests will handle it.
+            return true;
+        }
+
+        $tokenAfter = $this->findNext(
+            Util\Tokens::$emptyTokens,
+            ($stackPtr + 1),
+            null,
+            true
+        );
+
+        if ($this->tokens[$tokenAfter]['code'] === T_NEW) {
             return true;
         }
 
@@ -1639,11 +1645,27 @@ class File
                 $owner = $this->tokens[$this->tokens[$lastBracket]['parenthesis_owner']];
                 if ($owner['code'] === T_FUNCTION
                     || $owner['code'] === T_CLOSURE
-                    || $owner['code'] === T_ARRAY
                 ) {
-                    // Inside a function or array declaration, this is a reference.
-                    return true;
-                }
+                    $params = $this->getMethodParameters($this->tokens[$lastBracket]['parenthesis_owner']);
+                    foreach ($params as $param) {
+                        $varToken = $tokenAfter;
+                        if ($param['variable_length'] === true) {
+                            $varToken = $this->findNext(
+                                (Util\Tokens::$emptyTokens + array(T_ELLIPSIS)),
+                                ($stackPtr + 1),
+                                null,
+                                true
+                            );
+                        }
+
+                        if ($param['token'] === $varToken
+                            && $param['pass_by_reference'] === true
+                        ) {
+                            // Function parameter declared to be passed by reference.
+                            return true;
+                        }
+                    }
+                }//end if
             } else {
                 $prev = false;
                 for ($t = ($this->tokens[$lastBracket]['parenthesis_opener'] - 1); $t >= 0; $t--) {
@@ -1654,24 +1676,40 @@ class File
                 }
 
                 if ($prev !== false && $this->tokens[$prev]['code'] === T_USE) {
+                    // Closure use by reference.
                     return true;
                 }
             }//end if
         }//end if
 
-        $tokenAfter = $this->findNext(
-            Util\Tokens::$emptyTokens,
-            ($stackPtr + 1),
-            null,
-            true
-        );
-
-        if ($this->tokens[$tokenAfter]['code'] === T_VARIABLE
-            && ($this->tokens[$tokenBefore]['code'] === T_OPEN_PARENTHESIS
-            || $this->tokens[$tokenBefore]['code'] === T_COMMA)
+        // Pass by reference in function calls and assign by reference in arrays.
+        if ($this->tokens[$tokenBefore]['code'] === T_OPEN_PARENTHESIS
+            || $this->tokens[$tokenBefore]['code'] === T_COMMA
+            || $this->tokens[$tokenBefore]['code'] === T_OPEN_SHORT_ARRAY
         ) {
-            return true;
-        }
+            if ($this->tokens[$tokenAfter]['code'] === T_VARIABLE) {
+                return true;
+            } else {
+                $skip   = Util\Tokens::$emptyTokens;
+                $skip[] = T_NS_SEPARATOR;
+                $skip[] = T_SELF;
+                $skip[] = T_PARENT;
+                $skip[] = T_STATIC;
+                $skip[] = T_STRING;
+                $skip[] = T_NAMESPACE;
+                $skip[] = T_DOUBLE_COLON;
+
+                $nextSignificantAfter = $this->findNext(
+                    $skip,
+                    ($stackPtr + 1),
+                    null,
+                    true
+                );
+                if ($this->tokens[$nextSignificantAfter]['code'] === T_VARIABLE) {
+                    return true;
+                }
+            }//end if
+        }//end if
 
         return false;
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -210,3 +210,10 @@ $text = preg_replace_callback(
 
 if (true || /* test */ -1 == $b) {}
 $y = 10 + /* test */ -2;
+
+// Issue #1604.
+Hooks::run( 'ParserOptionsRegister', [
+	&self::$defaults,
+	&self::$inCacheKey,
+	&self::$lazyOptions,
+] );

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -204,3 +204,10 @@ $text = preg_replace_callback(
 
 if (true || /* test */ -1 == $b) {}
 $y = 10 + /* test */ -2;
+
+// Issue #1604.
+Hooks::run( 'ParserOptionsRegister', [
+	&self::$defaults,
+	&self::$inCacheKey,
+	&self::$lazyOptions,
+] );

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -36,6 +36,7 @@ require_once 'ErrorSuppressionTest.php';
 require_once 'File/GetMethodParametersTest.php';
 require_once 'File/FindExtendedClassNameTest.php';
 require_once 'File/FindImplementedInterfaceNamesTest.php';
+require_once 'File/IsReferenceTest.php';
 
 class AllTests
 {
@@ -66,6 +67,7 @@ class AllTests
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodParametersTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindExtendedClassNameTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindImplementedInterfaceNamesTest');
+        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\IsReferenceTest');
         return $suite;
 
     }//end suite()

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -25,3 +25,6 @@ class MyClass {
 
 /* testNullableTypeHint */
 function nullableTypeHint(?int $var1, ?\bar $var2) {}
+
+/* testBitwiseAndConstantExpressionDefaultValue */
+function myFunction($a = 10 & 20) {}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -354,4 +354,38 @@ class GetMethodParametersTest extends \PHPUnit_Framework_TestCase
     }//end testDefaultValues()
 
 
+    /**
+     * Verify "bitwise and" in default value !== pass-by-reference.
+     *
+     * @return void
+     */
+    public function testBitwiseAndConstantExpressionDefaultValue()
+    {
+        $expected    = array();
+        $expected[0] = array(
+                        'name'              => '$a',
+                        'content'           => '$a = 10 & 20',
+                        'default'           => '10 & 20',
+                        'pass_by_reference' => false,
+                        'variable_length'   => false,
+                        'type_hint'         => '',
+                        'nullable_type'     => false,
+                       );
+
+        $start    = ($this->phpcsFile->numTokens - 1);
+        $function = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testBitwiseAndConstantExpressionDefaultValue */'
+        );
+
+        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        unset($found[0]['token']);
+        $this->assertSame($expected, $found);
+
+    }//end testBitwiseAndConstantExpressionDefaultValue()
+
+
 }//end class

--- a/tests/Core/File/IsReferenceTest.inc
+++ b/tests/Core/File/IsReferenceTest.inc
@@ -1,0 +1,139 @@
+<?php
+/* @codingStandardsIgnoreFile */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+/* bitwiseAndA */
+error_reporting( E_NOTICE & E_STRICT );
+
+/* bitwiseAndB */
+$a = [ $something & $somethingElse ];
+
+/* bitwiseAndC */
+$a = [ $first, $something & self::$somethingElse ];
+
+/* bitwiseAndD */
+$a = array $first, $something & $somethingElse );
+
+/* bitwiseAndE */
+$a = [ 'a' => $first, 'b' => $something & $somethingElse ];
+
+/* bitwiseAndF */
+$a = array( 'a' => $first, 'b' => $something & \MyClass::$somethingElse );
+
+/* bitwiseAndG */
+$a = $something & $somethingElse;
+
+/* bitwiseAndH */
+function myFunction($a = 10 & 20) {}
+
+/* bitwiseAndI */
+$closure = function ($a = MY_CONSTANT & parent::OTHER_CONSTANT) {};
+
+/* functionReturnByReference */
+function &myFunction() {}
+
+/* functionPassByReferenceA */
+function myFunction( &$a ) {}
+
+/* functionPassByReferenceB */
+function myFunction( $a, &$b ) {}
+
+/* functionPassByReferenceC */
+$closure = function ( &$a ) {};
+
+/* functionPassByReferenceD */
+$closure = function ( $a, &$b ) {};
+
+/* functionPassByReferenceE */
+function myFunction(array &$one) {}
+
+/* functionPassByReferenceF */
+$closure = function (\MyClass &$one) {};
+
+/* functionPassByReferenceG */
+$closure = function myFunc($param, &...$moreParams) {};
+
+/* foreachValueByReference */
+foreach( $array as $key => &$value ) {}
+
+/* foreachKeyByReference */
+foreach( $array as &$key => $value ) {}
+
+/* arrayValueByReferenceA */
+$a = [ 'a' => &$something ];
+
+/* arrayValueByReferenceB */
+$a = [ 'a' => $something, 'b' => &$somethingElse ];
+
+/* arrayValueByReferenceC */
+$a = [ &$something ];
+
+/* arrayValueByReferenceD */
+$a = [ $something, &$somethingElse ];
+
+/* arrayValueByReferenceE */
+$a = array( 'a' => &$something );
+
+/* arrayValueByReferenceF */
+$a = array( 'a' => $something, 'b' => &$somethingElse );
+
+/* arrayValueByReferenceG */
+$a = array( &$something );
+
+/* arrayValueByReferenceH */
+$a = array( $something, &$somethingElse );
+
+/* assignByReferenceA */
+$b = &$something;
+
+/* assignByReferenceB */
+$b =& $something;
+
+/* assignByReferenceC */
+$b .= &$something;
+
+/* assignByReferenceD */
+$myValue = &$obj->getValue();
+
+/* assignByReferenceE */
+$collection = &collector();
+
+/* passByReferenceA */
+functionCall(&$something, $somethingElse);
+
+/* passByReferenceB */
+functionCall($something, &$somethingElse);
+
+/* passByReferenceC */
+functionCall($something, &$this->somethingElse);
+
+/* passByReferenceD */
+functionCall($something, &self::$somethingElse);
+
+/* passByReferenceE */
+functionCall($something, &parent::$somethingElse);
+
+/* passByReferenceF */
+functionCall($something, &static::$somethingElse);
+
+/* passByReferenceG */
+functionCall($something, &SomeClass::$somethingElse);
+
+/* passByReferenceH */
+functionCall(&\SomeClass::$somethingElse);
+
+/* passByReferenceI */
+functionCall($something, &\SomeNS\SomeClass::$somethingElse);
+
+/* passByReferenceJ */
+functionCall($something, &namespace\SomeClass::$somethingElse);
+
+/* newByReferenceA */
+$foobar2 = &new Foobar();
+
+/* newByReferenceB */
+functionCall( $something , &new Foobar() );
+
+/* useByReference */
+$closure = function() use (&$var){};

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:isReference method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Files\DummyFile;
+
+class IsReferenceTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
+     *
+     * @var \PHP_CodeSniffer\Files\File
+     */
+    private $phpcsFile;
+
+
+    /**
+     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
+     *
+     * Methods used for these tests can be found in a test case file in the same
+     * directory and with the same name, using the .inc extension.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $config            = new Config();
+        $config->standards = array('Generic');
+
+        $ruleset = new Ruleset($config);
+
+        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
+        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
+        $this->phpcsFile->process();
+
+    }//end setUp()
+
+
+    /**
+     * Clean up after finished test.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->phpcsFile);
+
+    }//end tearDown()
+
+
+    /**
+     * Test a class that extends another.
+     *
+     * @param string $identifier Comment which preceeds the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @dataProvider dataIsReference
+     *
+     * @return void
+     */
+    public function testIsReference($identifier, $expected)
+    {
+        $start      = ($this->phpcsFile->numTokens - 1);
+        $delim      = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            $identifier
+        );
+        $bitwiseAnd = $this->phpcsFile->findNext(T_BITWISE_AND, ($delim + 1));
+
+        $result = $this->phpcsFile->isReference($bitwiseAnd);
+        $this->assertSame($expected, $result);
+
+    }//end testIsReference()
+
+
+    /**
+     * Data provider for the IsReference test.
+     *
+     * @see testIsReference()
+     *
+     * @return array
+     */
+    public function dataIsReference()
+    {
+        return array(
+                array(
+                 '/* bitwiseAndA */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndB */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndC */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndD */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndE */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndF */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndG */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndH */',
+                 false,
+                ),
+                array(
+                 '/* bitwiseAndI */',
+                 false,
+                ),
+                array(
+                 '/* functionReturnByReference */',
+                 true,
+                ),
+                array(
+                 '/* functionPassByReferenceA */',
+                 true,
+                ),
+                array(
+                 '/* functionPassByReferenceB */',
+                 true,
+                ),
+                array(
+                 '/* functionPassByReferenceC */',
+                 true,
+                ),
+                array(
+                 '/* functionPassByReferenceD */',
+                 true,
+                ),
+                array(
+                 '/* functionPassByReferenceE */',
+                 true,
+                ),
+                array(
+                 '/* functionPassByReferenceF */',
+                 true,
+                ),
+                array(
+                 '/* functionPassByReferenceG */',
+                 true,
+                ),
+                array(
+                 '/* foreachValueByReference */',
+                 true,
+                ),
+                array(
+                 '/* foreachKeyByReference */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceA */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceB */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceC */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceD */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceE */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceF */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceG */',
+                 true,
+                ),
+                array(
+                 '/* arrayValueByReferenceH */',
+                 true,
+                ),
+                array(
+                 '/* assignByReferenceA */',
+                 true,
+                ),
+                array(
+                 '/* assignByReferenceB */',
+                 true,
+                ),
+                array(
+                 '/* assignByReferenceC */',
+                 true,
+                ),
+                array(
+                 '/* assignByReferenceD */',
+                 true,
+                ),
+                array(
+                 '/* assignByReferenceE */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceA */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceB */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceC */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceD */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceE */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceF */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceG */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceH */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceI */',
+                 true,
+                ),
+                array(
+                 '/* passByReferenceJ */',
+                 true,
+                ),
+                array(
+                 '/* newByReferenceA */',
+                 true,
+                ),
+                array(
+                 '/* newByReferenceB */',
+                 true,
+                ),
+                array(
+                 '/* useByReference */',
+                 true,
+                ),
+               );
+
+    }//end dataIsReference()
+
+
+}//end class


### PR DESCRIPTION
The `File::isReference()` method misidentified a number of situations where the `T_BITWISE_AND` token was encountered, most notably:
* An array assignment of a calculated value with a _bitwise and_ operator in it ,was being misidentified as a reference.
* A calculated default value for a function parameter with a _bitwise and_ operator in it, was being misidentified as a reference.
* New by reference was not recognized as a reference.
* References to class properties with `self::`, `parent::`, `static::`, `namespace\Class::`, `classname::` were not recognized as references.

This PR fixes these cases and adds dedicated unit test files for this method.

Fixes #1604

As part of this fix, the `File::getMethodParameters()` method also needed to be fixed.

Since PHP 5.6, default values in function declarations can contain constant expressions.
These expressions can contain a `T_BITWISE_AND`, but the `File::getMethodParameters()` method did not account for this and would misidentify the `T_BITWISE_AND` as indicating that the variable was being passed by reference.

Includes a new unit test for the `File::getMethodParameters()` method to specifically safeguard against this issue.