### PR TITLE
PSR2/MethodDeclaration unit tests: minor syntax fix

### DIFF
--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
@@ -9,11 +9,9 @@ class MyClass
     static public function myFunction() {}
     final public function myFunction() {}
     public final function myFunction() {}
-    abstract private function myFunction() {}
-    private abstract function myFunction() {}
+    abstract private function myFunction();
+    private abstract function myFunction();
     final public static function myFunction() {}
-    static protected final abstract function myFunction() {}
+    static protected final abstract function myFunction();
     public function _() {}
 }
-
-?>

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
@@ -9,11 +9,9 @@ class MyClass
     public static function myFunction() {}
     final public function myFunction() {}
     final public function myFunction() {}
-    abstract private function myFunction() {}
-    abstract private function myFunction() {}
+    abstract private function myFunction();
+    abstract private function myFunction();
     final public static function myFunction() {}
-    abstract final protected static function myFunction() {}
+    abstract final protected static function myFunction();
     public function _() {}
 }
-
-?>


### PR DESCRIPTION
Abstract function declarations do not have braces, but a semi-colon at the end.

No functional changes.