### PR TITLE
Resolve problem: illegal character in Tokenizer

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -189,8 +189,7 @@ abstract class Tokenizer
             ) {
                 // There are no tabs in this content, or we aren't replacing them.
                 if ($checkEncoding === true) {
-                    // Not using the default encoding, so take a bit more care.
-                    $length = @iconv_strlen($this->tokens[$i]['content'], $this->config->encoding);
+                    $length = mb_strlen($this->tokens[$i]['content'], $this->config->encoding);
                     if ($length === false) {
                         // String contained invalid characters, so revert to default.
                         $length = strlen($this->tokens[$i]['content']);

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -155,9 +155,6 @@ abstract class Tokenizer
         $inTests    = defined('PHP_CODESNIFFER_IN_TESTS');
 
         $checkEncoding = false;
-        if (function_exists('iconv_strlen') === true) {
-            $checkEncoding = true;
-        }
 
         $checkAnnotations = $this->config->annotations;
 
@@ -188,13 +185,9 @@ abstract class Tokenizer
                 || strpos($this->tokens[$i]['content'], "\t") === false
             ) {
                 // There are no tabs in this content, or we aren't replacing them.
-                if ($checkEncoding === true) {
-                    $length = mb_strlen($this->tokens[$i]['content'], $this->config->encoding);
-                    if ($length === false) {
-                        // String contained invalid characters, so revert to default.
-                        $length = strlen($this->tokens[$i]['content']);
-                    }
-                } else {
+                $length = mb_strlen($this->tokens[$i]['content'], $this->config->encoding);
+                if ($length === false) {
+                    // String contained invalid characters, so revert to default.
                     $length = strlen($this->tokens[$i]['content']);
                 }
 
@@ -268,9 +261,6 @@ abstract class Tokenizer
     public function replaceTabsInToken(&$token, $prefix=' ', $padding=' ')
     {
         $checkEncoding = false;
-        if (function_exists('iconv_strlen') === true) {
-            $checkEncoding = true;
-        }
 
         $currColumn = $token['column'];
         $tabWidth   = $this->config->tabWidth;
@@ -299,14 +289,10 @@ abstract class Tokenizer
             foreach ($tabs as $content) {
                 if ($content !== '') {
                     $newContent .= $content;
-                    if ($checkEncoding === true) {
-                        // Not using the default encoding, so take a bit more care.
-                        $contentLength = @iconv_strlen($content, $this->config->encoding);
-                        if ($contentLength === false) {
-                            // String contained invalid characters, so revert to default.
-                            $contentLength = strlen($content);
-                        }
-                    } else {
+
+                    $contentLength = mb_strlen($content, $this->config->encoding);
+                    if ($contentLength === false) {
+                        // String contained invalid characters, so revert to default.
                         $contentLength = strlen($content);
                     }
 


### PR DESCRIPTION
When in file we have polish characters (eq: "Błąd") or Cyrillic, and we run Sniffer via PHPStorm IDE Sniffer will stop and we will get error: 
```iconv_strlen(): Detected an illegal character in input string in /vendor/squizlabs/php_codesniffer/src/Tokenizers/Tokenizer.php on line 193```
This proposal will fix this issue.