### PR TITLE
Squiz/FunctionComment: Fix type hint suggestion for nullable arrays

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -374,7 +374,11 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 // Check type hint for array and custom type.
                 $suggestedTypeHint = '';
                 if (strpos($suggestedName, 'array') !== false || substr($suggestedName, -2) === '[]') {
-                    $suggestedTypeHint = 'array';
+                    if (strpos($suggestedName, '?') === 0) {
+                        $suggestedTypeHint = '?array';
+                    } else {
+                        $suggestedTypeHint = 'array';
+                    }
                 } else if (strpos($suggestedName, 'callable') !== false) {
                     $suggestedTypeHint = 'callable';
                 } else if (strpos($suggestedName, 'callback') !== false) {


### PR DESCRIPTION
```php
/**
 * Example function.
 *
 * @param ?array $args Arguments.
 *
 * @return void
 */
protected function doSomething(?array $args): void
{

}//end doSomething()
```

If you have a function with a nullable array as parameter and validate it against the Squiz standard, the sniffer complains about an incorrect data type:

```
 | ERROR | Expected type hint "array"; found "?array" for $args
```

This PR fixes the incorrect type hint suggestion.