### PR TITLE
Squiz.PHP.EmbeddedPhp: two bug fixes for when there's only a comment

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -341,31 +341,33 @@ class EmbeddedPhpSniff implements Sniff
         }
 
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closeTag - 1), $stackPtr, true);
-        if ((isset($tokens[$prev]['scope_opener']) === false
-            || $tokens[$prev]['scope_opener'] !== $prev)
-            && (isset($tokens[$prev]['scope_closer']) === false
-            || $tokens[$prev]['scope_closer'] !== $prev)
-            && $tokens[$prev]['code'] !== T_SEMICOLON
-        ) {
-            $error = 'Inline PHP statement must end with a semicolon';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSemicolon');
-            if ($fix === true) {
-                $phpcsFile->fixer->addContent($prev, ';');
-            }
-        } else if ($tokens[$prev]['code'] === T_SEMICOLON) {
-            $statementCount = 1;
-            for ($i = ($stackPtr + 1); $i < $prev; $i++) {
-                if ($tokens[$i]['code'] === T_SEMICOLON) {
-                    $statementCount++;
+        if ($prev !== $stackPtr) {
+            if ((isset($tokens[$prev]['scope_opener']) === false
+                || $tokens[$prev]['scope_opener'] !== $prev)
+                && (isset($tokens[$prev]['scope_closer']) === false
+                || $tokens[$prev]['scope_closer'] !== $prev)
+                && $tokens[$prev]['code'] !== T_SEMICOLON
+            ) {
+                $error = 'Inline PHP statement must end with a semicolon';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSemicolon');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContent($prev, ';');
+                }
+            } else if ($tokens[$prev]['code'] === T_SEMICOLON) {
+                $statementCount = 1;
+                for ($i = ($stackPtr + 1); $i < $prev; $i++) {
+                    if ($tokens[$i]['code'] === T_SEMICOLON) {
+                        $statementCount++;
+                    }
+                }
+
+                if ($statementCount > 1) {
+                    $error = 'Inline PHP statement must contain a single statement; %s found';
+                    $data  = array($statementCount);
+                    $phpcsFile->addError($error, $stackPtr, 'MultipleStatements', $data);
                 }
             }
-
-            if ($statementCount > 1) {
-                $error = 'Inline PHP statement must contain a single statement; %s found';
-                $data  = array($statementCount);
-                $phpcsFile->addError($error, $stackPtr, 'MultipleStatements', $data);
-            }
-        }
+        }//end if
 
         $trailingSpace = 0;
         if ($tokens[($closeTag - 1)]['code'] === T_WHITESPACE) {

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -308,7 +308,7 @@ class EmbeddedPhpSniff implements Sniff
         }
 
         // Check that there is one, and only one space at the start of the statement.
-        $firstContent = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), ($closeTag - 1), true);
+        $firstContent = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $closeTag, true);
 
         if ($firstContent === false) {
             $error = 'Empty embedded PHP tag found';

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
@@ -113,3 +113,5 @@ function foo()
 <?php echo 'oops'; // Something.?>
 
 <?php /* translators: My sites label */ ?>
+<?php /* translators: My sites label */?>
+<?php /* translators: My sites label */      ?>

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
@@ -111,3 +111,5 @@ function foo()
 <?php echo 'oops'; // Something. ?>
 <?php echo 'oops'; // Something.      ?>
 <?php echo 'oops'; // Something.?>
+
+<?php /* translators: My sites label */ ?>

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
@@ -111,3 +111,5 @@ function foo()
 <?php echo 'oops'; // Something. ?>
 <?php echo 'oops'; // Something. ?>
 <?php echo 'oops'; // Something. ?>
+
+<?php /* translators: My sites label */ ?>

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
@@ -113,3 +113,5 @@ function foo()
 <?php echo 'oops'; // Something. ?>
 
 <?php /* translators: My sites label */ ?>
+<?php /* translators: My sites label */ ?>
+<?php /* translators: My sites label */ ?>

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.php
@@ -53,6 +53,8 @@ class EmbeddedPhpUnitTest extends AbstractSniffUnitTest
                 102 => 1,
                 112 => 1,
                 113 => 1,
+                116 => 1,
+                117 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
### Squiz.PHP.EmbeddedPhp: prevent adding superfluous semi-colon

When a snippet of embedded PHP contains only a comment, the `Squiz.PHP.EmbeddedPhp` sniff would add a semi-colon before the comment which is unnecessary and makes for untidy code.

Includes unit tests.

Without this fix, the unit test snippet would be "fixed" to look like:
```php
<?php ;/* translators: My sites label */ ?>
```

While the change looks more extensive because of the change in indentation, in reality all I did was wrap the relevant code in an `if ($prev !== $stackPtr) {}`.

----

### Squiz.PHP.EmbeddedPhp: prevent removing embedded PHP when no space between comment and close tag

When there is no space between a `/* .. */` comment and the close tag, PHPCS would report an `Empty embedded PHP tag found (Squiz.PHP.EmbeddedPhp.Empty)` error and the fixer would accidentally remove a complete line of embedded PHP.

Includes unit tests.

This bug is related to the inconsistency in `findNext()` as previously reported in #1319