### PR TITLE
Squiz/ObjectOperatorSpacing: add fixed test file

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc.fixed
@@ -1,21 +1,19 @@
 <?php
 $this->testThis();
-$this-> testThis();
-$this    ->  testThis();
+$this->testThis();
+$this->testThis();
 $this->/* comment here */testThis();
-$this/* comment here */ -> testThis();
-$this
-    ->testThis();
-$this->
-    testThis();
+$this/* comment here */->testThis();
+$this->testThis();
+$this->testThis();
 
 // @codingStandardsChangeSetting Squiz.WhiteSpace.ObjectOperatorSpacing ignoreNewlines true
 
 $this->testThis();
-$this-> testThis();
-$this    ->  testThis();
+$this->testThis();
+$this->testThis();
 $this->/* comment here */testThis();
-$this/* comment here */ -> testThis();
+$this/* comment here */->testThis();
 $this
     ->testThis();
 $this->
@@ -24,22 +22,20 @@ $this->
 // @codingStandardsChangeSetting Squiz.WhiteSpace.ObjectOperatorSpacing ignoreNewlines false
 
 thisObject::testThis();
-thisObject:: testThis();
-thisObject    ::  testThis();
+thisObject::testThis();
+thisObject::testThis();
 thisObject::/* comment here */testThis();
-thisObject/* comment here */ :: testThis();
-thisObject
-    ::testThis();
-thisObject::
-    testThis();
+thisObject/* comment here */::testThis();
+thisObject::testThis();
+thisObject::testThis();
 	
 // @codingStandardsChangeSetting Squiz.WhiteSpace.ObjectOperatorSpacing ignoreNewlines true
 
 thisObject::testThis();
-thisObject:: testThis();
-thisObject    ::  testThis();
+thisObject::testThis();
+thisObject::testThis();
 thisObject::/* comment here */testThis();
-thisObject/* comment here */ :: testThis();
+thisObject/* comment here */::testThis();
 thisObject
     ::testThis();
 thisObject::


### PR DESCRIPTION
Saw that this sniff does contain fixers, but didn't have a `.fixed` file to unit test the fixes made.

This PR adds the file. The unit tests pass and the fixes look good.