### PR TITLE
Squiz.Strings.DoubleQuoteUsage replaces tabs with spaces when fixing

### DIFF
--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -44,11 +44,6 @@ class DoubleQuoteUsageSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // We are only interested in the first token in a multi-line string.
-        if ($tokens[$stackPtr]['code'] === $tokens[($stackPtr - 1)]['code']) {
-            return;
-        }
-
         // If tabs are being converted to spaces by the tokeniser, the
         // original content should be used instead of the converted content.
         if (isset($tokens[$stackPtr]['orig_content']) === true) {
@@ -75,15 +70,17 @@ class DoubleQuoteUsageSniff implements Sniff
             }
         }
 
+        $skipTo = ($lastStringToken + 1);
+
         // Check if it's a double quoted string.
         if (strpos($workingString, '"') === false) {
-            return;
+            return $skipTo;
         }
 
         // Make sure it's not a part of a string started in a previous line.
         // If it is, then we have already checked it.
         if ($workingString[0] !== '"') {
-            return;
+            return $skipTo;
         }
 
         // The use of variables in double quoted strings is not allowed.
@@ -97,7 +94,7 @@ class DoubleQuoteUsageSniff implements Sniff
                 }
             }
 
-            return;
+            return $skipTo;
         }//end if
 
         $allowedChars = array(
@@ -123,7 +120,7 @@ class DoubleQuoteUsageSniff implements Sniff
 
         foreach ($allowedChars as $testChar) {
             if (strpos($workingString, $testChar) !== false) {
-                return;
+                return $skipTo;
             }
         }
 
@@ -144,6 +141,8 @@ class DoubleQuoteUsageSniff implements Sniff
 
             $phpcsFile->fixer->endChangeset();
         }
+
+        return $skipTo;
 
     }//end process()
 

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -49,7 +49,14 @@ class DoubleQuoteUsageSniff implements Sniff
             return;
         }
 
-        $workingString   = $tokens[$stackPtr]['content'];
+        // If tabs are being converted to spaces by the tokeniser, the
+        // original content should be used instead of the converted content.
+        if (isset($tokens[$stackPtr]['orig_content']) === true) {
+            $workingString = $tokens[$stackPtr]['orig_content'];
+        } else {
+            $workingString = $tokens[$stackPtr]['content'];
+        }
+
         $lastStringToken = $stackPtr;
 
         $i = ($stackPtr + 1);
@@ -57,7 +64,12 @@ class DoubleQuoteUsageSniff implements Sniff
             while ($i < $phpcsFile->numTokens
                 && $tokens[$i]['code'] === $tokens[$stackPtr]['code']
             ) {
-                $workingString  .= $tokens[$i]['content'];
+                if (isset($tokens[$i]['orig_content']) === true) {
+                    $workingString .= $tokens[$i]['orig_content'];
+                } else {
+                    $workingString .= $tokens[$i]['content'];
+                }
+
                 $lastStringToken = $i;
                 $i++;
             }

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -73,13 +73,7 @@ class DoubleQuoteUsageSniff implements Sniff
         $skipTo = ($lastStringToken + 1);
 
         // Check if it's a double quoted string.
-        if (strpos($workingString, '"') === false) {
-            return $skipTo;
-        }
-
-        // Make sure it's not a part of a string started in a previous line.
-        // If it is, then we have already checked it.
-        if ($workingString[0] !== '"') {
+        if ($workingString[0] !== '"' || substr($workingString, -1) !== '"') {
             return $skipTo;
         }
 

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
@@ -29,6 +29,9 @@ $string = "\123 \234"."\u123"."\e";
 echo "window.location = \"".$url."\";\n";
 echo ""
 
+$string = "Hello
+			there";
+
 function test() {
     echo "It Worked';
 }

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
@@ -29,6 +29,9 @@ $string = "\123 \234"."\u123"."\e";
 echo 'window.location = "'.$url."\";\n";
 echo ''
 
+$string = 'Hello
+			there';
+
 function test() {
     echo "It Worked';
 }

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
@@ -38,6 +38,7 @@ class DoubleQuoteUsageUnitTest extends AbstractSniffUnitTest
                 22 => 1,
                 29 => 1,
                 30 => 1,
+                32 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
### Squiz/DoubleQuoteUsage: Use original string when testing and fixing double quotes

If a string contains tabs, they were previously - unintentionally - replaced by spaces while that is not the responsibility of this sniff.

Includes unit test,

--- 

While examining the sniff code to fix the above issue, I also noticed two other optimizations which could benefit this sniff:

### Squiz/DoubleQuoteUsage: Skip past subsequent tokens in a multi-line string

As the last token of the multi-line string is known, it can be returned to skip past subsequent tokens in a multi-line string instead of checking each string token.

### Squiz/DoubleQuoteUsage: Make check for double quoted string a little more specific and strict

Only check strings which are finished double quotes strings.
This offers additional protection against examining unfinished strings during live code checking.