### PR TITLE
Squiz.Commenting.InlineComment will fail to fix comments at the end of the file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1219,6 +1219,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineCommentUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineCommentUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineCommentUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="InlineCommentUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LongConditionClosingCommentUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LongConditionClosingCommentUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -211,17 +211,25 @@ class InlineCommentSniff implements Sniff
         // The below section determines if a comment block is correctly capitalised,
         // and ends in a full-stop. It will find the last comment in a block, and
         // work its way up.
-        $nextComment = $phpcsFile->findNext(array(T_COMMENT), ($stackPtr + 1), null, false);
-        if (($nextComment !== false)
-            && (($tokens[$nextComment]['line']) === ($tokens[$stackPtr]['line'] + 1))
+        $nextComment = $phpcsFile->findNext(T_COMMENT, ($stackPtr + 1), null, false);
+        if ($nextComment !== false
+            && $tokens[$nextComment]['line'] === ($tokens[$stackPtr]['line'] + 1)
         ) {
-            return;
+            $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $nextComment, true);
+            if ($nextNonWhitespace === false) {
+                return;
+            }
         }
 
         $topComment  = $stackPtr;
         $lastComment = $stackPtr;
         while (($topComment = $phpcsFile->findPrevious(array(T_COMMENT), ($lastComment - 1), null, false)) !== false) {
             if ($tokens[$topComment]['line'] !== ($tokens[$lastComment]['line'] - 1)) {
+                break;
+            }
+
+            $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($topComment + 1), $lastComment, true);
+            if ($nextNonWhitespace !== false) {
                 break;
             }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -278,6 +278,12 @@ class InlineCommentSniff implements Sniff
         // Finally, the line below the last comment cannot be empty if this inline
         // comment is on a line by itself.
         if ($tokens[$previousContent]['line'] < $tokens[$stackPtr]['line']) {
+            $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+            if ($next === false) {
+                // Ignore if the comment is the last non-whitespace token in a file.
+                return;
+            }
+
             $start = false;
             for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
                 if ($tokens[$i]['line'] === ($tokens[$stackPtr]['line'] + 1)) {
@@ -292,7 +298,6 @@ class InlineCommentSniff implements Sniff
             $error = 'There must be no blank line following an inline comment';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter');
             if ($fix === true) {
-                $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
                 $phpcsFile->fixer->beginChangeset();
                 for ($i = ($stackPtr + 1); $i < $next; $i++) {
                     if ($tokens[$i]['line'] === $tokens[$next]['line']) {

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
@@ -123,6 +123,12 @@ echo $foo;
  */
 include_once($blah);
 
+// some comment without capital or full stop
+echo $foo; // An unrelated comment.
+
+// An unrelated comment.
+echo $foo; // some comment without capital or full stop
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
@@ -122,3 +122,12 @@ echo $foo;
  * Comments about the include
  */
 include_once($blah);
+
+/*
+ * N.B.: The below test line must be the last test in the file.
+ * Testing that a new line after an inline comment when it's the last non-whitespace
+ * token in a file, does *not* throw an error as this would conflict with the common
+ * "new line required at end of file" rule.
+ */
+
+// For this test line having an empty line below it, is fine.

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
@@ -115,3 +115,12 @@ echo $foo;
  * Comments about the include
  */
 include_once($blah);
+
+/*
+ * N.B.: The below test line must be the last test in the file.
+ * Testing that a new line after an inline comment when it's the last non-whitespace
+ * token in a file, does *not* throw an error as this would conflict with the common
+ * "new line required at end of file" rule.
+ */
+
+// For this test line having an empty line below it, is fine.

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
@@ -116,6 +116,12 @@ echo $foo;
  */
 include_once($blah);
 
+// some comment without capital or full stop
+echo $foo; // An unrelated comment.
+
+// An unrelated comment.
+echo $foo; // some comment without capital or full stop
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.js
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.js
@@ -121,3 +121,9 @@ console.info(foo);
 //**
 * invalid comment
 */
+
+// some comment without capital or full stop
+console.log(foo); // An unrelated comment.
+
+// An unrelated comment.
+console.log(foo); // some comment without capital or full stop

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.js.fixed
@@ -1,0 +1,119 @@
+// Some content here.
+var code = 'hello';
+
+// This comment contains # multiple
+// hash signs (#).
+code = 'hello';
+
+/**
+ * This is the first line of a function comment.
+ * This is the second line.
+ */
+function testFunction()
+{
+    // Callback methods which are added by external objects.
+    this.callbacks = {};
+
+}//end testFunction()
+
+/**
+ * This is the first line of a class comment.
+ * This is the second line.
+ */
+myClass.prototype = {
+
+    /**
+     * This is the first line of a method comment.
+     * This is the second line.
+     */
+    load: function(url, callback)
+    {
+        // Some code here.
+    }
+};
+
+// some code goes here!
+/*
+    A longer comment goes here.
+    It spans multiple lines!!
+    Or does it?
+*/
+
+// 0This is a simple multi-line
+// comment!
+code = 'hello';
+
+// This is not valid.
+code = 'hello';
+
+// Neither is this!
+code = 'hello';
+
+code = 'hello';
+
+/** Neither is this! **/
+code = 'hello';
+
+/**
+ * This is the first line of a function comment.
+ * This is the second line.
+ */
+var myFunction = function() {
+}
+
+/**
+ * This is the first line of a function comment.
+ * This is the second line.
+ */
+myFunction = function() {
+}
+
+/**
+ * This is the first line of a function comment.
+ * This is the second line.
+ */
+myClass.myFunction = function() {
+}
+
+dfx.getIframeDocument = function(iframe)
+{
+    return doc;
+
+};//end dfx.getIframeDocument()
+
+mig.Gallery.prototype = {
+
+    init: function(cb)
+    {
+
+    },//end init()
+
+    imageClicked: function(id)
+    {
+
+    }//end imageClicked()
+
+};
+
+// Here is some inline example code:
+// -> One
+// -> One.One
+// -> Two
+/*
+    Here is some inline example code:
+        -> One
+            -> One.One
+        -> Two
+*/
+
+
+var foo = 'foo'; // Var set to foo.
+
+console.info(foo);
+
+// Comment here.
+console.info(foo);
+
+// **
+* invalid comment
+*/

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.js.fixed
@@ -117,3 +117,9 @@ console.info(foo);
 // **
 * invalid comment
 */
+
+// some comment without capital or full stop
+console.log(foo); // An unrelated comment.
+
+// An unrelated comment.
+console.log(foo); // some comment without capital or full stop

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.php
@@ -44,6 +44,8 @@ class InlineCommentUnitTest extends AbstractSniffUnitTest
                        96  => 1,
                        97  => 3,
                        118 => 1,
+                       126 => 2,
+                       130 => 2,
                       );
 
             return $errors;
@@ -60,6 +62,8 @@ class InlineCommentUnitTest extends AbstractSniffUnitTest
                     104 => 3,
                     118 => 1,
                     121 => 1,
+                    125 => 2,
+                    129 => 2,
                    );
         default:
             return array();


### PR DESCRIPTION
I came across this issue when running `phpcbf` with the complete `WordPress` standard against the WPCS unit test files in an attempt to find fixer conflicts.

When an inline comment is the last non-whitespace content in a file, the sniff *will* report an error, but will always fail to fix it as the value of `$next` (formely on line 295) would be `false`.
The file would get the "FAILED TO FIX" status as there is still one "fixable" error remaining, even though the file is correctly overwritten by the fixed file.

As whether or not there should be a blank line at the end of a file is another matter and is covered by the `Generic.Files.EndFileNewline` / `Generic.Files.EndFileNoNewLine` sniffs, this specific case should IMHO not be handled by this sniff anyway.

The fix I'm proposing is to exit out of the sniff if the inline comment being examined is the last non-whitespace token in the file.

Includes unit tests demonstrating the issue.