### PR TITLE
PHPDocs fixes

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -313,8 +313,6 @@ class Config
      * @param array $cliArgs         An array of values gathered from CLI args.
      * @param bool  $dieOnUnknownArg Whether or not to kill the process when an
      *                               unknown command line arg is found.
-     *
-     * @return void
      */
     public function __construct(array $cliArgs=[], $dieOnUnknownArg=true)
     {

--- a/src/Files/DummyFile.php
+++ b/src/Files/DummyFile.php
@@ -27,8 +27,6 @@ class DummyFile extends File
      * @param string                   $content The content of the file.
      * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset used for the run.
      * @param \PHP_CodeSniffer\Config  $config  The config data for the run.
-     *
-     * @return void
      */
     public function __construct($content, Ruleset $ruleset, Config $config)
     {

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2264,7 +2264,7 @@ class File
      *                                  If value is omitted, tokens with any value will
      *                                  be returned.
      *
-     * @return int | bool
+     * @return int|bool
      */
     public function findFirstOnLine($types, $start, $exclude=false, $value=null)
     {

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -221,8 +221,6 @@ class File
      * @param string                   $path    The absolute path to the file to process.
      * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset used for the run.
      * @param \PHP_CodeSniffer\Config  $config  The config data for the run.
-     *
-     * @return void
      */
     public function __construct($path, Ruleset $ruleset, Config $config)
     {

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -61,8 +61,6 @@ class FileList implements \Iterator, \Countable
      *
      * @param \PHP_CodeSniffer\Config  $config  The config data for the run.
      * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset used for the run.
-     *
-     * @return void
      */
     public function __construct(Config $config, Ruleset $ruleset)
     {

--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -23,8 +23,6 @@ class LocalFile extends File
      * @param string                   $path    The absolute path to the file.
      * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset used for the run.
      * @param \PHP_CodeSniffer\Config  $config  The config data for the run.
-     *
-     * @return void
      */
     public function __construct($path, Ruleset $ruleset, Config $config)
     {

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -63,10 +63,10 @@ class Filter extends \RecursiveFilterIterator
     /**
      * Constructs a filter.
      *
-     * @param \RecursiveIterator       $iterator The iterator we are using to get file paths.
-     * @param string                   $basedir  The top-level path we are filtering.
-     * @param \PHP_CodeSniffer\Config  $config   The config data for the run.
-     * @param \PHP_CodeSniffer\Ruleset $ruleset  The ruleset used for the run.
+     * @param \RecursiveIterator $iterator The iterator we are using to get file paths.
+     * @param string             $basedir  The top-level path we are filtering.
+     * @param Config             $config   The config data for the run.
+     * @param Ruleset            $ruleset  The ruleset used for the run.
      */
     public function __construct($iterator, $basedir, Config $config, Ruleset $ruleset)
     {

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -67,8 +67,6 @@ class Filter extends \RecursiveFilterIterator
      * @param string                   $basedir  The top-level path we are filtering.
      * @param \PHP_CodeSniffer\Config  $config   The config data for the run.
      * @param \PHP_CodeSniffer\Ruleset $ruleset  The ruleset used for the run.
-     *
-     * @return void
      */
     public function __construct($iterator, $basedir, Config $config, Ruleset $ruleset)
     {

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -91,7 +91,8 @@ class Reporter
      *
      * @param Config $config The config data for the run.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If a report is not available.
+     * @throws DeepExitException
+     * @throws RuntimeException If a report is not available.
      */
     public function __construct(Config $config)
     {

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -89,7 +89,7 @@ class Reporter
      * output file (or a temp file if none is specified) initialised by
      * clearing the current contents.
      *
-     * @param \PHP_CodeSniffer\Config $config The config data for the run.
+     * @param Config $config The config data for the run.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If a report is not available.
      */

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -91,7 +91,6 @@ class Reporter
      *
      * @param \PHP_CodeSniffer\Config $config The config data for the run.
      *
-     * @return void
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If a report is not available.
      */
     public function __construct(Config $config)

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -28,10 +28,10 @@ class Cbf implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -34,6 +34,8 @@ class Cbf implements Report
      * @param int   $width       Maximum allowed line width.
      *
      * @return bool
+     *
+     * @throws DeepExitException
      */
     public function generateFileReport($report, File $phpcsFile, $showSources=false, $width=80)
     {

--- a/src/Reports/Checkstyle.php
+++ b/src/Reports/Checkstyle.php
@@ -23,10 +23,10 @@ class Checkstyle implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -23,10 +23,10 @@ class Code implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Csv.php
+++ b/src/Reports/Csv.php
@@ -22,10 +22,10 @@ class Csv implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -22,10 +22,10 @@ class Diff implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Emacs.php
+++ b/src/Reports/Emacs.php
@@ -22,10 +22,10 @@ class Emacs implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -23,10 +23,10 @@ class Full implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -23,10 +23,10 @@ class Info implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -23,10 +23,10 @@ class Json implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -24,10 +24,10 @@ class Junit implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -87,10 +87,10 @@ class Notifysend implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -22,10 +22,10 @@ interface Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -23,10 +23,10 @@ class Source implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -23,10 +23,10 @@ class Summary implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -31,10 +31,10 @@ abstract class VersionControl implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -23,10 +23,10 @@ class Xml implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array $report      Prepared report data.
+     * @param File  $phpcsFile   The file being reported on.
+     * @param bool  $showSources Show sources?
+     * @param int   $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -119,7 +119,7 @@ class Ruleset
     /**
      * Initialise the ruleset that the run will use.
      *
-     * @param \PHP_CodeSniffer\Config $config The config data for the run.
+     * @param Config $config The config data for the run.
      *
      */
     public function __construct(Config $config)

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -121,7 +121,6 @@ class Ruleset
      *
      * @param \PHP_CodeSniffer\Config $config The config data for the run.
      *
-     * @return void
      */
     public function __construct(Config $config)
     {

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -121,6 +121,7 @@ class Ruleset
      *
      * @param Config $config The config data for the run.
      *
+     * @throws RuntimeException If no sniffs are registered.
      */
     public function __construct(Config $config)
     {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -39,9 +39,9 @@ class SwitchDeclarationSniff implements Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the
+     *                        stack passed in $tokens.
      *
      * @return void
      */
@@ -204,11 +204,11 @@ class SwitchDeclarationSniff implements Sniff
      *
      * Note that nested switches are ignored.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position to start looking at.
-     * @param int                         $end       The position to stop looking at.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position to start looking at.
+     * @param int  $end       The position to stop looking at.
      *
-     * @return int | bool
+     * @return int|bool
      */
     private function findNextCase($phpcsFile, $stackPtr, $end)
     {
@@ -231,9 +231,9 @@ class SwitchDeclarationSniff implements Sniff
     /**
      * Returns true if a nested terminating statement is found.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position to start looking at.
-     * @param int                         $end       The position to stop looking at.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position to start looking at.
+     * @param int  $end       The position to stop looking at.
      *
      * @return bool
      */

--- a/src/Tokenizers/CSS.php
+++ b/src/Tokenizers/CSS.php
@@ -26,7 +26,6 @@ class CSS extends PHP
      * @param \PHP_CodeSniffer\Config $config  The config data for the run.
      * @param string                  $eolChar The EOL char used in the content.
      *
-     * @return void
      * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
     public function __construct($content, Config $config, $eolChar='\n')

--- a/src/Tokenizers/JS.php
+++ b/src/Tokenizers/JS.php
@@ -256,7 +256,6 @@ class JS extends Tokenizer
      * @param \PHP_CodeSniffer\Config $config  The config data for the run.
      * @param string                  $eolChar The EOL char used in the content.
      *
-     * @return void
      * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
     public function __construct($content, Config $config, $eolChar='\n')

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -78,8 +78,6 @@ abstract class Tokenizer
      * @param string                         $content The content to tokenize,
      * @param \PHP_CodeSniffer\Config | null $config  The config data for the run.
      * @param string                         $eolChar The EOL char used in the content.
-     *
-     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
     public function __construct($content, $config, $eolChar='\n')
     {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -79,7 +79,6 @@ abstract class Tokenizer
      * @param \PHP_CodeSniffer\Config | null $config  The config data for the run.
      * @param string                         $eolChar The EOL char used in the content.
      *
-     * @return void
      * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
     public function __construct($content, $config, $eolChar='\n')

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -9,6 +9,7 @@
 
 namespace PHP_CodeSniffer\Tokenizers;
 
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util;
 
@@ -75,9 +76,9 @@ abstract class Tokenizer
     /**
      * Initialise and run the tokenizer.
      *
-     * @param string                         $content The content to tokenize,
-     * @param \PHP_CodeSniffer\Config | null $config  The config data for the run.
-     * @param string                         $eolChar The EOL char used in the content.
+     * @param string      $content The content to tokenize,
+     * @param Config|null $config  The config data for the run.
+     * @param string      $eolChar The EOL char used in the content.
      */
     public function __construct($content, $config, $eolChar='\n')
     {


### PR DESCRIPTION
- [x] ~~removed return statements in constructors~~ (it was merged somewhere before, not from my PR...)
- [x] removed `@return void` tag from constructors docs
- [x] fixed variable types in docs (use imported class instead of invalid FQCN)
- [x] added missing throws tags
- [x] removed redundant throw tag