### PR TITLE
Feature - function comment throw tag - process functions without doc comment

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -63,9 +63,7 @@ class FunctionCommentThrowTagSniff extends AbstractScopeSniff
                 return;
             }
 
-            if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-                && $tokens[$commentEnd]['code'] !== T_COMMENT
-            ) {
+            if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
                 // Function doesn't have a doc comment.
                 return;
             }

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -80,7 +80,7 @@ class FunctionCommentThrowTagSniff extends AbstractScopeSniff
         $currPos          = $stackPtr;
         $foundThrows      = false;
         while ($currPos < $currScopeEnd && $currPos !== false) {
-            if ($phpcsFile->hasCondition($currPos, T_CLOSURE) === false) {
+            if ($this->isLastScope($tokens[$currPos]['conditions'], $currScope) === true) {
                 $foundThrows = true;
 
                 /*
@@ -239,6 +239,29 @@ class FunctionCommentThrowTagSniff extends AbstractScopeSniff
     {
 
     }//end processTokenOutsideScope()
+
+
+    /**
+     * Check if $scope is the last closure/function/try condition.
+     *
+     * @param array $conditions Conditions of the tag.
+     * @param int   $scope      Scope to check in conditions.
+     *
+     * @return bool
+     */
+    private function isLastScope(array $conditions, $scope)
+    {
+        foreach (array_reverse($conditions, true) as $ptr => $code) {
+            if ($code !== T_FUNCTION && $code !== T_CLOSURE && $code !== T_TRY) {
+                continue;
+            }
+
+            return $ptr === $scope;
+        }
+
+        return false;
+
+    }//end isLastScope()
 
 
 }//end class

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
@@ -358,3 +358,49 @@ class Test
         };
     }
 }
+
+// @codingStandardsChangeSetting Squiz.Commenting.FunctionCommentThrowTag skipFunctionsWithoutDocComment false
+
+class FunctionsWithoutDocComment
+{
+    public function throwExceptionInClosure()
+    {
+        return function () {
+            throw new \InvalidArgumentException();
+        };
+    }
+
+    public function throwExceptionInAnonymousClass()
+    {
+        return new class {
+            public function x()
+            {
+                throw new \RuntimeException();
+            }
+        };
+    }
+
+    public function caughtException()
+    {
+        try {
+            throw new \Exception();
+        } catch (\Throwable $e) {
+        }
+    }
+
+    public function throwException()
+    {
+        throw new \ErrorException();
+    }
+
+    public function crazyExample()
+    {
+        return function () {
+            return new class {
+                public function x() {
+                    throw new \Exception();
+                }
+            };
+        };
+    }
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.php
@@ -36,6 +36,9 @@ class FunctionCommentThrowTagUnitTest extends AbstractSniffUnitTest
                 200 => 1,
                 219 => 1,
                 287 => 1,
+                376 => 1,
+                391 => 1,
+                400 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
This PR contains feature and fix which I find out on working on the feature...

The feature is possibility to enable processing functions without doc comment.
Previously sniff was processing only functions with doc comment before. I've added new variable which allows to change that behaviour. By default the variable is set to `true` so we skip functions without doc comment, to keep backward compatibility. Basically, previous functionality is not changed here, and if user would like to enable this feature must do it by setting the variable in his ruleset.

The bug was with anonymous classes, sniff suggest adding throw tag on wrong function, when function contains an anonymous function with method which throw an exception:

```php
class A
{
  public function b()
  {
    return new class {
      public function c()
      {
        throw new \Exception();
      }
    }
  }
}
```

so in above example throw should be documented for method `c` of anonymous class, not on method `A::b`.

Another one, maybe shouldn't be considered as a bug, is the following:
```php
function x() {
    try {
        throw new \Exception();
    } catch(\Exception $e) {
    }
}
```
In that case `\Exception` is not going to be forced to be documented anymore.