### PR TITLE
Squiz.WhiteSpace.SuperfluousWhitespace - Multi Line String check

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -188,11 +188,12 @@ class SuperfluousWhitespaceSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }
-        } else if($tokens[$stackPtr]['code'] === T_CONSTANT_ENCAPSED_STRING) {
+        } else if ($tokens[$stackPtr]['code'] === T_CONSTANT_ENCAPSED_STRING) {
             // Ignore single line strings.
             if (strpos($tokens[$stackPtr]['content'], $phpcsFile->eolChar) === false) {
                 return;
             }
+
             // Ignore multi line strings if required.
             if ($this->ignoreMultiLineStrings === true) {
                 return;

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
@@ -47,13 +47,28 @@ function myFunction3()
 }
 
 // @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
+ 
+
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultiLineStrings false
 
 function myFunction4()
 {
     echo "multi    
     line  
-    string 
+    string
     whitespace ";
+    echo 'code here'; 
+}
+
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultiLineStrings true
+
+function myFunction5()
+{
+    echo "multi    
+    line  
+    string
+    whitespace ";
+    echo 'code here'; 
 }
 
 // Уберём из системных свойств все кроме информации об услугах

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
@@ -38,7 +38,7 @@ function myFunction2()
 
 // @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines true
 
-function myFunction2()
+function myFunction3()
 {
     echo 'code here';
     
@@ -47,6 +47,14 @@ function myFunction2()
 }
 
 // @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
+
+function myFunction4()
+{
+    echo "multi    
+    line  
+    string 
+    whitespace ";
+}
 
 // Уберём из системных свойств все кроме информации об услугах
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc.fixed
@@ -44,12 +44,27 @@ function myFunction3()
 
 // @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
 
+
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultiLineStrings false
+
 function myFunction4()
+{
+    echo "multi
+    line
+    string
+    whitespace ";
+    echo 'code here';
+}
+
+// @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreMultiLineStrings true
+
+function myFunction5()
 {
     echo "multi    
     line  
-    string 
+    string
     whitespace ";
+    echo 'code here';
 }
 
 // Уберём из системных свойств все кроме информации об услугах

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc.fixed
@@ -34,7 +34,7 @@ function myFunction2()
 
 // @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines true
 
-function myFunction2()
+function myFunction3()
 {
     echo 'code here';
     
@@ -43,6 +43,14 @@ function myFunction2()
 }
 
 // @codingStandardsChangeSetting Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
+
+function myFunction4()
+{
+    echo "multi    
+    line  
+    string 
+    whitespace ";
+}
 
 // Уберём из системных свойств все кроме информации об услугах
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -39,7 +39,7 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                     23 => 1,
                     28 => 1,
                     33 => 1,
-                    53 => 1,
+                    61 => 1,
                    );
             break;
         case 'SuperfluousWhitespaceUnitTest.1.js':

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -39,7 +39,12 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                     23 => 1,
                     28 => 1,
                     33 => 1,
-                    61 => 1,
+                    50 => 1,
+                    56 => 1,
+                    57 => 1,
+                    60 => 1,
+                    71 => 1,
+                    76 => 1,
                    );
             break;
         case 'SuperfluousWhitespaceUnitTest.1.js':


### PR DESCRIPTION
# Superflous whitespace check for multi line string
Have extended the SuperfluousWhitespace check to be able to detect and fix whitespace at the EOL in a multi line string deceleration.

Have included an option to ignore this check and set the default value to true so this is a non breaking change.

## Why
This is in my teams coding standards and something that we weren't able to get reported by Code Sniffer in our build pipeline. It is often found in multi line SQL definitions where a space has been left after the SELECT, FROM or WHERE.

I originally thought of adding a new custom rule but thought it fitted well within the existing SuperfluousWhitespace so decided to extend.
