### PR TITLE
Travis: run the build tests against PHP 7.2 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - php: 7.0
       env: CUSTOM_INI=1
     - php: 7.1
+    - php: 7.2
     - php: nightly
     - php: hhvm
 


### PR DESCRIPTION
The new Trusty images as per Sept 7 include an image for PHP 7.2 (even though it hasn't been released yet) and nightly is now PHP 7.3-dev.