### PR TITLE
Using the '--sniffs' argument has a problem with case sensitivity

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -200,15 +200,15 @@ class Ruleset
 
         $sniffRestrictions = array();
         foreach ($restrictions as $sniffCode) {
-            $parts     = explode('.', strtolower($sniffCode));
-            $sniffName = $parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
+            $parts     = explode('.', $sniffCode);
+            $sniffName = $parts[0].'\Sniffs\\'.$parts[1].'\\'.$parts[2].'Sniff';
             $sniffRestrictions[$sniffName] = true;
         }
 
         $sniffExclusions = array();
         foreach ($exclusions as $sniffCode) {
-            $parts     = explode('.', strtolower($sniffCode));
-            $sniffName = $parts[0].'\sniffs\\'.$parts[1].'\\'.$parts[2].'sniff';
+            $parts     = explode('.', $sniffCode);
+            $sniffName = $parts[0].'\Sniffs\\'.$parts[1].'\\'.$parts[2].'Sniff';
             $sniffExclusions[$sniffName] = true;
         }
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -434,9 +434,9 @@ class Common
      */
     public static function cleanSniffClass($sniffClass)
     {
-        $newName = strtolower($sniffClass);
+        $newName = $sniffClass;
 
-        $sniffPos = strrpos($newName, '\sniffs\\');
+        $sniffPos = strrpos($newName, '\Sniffs\\');
         if ($sniffPos === false) {
             // Nothing we can do as it isn't in a known format.
             return $newName;

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -157,7 +157,7 @@ abstract class AbstractSniffUnitTest extends TestCase
         $sniffClassName = str_replace('\Tests\\', '\Sniffs\\', $sniffClassName);
         $sniffClassName = Common::cleanSniffClass($sniffClassName);
 
-        $restrictions = array(strtolower($sniffClassName) => true);
+        $restrictions = array($sniffClassName => true);
         $ruleset->registerSniffs(array($sniffFile), $restrictions, array());
         $ruleset->populateTokenListeners();
 


### PR DESCRIPTION
When using the '--sniffs'  argument with phpcs you have to enter the the sniffs case sensitive for the sniff to work.
However when using any other casing (like all lowercase) of the same letters, phpcs will not fail.
Instead it will find the sniff and run it, but it will never report any errors.
If different letters are used, phpcs obviously complains directly that it can't find the sniff.

This is since the matching of errors to sniffs is done with in_array(), which is case sensitive. But the loading of sniffs uses strtolower() in various places.

So this patch makes the '--sniffs' argument fully case sensitive.