### PR TITLE
Enable process substitution

### DIFF
--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -70,6 +70,11 @@ class Common
             }
         }
 
+        // Check for process substitution
+        if (strpos($path, '/dev/fd') === 0) {
+            return str_replace('/dev/fd', 'php://fd', $path);
+        }
+
         // No extra work needed if this is not a phar file.
         if (self::isPharFile($path) === false) {
             return realpath($path);

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -70,7 +70,7 @@ class Common
             }
         }
 
-        // Check for process substitution
+        // Check for process substitution.
         if (strpos($path, '/dev/fd') === 0) {
             return str_replace('/dev/fd', 'php://fd', $path);
         }


### PR DESCRIPTION
When using bash process substitution leaves a file descriptor to read
from. PHP needs its own stream for this, so this translates the two.

Example

`phpcs --file-list=<(git diff origin/master --name-only -- '*.php')`

To only run code sniffer for the changed files