### PR TITLE
New "Generic.PHP.DiscourageGoto" sniff

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -273,6 +273,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DeprecatedFunctionsStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagStandard.xml" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DiscourageGotoStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenFunctionsStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseConstantStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseKeywordStandard.xml" role="php" />
@@ -368,6 +369,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DeprecatedFunctionsSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DiscourageGotoSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenFunctionsSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseConstantSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseKeywordSniff.php" role="php" />
@@ -568,6 +570,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagUnitTest.2.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DiscourageGotoUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DiscourageGotoUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenFunctionsUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenFunctionsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseConstantUnitTest.inc" role="test" />

--- a/src/Standards/Generic/Docs/PHP/DiscourageGotoStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/DiscourageGotoStandard.xml
@@ -1,0 +1,7 @@
+<documentation title="Goto">
+    <standard>
+    <![CDATA[
+    Discourage the use of the PHP `goto` language construct.
+    ]]>
+    </standard>
+</documentation>

--- a/src/Standards/Generic/Sniffs/PHP/DiscourageGotoSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DiscourageGotoSniff.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Discourage the use of the PHP `goto` language construct.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DiscourageGotoSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_GOTO,
+                T_GOTO_LABEL,
+               );
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $phpcsFile->addWarning('Using the "goto" language construct is discouraged', $stackPtr, 'Found');
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+goto a;
+echo 'Foo';
+
+a:
+echo 'Bar';
+
+for($i=0,$j=50; $i<100; $i++) {
+    while($j--) {
+        if($j==17) goto end;
+    }
+}
+echo "i = $i";
+
+end: {
+  echo 'j hit 17';
+}

--- a/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DiscourageGotoUnitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Unit test class for the DiscourageGoto sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class DiscourageGotoUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return array();
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return array(
+                3  => 1,
+                6  => 1,
+                11 => 1,
+                16 => 1,
+               );
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Usage of goto is often seen as a typical code smell.

Includes docs file and unit tests.

Closes #1662