### PR TITLE
Squiz/ArrayBrackets: Add `fixed` file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1109,6 +1109,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <dir name="Tests">
        <dir name="Arrays">
         <file baseinstalldir="PHP/CodeSniffer" name="ArrayBracketSpacingUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ArrayBracketSpacingUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ArrayBracketSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ArrayDeclarationUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ArrayDeclarationUnitTest.1.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc.fixed
@@ -1,0 +1,27 @@
+<?php
+$myArray['key']                = $value;
+$myArray['key'] = $value;
+$myArray['key'] = $value;
+$myArray['key']            = $value;
+if ($array[($index + 1)] === true) {
+} else if ($array[($index + 1)] === null) {
+}
+$array = [
+    'foo' => 'bar',
+    'bar' => 'foo',
+];
+
+if ($foo) {}
+[$a, $b] = $c;
+
+echo foo()[1];
+
+echo $this->addedCustomFunctions['nonce'];
+echo $this->deprecated_functions[$function_name]['version'];
+
+echo [ 1,2,3 ][0];
+echo [ 1,2,3 ][0];
+echo 'PHP'[0];
+
+$array = [];
+$var = $var[$var[$var]]]; // Syntax error


### PR DESCRIPTION
The fixed file highlights that the fixer does not only remove spaces, but also removes comments.

Whether this is intentional or not, is unclear to me.

If it is unintentional, I'd be happy to add a second commit to fix this.