### PR TITLE
`getTokensAsString()` method: Add option to respect original content

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1679,12 +1679,14 @@ class File
      * Returns the content of the tokens from the specified start position in
      * the token stack for the specified length.
      *
-     * @param int $start  The position to start from in the token stack.
-     * @param int $length The length of tokens to traverse from the start pos.
+     * @param int $start       The position to start from in the token stack.
+     * @param int $length      The length of tokens to traverse from the start pos.
+     * @param int $origContent Whether the original content or the tab replaced
+     *                         content should be used.
      *
      * @return string The token contents.
      */
-    public function getTokensAsString($start, $length)
+    public function getTokensAsString($start, $length, $origContent=false)
     {
         $str = '';
         $end = ($start + $length);
@@ -1693,7 +1695,13 @@ class File
         }
 
         for ($i = $start; $i < $end; $i++) {
-            $str .= $this->tokens[$i]['content'];
+            // If tabs are being converted to spaces by the tokeniser, the
+            // original content should be used instead of the converted content.
+            if ($origContent === true && isset($this->tokens[$i]['orig_content']) === true) {
+                $str .= $this->tokens[$i]['orig_content'];
+            } else {
+                $str .= $this->tokens[$i]['content'];
+            }
         }
 
         return $str;


### PR DESCRIPTION
When a file uses tabs and a `tab-width` is set, the `content` will have spaces instead of tabs.
This could lead to situations where the output of `getTokensAsString()` when used to move content about would unintentionally replace tabs with spaces.

This small change allows for retrieving the original content by passing a third parameter.

I've chosen to add a parameter rather than change the default function behaviour to prevent breaks for existing sniffs relying on this behaviour, like the Squiz/ArrayDeclaration sniff: https://github.com/squizlabs/PHP_CodeSniffer/blob/2ca6cf56420616cb47a88249eb5e3520f0e31ac7/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php#L477-L480