### PR TITLE
New Generic/LowerCaseTypeDeclaration sniff

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -269,6 +269,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenFunctionsStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseConstantStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseKeywordStandard.xml" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseTypeDeclarationStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="NoSilencedErrorsStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="UpperCaseConstantStandard.xml" role="php" />
@@ -367,6 +368,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenFunctionsSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseConstantSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseKeywordSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseTypeDeclarationSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="NoSilencedErrorsSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="SyntaxSniff.php" role="php" />
@@ -583,6 +585,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseKeywordUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseKeywordUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseKeywordUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseTypeDeclarationUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseTypeDeclarationUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowerCaseTypeDeclarationUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="NoSilencedErrorsUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="NoSilencedErrorsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.inc" role="test" />

--- a/src/Standards/Generic/Docs/PHP/LowerCaseTypeDeclarationStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/LowerCaseTypeDeclarationStandard.xml
@@ -1,0 +1,24 @@
+<documentation title="Lowercase Type Declaration">
+    <standard>
+    <![CDATA[
+    All non-classname based type declarations should be lowercase.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Lowercase type declarations used.">
+        <![CDATA[
+function foo(int $a): float {} {}
+        ]]>
+        </code>
+        <code title="Valid: Mixed case classname based type declarations used.">
+        <![CDATA[
+function foo(MyClass $a): \Baz {}
+        ]]>
+        </code>
+        <code title="Invalid: Non-lowercase type declarations used.">
+        <![CDATA[
+function foo(INT $a): Float {} {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeDeclarationSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeDeclarationSniff.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Verify that type declarations are lowercase.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class LowerCaseTypeDeclarationSniff implements Sniff
+{
+
+    /**
+     * A list of parameter type declarations to examine.
+     *
+     * Used to be able to distinguish the target type
+     * declarations from class name type declarations.
+     *
+     * Class based parameter type declarations were introduced in PHP 5.0.
+     * All other types have become available after.
+     *
+     * The key is a lowercase type hint, the value is the token code
+     * this type declaration will have in the token stack.
+     *
+     * @var array
+     */
+    protected $parameterTypes = [
+        'self'     => T_SELF,
+        'parent'   => T_PARENT,
+
+        // PHP 5.1.
+        'array'    => T_ARRAY_HINT,
+
+        // PHP 5.4.
+        'callable' => T_CALLABLE,
+
+        // PHP 7.0.
+        'bool'     => T_STRING,
+        'float'    => T_STRING,
+        'int'      => T_STRING,
+        'string'   => T_STRING,
+
+        // PHP 7.1.
+        'iterable' => T_STRING,
+
+        // PHP 7.2.
+        'object'   => T_STRING,
+    ];
+
+    /**
+     * A list of return type declarations to examine.
+     *
+     * Used to be able to distinguish the target type
+     * declarations from class name type declarations.
+     *
+     * Return declarations were introduced in PHP 7.0.
+     * Some additional types have become available after.
+     *
+     * @var array
+     */
+    protected $returnTypes = [
+        'array'    => true,
+        'bool'     => true,
+        'callable' => true,
+        'float'    => true,
+        'int'      => true,
+        'parent'   => true,
+        'self'     => true,
+        'string'   => true,
+
+        // PHP 7.1.
+        'iterable' => true,
+        'void'     => true,
+
+        // PHP 7.2.
+        'object'   => true,
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION,
+            T_CLOSURE,
+            T_RETURN_TYPE,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_FUNCTION
+            || $tokens[$stackPtr]['code'] === T_CLOSURE
+        ) {
+            // Get all parameters from method signature.
+            $paramNames = $phpcsFile->getMethodParameters($stackPtr);
+            if (empty($paramNames) === true) {
+                return;
+            }
+
+            foreach ($paramNames as $param) {
+                if ($param['type_hint'] === '') {
+                    continue;
+                }
+
+                // Strip off potential nullable indication.
+                $typeHint   = ltrim($param['type_hint'], '?');
+                $typeHintLC = strtolower($typeHint);
+
+                if (isset($this->parameterTypes[$typeHintLC]) === true && $typeHintLC !== $typeHint) {
+                    $typePtr = $phpcsFile->findPrevious(
+                        $this->parameterTypes[$typeHintLC],
+                        ($param['token'] - 1),
+                        $stackPtr,
+                        false,
+                        $typeHint,
+                        true
+                    );
+                    if ($typePtr === false) {
+                        continue;
+                    }
+
+                    $error = 'Parameter type declarations must be lowercase; expected "%s" but found "%s"';
+                    $data  = [
+                        strtolower($param['type_hint']),
+                        $param['type_hint'],
+                    ];
+
+                    $fix = $phpcsFile->addFixableError($error, $typePtr, 'ParameterTypeFound', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($typePtr, $typeHintLC);
+                    }
+                }//end if
+            }//end foreach
+        } else {
+            // Return type.
+            $content   = $tokens[$stackPtr]['content'];
+            $contentLC = strtolower($content);
+
+            if (isset($this->returnTypes[$contentLC]) === true && $contentLC !== $content) {
+                $error = 'Return type declarations must be lowercase; expected "%s" but found "%s"';
+                $data  = [
+                    $contentLC,
+                    $content,
+                ];
+
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'ReturnTypeFound', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($stackPtr, $contentLC);
+                }
+            }
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeDeclarationUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeDeclarationUnitTest.inc
@@ -1,0 +1,95 @@
+<?php
+
+// Ok: No function parameters or no (return) type declaration.
+function baz() {}
+function bax( $a, $b ) {}
+$ok = function($a) {};
+
+/*
+ * Correct parameter type declarations.
+ * Includes variations for testing sniff functioning independent
+ * of code style, with closures and with nullable type hints.
+ */
+function fooA(array $a) {}
+function fooB(callable $a) {}
+function fooC  (   bool    $a   ) {}
+function fooD(int $a) {}
+$a = function (float $a) {};
+$b = function (string $a) {};
+function fooE(?iterable $a) {}
+function fooF(?object $a) {}
+
+// Class/interface type declaration.
+function fooG(stdClass $a) {}
+function fooH(MyClass $a) {}
+function fooI(\MyClass $a) {}
+function fooJ(MyNamespace\MyClass $a) {}
+function fooK(\MyNamespace\MyClass $a) {}
+
+class MyClass {
+    function fooL(self $a) {}
+}
+
+// Invalid type declarations - will be treated as class/interface names.
+function fooM(boolean $a) {}
+function fooN(integer $a) {}
+
+class MyOtherClass extends MyClass {
+    function fooO(static $a) {}
+}
+
+/*
+ * Test wrong case.
+ */
+function fooAA(Array $a) {}
+function fooAB(CALLABLE $a) {}
+function fooAC  (    BooL    $a  ) {}
+function fooAD(INT $a) {}
+$c = function (Float $a) {};
+$d = function (String $a) {};
+function fooAE(?IteRaBle $a) {}
+function fooAF(?Object $a) {}
+
+class MyClass {
+    function fooAG(SELF $a) {}
+    function fooAH(Parent $a) {}
+}
+
+
+/*
+ * PHP 7: correct return type declarations.
+ * Includes variations for testing sniff functioning independent
+ * of code style, with closures and with nullable type hints.
+ */
+function barA(): bool {}
+function barB():int{}
+function barC(): float {}
+function barD(): ?string {}
+function barE(): array {}
+$e = function (): callable {};
+function barF(): self {}
+function barG(): ?parent {}
+function barH(): Baz {}
+$f = function (): \Baz {};
+function barI(): myNamespace\Baz {}
+function barJ(): \myNamespace\Baz {}
+function barK()  : iterable   {}
+function barL()
+    : void {}
+function barM(): object {}
+
+/*
+ * Test wrong case.
+ */
+function barA(): Bool {}
+function barB():INT{}
+function barC(): Float {}
+function barD(): ?String {}
+function barE(): ARRAY {}
+$e = function (): CallAble {};
+function barF(): SELF {}
+function barG(): ?Parent {}
+function barK()  : IterAble   {}
+function barL()
+    : VOID {}
+function barM(): Object {}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeDeclarationUnitTest.inc.fixed
@@ -1,0 +1,95 @@
+<?php
+
+// Ok: No function parameters or no (return) type declaration.
+function baz() {}
+function bax( $a, $b ) {}
+$ok = function($a) {};
+
+/*
+ * Correct parameter type declarations.
+ * Includes variations for testing sniff functioning independent
+ * of code style, with closures and with nullable type hints.
+ */
+function fooA(array $a) {}
+function fooB(callable $a) {}
+function fooC  (   bool    $a   ) {}
+function fooD(int $a) {}
+$a = function (float $a) {};
+$b = function (string $a) {};
+function fooE(?iterable $a) {}
+function fooF(?object $a) {}
+
+// Class/interface type declaration.
+function fooG(stdClass $a) {}
+function fooH(MyClass $a) {}
+function fooI(\MyClass $a) {}
+function fooJ(MyNamespace\MyClass $a) {}
+function fooK(\MyNamespace\MyClass $a) {}
+
+class MyClass {
+    function fooL(self $a) {}
+}
+
+// Invalid type declarations - will be treated as class/interface names.
+function fooM(boolean $a) {}
+function fooN(integer $a) {}
+
+class MyOtherClass extends MyClass {
+    function fooO(static $a) {}
+}
+
+/*
+ * Test wrong case.
+ */
+function fooAA(array $a) {}
+function fooAB(callable $a) {}
+function fooAC  (    bool    $a  ) {}
+function fooAD(int $a) {}
+$c = function (float $a) {};
+$d = function (string $a) {};
+function fooAE(?iterable $a) {}
+function fooAF(?object $a) {}
+
+class MyClass {
+    function fooAG(self $a) {}
+    function fooAH(parent $a) {}
+}
+
+
+/*
+ * PHP 7: correct return type declarations.
+ * Includes variations for testing sniff functioning independent
+ * of code style, with closures and with nullable type hints.
+ */
+function barA(): bool {}
+function barB():int{}
+function barC(): float {}
+function barD(): ?string {}
+function barE(): array {}
+$e = function (): callable {};
+function barF(): self {}
+function barG(): ?parent {}
+function barH(): Baz {}
+$f = function (): \Baz {};
+function barI(): myNamespace\Baz {}
+function barJ(): \myNamespace\Baz {}
+function barK()  : iterable   {}
+function barL()
+    : void {}
+function barM(): object {}
+
+/*
+ * Test wrong case.
+ */
+function barA(): bool {}
+function barB():int{}
+function barC(): float {}
+function barD(): ?string {}
+function barE(): array {}
+$e = function (): callable {};
+function barF(): self {}
+function barG(): ?parent {}
+function barK()  : iterable   {}
+function barL()
+    : void {}
+function barM(): object {}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeDeclarationUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeDeclarationUnitTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Unit test class for the LowerCaseTypeDeclaration sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class LowerCaseTypeDeclarationUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            // Parameter type declarations.
+            44 => 1,
+            45 => 1,
+            46 => 1,
+            47 => 1,
+            48 => 1,
+            49 => 1,
+            50 => 1,
+            51 => 1,
+            54 => 1,
+            55 => 1,
+
+            // Return type declarations.
+            84 => 1,
+            85 => 1,
+            86 => 1,
+            87 => 1,
+            88 => 1,
+            89 => 1,
+            90 => 1,
+            91 => 1,
+            92 => 1,
+            94 => 1,
+            95 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
New sniff to verify that all non-classname based type declarations are lowercase, both for parameter type declarations as well as return type declarations.

Includes extensive unit tests.

Includes auto-fixer.

Fixes #1684