### PR TITLE
Custom property arrays: be lenient about space usage

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -950,9 +950,9 @@ class Ruleset
 
                             list($k,$v) = explode('=>', $val.'=>');
                             if ($v !== '') {
-                                $values[$k] = $v;
+                                $values[trim($k)] = trim($v);
                             } else {
-                                $values[] = $k;
+                                $values[] = trim($k);
                             }
                         }
 


### PR DESCRIPTION
While it is debatable whether it is a bug or a feature that custom property arrays are unforgiving about spaces surrounding the individual keys and values, all custom array properties in PHPCS itself do not expect spaces around them.

This minor change removes spaces around array keys and values before the property is passed to the sniff.

This means that each of the below examples will now result in the same property value being set:
```xml
<rule ref="Generic.PHP.ForbiddenFunctions">
        <properties>
            <property name="forbiddenFunctions" value="print=>echo,create_function=>null" type="array" />
            <property name="forbiddenFunctions" value="print=>echo, create_function=>null" type="array" />
            <property name="forbiddenFunctions" value="print => echo, create_function => null" type="array" />
        </properties>
</rule>
```

Fixes #1688