### PR TITLE
Squiz/SemicolonSpacing: improve handling of semicolons in `for` control structures

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc
@@ -16,3 +16,15 @@ $sum = $a // + $b
 ;
 $sum = $a /* + $b
     + $c */ ;
+
+/*
+ * Test that the sniff does *not* throw incorrect errors for semi-colons in
+ * "empty" parts of a `for` control structure.
+ */
+for ($i = 1; ; $i++) {}
+for ( ; $ptr >= 0; $ptr-- ) {}
+for ( ; ; ) {}
+
+// But it should when the semi-colon in a `for` follows a comment (but shouldn't move the semi-colon).
+for ( /* Deliberately left empty. */ ; $ptr >= 0; $ptr-- ) {}
+for ( $i = 1 ; /* Deliberately left empty. */ ; $i++ ) {}

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.inc.fixed
@@ -16,3 +16,15 @@ $sum = $a; // + $b
 
 $sum = $a; /* + $b
     + $c */
+
+/*
+ * Test that the sniff does *not* throw incorrect errors for semi-colons in
+ * "empty" parts of a `for` control structure.
+ */
+for ($i = 1; ; $i++) {}
+for ( ; $ptr >= 0; $ptr-- ) {}
+for ( ; ; ) {}
+
+// But it should when the semi-colon in a `for` follows a comment (but shouldn't move the semi-colon).
+for ( /* Deliberately left empty. */; $ptr >= 0; $ptr-- ) {}
+for ( $i = 1; /* Deliberately left empty. */; $i++ ) {}

--- a/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SemicolonSpacingUnitTest.php
@@ -39,6 +39,8 @@ class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
                     14 => 1,
                     16 => 1,
                     18 => 1,
+                    29 => 1,
+                    30 => 2,
                    );
             break;
         case 'SemicolonSpacingUnitTest.js':


### PR DESCRIPTION
This is a solution for issue #1690 in which I've basically implemented the first of the three options mentioned in the issue.

> Selectively exclude semi-colons found within a for() condition when they are preceded by the open parenthesis or by another ;.

Includes unit tests.

Fixes #1690