### PR TITLE
Allow empty {} on single line in Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -63,9 +63,11 @@ class ScopeClosingBraceSniff implements Sniff
         $scopeStart  = $tokens[$stackPtr]['scope_opener'];
         $scopeEnd    = $tokens[$stackPtr]['scope_closer'];
 
-        // Check that the closing brace is on it's own line.
+        // Check that the closing brace is on it's own line. Empty {} is always allowed.
         $lastContent = $phpcsFile->findPrevious(array(T_INLINE_HTML, T_WHITESPACE, T_OPEN_TAG), ($scopeEnd - 1), $scopeStart, true);
-        if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']) {
+        if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']
+            && $scopeEnd !== ($scopeStart + 1)
+        ) {
             $error = 'Closing brace must be on a line by itself';
             $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'ContentBefore');
             if ($fix === true) {

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
@@ -10,9 +10,11 @@ class Test
     {
      }
 
-    function test2() {}
+    function test2() {foo();}
 
-    private function _test3()
+    function test3() {}
+
+    private function _test4()
     {
     }
 
@@ -92,6 +94,8 @@ switch ($blah) {
 <?php
 public function foo()
 {
+    $foo('description', function () {});
+
     $foo('some
     long description', function () {
     });

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
@@ -10,10 +10,12 @@ class Test
     {
     }
 
-    function test2() {
+    function test2() {foo();
     }
 
-    private function _test3()
+    function test3() {}
+
+    private function _test4()
     {
     }
 
@@ -93,6 +95,8 @@ switch ($blah) {
 <?php
 public function foo()
 {
+    $foo('description', function () {});
+
     $foo('some
     long description', function () {
     });

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -28,9 +28,9 @@ class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
         return array(
                 11  => 1,
                 13  => 1,
-                24  => 1,
-                80  => 1,
-                102 => 1,
+                26  => 1,
+                82  => 1,
+                106 => 1,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
Allows non-awkward single line syntax for empty functions/classes.

Fixes one of the cases mentioned in #1580.