### PR TITLE
Squiz.Arrays.ArrayBracketSpacing is removing some comments during fixing

### DIFF
--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
@@ -45,11 +45,13 @@ class ArrayBracketSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === T_OPEN_SQUARE_BRACKET) {
-        } else {
-            if (isset($tokens[$stackPtr]['bracket_opener']) === false) {
-                return;
-            }
+        if (($tokens[$stackPtr]['code'] === T_OPEN_SQUARE_BRACKET
+            && isset($tokens[$stackPtr]['bracket_closer']) === false)
+            || ($tokens[$stackPtr]['code'] === T_CLOSE_SQUARE_BRACKET
+            && isset($tokens[$stackPtr]['bracket_opener']) === false)
+        ) {
+            // Bow out for parse error/during live coding.
+            return;
         }
 
         // Square brackets can not have a space before them.

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
@@ -56,8 +56,8 @@ class ArrayBracketSpacingSniff implements Sniff
 
         // Square brackets can not have a space before them.
         $prevType = $tokens[($stackPtr - 1)]['code'];
-        if (isset(Tokens::$emptyTokens[$prevType]) === true) {
-            $nonSpace = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 2), null, true);
+        if ($prevType === T_WHITESPACE) {
+            $nonSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 2), null, true);
             $expected = $tokens[$nonSpace]['content'].$tokens[$stackPtr]['content'];
             $found    = $phpcsFile->getTokensAsString($nonSpace, ($stackPtr - $nonSpace)).$tokens[$stackPtr]['content'];
             $error    = 'Space found before square bracket; expected "%s" but found "%s"';
@@ -74,8 +74,8 @@ class ArrayBracketSpacingSniff implements Sniff
         // Open square brackets can't ever have spaces after them.
         if ($tokens[$stackPtr]['code'] === T_OPEN_SQUARE_BRACKET) {
             $nextType = $tokens[($stackPtr + 1)]['code'];
-            if (isset(Tokens::$emptyTokens[$nextType]) === true) {
-                $nonSpace = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 2), null, true);
+            if ($nextType === T_WHITESPACE) {
+                $nonSpace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 2), null, true);
                 $expected = $tokens[$stackPtr]['content'].$tokens[$nonSpace]['content'];
                 $found    = $phpcsFile->getTokensAsString($stackPtr, ($nonSpace - $stackPtr + 1));
                 $error    = 'Space found after square bracket; expected "%s" but found "%s"';

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayBracketSpacingSniff.php
@@ -45,22 +45,11 @@ class ArrayBracketSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // PHP 5.4 introduced a shorthand array declaration syntax, so we need
-        // to ignore the these type of array declarations because this sniff is
-        // only dealing with array usage.
         if ($tokens[$stackPtr]['code'] === T_OPEN_SQUARE_BRACKET) {
-            $openBracket = $stackPtr;
         } else {
             if (isset($tokens[$stackPtr]['bracket_opener']) === false) {
                 return;
             }
-
-            $openBracket = $tokens[$stackPtr]['bracket_opener'];
-        }
-
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($openBracket - 1), null, true);
-        if ($tokens[$prev]['code'] === T_EQUAL) {
-            return;
         }
 
         // Square brackets can not have a space before them.

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc
@@ -26,3 +26,6 @@ echo 'PHP'[ 0 ];
 $array = [];
 $var = $var[$var[$var]]]; // Syntax error
 $var = $var[$var[$var]; // Syntax error
+
+$myArray[ /* key start */'key'] = $value;
+$myArray[ /* key start */'key'/* key end */ ] = $value;

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc
@@ -25,3 +25,4 @@ echo 'PHP'[ 0 ];
 
 $array = [];
 $var = $var[$var[$var]]]; // Syntax error
+$var = $var[$var[$var]; // Syntax error

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 $myArray['key']                = $value;
-$myArray['key'] = $value;
-$myArray['key'] = $value;
+$myArray[/* key start */'key'] = $value;
+$myArray[/* key start */'key'/* key end */] = $value;
 $myArray['key']            = $value;
 if ($array[($index + 1)] === true) {
 } else if ($array[($index + 1)] === null) {
@@ -26,3 +26,6 @@ echo 'PHP'[0];
 $array = [];
 $var = $var[$var[$var]]]; // Syntax error
 $var = $var[$var[$var]; // Syntax error
+
+$myArray[/* key start */'key'] = $value;
+$myArray[/* key start */'key'/* key end */] = $value;

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.inc.fixed
@@ -25,3 +25,4 @@ echo 'PHP'[0];
 
 $array = [];
 $var = $var[$var[$var]]]; // Syntax error
+$var = $var[$var[$var]; // Syntax error

--- a/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayBracketSpacingUnitTest.php
@@ -26,14 +26,14 @@ class ArrayBracketSpacingUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return array(
-                3  => 1,
-                4  => 2,
                 5  => 3,
                 7  => 3,
                 17 => 2,
                 20 => 2,
                 23 => 2,
                 24 => 2,
+                30 => 1,
+                31 => 2,
                );
 
     }//end getErrorList()


### PR DESCRIPTION
As discussed in https://github.com/squizlabs/PHP_CodeSniffer/pull/1673#issuecomment-335048664, this PR addresses the `Squiz.Arrays.ArrayBracketSpacing` sniff unintentionally removing comments which were placed adjacent to the brackets.
This should not happen anymore once this PR has been merged.

Includes adjusted and additional unit tests.

While looking at the sniff, I noticed two other improvements begging to be made :heart_eyes_cat: 
* The sniff still had some checks in it to prevent it acting on short array syntax. As the short array open/close brackets have their own tokens now, these checks are no longer needed.
* The sniff had a sanity check for parse errors/live coding for the close bracket, but not for the open bracket.

Both of these additional issues have been fixed in separate commits.