### PR TITLE
New Generic.WhiteSpace.ArbitraryParenthesesSpacing sniff

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -296,6 +296,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="SubversionPropertiesStandard.xml" role="php" />
        </dir>
        <dir name="WhiteSpace">
+        <file baseinstalldir="PHP/CodeSniffer" name="ArbitraryParenthesesSpacingStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentStandard.xml" role="php" />
@@ -394,6 +395,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="SubversionPropertiesSniff.php" role="php" />
        </dir>
        <dir name="WhiteSpace">
+        <file baseinstalldir="PHP/CodeSniffer" name="ArbitraryParenthesesSpacingSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentSniff.php" role="php" />
@@ -610,6 +612,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="UnnecessaryStringConcatUnitTest.php" role="test" />
        </dir>
        <dir name="WhiteSpace">
+        <file baseinstalldir="PHP/CodeSniffer" name="ArbitraryParenthesesSpacingUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ArbitraryParenthesesSpacingUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ArbitraryParenthesesSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.inc" role="test" />

--- a/src/Standards/Generic/Docs/WhiteSpace/ArbitraryParenthesesSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/WhiteSpace/ArbitraryParenthesesSpacingStandard.xml
@@ -1,0 +1,26 @@
+<documentation title="Arbitrary Parentheses Spacing">
+    <standard>
+    <![CDATA[
+    Arbitrary sets of parentheses should have no spaces inside.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: no spaces on the inside of a set of arbitrary parentheses.">
+        <![CDATA[
+$a = (null !== $extra);
+        ]]>
+        </code>
+        <code title="Invalid: spaces on the inside of a set of arbitrary parentheses.">
+        <![CDATA[
+$a = ( null !== $extra );
+        ]]>
+        </code>
+        <code title="Invalid: new lines on the inside of a set of arbitrary parentheses.">
+        <![CDATA[
+$a = (
+    null !== $extra
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Check & fix whitespace on the inside of arbitrary parentheses.
+ *
+ * Arbitrary parentheses are those which are not owned by a function (call), array or control structure.
+ * Spacing on the outside is not checked on purpose as this would too easily conflict with other spacing rules.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ArbitraryParenthesesSpacingSniff implements Sniff
+{
+
+    /**
+     * The number of spaces desired on the inside of the parentheses.
+     *
+     * @var integer
+     */
+    public $spacingInside = 0;
+
+    /**
+     * Allow newlines instead of spaces.
+     *
+     * @var boolean
+     */
+    public $ignoreNewlines = false;
+
+    /**
+     * Tokens which when they precede an open parenthesis indicate
+     * that this is a type of structure this sniff should ignore.
+     *
+     * @var array
+     */
+    private $ignoreTokens = [];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $this->ignoreTokens = Tokens::$functionNameTokens;
+
+        $this->ignoreTokens[T_VARIABLE]            = T_VARIABLE;
+        $this->ignoreTokens[T_CLOSE_PARENTHESIS]   = T_CLOSE_PARENTHESIS;
+        $this->ignoreTokens[T_CLOSE_CURLY_BRACKET] = T_CLOSE_CURLY_BRACKET;
+        $this->ignoreTokens[T_CLOSE_SQUARE_BRACKET] = T_CLOSE_SQUARE_BRACKET;
+        $this->ignoreTokens[T_CLOSE_SHORT_ARRAY]    = T_CLOSE_SHORT_ARRAY;
+
+        $this->ignoreTokens[T_ANON_CLASS] = T_ANON_CLASS;
+        $this->ignoreTokens[T_USE]        = T_USE;
+        $this->ignoreTokens[T_LIST]       = T_LIST;
+        $this->ignoreTokens[T_DECLARE]    = T_DECLARE;
+        $this->ignoreTokens[T_THROW]      = T_THROW;
+        $this->ignoreTokens[T_YIELD]      = T_YIELD;
+        $this->ignoreTokens[T_YIELD_FROM] = T_YIELD_FROM;
+        $this->ignoreTokens[T_CLONE]      = T_CLONE;
+
+        return [
+            T_OPEN_PARENTHESIS,
+            T_CLOSE_PARENTHESIS,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['parenthesis_owner']) === true) {
+            // This parenthesis is owned by a function/control structure etc.
+            return;
+        }
+
+        // More checking for the type of parenthesis we *don't* want to handle.
+        $opener = $stackPtr;
+        if ($tokens[$stackPtr]['code'] === T_CLOSE_PARENTHESIS) {
+            if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
+                // Parse error.
+                return;
+            }
+
+            $opener = $tokens[$stackPtr]['parenthesis_opener'];
+        }
+
+        $preOpener = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
+        if ($preOpener !== false && isset($this->ignoreTokens[$tokens[$preOpener]['code']]) === true) {
+            // Function or language construct call.
+            return;
+        }
+
+        // Check for empty parentheses.
+        if ($tokens[$stackPtr]['code'] === T_OPEN_PARENTHESIS
+            && isset($tokens[$stackPtr]['parenthesis_closer']) === true
+        ) {
+            $nextNonEmpty = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty === $tokens[$stackPtr]['parenthesis_closer']) {
+                $phpcsFile->addWarning('Empty set of arbitrary parentheses found.', $stackPtr, 'FoundEmpty');
+
+                return ($tokens[$stackPtr]['parenthesis_closer'] + 1);
+            }
+        }
+
+        // Check the spacing on the inside of the parentheses.
+        $this->spacingInside = (int) $this->spacingInside;
+
+        if ($tokens[$stackPtr]['code'] === T_OPEN_PARENTHESIS
+            && isset($tokens[($stackPtr + 1)], $tokens[($stackPtr + 2)]) === true
+        ) {
+            $nextToken = $tokens[($stackPtr + 1)];
+
+            if ($nextToken['code'] !== T_WHITESPACE) {
+                $inside = 0;
+            } else {
+                if ($tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']) {
+                    $inside = 'newline';
+                } else {
+                    $inside = $nextToken['length'];
+                }
+            }
+
+            if ($this->spacingInside !== $inside
+                && ($inside !== 'newline' || $this->ignoreNewlines === false)
+            ) {
+                $error = 'Expected %s space after open parenthesis; %s found';
+                $data  = [
+                    $this->spacingInside,
+                    $inside,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterOpen', $data);
+
+                if ($fix === true) {
+                    $expected = '';
+                    if ($this->spacingInside > 0) {
+                        $expected = str_repeat(' ', $this->spacingInside);
+                    }
+
+                    if ($inside === 0) {
+                        if ($expected !== '') {
+                            $phpcsFile->fixer->addContent($stackPtr, $expected);
+                        }
+                    } else if ($inside === 'newline') {
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($i = ($stackPtr + 2); $i < $phpcsFile->numTokens; $i++) {
+                            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                                break;
+                            }
+
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), $expected);
+                        $phpcsFile->fixer->endChangeset();
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), $expected);
+                    }
+                }//end if
+            }//end if
+        }//end if
+
+        if ($tokens[$stackPtr]['code'] === T_CLOSE_PARENTHESIS
+            && isset($tokens[($stackPtr - 1)], $tokens[($stackPtr - 2)]) === true
+        ) {
+            $prevToken = $tokens[($stackPtr - 1)];
+
+            if ($prevToken['code'] !== T_WHITESPACE) {
+                $inside = 0;
+            } else {
+                if ($tokens[($stackPtr - 2)]['line'] !== $tokens[$stackPtr]['line']) {
+                    $inside = 'newline';
+                } else {
+                    $inside = $prevToken['length'];
+                }
+            }
+
+            if ($this->spacingInside !== $inside
+                && ($inside !== 'newline' || $this->ignoreNewlines === false)
+            ) {
+                $error = 'Expected %s space before close parenthesis; %s found';
+                $data  = [
+                    $this->spacingInside,
+                    $inside,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceBeforeClose', $data);
+
+                if ($fix === true) {
+                    $expected = '';
+                    if ($this->spacingInside > 0) {
+                        $expected = str_repeat(' ', $this->spacingInside);
+                    }
+
+                    if ($inside === 0) {
+                        if ($expected !== '') {
+                            $phpcsFile->fixer->addContentBefore($stackPtr, $expected);
+                        }
+                    } else if ($inside === 'newline') {
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($i = ($stackPtr - 2); $i > 0; $i--) {
+                            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                                break;
+                            }
+
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->replaceToken(($stackPtr - 1), $expected);
+                        $phpcsFile->fixer->endChangeset();
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($stackPtr - 1), $expected);
+                    }
+                }//end if
+            }//end if
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * Make sure the sniff does not act on structures it shouldn't act on.
+ * All parentheses have extra spacing around it to test this properly.
+ */
+$b = functioncall( $something ) ;
+$b = function( $something ) {};
+$c = myFunction( $arg1 , $arg2 = array( ) );
+
+function something( $param ) {}
+
+$d = new MyClass(  );
+$e = new class(  ) {};
+
+try {
+} catch( Exception ) {
+}
+
+include( PATH . 'file.php' );
+
+if ( in_array( $arg1, array( 'foo','bar' ) ) ) {}
+isset( $abc );
+unset( $abc );
+empty( $abc );
+eval( $abc );
+exit( $abc );
+clone( $_date1 <= $_date2 ? $_date1 : $_date2 );
+declare( ticks=1 );
+list( $post_mime_types, $avail_post_mime_types ) = wp_edit_attachments_query( $q );
+throw( $e );
+yield from ( function(){} );
+
+$obj->{$var}( $foo,$bar );
+
+(function( $a, $b ) {
+    return function( $c, $d ) use ( $a, $b ) {
+        echo $a, $b, $c, $d;
+    };
+})( 'a','b' )( 'c','d' );
+
+$closure( $foo,$bar );
+$var = $closure() + $closure( $foo,$bar ) + self::$closure( $foo,$bar );
+
+class Test {
+    public static function baz( $foo, $bar ) {
+        $a = new self( $foo,$bar );
+        $b = new static( $foo,$bar );
+    }
+}
+
+/*
+ * Test warning for empty parentheses.
+ */
+$a = 4 + (); // Warning.
+$a = 4 + (   ); // Warning.
+$a = 4 + (/* Not empty */);
+
+/*
+ * Test the actual sniff.
+ */
+if ((null !== $extra) && ($row->extra !== $extra)) {}
+
+if (( null !== $extra ) && ( $row->extra !== $extra )) {} // Bad x 4.
+
+if ((        null !== $extra // Bad x 1.
+    && is_int($extra))
+    && ( $row->extra !== $extra // Bad x 1.
+        || $something      ) // Bad x 1.
+) {}
+
+if (( null !== $extra ) // Bad x 2.
+    && ( $row->extra !== $extra ) // Bad x 2.
+) {}
+
+$a = (null !== $extra);
+$a = ( null !== $extra ); // Bad x 2.
+
+$sx = $vert ? ($w - 1) : 0;
+
+$this->is_overloaded = ( ( ini_get("mbstring.func_overload") & 2 ) != 0 ) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ($operation->axis & 1) != 0, ($operation->axis & 2) != 0 );
+
+if ( $success && ('nothumb' == $target || 'all' == $target) ) {}
+
+$directory = ('/' == $file[ strlen($file)-1 ]);
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if ((null !== $extra) && ($row->extra !== $extra)) {} // Bad x 4.
+
+if (( null !== $extra ) && ( $row->extra !== $extra )) {}
+
+if ((        null !== $extra // Bad x 1.
+    && is_int($extra)) // Bad x 1.
+    && ( $row->extra !== $extra
+        || $something      ) // Bad x 1.
+) {}
+
+if ((null !== $extra) // Bad x 2.
+    && ($row->extra !== $extra) // Bad x 2.
+) {}
+
+$a = (null !== $extra); // Bad x 2.
+$a = ( null !== $extra );
+
+$sx = $vert ? ($w - 1) : 0; // Bad x 2.
+
+$this->is_overloaded = ((ini_get("mbstring.func_overload") & 2) != 0) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ($operation->axis & 1) != 0, ($operation->axis & 2) != 0 ); // Bad x 4.
+
+if ( $success && ('nothumb' == $target || 'all' == $target) ) {} // Bad x 2.
+
+$directory = ('/' == $file[ strlen($file)-1 ]); // Bad x 2.
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+/*
+ * Test handling of ignoreNewlines.
+ */
+if (
+    (
+        null !== $extra
+    ) && (
+        $row->extra !== $extra
+    )
+) {} // Bad x 4, 1 x line 123, 2 x line 125, 1 x line 127.
+
+
+$a = (
+    null !== $extra
+); // Bad x 2, 1 x line 131, 1 x line 133.
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if (
+    (
+        null !== $extra
+    ) && (
+        $row->extra !== $extra
+    )
+) {} // Bad x 4, 1 x line 137, 2 x line 139, 1 x line 141.
+
+$a = (
+    null !== $extra
+); // Bad x 2, 1 x line 144, 1 x line 146.
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
+if (
+    (
+        null !== $extra
+    ) && (
+        $row->extra !== $extra
+    )
+) {}
+
+$a = (
+    null !== $extra
+);
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * Make sure the sniff does not act on structures it shouldn't act on.
+ * All parentheses have extra spacing around it to test this properly.
+ */
+$b = functioncall( $something ) ;
+$b = function( $something ) {};
+$c = myFunction( $arg1 , $arg2 = array( ) );
+
+function something( $param ) {}
+
+$d = new MyClass(  );
+$e = new class(  ) {};
+
+try {
+} catch( Exception ) {
+}
+
+include( PATH . 'file.php' );
+
+if ( in_array( $arg1, array( 'foo','bar' ) ) ) {}
+isset( $abc );
+unset( $abc );
+empty( $abc );
+eval( $abc );
+exit( $abc );
+clone( $_date1 <= $_date2 ? $_date1 : $_date2 );
+declare( ticks=1 );
+list( $post_mime_types, $avail_post_mime_types ) = wp_edit_attachments_query( $q );
+throw( $e );
+yield from ( function(){} );
+
+$obj->{$var}( $foo,$bar );
+
+(function( $a, $b ) {
+    return function( $c, $d ) use ( $a, $b ) {
+        echo $a, $b, $c, $d;
+    };
+})( 'a','b' )( 'c','d' );
+
+$closure( $foo,$bar );
+$var = $closure() + $closure( $foo,$bar ) + self::$closure( $foo,$bar );
+
+class Test {
+    public static function baz( $foo, $bar ) {
+        $a = new self( $foo,$bar );
+        $b = new static( $foo,$bar );
+    }
+}
+
+/*
+ * Test warning for empty parentheses.
+ */
+$a = 4 + (); // Warning.
+$a = 4 + (   ); // Warning.
+$a = 4 + (/* Not empty */);
+
+/*
+ * Test the actual sniff.
+ */
+if ((null !== $extra) && ($row->extra !== $extra)) {}
+
+if ((null !== $extra) && ($row->extra !== $extra)) {} // Bad x 4.
+
+if ((null !== $extra // Bad x 1.
+    && is_int($extra))
+    && ($row->extra !== $extra // Bad x 1.
+        || $something) // Bad x 1.
+) {}
+
+if ((null !== $extra) // Bad x 2.
+    && ($row->extra !== $extra) // Bad x 2.
+) {}
+
+$a = (null !== $extra);
+$a = (null !== $extra); // Bad x 2.
+
+$sx = $vert ? ($w - 1) : 0;
+
+$this->is_overloaded = ((ini_get("mbstring.func_overload") & 2) != 0) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ($operation->axis & 1) != 0, ($operation->axis & 2) != 0 );
+
+if ( $success && ('nothumb' == $target || 'all' == $target) ) {}
+
+$directory = ('/' == $file[ strlen($file)-1 ]);
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if (( null !== $extra ) && ( $row->extra !== $extra )) {} // Bad x 4.
+
+if (( null !== $extra ) && ( $row->extra !== $extra )) {}
+
+if (( null !== $extra // Bad x 1.
+    && is_int($extra) ) // Bad x 1.
+    && ( $row->extra !== $extra
+        || $something ) // Bad x 1.
+) {}
+
+if (( null !== $extra ) // Bad x 2.
+    && ( $row->extra !== $extra ) // Bad x 2.
+) {}
+
+$a = ( null !== $extra ); // Bad x 2.
+$a = ( null !== $extra );
+
+$sx = $vert ? ( $w - 1 ) : 0; // Bad x 2.
+
+$this->is_overloaded = ( ( ini_get("mbstring.func_overload") & 2 ) != 0 ) && function_exists('mb_substr'); // Bad x 4.
+
+$image->flip( ( $operation->axis & 1 ) != 0, ( $operation->axis & 2 ) != 0 ); // Bad x 4.
+
+if ( $success && ( 'nothumb' == $target || 'all' == $target ) ) {} // Bad x 2.
+
+$directory = ( '/' == $file[ strlen($file)-1 ] ); // Bad x 2.
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+/*
+ * Test handling of ignoreNewlines.
+ */
+if (
+    (null !== $extra) && ($row->extra !== $extra)
+) {} // Bad x 4, 1 x line 123, 2 x line 125, 1 x line 127.
+
+
+$a = (null !== $extra); // Bad x 2, 1 x line 131, 1 x line 133.
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 1
+if (
+    ( null !== $extra ) && ( $row->extra !== $extra )
+) {} // Bad x 4, 1 x line 137, 2 x line 139, 1 x line 141.
+
+$a = ( null !== $extra ); // Bad x 2, 1 x line 144, 1 x line 146.
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing spacingInside 0
+
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines true
+if (
+    (
+        null !== $extra
+    ) && (
+        $row->extra !== $extra
+    )
+) {}
+
+$a = (
+    null !== $extra
+);
+// @codingStandardsChangeSetting Generic.WhiteSpace.ArbitraryParenthesesSpacing ignoreNewlines false

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Unit test class for the ArbitraryParenthesesSpacing sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2017 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ArbitraryParenthesesSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            64  => 4,
+            66  => 1,
+            68  => 1,
+            69  => 1,
+            72  => 2,
+            73  => 2,
+            77  => 2,
+            81  => 4,
+            90  => 4,
+            94  => 1,
+            95  => 1,
+            97  => 1,
+            100 => 2,
+            101 => 2,
+            104 => 2,
+            107 => 2,
+            109 => 4,
+            111 => 4,
+            113 => 2,
+            115 => 2,
+            123 => 1,
+            125 => 2,
+            127 => 1,
+            131 => 1,
+            133 => 1,
+            137 => 1,
+            139 => 2,
+            141 => 1,
+            144 => 1,
+            146 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [
+            55 => 1,
+            56 => 1,
+        ];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
While working on the big WP Core auto-fixing project, I realized there was no sniff available to check the whitespace around arbitrary parentheses. So, here goes.

This new sniff checks the spacing on the **_inside_** of arbitrary parentheses.
A conscious choice has been made not to check on the outside as this would very quickly conflict with other sniffs.

Arbitrary parentheses, for the purposes of this sniff, are all parentheses which do not belong to a control structure, function declaration, function call or language construct.
This is to prevent conflicts and duplication with rules for those type of constructs.

**Notes:**
* The sniff will throw (fixable) errors when an incorrect amount of whitespace (too much/too little) has been found on the inside or the parenthesis.
* The sniff will throw a warning when an empty set of arbitrary parentheses is encountered.
* The desired amount of whitespace on the inside of the parentheses can be configured using the `spacingInside` property. Default: `0`.
* Whether or not to allow new lines can be configured using the `ignoreNewlines` property. Default: `false`.

Includes extensive unit tests.

#### Todo once the sniff has been merged:

- [ ] Add info on the custom properties to the wiki