### PR TITLE
Generic.WhiteSpaceDisallowSpaceIndent fixer bug when line only contains superfluous whitespace

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -80,6 +80,16 @@ class DisallowSpaceIndentSniff implements Sniff
                 continue;
             }
 
+            if ($tokens[$i]['code'] === T_WHITESPACE
+                && isset($tokens[($i + 1)]) === true
+                && $tokens[($i + 1)]['line'] !== $tokens[$i]['line']
+            ) {
+                // Blank line, ignore.
+                // If needed, the Squiz.WhiteSpace.SuperfluousWhitespace sniff can clean up
+                // superfluous whitespace on the line.
+                continue;
+            }
+
             // If tabs are being converted to spaces by the tokeniser, the
             // original content should be checked instead of the converted content.
             if (isset($tokens[$i]['orig_content']) === true) {

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.inc
@@ -68,3 +68,7 @@ $x = 1;
 	        echo 'And another one.'
     	    echo 'And another one.'
         	echo 'And another one.'
+
+// The next line has four spaces. This is a specific test case. Do not remove the spaces.
+    
+$bar = 2;

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.inc.fixed
@@ -68,3 +68,7 @@ $x = 1;
 			echo 'And another one.'
 			echo 'And another one.'
 			echo 'And another one.'
+
+// The next line has four spaces. This is a specific test case. Do not remove the spaces.
+    
+$bar = 2;


### PR DESCRIPTION
When the `Generic.WhiteSpace.DisallowSpaceIndent` sniff encountered spaces on an otherwise empty line, the fixer would replace the spaces with tabs, remove the new line character and in effect prefix the whitespace to the next line.

In other words, without the fix contains in this PR, this code snippet:
```php
// The next line has four spaces. This is a specific test case. Do not remove the spaces.

$bar = 2;
```
would be fixed as:
```php
// The next line has four spaces. This is a specific test case. Do not remove the spaces.
	$bar = 2;
```

Includes unit test demonstrating the issue.

The fix in this PR results in this sniff ignoring lines which only contain whitespace.
Superfluous whitespace can be trimmed from lines using this `Squiz.WhiteSpace.SuperfluousWhitespace` sniff after all.

Originally reported in https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1192

N.B.: I am aware that this PR will cause a merge conflict in the test files with my other PR involving this sniff #1599. I will rebase whichever PR needs it once either one of them has been merged.
As the issues are unrelated, a separate PR to fix this issue seems warranted.