### PR TITLE
Squiz/NonExecutableCode: fix undefined index during live coding reviews

### DIFF
--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.inc
@@ -259,3 +259,22 @@ class HttpStatus
     const CONTINUE = 100;
     const SWITCHING_PROTOCOLS = 101;
 }
+
+interface ABC {
+	public function noError($name, $var);
+}
+
+trait Something {
+	function getReturnType() {
+	    echo 'no error';
+	}
+}
+
+$a = new class {
+    public function log($msg)
+    {
+        echo 'no error';
+    }
+};
+
+interface MyInterface {

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -69,6 +69,7 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
             234 => 1,
             235 => 2,
             239 => 1,
+            273 => 2,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
First fix in a series to fix the issues found.

Error encountered: `Undefined index: scope_closer in phpcs/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php on line 238`

Error occurs when an unfinished function or OO structure is encountered.

While looking at the code, I saw three more minor improvements which I have included in this PR:
* Account for modern PHP OO structures.
    The sniff is designed to skip over declarations, but only accounted for functions, classes and interfaces.
    This has been updated to include closures, traits and anonymous classes.
* Add the semi-colon to the ignore list for reporting.
    In this context a 'lone' semi-colon is most often encountered at the end of a closure or anonymous class, so this might as well be skipped over.
* The sniff can thrown two or more errors on the same line when several "exit" commands have been found above the line.
    I've adjusted the error message to also report on the line where the "exit" command was encountered to make it easier to fix/debug these type of errors.

Includes unit tests.

To reproduce/test: take the updated unit test file and just run the original sniff over it.