### PR TITLE
Zend/ValidVariableName: fix undefined index error when exception is encountered

### DIFF
--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -139,7 +139,12 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $tokens      = $phpcsFile->getTokens();
         $varName     = ltrim($tokens[$stackPtr]['content'], '$');
         $memberProps = $phpcsFile->getMemberProperties($stackPtr);
-        $public      = ($memberProps['scope'] === 'public');
+        if (empty($memberProps) === true) {
+            // Exception encountered.
+            return;
+        }
+
+        $public = ($memberProps['scope'] === 'public');
 
         if ($public === true) {
             if (substr($varName, 0, 1) === '_') {

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -101,3 +101,10 @@ $someObject->my_function($var_name);
 var_dump($http_response_header);
 var_dump($HTTP_RAW_POST_DATA);
 var_dump($php_errormsg);
+
+interface Base
+{
+    protected $anonymous;
+
+    public function __construct();
+}

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -67,21 +67,22 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            6  => 1,
-            14 => 1,
-            20 => 1,
-            26 => 1,
-            32 => 1,
-            39 => 1,
-            45 => 1,
-            51 => 1,
-            64 => 1,
-            70 => 1,
-            73 => 1,
-            76 => 1,
-            79 => 1,
-            82 => 1,
-            94 => 1,
+            6   => 1,
+            14  => 1,
+            20  => 1,
+            26  => 1,
+            32  => 1,
+            39  => 1,
+            45  => 1,
+            51  => 1,
+            64  => 1,
+            70  => 1,
+            73  => 1,
+            76  => 1,
+            79  => 1,
+            82  => 1,
+            94  => 1,
+            107 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
Second fix in a series to fix the issues found.

Error encountered: `Undefined index: scope in phpcs/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php on line 142`

Error occurred when a variable was encountered in an interface.

Includes unit test