### PR TITLE
Generic/DisallowLongArray: fix undefined index when running fixer

### DIFF
--- a/src/Standards/Generic/Sniffs/Arrays/DisallowLongArraySyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/DisallowLongArraySyntaxSniff.php
@@ -39,13 +39,23 @@ class DisallowLongArraySyntaxSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        $tokens = $phpcsFile->getTokens();
+
         $phpcsFile->recordMetric($stackPtr, 'Short array syntax used', 'no');
 
         $error = 'Short array syntax must be used to define arrays';
-        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found');
+
+        if (isset($tokens[$stackPtr]['parenthesis_opener']) === false
+            || isset($tokens[$stackPtr]['parenthesis_closer']) === false
+        ) {
+            // Live coding/parse error, just show the error, don't try and fix it.
+            $phpcsFile->addError($error, $stackPtr, 'Found');
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'Found');
 
         if ($fix === true) {
-            $tokens = $phpcsFile->getTokens();
             $opener = $tokens[$stackPtr]['parenthesis_opener'];
             $closer = $tokens[$stackPtr]['parenthesis_closer'];
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.inc
@@ -21,3 +21,18 @@ abstract function foo(): array;
 abstract function foo(): Foo\Bar;
 
 abstract function foo(): \Foo\Bar;
+
+// The following function has a simulated git conflict for testing.
+// This is not a merge conflict - it is a valid test case to test handling of arrays without associated closer.
+// Please do not remove.
+function test()
+    {
+        $arr = array(
+            'a' => 'a'
+<<<<<<< HEAD
+            'b' => 'b'
+=======
+            'c' => 'c'
+>>>>>>> master
+        );
+    }

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.inc.fixed
@@ -10,7 +10,7 @@ $foo = [
         3
        ];
 $var = /*comment*/[1,2,3];
-$var = [];
+$var = array;
 
 function foo(array $array) {}
 
@@ -21,3 +21,18 @@ abstract function foo(): array;
 abstract function foo(): Foo\Bar;
 
 abstract function foo(): \Foo\Bar;
+
+// The following function has a simulated git conflict for testing.
+// This is not a merge conflict - it is a valid test case to test handling of arrays without associated closer.
+// Please do not remove.
+function test()
+    {
+        $arr = array(
+            'a' => 'a'
+<<<<<<< HEAD
+            'b' => 'b'
+=======
+            'c' => 'c'
+>>>>>>> master
+        );
+    }

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -32,6 +32,7 @@ class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
             7  => 1,
             12 => 1,
             13 => 1,
+            30 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
Third fix in a series to fix the issues found.

Error encountered: `Undefined index:  in phpcs/src/Fixer.php on line 524`

Error occurred when due to, for instance, a git merge conflict artifact, the array closer has not been determined.

Includes unit tests.

One of the already existing unit tests results has been adjusted. a found `array` keyword without parentheses was previously being fixed to short array syntax.
However, as this is "unfinished" code, it could just as easily have been the start of an array function call like `array_merge()`, making this a risky fix.

For this case as well as the new case, the error will still be reported, but the fixer will no longer run for these.

To reproduce/test: take the updated unit test file and just run the original sniff over it.