### PR TITLE
Squiz/InlineComment: fix fixer conflict when comment found at end of function

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -292,6 +292,19 @@ class InlineCommentSniff implements Sniff
                 return;
             }
 
+            $errorCode = 'SpacingAfter';
+
+            if (isset($tokens[$stackPtr]['conditions']) === true) {
+                $type         = end($tokens[$stackPtr]['conditions']);
+                $conditionPtr = key($tokens[$stackPtr]['conditions']);
+
+                if (in_array($type, [T_FUNCTION, T_CLOSURE], true) === true
+                    && $tokens[$conditionPtr]['scope_closer'] === $next
+                ) {
+                    $errorCode = 'SpacingAfterAtFunctionEnd';
+                }
+            }
+
             for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
                 if ($tokens[$i]['line'] === ($tokens[$stackPtr]['line'] + 1)) {
                     if ($tokens[$i]['code'] !== T_WHITESPACE) {
@@ -303,7 +316,7 @@ class InlineCommentSniff implements Sniff
             }
 
             $error = 'There must be no blank line following an inline comment';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter');
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, $errorCode);
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
                 for ($i = ($stackPtr + 1); $i < $next; $i++) {

--- a/src/Standards/Squiz/ruleset.xml
+++ b/src/Standards/Squiz/ruleset.xml
@@ -89,4 +89,9 @@
    <severity>0</severity>
  </rule>
 
+ <!-- Prevent fixer conflict for conflicting rules. -->
+ <rule ref="Squiz.Commenting.InlineComment">
+  <exclude name="Squiz.Commenting.InlineComment.SpacingAfterAtFunctionEnd"/>
+ </rule>
+
 </ruleset>


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
Fourth fix in a series to fix the issues found.

When an inline comment is found at the end of a function, removing a blank line after it conflicts with the `Squiz.WhiteSpace.FunctionClosingBraceSpace` sniff which demands a blank line at the end of a function.

To reproduce the issue, run (against `master`):
`phpcbf -p -s --standard=Squiz ./src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc -vv`

I have chosen to fix this by adding a specific error code for that situation and excluding that error code from the `Squiz` ruleset.

This way, the backward-compatibility break for other standards using the `Squiz.Commenting.InlineComment` sniff will be smallest.
Only if a standard explicitly in/excluded the `Squiz.Commenting.InlineComment.SpacingAfter` errorcode will this have any effect on them.

The unit tests already contain a test covering this. As the errorcode is excluded via the ruleset, the results of the unit tests do not change.

Fixes #1709