### PR TITLE
Squiz/MultiLineFunctionDeclaration: add fixed files

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1293,7 +1293,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseFunctionKeywordsUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseFunctionKeywordsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MultiLineFunctionDeclarationUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="MultiLineFunctionDeclarationUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MultiLineFunctionDeclarationUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="MultiLineFunctionDeclarationUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MultiLineFunctionDeclarationUnitTest.php" role="test" />
        </dir>
        <dir name="NamingConventions">

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
@@ -1,0 +1,175 @@
+<?php
+public function someFunctionWithAVeryLongName(
+    $firstParameter='something',
+    $secondParameter='booooo',
+    $third=null,
+    $fourthParameter=false,
+    $fifthParameter=123.12,
+    $sixthParam=true
+) {
+}
+
+function someFunctionWithAVeryLongName2(
+    $firstParameter='something',
+    $secondParameter='booooo',
+) {
+}
+
+function blah() 
+{
+}
+
+function blah()
+{
+}
+
+class MyClass
+{
+
+    public function someFunctionWithAVeryLongName(
+        $firstParameter='something',
+        $secondParameter='booooo',
+        $third=null,
+        $fourthParameter=false,
+        $fifthParameter=123.12,
+        $sixthParam=true
+    ) /** w00t */ {
+    }
+
+    public function someFunctionWithAVeryLongName2(
+        $firstParameter='something',
+        $secondParameter='booooo',
+        $third=null
+    ) {
+    }
+
+     public function someFunctionWithAVeryLongName3(
+         $firstParameter,
+         $secondParameter,
+         $third=null
+     ) {
+     }
+
+     public function someFunctionWithAVeryLongName4(
+         $firstParameter,
+         $secondParameter
+     ) {
+     }
+
+     public function someFunctionWithAVeryLongName5(
+         $firstParameter,
+         $secondParameter=array(1,2,3),
+         $third=null
+     ) {
+     }
+
+}
+
+$noArgs_longVars = function () use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$longArgs_longVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$longArgs_longVars = function (
+    $longArgument,
+    $muchLongerArgument
+) use (
+    $muchLongerVar3
+) {
+    // body
+};
+
+$noArgs_longVars = function () use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+usort(
+    $data,
+    function ($a, $b) {
+        // body
+    }
+);
+
+function myFunction(
+    $firstParameter,
+    $secondParameter=[1,2,3],
+    $third=null
+) {
+}
+
+if (array_filter(
+    $commands,
+    function ($cmd) use ($commandName) {
+        return ($cmd['name'] == $commandName);
+    }
+)) {
+    // Do something
+}
+
+function foo( // comment
+    $bar,
+    $baz
+) { // comment
+    // ...
+}
+
+function foo($bar = [
+    1,
+    2,
+], $foo)
+{
+    // body
+}
+
+$foo = function ($bar = [
+    1,
+    2,
+]) use ($longVar1, $longerVar2) {
+    // body
+};
+
+function foo(
+    $bar = [
+    1,
+    2,
+],
+    $foo
+) {
+    // body
+}
+
+function foo(
+    $bar = [
+        1,
+        2,
+    ],
+    $foo
+) {
+    // body
+}
+
+function foo(
+    $param1,
+    $param2,
+    $param3,
+) : SomeClass {
+}

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.js.fixed
@@ -1,0 +1,81 @@
+
+function someFunctionWithAVeryLongName(
+    firstParameter='something',
+    secondParameter='booooo',
+    third=null,
+    fourthParameter=false,
+    fifthParameter=123.12,
+    sixthParam=true
+) {
+}
+
+function someFunctionWithAVeryLongName2(
+    firstParameter='something',
+    secondParameter='booooo',
+) {
+}
+
+function blah() 
+{
+}
+
+function blah()
+{
+}
+
+var object =
+{
+
+    someFunctionWithAVeryLongName: function (
+        firstParameter='something',
+        secondParameter='booooo',
+        third=null,
+        fourthParameter=false,
+        fifthParameter=123.12,
+        sixthParam=true
+    ) /** w00t */ {
+    }
+
+    someFunctionWithAVeryLongName2: function (
+        firstParameter='something',
+        secondParameter='booooo',
+        third=null
+    ) {
+    }
+
+     someFunctionWithAVeryLongName3: function (
+         firstParameter,
+         secondParameter,
+         third=null
+     ) {
+     }
+
+     someFunctionWithAVeryLongName4: function (
+         firstParameter,
+         secondParameter
+     ) {
+     }
+
+     someFunctionWithAVeryLongName5: function (
+         firstParameter,
+         secondParameter=array(1,2,3),
+         third=null
+     ) {
+     }
+
+}
+
+var a = Function('return 1+1');
+
+class test
+{
+    myFunction() 
+    {
+       return false;
+    }
+
+    myFunction2()
+    {
+       return false;
+    }
+}


### PR DESCRIPTION
While working on the fixes related to https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 I noticed that there were no `fixed` files for the `Squiz.Functions.MultiLineFunctionDeclaration` sniff.