### PR TITLE
Squiz/FunctionDeclarationArgumentSpacing: fix fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class FunctionDeclarationArgumentSpacingSniff implements Sniff
 {
@@ -203,7 +204,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                 // Before we throw an error, make sure there is no type hint.
                 $comma     = $phpcsFile->findPrevious(T_COMMA, ($nextParam - 1));
-                $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($comma + 1), null, true);
+                $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($comma + 1), null, true);
                 if ($phpcsFile->isReference($nextToken) === true) {
                     $nextToken++;
                 }
@@ -292,7 +293,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                 // Before we throw an error, make sure there is no type hint.
                 $bracket   = $phpcsFile->findPrevious(T_OPEN_PARENTHESIS, ($nextParam - 1));
-                $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($bracket + 1), null, true);
+                $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($bracket + 1), null, true);
                 if ($phpcsFile->isReference($nextToken) === true) {
                     $nextToken++;
                 }

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc
@@ -75,3 +75,12 @@ function MissingParamTypeInDocBlock(array$a = null, callable$c, \ArrayObject$o, 
 function myFunc(...$args) {}
 function myFunc( ...$args) {}
 function myFunc(... $args) {}
+
+function foo( // comment
+    $bar,
+    \NS\ClassName     $nsTypeHint,
+    /* not a type hint */ $baz,
+    string $withTypeHint
+) { // comment
+    // ...
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.inc.fixed
@@ -75,3 +75,12 @@ function MissingParamTypeInDocBlock(array $a=null, callable $c, \ArrayObject $o,
 function myFunc(...$args) {}
 function myFunc(...$args) {}
 function myFunc(... $args) {}
+
+function foo( // comment
+    $bar,
+    \NS\ClassName $nsTypeHint,
+    /* not a type hint */ $baz,
+    string $withTypeHint
+) { // comment
+    // ...
+}

--- a/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/FunctionDeclarationArgumentSpacingUnitTest.php
@@ -49,6 +49,7 @@ class FunctionDeclarationArgumentSpacingUnitTest extends AbstractSniffUnitTest
             58 => 1,
             73 => 7,
             76 => 1,
+            81 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
Fifth fix in a series to fix the issues found.

When a function declaration contains comments, the `FunctionDeclarationArgumentSpacing` sniff would mistakingly see them as type hints, causing a fixer conflict between that sniff and the `PEAR.Functions.FunctionDeclaration`/`Squiz.Functions.MultiLineFunctionDeclaration` sniff.

Includes unit test demonstrating the issue.