### PR TITLE
PEAR/FunctionDeclaration: fix undefined offset error

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -263,10 +263,12 @@ class FunctionDeclarationSniff implements Sniff
         $functionIndent = 0;
         for ($i = ($stackPtr - 1); $i >= 0; $i--) {
             if ($tokens[$i]['line'] !== $tokens[$stackPtr]['line']) {
-                $i++;
                 break;
             }
         }
+
+        // Move $i back to the line the function is or to 0.
+        $i++;
 
         if ($tokens[$i]['code'] === T_WHITESPACE) {
             $functionIndent = strlen($tokens[$i]['content']);


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
Sixth fix in a series to fix the issues found.

For a JS function declared at the very top of the file, there may not be a token on a previous line.

Always moving the pointer one forward at the end of the loop prevents an `undefined offset -1` error.

To reproduce the issue, run:
`phpcbf -p -s --standard=Squiz ./src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.js -vv`