### PR TITLE
PEAR/FunctionDeclaration: fix fixer conflict in handling of unfinished closures

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -99,10 +99,14 @@ class FunctionDeclarationSniff implements Sniff
             }
         }//end if
 
-        // Must be one space before the opening parenthesis. For closures, this is
-        // enforced by the first check because there is no content between the keywords
+        // Must be no space before the opening parenthesis. For closures, this is
+        // enforced by the previous check because there is no content between the keywords
         // and the opening parenthesis.
-        if ($tokens[$stackPtr]['code'] === T_FUNCTION) {
+        // Unfinished closures are tokenized as T_FUNCTION however, and can be excluded
+        // by checking for the scope_opener.
+        if ($tokens[$stackPtr]['code'] === T_FUNCTION
+            && isset($tokens[$stackPtr]['scope_opener']) === true
+        ) {
             if ($tokens[($openBracket - 1)]['content'] === $phpcsFile->eolChar) {
                 $spaces = 'newline';
             } else if ($tokens[($openBracket - 1)]['code'] === T_WHITESPACE) {

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -237,3 +237,5 @@ function foo(
 /* hello */ { echo 'hi';
     // body
 }
+
+$a = function () {

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
@@ -237,3 +237,5 @@ function foo(
 /* hello */ echo 'hi';
     // body
 }
+
+$a = function () {

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.js
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.js
@@ -54,3 +54,6 @@ class test
        return false;
     }
 }
+
+( function ( $ ) {
+    foo(function ( value ) {} )( jQuery );

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.js.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.js.fixed
@@ -55,3 +55,6 @@ class test
        return false;
     }
 }
+
+( function ( $ ) {
+    foo(function ( value ) {} )( jQuery );


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
Seventh fix in a series to fix the issues found.

Closures - both JS as well as in PHP - have their own token, but only if the structure is finished.
For live coding/parse errors, the structure will be identified as `T_FUNCTION`.

This caused a fixer conflict within the `PEAR.Functions.FunctionDeclaration` sniff and by extension in the `Squiz.Functions.MultiLineFunctionDeclaration` sniff, between the `SpaceAfterFunction` and the `SpaceBeforeOpenParen` error codes.

Unfinished closures can be distinguished from functions by checking for the `scope_opener` having been set.

Includes unit tests.