### PR TITLE
Tests: Add unit tests for the `File::getMemberProperties()` method

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -136,6 +136,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="FindExtendedClassNameTest.php" role="test" />
       <file baseinstalldir="" name="FindImplementedInterfaceNamesTest.inc" role="test" />
       <file baseinstalldir="" name="FindImplementedInterfaceNamesTest.php" role="test" />
+      <file baseinstalldir="" name="GetMemberPropertiesTest.inc" role="test" />
+      <file baseinstalldir="" name="GetMemberPropertiesTest.php" role="test" />
       <file baseinstalldir="" name="GetMethodParametersTest.inc" role="test" />
       <file baseinstalldir="" name="GetMethodParametersTest.php" role="test" />
       <file baseinstalldir="" name="IsReferenceTest.inc" role="test" />

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1481,8 +1481,9 @@ class File
      *
      * <code>
      *   array(
-     *    'scope'       => 'public', // public protected or protected
-     *    'is_static'   => false,    // true if the static keyword was found.
+     *    'scope'           => 'public', // public protected or protected.
+     *    'scope_specified' => false,    // true if the scope was explicitely specified.
+     *    'is_static'       => false,    // true if the static keyword was found.
      *   );
      * </code>
      *

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1536,15 +1536,22 @@ class File
             T_WHITESPACE  => T_WHITESPACE,
             T_COMMENT     => T_COMMENT,
             T_DOC_COMMENT => T_DOC_COMMENT,
-            T_VARIABLE    => T_VARIABLE,
-            T_COMMA       => T_COMMA,
         ];
 
         $scope          = 'public';
         $scopeSpecified = false;
         $isStatic       = false;
 
-        for ($i = ($stackPtr - 1); $i > 0; $i--) {
+        $startOfStatement = $this->findPrevious(
+            [
+                T_SEMICOLON,
+                T_OPEN_CURLY_BRACKET,
+                T_CLOSE_CURLY_BRACKET,
+            ],
+            ($stackPtr - 1)
+        );
+
+        for ($i = ($startOfStatement + 1); $i < $stackPtr; $i++) {
             if (isset($valid[$this->tokens[$i]['code']]) === false) {
                 break;
             }

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1532,6 +1532,7 @@ class File
             T_PRIVATE     => T_PRIVATE,
             T_PROTECTED   => T_PROTECTED,
             T_STATIC      => T_STATIC,
+            T_VAR         => T_VAR,
             T_WHITESPACE  => T_WHITESPACE,
             T_COMMENT     => T_COMMENT,
             T_DOC_COMMENT => T_DOC_COMMENT,

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -106,6 +106,12 @@ class a
         $_sheet,
         $_FieldParser,
         $_key;
+
+    private
+        $varN = true,
+        $varO = array( 'a', 'b' ),
+        $varP = 'string',
+        $varQ = 123;
 }
 
 var_dump($http_response_header);

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -53,7 +53,11 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest
             106 => 1,
             107 => 1,
             108 => 1,
-            117 => 1,
+            111 => 1,
+            112 => 1,
+            113 => 1,
+            114 => 1,
+            123 => 1,
         ];
 
         return $errors;

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestSuite;
 
 require_once 'IsCamelCapsTest.php';
 require_once 'ErrorSuppressionTest.php';
+require_once 'File/GetMemberPropertiesTest.php';
 require_once 'File/GetMethodParametersTest.php';
 require_once 'File/FindExtendedClassNameTest.php';
 require_once 'File/FindImplementedInterfaceNamesTest.php';
@@ -45,6 +46,7 @@ class AllTests
         $suite = new TestSuite('PHP CodeSniffer Core');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\IsCamelCapsTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\ErrorSuppressionTest');
+        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMemberPropertiesTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodParametersTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindExtendedClassNameTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindImplementedInterfaceNamesTest');

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -36,6 +36,35 @@ class TestMemberProperties
     /* testNoPrefix */
     $varK = true;
 
+
+    protected static
+        /* testGroupProtectedStatic 1 */
+        $varL,
+        /* testGroupProtectedStatic 2 */
+        $varM,
+        /* testGroupProtectedStatic 3 */
+        $varN;
+
+    private
+        /* testGroupPrivate 1 */
+        $varO = true,
+        /* testGroupPrivate 2 */
+        $varP = array( 'a' => 'a', 'b' => 'b' ),
+        /* testGroupPrivate 3 */
+        $varQ = 'string',
+        /* testGroupPrivate 4 */
+        $varR = 123,
+        /* testGroupPrivate 5 */
+        $varS = ONE / self::THREE,
+        /* testGroupPrivate 6 */
+        $varT = [
+			'a' => 'a',
+			'b' => 'b'
+		],
+        /* testGroupPrivate 7 */
+        $varU = __DIR__ . "/base";
+
+
     /* testMethodParam */
     public function methodName($param) {
         /* testImportedGlobal */

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -1,0 +1,59 @@
+<?php
+/* @codingStandardsIgnoreFile */
+
+class TestMemberProperties
+{
+    /* testVar */
+    var $varA = true;
+
+    /* testPublic */
+    public $varB = true;
+
+    /* testProtected */
+    protected $varC = true;
+
+    /* testPrivate */
+    private $varD = true;
+
+    /* testStatic */
+    static $varE = true;
+
+    /* testStaticVar */
+    static var $varF = true;
+
+    /* testVarStatic */
+    var static $varG = true;
+
+    /* testPublicStatic */
+    public static $varH = true;
+
+    /* testProtectedStatic */
+    static protected $varI = true;
+
+    /* testPrivateStatic */
+    private static $varJ = true;
+
+    /* testNoPrefix */
+    $varK = true;
+
+    /* testMethodParam */
+    public function methodName($param) {
+        /* testImportedGlobal */
+        global $importedGlobal = true;
+
+        /* testLocalVariable */
+        $localVariable = true;
+    }
+}
+
+interface Base
+{
+    /* testInterfaceProperty */
+    protected $anonymous;
+}
+
+/* testGlobalVariable */
+$globalVariable = true;
+
+/* testNotAVariable */
+return;

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -73,6 +73,10 @@ class TestMemberProperties
         /* testLocalVariable */
         $localVariable = true;
     }
+
+    /* testPropertyAfterMethod */
+    private static $varV = true;
+
 }
 
 interface Base

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -267,6 +267,14 @@ class GetMemberPropertiesTest extends TestCase
                 ],
             ],
             [
+                '/* testPropertyAfterMethod */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                ],
+            ],
+            [
                 '/* testInterfaceProperty */',
                 [],
             ],

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -187,6 +187,86 @@ class GetMemberPropertiesTest extends TestCase
                 ],
             ],
             [
+                '/* testGroupProtectedStatic 1 */',
+                [
+                    'scope'            => 'protected',
+                    'scope_specified' => true,
+                    'is_static'        => true,
+                ],
+            ],
+            [
+                '/* testGroupProtectedStatic 2 */',
+                [
+                    'scope'            => 'protected',
+                    'scope_specified' => true,
+                    'is_static'        => true,
+                ],
+            ],
+            [
+                '/* testGroupProtectedStatic 3 */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 1 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 2 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 3 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 4 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 5 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 6 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 7 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
                 '/* testInterfaceProperty */',
                 [],
             ],

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::getMemberProperties method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Exceptions\TokenizerException;
+use PHPUnit\Framework\TestCase;
+
+class GetMemberPropertiesTest extends TestCase
+{
+
+    /**
+     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
+     *
+     * @var \PHP_CodeSniffer\Files\File
+     */
+    private $phpcsFile;
+
+
+    /**
+     * Initialize & tokenize PHP_CodeSniffer_File with code from the test case file.
+     *
+     * Methods used for these tests can be found in a test case file in the same
+     * directory and with the same name, using the .inc extension.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $config            = new Config();
+        $config->standards = ['Generic'];
+
+        $ruleset = new Ruleset($config);
+
+        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
+        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
+        $this->phpcsFile->process();
+
+    }//end setUp()
+
+
+    /**
+     * Clean up after finished test.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->phpcsFile);
+
+    }//end tearDown()
+
+
+    /**
+     * Test the getMemberProperties() method.
+     *
+     * @param string $identifier Comment which preceeds the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @dataProvider dataGetMemberProperties
+     *
+     * @return void
+     */
+    public function testGetMemberProperties($identifier, $expected)
+    {
+        $start    = ($this->phpcsFile->numTokens - 1);
+        $delim    = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            $identifier
+        );
+        $variable = $this->phpcsFile->findNext(T_VARIABLE, ($delim + 1));
+
+        $result = $this->phpcsFile->getMemberProperties($variable);
+        $this->assertSame($expected, $result);
+
+    }//end testGetMemberProperties()
+
+
+    /**
+     * Data provider for the GetMemberProperties test.
+     *
+     * @see testGetMemberProperties()
+     *
+     * @return array
+     */
+    public function dataGetMemberProperties()
+    {
+        return [
+            [
+                '/* testVar */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testPublic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testProtected */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testPrivate */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testStatic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => true,
+                ],
+            ],
+            [
+                '/* testStaticVar */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => true,
+                ],
+            ],
+            [
+                '/* testVarStatic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => true,
+                ],
+            ],
+            [
+                '/* testPublicStatic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                ],
+            ],
+            [
+                '/* testProtectedStatic */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                ],
+            ],
+            [
+                '/* testPrivateStatic */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                ],
+            ],
+            [
+                '/* testNoPrefix */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testInterfaceProperty */',
+                [],
+            ],
+        ];
+
+    }//end dataGetMemberProperties()
+
+
+    /**
+     * Test receiving an expected exception when a non property is passed.
+     *
+     * @param string $identifier Comment which preceeds the test case.
+     *
+     * @expectedException        PHP_CodeSniffer\Exceptions\TokenizerException
+     * @expectedExceptionMessage $stackPtr is not a class member var
+     *
+     * @dataProvider dataNotClassProperty
+     *
+     * @return void
+     */
+    public function testNotClassPropertyException($identifier)
+    {
+        $start    = ($this->phpcsFile->numTokens - 1);
+        $delim    = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            $identifier
+        );
+        $variable = $this->phpcsFile->findNext(T_VARIABLE, ($delim + 1));
+
+        $result = $this->phpcsFile->getMemberProperties($variable);
+
+    }//end testNotClassPropertyException()
+
+
+    /**
+     * Data provider for the NotClassPropertyException test.
+     *
+     * @see testNotClassPropertyException()
+     *
+     * @return array
+     */
+    public function dataNotClassProperty()
+    {
+        return [
+            ['/* testImportedGlobal */'],
+            ['/* testLocalVariable */'],
+            ['/* testGlobalVariable */'],
+        ];
+
+    }//end dataNotClassProperty()
+
+
+    /**
+     * Test receiving an expected exception when a non variable is passed.
+     *
+     * @expectedException        PHP_CodeSniffer\Exceptions\TokenizerException
+     * @expectedExceptionMessage $stackPtr must be of type T_VARIABLE
+     *
+     * @return void
+     */
+    public function testNotAVariableException()
+    {
+        $start = ($this->phpcsFile->numTokens - 1);
+        $delim = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testNotAVariable */'
+        );
+        $next  = $this->phpcsFile->findNext(T_WHITESPACE, ($delim + 1), null, true);
+
+        $result = $this->phpcsFile->getMemberProperties($next);
+
+    }//end testNotAVariableException()
+
+
+}//end class


### PR DESCRIPTION
Adds dedicated unit tests for the `File::getMemberProperties()` method.

Also minor documentation update for the method itself.

Related to #1707

-----

### Updated

I realized after I'd pulled it that I'd forgotten to add the new tests to the `tests/Core/AllTests.php` file. 

Once I added them, a bug with PHP4 `var $property` type declarations started showing.
I fixed that in a separate commit.

I also realized that the tests didn't yet cover "_group property declarations_". While these aren't very common in most PHP projects, they are supported by the language and therefore should be correctly handled by the `File::getMemberProperties()` method.

Once I added the additional unit tests, it became clear that _group property declarations_ which included value definitions were not (yet) supported by the method, so that has been fixed in an additional separate commit.