### PR TITLE
Generic/MultipleStatementAlignment: fix fatal error

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -180,7 +180,7 @@ class MultipleStatementAlignmentSniff implements Sniff
                     $assignColumn = ($varEnd + 1);
                 } else {
                     $padding = ($assignments[$prevAssign]['assign_col'] - $varEnd + $assignments[$prevAssign]['assign_len'] - $assignLen);
-                    if ($padding === 0) {
+                    if ($padding <= 0) {
                         $padding = 1;
                     }
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.js
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.js
@@ -108,3 +108,8 @@ function() {
     if (condition)
         foo = .4
 }
+
+x = x << y;
+x  <<= y;
+x = x >> y;
+x >>= y;

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.js.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.js.fixed
@@ -108,3 +108,8 @@ function() {
     if (condition)
         foo = .4
 }
+
+x   = x << y;
+x <<= y;
+x   = x >> y;
+x >>= y;

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -107,6 +107,9 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
                 85  => 1,
                 86  => 1,
                 100 => 1,
+                112 => 1,
+                113 => 1,
+                114 => 1,
             ];
             break;
         default:


### PR DESCRIPTION
Came across this error when running fixer conflict checks for the various standards. (See https://github.com/squizlabs/PHP_CodeSniffer/pull/1645#issuecomment-336314794 )
Eighth fix in a series to fix the issues found.

In certain cases, it was possible for the `$expected` padding to become less than zero, leading to the following fatal error during fixing:
`str_repeat(): Second argument has to be greater than or equal to 0 in phpcs/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php on line 293`

This PR fixes that.

Includes unit tests.