### PR TITLE
Tests: fix unintentional parse error in js test file

### DIFF
--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.3.js
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.3.js
@@ -1,2 +1,2 @@
 
-alert('hi);
+alert('hi');

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.3.js
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.3.js
@@ -1,2 +1,2 @@
 
-alert('hi);
+alert('hi');


### PR DESCRIPTION
Related to #1718 

This typo highlights a bug in the JS Tokenizer were the original file would be processed in such a way that the `'hi);` would end up being tokenized as `T_WHITESPACE`.

Strangely enough, the `1` and `2` JS test files for these two sniffs *do* get tokenized correctly.