### PR TITLE
Squiz/ScopeKeywordSpacing: improve sniff + fix fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -44,19 +44,23 @@ class ScopeKeywordSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        if (isset($tokens[($stackPtr + 1)]) === false) {
+            return;
+        }
+
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($tokens[$stackPtr]['code'] === T_STATIC
-            && ($tokens[$nextToken]['code'] === T_DOUBLE_COLON
+            && (($nextToken === false || $tokens[$nextToken]['code'] === T_DOUBLE_COLON)
             || $tokens[$prevToken]['code'] === T_NEW)
         ) {
-            // Late static binding, e.g., static:: OR new static() usage.
+            // Late static binding, e.g., static:: OR new static() usage or live coding.
             return;
         }
 
         if ($tokens[$prevToken]['code'] === T_AS) {
-            // Trait visibilty change, e.g., "use HelloWorld { sayHello as private; }".
+            // Trait visibility change, e.g., "use HelloWorld { sayHello as private; }".
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -60,6 +60,23 @@ class ScopeKeywordSpacingSniff implements Sniff
             return;
         }
 
+        if ($nextToken !== false && $tokens[$nextToken]['code'] === T_VARIABLE) {
+            $endOfStatement = $phpcsFile->findNext(T_SEMICOLON, ($nextToken + 1));
+            if ($endOfStatement === false) {
+                // Live coding.
+                return;
+            }
+
+            $multiProperty = $phpcsFile->findNext(T_VARIABLE, ($nextToken + 1), $endOfStatement);
+            if ($multiProperty !== false
+                && $tokens[$stackPtr]['line'] !== $tokens[$nextToken]['line']
+                && $tokens[$nextToken]['line'] !== $tokens[$endOfStatement]['line']
+            ) {
+                // Allow for multiple properties definitions to each be on their own line.
+                return;
+            }
+        }
+
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
             $spacing = 0;
         } else {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -44,8 +44,8 @@ class ScopeKeywordSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($tokens[$stackPtr]['code'] === T_STATIC
             && ($tokens[$nextToken]['code'] === T_DOUBLE_COLON

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -82,10 +82,21 @@ class ScopeKeywordSpacingSniff implements Sniff
                 if ($spacing === 0) {
                     $phpcsFile->fixer->addContent($stackPtr, ' ');
                 } else {
+                    $phpcsFile->fixer->beginChangeset();
+
+                    for ($i = ($stackPtr + 2); $i < $phpcsFile->numTokens; $i++) {
+                        if (isset($tokens[$i]) === false || $tokens[$i]['code'] !== T_WHITESPACE) {
+                            break;
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                    $phpcsFile->fixer->endChangeset();
                 }
-            }
-        }
+            }//end if
+        }//end if
 
     }//end process()
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
@@ -38,7 +38,7 @@ abstract class Foo
     }
 }
 
-if ($geometry instanceof static) {
+if ($geometry instanceof static      || $geometry instanceof static) {
     echo 'foo';
 }
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
@@ -58,3 +58,27 @@ abstract class Foo
         static   /* comment */ :: bar();
     }
 }
+
+class MyOtherClass
+{
+    public
+        $varK = array( 'a', 'b' );
+
+    protected    $varK,
+        $varL,
+        $varM;
+
+    protected static
+        $varK, $varL, $varM;
+
+    private
+        $varO = true,
+        $varP = array( 'a' => 'a', 'b' => 'b' ),
+        $varQ = 'string',
+        $varR = 123;
+
+    // Intentionally missing a semi-colon for testing.
+    public
+        $varS,
+        $varT
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
@@ -45,3 +45,16 @@ if ($geometry instanceof static      || $geometry instanceof static) {
 class MyClass1 {
     use HelloWorld { sayHello as private; }
 }
+
+abstract class Foo
+{
+    public static function getInstance()
+    {
+        return new /* comment */   static();
+    }
+
+    public static function output()
+    {
+        static   /* comment */ :: bar();
+    }
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
@@ -42,3 +42,16 @@ if ($geometry instanceof static      || $geometry instanceof static) {
 class MyClass1 {
     use HelloWorld { sayHello as private; }
 }
+
+abstract class Foo
+{
+    public static function getInstance()
+    {
+        return new /* comment */   static();
+    }
+
+    public static function output()
+    {
+        static   /* comment */ :: bar();
+    }
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
@@ -35,7 +35,7 @@ abstract class Foo
     }
 }
 
-if ($geometry instanceof static) {
+if ($geometry instanceof static      || $geometry instanceof static) {
     echo 'foo';
 }
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
@@ -55,3 +55,25 @@ abstract class Foo
         static   /* comment */ :: bar();
     }
 }
+
+class MyOtherClass
+{
+    public $varK = array( 'a', 'b' );
+
+    protected $varK,
+        $varL,
+        $varM;
+
+    protected static $varK, $varL, $varM;
+
+    private
+        $varO = true,
+        $varP = array( 'a' => 'a', 'b' => 'b' ),
+        $varQ = 'string',
+        $varR = 123;
+
+    // Intentionally missing a semi-colon for testing.
+    public
+        $varS,
+        $varT
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -35,6 +35,9 @@ class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
             26 => 1,
             28 => 1,
             29 => 1,
+            64 => 1,
+            67 => 1,
+            71 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Tenth PR in the series to fix fixer conflicts.

Fixer conflict can be reproduced by running the below command against `master`:
`phpcbf -p -s ./src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.inc --standard=Squiz`

To fix this, I reviewed the whole sniff.

Notes:
* The sniff did not have a `fixed` file, so added that.
* The check for whether or not the scope keyword is used for a property or in another capacity, should be done in a style-independent manner. As it was, the sniff could trigger in undesired situations. Fixed + added unit tests to safeguard against this.
* When there would be more than one whitespace token between the keyword and the next content, only one whitespace token would be addressed by the fixer. The next whitespace token would fall through to the next loop. This was the cause of the fixer conflict. Improved the fixer to deal with all whitespace tokens in one go.
* Related to #1715: the sniff would also indiscriminately kick into action on multi-line multi-property definitions. IMHO those should be handled by a separate sniff if so desired. For now, I've fixed this by bowing out when it's indisputable that a multi-line multi-property definition is detected. Includes unit tests.
* Lastly, I've added some minor safeguard against the sniff kicking into action too early during live coding.