### PR TITLE
 Squiz/MemberVarSpacing: improved handling of multi-line property declarations

### DIFF
--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -121,7 +121,10 @@ abstract class AbstractScopeSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where this
      *                                               token was found.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      * @see    processTokenWithinScope()
      */
     final public function process(File $phpcsFile, $stackPtr)
@@ -129,16 +132,23 @@ abstract class AbstractScopeSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         $foundScope = false;
+        $skipPtrs   = [];
         foreach ($tokens[$stackPtr]['conditions'] as $scope => $code) {
             if (isset($this->scopeTokens[$code]) === true) {
-                $this->processTokenWithinScope($phpcsFile, $stackPtr, $scope);
+                $skipPtrs[] = $this->processTokenWithinScope($phpcsFile, $stackPtr, $scope);
                 $foundScope = true;
             }
         }
 
         if ($this->listenOutside === true && $foundScope === false) {
-            $this->processTokenOutsideScope($phpcsFile, $stackPtr);
+            $skipPtrs[] = $this->processTokenOutsideScope($phpcsFile, $stackPtr);
         }
+
+        if (empty($skipPtrs) === false) {
+            return min($skipPtrs);
+        }
+
+        return;
 
     }//end process()
 
@@ -154,7 +164,10 @@ abstract class AbstractScopeSniff implements Sniff
      *                                               opened the scope that this test is
      *                                               listening for.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     abstract protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope);
 
@@ -167,7 +180,10 @@ abstract class AbstractScopeSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where this
      *                                               token was found.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     abstract protected function processTokenOutsideScope(File $phpcsFile, $stackPtr);
 

--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -49,7 +49,10 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      * @param int                         $stackPtr  The position where the token was found.
      * @param int                         $currScope The current scope opener token.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     final protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
@@ -61,7 +64,7 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
             // Check to see if this string has a variable in it.
             $pattern = '|(?<!\\\\)(?:\\\\{2})*\${?[a-zA-Z0-9_]+}?|';
             if (preg_match($pattern, $tokens[$stackPtr]['content']) !== 0) {
-                $this->processVariableInString($phpcsFile, $stackPtr);
+                return $this->processVariableInString($phpcsFile, $stackPtr);
             }
 
             return;
@@ -115,9 +118,9 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
         }//end if
 
         if ($inFunction === true) {
-            $this->processVariable($phpcsFile, $stackPtr);
+            return $this->processVariable($phpcsFile, $stackPtr);
         } else {
-            $this->processMemberVar($phpcsFile, $stackPtr);
+            return $this->processMemberVar($phpcsFile, $stackPtr);
         }
 
     }//end processTokenWithinScope()
@@ -130,21 +133,24 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      *                                               token was found.
      * @param int                         $stackPtr  The position where the token was found.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     final protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         // These variables are not member vars.
         if ($tokens[$stackPtr]['code'] === T_VARIABLE) {
-            $this->processVariable($phpcsFile, $stackPtr);
+            return $this->processVariable($phpcsFile, $stackPtr);
         } else if ($tokens[$stackPtr]['code'] === T_DOUBLE_QUOTED_STRING
             || $tokens[$stackPtr]['code'] === T_HEREDOC
         ) {
             // Check to see if this string has a variable in it.
             $pattern = '|(?<!\\\\)(?:\\\\{2})*\${?[a-zA-Z0-9_]+}?|';
             if (preg_match($pattern, $tokens[$stackPtr]['content']) !== 0) {
-                $this->processVariableInString($phpcsFile, $stackPtr);
+                return $this->processVariableInString($phpcsFile, $stackPtr);
             }
         }
 
@@ -158,7 +164,10 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      *                                               token was found.
      * @param int                         $stackPtr  The position where the token was found.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     abstract protected function processMemberVar(File $phpcsFile, $stackPtr);
 
@@ -170,7 +179,10 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      *                                               token was found.
      * @param int                         $stackPtr  The position where the token was found.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     abstract protected function processVariable(File $phpcsFile, $stackPtr);
 
@@ -186,7 +198,10 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
      * @param int                         $stackPtr  The position where the double quoted
      *                                               string was found.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     abstract protected function processVariableInString(File $phpcsFile, $stackPtr);
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -37,24 +37,35 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position where the token was found.
      *
-     * @return void
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached.
      */
     protected function processMemberVar(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        $ignore   = Tokens::$methodPrefixes;
-        $ignore[] = T_VAR;
+        $validPrefixes   = Tokens::$methodPrefixes;
+        $validPrefixes[] = T_VAR;
+
+        $startOfStatement = $phpcsFile->findPrevious($validPrefixes, ($stackPtr - 1), null, false, null, true);
+        if ($startOfStatement === false) {
+            return;
+        }
+
+        $endOfStatement = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1), null, false, null, true);
+
+        $ignore   = $validPrefixes;
         $ignore[] = T_WHITESPACE;
 
-        $start = $stackPtr;
-        $prev  = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
+        $start = $startOfStatement;
+        $prev  = $phpcsFile->findPrevious($ignore, ($startOfStatement - 1), null, true);
         if (isset(Tokens::$commentTokens[$tokens[$prev]['code']]) === true) {
             // Assume the comment belongs to the member var if it is on a line by itself.
             $prevContent = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
             if ($tokens[$prevContent]['line'] !== $tokens[$prev]['line']) {
                 // Check the spacing, but then skip it.
-                $foundLines = ($tokens[$stackPtr]['line'] - $tokens[$prev]['line'] - 1);
+                $foundLines = ($tokens[$startOfStatement]['line'] - $tokens[$prev]['line'] - 1);
                 if ($foundLines > 0) {
                     $error = 'Expected 0 blank lines after member var comment; %s found';
                     $data  = [$foundLines];
@@ -67,8 +78,8 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
                             $phpcsFile->fixer->replaceToken($prev, rtrim($tokens[$prev]['content']));
                         }
 
-                        for ($i = ($prev + 1); $i <= $stackPtr; $i++) {
-                            if ($tokens[$i]['line'] === $tokens[$stackPtr]['line']) {
+                        for ($i = ($prev + 1); $i <= $startOfStatement; $i++) {
+                            if ($tokens[$i]['line'] === $tokens[$startOfStatement]['line']) {
                                 break;
                             }
 
@@ -85,7 +96,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         }//end if
 
         // There needs to be n blank lines before the var, not counting comments.
-        if ($start === $stackPtr) {
+        if ($start === $startOfStatement) {
             // No comment found.
             $first = $phpcsFile->findFirstOnLine(Tokens::$emptyTokens, $start, true);
             if ($first === false) {
@@ -114,6 +125,10 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
         if ($foundLines === $spacing) {
+            if ($endOfStatement !== false) {
+                return $endOfStatement;
+            }
+
             return;
         }
 
@@ -122,7 +137,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
             $foundLines,
         ];
 
-        $fix = $phpcsFile->addFixableError($errorMsg, $stackPtr, $errorCode, $data);
+        $fix = $phpcsFile->addFixableError($errorMsg, $startOfStatement, $errorCode, $data);
         if ($fix === true) {
             $phpcsFile->fixer->beginChangeset();
             for ($i = ($prev + 1); $i < $first; $i++) {
@@ -143,6 +158,12 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
 
             $phpcsFile->fixer->endChangeset();
         }//end if
+
+        if ($endOfStatement !== false) {
+            return $endOfStatement;
+        }
+
+        return;
 
     }//end processMemberVar()
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
@@ -246,3 +246,21 @@ class phpcsCommentTest {
     public $var1 = 'value';
 
 }
+
+class MyOtherClass
+{
+    public
+        $varK = array( 'a', 'b' );
+    protected static
+        $varK,
+        $varL,
+        $varM;
+
+
+
+    private
+        $varO = true,
+        $varP = array( 'a' => 'a', 'b' => 'b' ),
+        $varQ = 'string',
+        $varR = 123;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
@@ -264,3 +264,30 @@ class MyOtherClass
         $varQ = 'string',
         $varR = 123;
 }
+
+// Make sure the determination of whether a property is the first property or not is done correctly.
+class ClassUsingSimpleTraits
+{
+    use HelloWorld;
+
+
+    /* comment */
+    public $firstVar = array( 'a', 'b' );
+    protected $secondVar = true;
+}
+
+class ClassUsingComplexTraits
+{
+    use A, B {
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+    }
+
+
+
+    public $firstVar = array( 'a', 'b' );
+
+
+    /* comment */
+    protected $secondVar = true;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -253,3 +253,27 @@ class MyOtherClass
         $varQ = 'string',
         $varR = 123;
 }
+
+// Make sure the determination of whether a property is the first property or not is done correctly.
+class ClassUsingSimpleTraits
+{
+    use HelloWorld;
+
+    /* comment */
+    public $firstVar = array( 'a', 'b' );
+
+    protected $secondVar = true;
+}
+
+class ClassUsingComplexTraits
+{
+    use A, B {
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+    }
+
+    public $firstVar = array( 'a', 'b' );
+
+    /* comment */
+    protected $secondVar = true;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -235,3 +235,21 @@ class phpcsCommentTest {
     public $var1 = 'value';
 
 }
+
+class MyOtherClass
+{
+
+    public
+        $varK = array( 'a', 'b' );
+
+    protected static
+        $varK,
+        $varL,
+        $varM;
+
+    private
+        $varO = true,
+        $varP = array( 'a' => 'a', 'b' => 'b' ),
+        $varQ = 'string',
+        $varR = 123;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -49,6 +49,9 @@ class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
             229 => 1,
             241 => 1,
             246 => 1,
+            252 => 1,
+            254 => 1,
+            261 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -52,6 +52,10 @@ class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
             252 => 1,
             254 => 1,
             261 => 1,
+            275 => 1,
+            276 => 1,
+            288 => 1,
+            292 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Related to #1715 and #1720, the other sniff involved in the fixer conflict mentioned in #1720.

**TL;DR>** Adds unit test cases with multi-line multi-property declarations and unit tests for class importing traits.

For the multi-line multi-property declarations I've adjusted the sniff to handle this more graciously as it would previously:
* correct the number of lines above the line for each variable
* not correct the number of lines above the line containing the scope keyword

IMHO this is incorrect and only the lines above the line containing the scope keyword should be checked & fixed.

By returning the `$stackPtr` of the semi-colon at the end of the property declaration, we skip past the additional variables.

As the abstract classes this class extends from did not allow for passing a "skip-to pointer" - in contrast to `Sniff` -, those have been adjusted as well to facilitate this.

For classes importing traits, the first property will currently not be recognized as such and will not receive special treatment.
This behavior has now been documented with unit tests. This behavior has not been changed.
