### PR TITLE
 Squiz/PostStatementComment: add fixed files 

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1192,7 +1192,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="LongConditionClosingCommentUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LongConditionClosingCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="PostStatementCommentUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="PostStatementCommentUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="PostStatementCommentUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="PostStatementCommentUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="PostStatementCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="VariableCommentUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="VariableCommentUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
@@ -18,3 +18,7 @@ class TestClass
     public $good = true; // Indeed.
 
 }//end class
+
+if (true || -1 == $b) { /* test */
+}
+$y = 10 + /* test */ -2;

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
@@ -21,3 +21,7 @@ class TestClass
 // Indeed.
 
 }//end class
+
+if (true || -1 == $b) { /* test */
+}
+$y = 10 + /* test */ -2;

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
@@ -3,11 +3,13 @@
 function test()
 {
     $string = 'hello';
-    $string = 'hello'; // Set string to hello.
+    $string = 'hello'; 
+// Set string to hello.
     // Valid comment.
 }
 
-function test() // This is a function
+function test() 
+// This is a function
 {
 
 }//end test()
@@ -15,6 +17,7 @@ function test() // This is a function
 
 class TestClass
 {
-    public $good = true; // Indeed.
+    public $good = true; 
+// Indeed.
 
 }//end class

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.js.fixed
@@ -1,0 +1,33 @@
+function test(id, buttons) 
+// cool function
+{
+    alert('hello');
+    alert('hello again'); 
+// And again.
+    // Valid comment.
+
+}//end test()
+
+var good = true; 
+// Indeed.
+
+mig.Gallery.prototype = {
+
+    init: function(cb)
+    {
+
+    },//end init()
+
+    imageClicked: function(id)
+    {
+
+    }//end imageClicked()
+
+};
+
+dfx.getIframeDocument = function(iframe)
+{
+
+    return doc;
+
+};//end dfx.getIframeDocument()


### PR DESCRIPTION
While debugging another fixer conflict related to #1645 (comment) I noticed that there were no fixed files for the `Squiz.Commenting.PostStatementComment` sniff.