### PR TITLE
Generic/AssignmentInCondition: add separate errorcode for assignment found in while

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -150,10 +150,15 @@ class AssignmentInConditionSniff implements Sniff
             }
 
             if ($hasVariable === true) {
+                $errorCode = 'Found';
+                if ($token['code'] === T_WHILE) {
+                    $errorCode = 'FoundInWhileCondition';
+                }
+
                 $phpcsFile->addWarning(
                     'Variable assignment found within a condition. Did you mean to do a comparison ?',
                     $hasAssignment,
-                    'Found'
+                    $errorCode
                 );
             }
 


### PR DESCRIPTION
A `while()` condition is the only control structure in which it is sometimes legitimate to use an assignment in condition.

Having a separate error code will enable people to selectively exclude warnings for this.