### PR TITLE
Improve handling of git merge conflicts in code

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2266,4 +2266,80 @@ class File
     }//end findImplementedInterfaceNames()
 
 
+    /**
+     * Determine if the passed token is part of a merge conflict boundary.
+     *
+     * Used to distinguish whether a token is an operator or part of a git
+     * merge conflict boundary.
+     * For PHP and CSS, only the T_SL token is checked.
+     * For JS, any of the following tokens will be checked: T_SL, T_ZSR,
+     * T_LESS_THAN, T_GREATER_THAN, T_IS_IDENTICAL and T_EQUAL.
+     *
+     * If a merge conflict boundary is found, it will return a stackPtr to
+     * to the end of the boundary to enable sniffs which listen for these
+     * operators to skip over the rest of the merge conflict boundary.
+     *
+     * @param int $stackPtr The position of the target token.
+     *
+     * @return boolean|integer Boolean false if the token is not part of
+     *                         a merge conflict boundary.
+     *                         An integer stackPtr to the end of the merge
+     *                         conflict boundary if it is.
+     */
+    public function isMergeConflictBoundary($stackPtr)
+    {
+        if ($this->tokens[$stackPtr]['code'] !== T_SL
+            && ($this->tokenizerType !== 'JS'
+            || isset(Util\Tokens::$gitBoundaryTokens[$this->tokens[$stackPtr]['code']]) === false)
+        ) {
+            return false;
+        }
+
+        $startOfLine = $stackPtr;
+        if ($this->tokens[$stackPtr]['column'] !== 1) {
+            for ($i = ($stackPtr - 1); $i >= 0; $i--) {
+                if ($this->tokens[$i]['column'] === 1) {
+                    $startOfLine = $i;
+                    break;
+                }
+            }
+        }
+
+        $endOfLine = $stackPtr;
+        if (isset($this->tokens[($stackPtr + 1)]) === true) {
+            for ($i = ($stackPtr + 1); $i < $this->numTokens; $i++) {
+                if ($this->tokens[$stackPtr]['line'] !== $this->tokens[$i]['line']) {
+                    $endOfLine = --$i;
+                    break;
+                }
+            }
+        }
+
+        $lineContent = trim($this->getTokensAsString($startOfLine, ($endOfLine - $startOfLine + 1)));
+
+        if ($this->tokens[$startOfLine]['code'] === T_SL
+            && $lineContent === '<<<<<<< HEAD'
+        ) {
+            return $endOfLine;
+        }
+
+        if ($this->tokenizerType === 'JS'
+            && $this->tokens[$startOfLine]['code'] === T_IS_IDENTICAL
+            && $lineContent === '======='
+        ) {
+            return $endOfLine;
+        }
+
+        if ($this->tokenizerType === 'JS'
+            && $this->tokens[$startOfLine]['code'] === T_ZSR
+            && substr($lineContent, 0, 8) === '>>>>>>> '
+        ) {
+            return $endOfLine;
+        }
+
+        return false;
+
+    }//end isMergeConflictBoundary()
+
+
 }//end class

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -64,6 +64,14 @@ class OperatorBracketSniff implements Sniff
             return;
         }
 
+        if (isset(Tokens::$gitBoundaryTokens[$tokens[$stackPtr]['code']]) === true) {
+            // Skip git merge boundaries.
+            $endBoundary = $phpcsFile->isMergeConflictBoundary($stackPtr);
+            if ($endBoundary !== false) {
+                return $endBoundary;
+            }
+        }
+
         // There is one instance where brackets aren't needed, which involves
         // the minus sign being used to assign a negative number to a variable.
         if ($tokens[$stackPtr]['code'] === T_MINUS) {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -98,6 +98,14 @@ class OperatorSpacingSniff implements Sniff
             }
         }
 
+        if (isset(Tokens::$gitBoundaryTokens[$tokens[$stackPtr]['code']]) === true) {
+            // Skip git merge boundaries.
+            $endBoundary = $phpcsFile->isMergeConflictBoundary($stackPtr);
+            if ($endBoundary !== false) {
+                return $endBoundary;
+            }
+        }
+
         if ($tokens[$stackPtr]['code'] === T_BITWISE_AND) {
             // If it's not a reference, then we expect one space either side of the
             // bitwise operator.

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
@@ -159,3 +159,16 @@ try {
 }
 
 $var = $foo['blah'] + [];
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+function testIgnoreMergeBoundaries()
+    {
+        $arr = array(
+            'a' => 'a'
+<<<<<<< HEAD
+            'b' => 'b'
+=======
+            'c' => 'c'
+>>>>>>> master
+        );
+    }

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
@@ -159,3 +159,16 @@ try {
 }
 
 $var = ($foo['blah'] + []);
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+function testIgnoreMergeBoundaries()
+    {
+        $arr = array(
+            'a' => 'a'
+<<<<<<< HEAD
+            'b' => 'b'
+=======
+            'c' => 'c'
+>>>>>>> master
+        );
+    }

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.js
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.js
@@ -114,3 +114,10 @@ if (something === true
 }
 
 if (true === /^\d*\.?\d*$/.test(input)) return true;
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+<<<<<<< HEAD
+result = 'something';
+=======
+result = 'else';
+>>>>>>> develop

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.js.fixed
@@ -114,3 +114,10 @@ if (something === true
 }
 
 if (true === /^\d*\.?\d*$/.test(input)) return true;
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+<<<<<<< HEAD
+result = 'something';
+=======
+result = 'else';
+>>>>>>> develop

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -217,3 +217,16 @@ Hooks::run( 'ParserOptionsRegister', [
 	&self::$inCacheKey,
 	&self::$lazyOptions,
 ] );
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+function testIgnoreMergeBoundaries()
+    {
+        $arr = array(
+            'a' => 'a'
+<<<<<<< HEAD
+            'b' => 'b'
+=======
+            'c' => 'c'
+>>>>>>> master
+        );
+    }

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -211,3 +211,16 @@ Hooks::run( 'ParserOptionsRegister', [
 	&self::$inCacheKey,
 	&self::$lazyOptions,
 ] );
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+function testIgnoreMergeBoundaries()
+    {
+        $arr = array(
+            'a' => 'a'
+<<<<<<< HEAD
+            'b' => 'b'
+=======
+            'c' => 'c'
+>>>>>>> master
+        );
+    }

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
@@ -98,3 +98,10 @@ x = x >>> y;
 x >>>= y;
 
 var foo = bar.map(baz=> baz.length);
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+<<<<<<< HEAD
+result = 'something';
+=======
+result = 'else';
+>>>>>>> develop

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js.fixed
@@ -92,3 +92,10 @@ x = x >>> y;
 x >>>= y;
 
 var foo = bar.map(baz => baz.length);
+
+// Test ignoring merge boundaries. VALID TESTCASE. DO NOT REMOVE.
+<<<<<<< HEAD
+result = 'something';
+=======
+result = 'else';
+>>>>>>> develop

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -545,6 +545,20 @@ final class Tokens
                                     T_TRAIT      => T_TRAIT,
                                    );
 
+    /**
+     * Tokens which could potentially be part of a git merge conflict boundary.
+     *
+     * @var array
+     */
+    public static $gitBoundaryTokens = array(
+                                        T_SL           => T_SL,
+                                        T_ZSR          => T_ZSR,
+                                        T_LESS_THAN    => T_LESS_THAN,
+                                        T_GREATER_THAN => T_GREATER_THAN,
+                                        T_IS_IDENTICAL => T_IS_IDENTICAL,
+                                        T_EQUAL        => T_EQUAL,
+                                       );
+
 
     /**
      * Given a token, returns the name of the token.


### PR DESCRIPTION
Eleventh PR in the series to fix fixer conflicts.

Fixer conflict can be reproduced by running the below command against `master`:
`phpcbf -p -s ./src/Standards/Squiz/Tests/PHP/HereDocUnitTest.inc --standard=Squiz`

To fix this, I have:
* Added a new `isMergeConflictBoundary()` method to the `File` class to distinguish between an operator and an operator token which is not actually an operator, but part of a git merge conflict boundary.
* Added a new static `$gitBoundaryTokens` array to the `Util\Tokens` class.
* Added some code to the `Squiz.Formatting.OperatorBracket` and the `Squiz.WhiteSpace.OperatorSpacing` sniffs to check if an operator is in fact a git merge boundary using the new `File::isMergeConflictBoundary()` method.
* Added unit tests to both sniffs to verify that it all works as it should + that it will stay that way ;-)

This fixer conflict was also the inspiration for PR #1724.