### PR TITLE
Squiz.CSS.EmptyStyleDefinition sees comment as style definition and fails to report error

### DIFF
--- a/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class EmptyStyleDefinitionSniff implements Sniff
 {
@@ -47,8 +48,11 @@ class EmptyStyleDefinitionSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        $next   = $phpcsFile->findNext([T_WHITESPACE, T_COLON], ($stackPtr + 1), null, true);
 
+        $ignore   = Tokens::$emptyTokens;
+        $ignore[] = T_COLON;
+
+        $next = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true);
         if ($next === false || $tokens[$next]['code'] === T_SEMICOLON || $tokens[$next]['line'] !== $tokens[$stackPtr]['line']) {
             $error = 'Style definition is empty';
             $phpcsFile->addError($error, $stackPtr, 'Found');

--- a/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.css
@@ -3,3 +3,9 @@
     margin-right:
     float: ;
 }
+
+#MetadataAdminScreen-addField-fieldType li {
+    margin-right: /* @todo */
+    margin-left: 10px;
+    float: /* Some comment. */ ;
+}

--- a/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.php
@@ -26,8 +26,10 @@ class EmptyStyleDefinitionUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            3 => 1,
-            4 => 1,
+            3  => 1,
+            4  => 1,
+            8  => 1,
+            10 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The `Squiz.CSS.EmptyStyleDefinition` sniff checks for CSS styles being defined without value.

This sniff would fail to report an issue if there is no value, but a comment is encountered instead.

Includes unit tests.