### PR TITLE
Squiz/CSS/ColonSpacing: fix fixer conflict

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1297,6 +1297,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionOpeningBraceSpaceUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionOpeningBraceSpaceUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColonSpacingUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ColonSpacingUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColonSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColourDefinitionUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColourDefinitionUnitTest.php" role="test" />

--- a/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php
@@ -68,7 +68,8 @@ class ColonSpacingSniff implements Sniff
             }
         }
 
-        if ($tokens[($stackPtr + 1)]['code'] === T_SEMICOLON) {
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($tokens[$next]['code'] === T_SEMICOLON || $tokens[$next]['code'] === T_STYLE) {
             // Empty style definition, ignore it.
             return;
         }

--- a/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.css
@@ -33,7 +33,10 @@ li {
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#2e62a8, endColorstr=#123363);
 }
 
-/* empty style def */
+/* Empty style defs. */
 .p {
     margin:;
+    margin-right:
+    margin-left: 10px;
+    float:/* Some comment. */ ;
 }

--- a/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.css.fixed
@@ -1,0 +1,37 @@
+body {
+font-family: Arial, Helvetica, sans-serif;
+margin: 40px 0 0 0;
+padding: 0;
+background: #8FB7DB url(diag_lines_bg.gif) top left;
+margin-top: 10px;
+margin-bottom: 0px;
+}
+
+.TableWidgetType .recover:hover {
+    background-color: #FFF;
+}
+
+#clearCache-settings:rootNodes-list_0 {
+    border-top: none;
+}
+
+.LookupEditScreenWidgetType-urls a, .LookupEditScreenWidgetType-urls a:visited {
+    text-decoration: none;
+    color: #444;
+}
+
+/* checking embedded PHP */
+li {
+    background: url(<?php print $staticserver; ?>/images/<?php print $staticdir; ?>/bullet.gif) left <?php print $left; ?>px no-repeat;
+    margin: 0px;
+    padding-left: 10px;
+    margin-bottom: <?php echo $marginBottom; ?>px;
+    margin-top: <?php echo $marginTop; ?>px;
+    line-height: 13px;
+    filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#2e62a8, endColorstr=#123363);
+}
+
+/* empty style def */
+.p {
+    margin:;
+}

--- a/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.css.fixed
@@ -31,7 +31,10 @@ li {
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#2e62a8, endColorstr=#123363);
 }
 
-/* empty style def */
+/* Empty style defs. */
 .p {
     margin:;
+    margin-right:
+    margin-left: 10px;
+    float: /* Some comment. */ ;
 }

--- a/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ColonSpacingUnitTest.php
@@ -36,6 +36,7 @@ class ColonSpacingUnitTest extends AbstractSniffUnitTest
             29 => 1,
             30 => 1,
             32 => 1,
+            41 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Twelfth PR in the series to fix fixer conflicts.

When encountering an empty CSS rule _without_ semi-colon, the `Squiz` standard would end up in a fixer loop caused by a conflict between the following three sniffs: `Squiz.CSS.Indentation`, `Squiz.CSS.ColonSpacing`, `Squiz.CSS.DisallowMultipleStyleDefinitions`.

To reproduce the fixer conflict, run the following command:
`phpcbf -p -s ./src/Standards/Squiz/Tests/CSS/EmptyStyleDefinitionUnitTest.inc --standard=Squiz -vv`
or just run the fixer using this original sniff against the updated test file as included in this PR.

This PR adds a `fixed` file to the unit tests for the `Squiz.CSS.ColonSpacing` sniff and fixes the fixer conflict by making a minor adjustment to that sniff.

Includes additional unit tests.
