### PR TITLE
Squiz/OperatorBracket: fix fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -265,13 +265,6 @@ class OperatorBracketSniff implements Sniff
      */
     public function addMissingBracketsError($phpcsFile, $stackPtr)
     {
-        $error = 'Arithmetic operation must be bracketed';
-        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'MissingBrackets');
-
-        if ($fix === false) {
-            return;
-        }
-
         $tokens = $phpcsFile->getTokens();
 
         $allowed = [
@@ -363,12 +356,21 @@ class OperatorBracketSniff implements Sniff
 
         $after = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($after - 1), null, true);
 
-        // Can only fix this error if both tokens are available for fixing.
-        // Adding one bracket without the other will create parse errors.
-        $phpcsFile->fixer->beginChangeset();
-        $phpcsFile->fixer->replaceToken($before, '('.$tokens[$before]['content']);
-        $phpcsFile->fixer->replaceToken($after, $tokens[$after]['content'].')');
-        $phpcsFile->fixer->endChangeset();
+        $error = 'Arithmetic operation must be bracketed';
+        if ($before === $after || $before === $stackPtr || $after === $stackPtr) {
+            $phpcsFile->addError($error, $stackPtr, 'MissingBrackets');
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'MissingBrackets');
+        if ($fix === true) {
+            // Can only fix this error if both tokens are available for fixing.
+            // Adding one bracket without the other will create parse errors.
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($before, '('.$tokens[$before]['content']);
+            $phpcsFile->fixer->replaceToken($after, $tokens[$after]['content'].')');
+            $phpcsFile->fixer->endChangeset();
+        }
 
     }//end addMissingBracketsError()
 

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
@@ -159,3 +159,5 @@ try {
 }
 
 $var = $foo['blah'] + [];
+
+$a = 2 * ${x} - ${minus};

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
@@ -159,3 +159,5 @@ try {
 }
 
 $var = ($foo['blah'] + []);
+
+$a = 2 * ${x} - ${minus};

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -63,6 +63,7 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
                 139 => 1,
                 150 => 1,
                 161 => 1,
+                163 => 2,
             ];
             break;
         case 'OperatorBracketUnitTest.js':


### PR DESCRIPTION
PR thirteen in the series to fix fixer conflicts.

The `Squiz.Formatting.OperatorBracket` sniff would conflict with itself if it could not identify correctly the start or end of the arithmetic expression which would cause it to go into a fixer loop.

The fix in this commit checks if that's the case before throwing the error and if so, does throw the error, but doesn't try to auto-fix it anymore.

Includes additional unit test highlighting the issue.