### PR TITLE
Generic/SpaceAfterNot: fix copy/paste artifact in JS test file

### DIFF
--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.js
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.js
@@ -1,4 +1,4 @@
-<?php
+
 if (!someVar || !x) {}
 if (! someVar || ! x) {}
 if (!foo() && (!x || true)) {}

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.js.fixed
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.js.fixed
@@ -1,4 +1,4 @@
-<?php
+
 if (! someVar || ! x) {}
 if (! someVar || ! x) {}
 if (! foo() && (! x || true)) {}


### PR DESCRIPTION
PR fourteen in the series to fix fixer conflicts.

This one was easily solved: It's a JS test file, not a PHP file :sunglasses: 