### PR TITLE
Add link to download the phar files in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PHP\_CodeSniffer requires PHP version 5.4.0 or greater, although individual snif
 Installation
 ------------
 
-The easiest way to get started with PHP\_CodeSniffer is to download the [Phar](http://php.net/manual/en/intro.phar.php) files for each of the commands:
+The easiest way to get started with PHP\_CodeSniffer is to [download the Phar files](https://github.com/squizlabs/PHP_CodeSniffer/releases/latest) for each of the commands:
 
     curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
     php phpcs.phar -h


### PR DESCRIPTION
There was a link pointing to the Phar documentation, which I confused with the link to download the actual phars. I think this link is confusing and useless.

Instead it makes much more sense to have a link to the files to download directly (I spent several minutes trying to find where to download those files).