### PR TITLE
Generic.WhiteSpace.Disallow[Space/Tab]Indent not inspecting content before open tag

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -75,7 +75,7 @@ class DisallowSpaceIndentSniff implements Sniff
         ];
 
         $tokens = $phpcsFile->getTokens();
-        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+        for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
             if ($tokens[$i]['column'] !== 1 || isset($checkTokens[$tokens[$i]['code']]) === false) {
                 continue;
             }

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -77,7 +77,7 @@ class DisallowTabIndentSniff implements Sniff
             T_DOC_COMMENT_STRING     => true,
         ];
 
-        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+        for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
             if (isset($checkTokens[$tokens[$i]['code']]) === false) {
                 continue;
             }


### PR DESCRIPTION
Both these sniffs include `T_INLINE_HTML` in the `$checkTokens` array, but would only start checking the file **after** the first PHP open tag, so if a file - such as a view - would start with inline HTML and only have the first PHP open tag on line 5, the first 4 lines would not be inspected, nor fixed for tabs vs spaces.

I have not added unit tests for this as it would require to either renumber all the unit tests òr to add a second unit test file for both sniffs. If so desired, I'd be happy to make those changes, but it seemed a bit over the top for such a small change.