### PR TITLE
The basepath setting can be unset

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -993,14 +993,19 @@ class Config
                     break;
                 }
 
+                $this->overriddenDefaults['basepath'] = true;
+
+                if (substr($arg, 9) === '') {
+                    $this->basepath = null;
+                    break;
+                }
+
                 $this->basepath = Util\Common::realpath(substr($arg, 9));
 
                 // It may not exist and return false instead.
                 if ($this->basepath === false) {
                     $this->basepath = substr($arg, 9);
                 }
-
-                $this->overriddenDefaults['basepath'] = true;
 
                 if (is_dir($this->basepath) === false) {
                     $error  = 'ERROR: The specified basepath "'.$this->basepath.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;


### PR DESCRIPTION
In a ruleset file (e.g. `phpcs.xml.dist`) it's possible to set CLI parameters with `  <arg name="awesome_arg" value="myval"/>`. 
The CLI itself always overrides the ruleset settings. Unfortunately, it's not possible to reset `basepath`, to show the full path of a file, when `basepath` is set in `phpcs.xml.dist`:
```
<arg name="basepath" value="."/>
```


currently, setting
```
bin/phpcs -q -w --report=emacs --basepath='' src/Util/Tokens.php 
```
will set `basepath` to '.' as you can see in the output of the command
```
src/Util/Tokens.php:7:15: warning - Line exceeds 85 characters; contains 94 characters
```


With this patch, setting basepath in CLI an XML to the empty string `""` will set the internal config settings to `null`. The full path will be show:
```
/private/tmp/src/Util/Tokens.php:7:15: warning - Line exceeds 85 characters; contains 94 characters
```

The full path is required for some IDE when you want to integrate third party tools, like `phpcs`.
