### PR TITLE
Build/Travis: bring back testing with alternative ini settings for PHP 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   include:
     - php: 5.4
     - php: 5.5
+    - php: 5.5
+      env: CUSTOM_INI=1
     - php: 5.6
     - php: 7.0
     - php: 7.0


### PR DESCRIPTION
When PHPCS 3.x was being prepared, the builds for PHP < 5.4 were removed from the Travis matrix. However, that also meant that the build against alternative ini settings was removed, while it shouldn't have been.

Re-added against an arbitrary PHP 5.x version.