### PR TITLE
Generic/DisallowAlternativePHPTags: improve unit tests

### DIFF
--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.3.inc
@@ -1,0 +1,7 @@
+<!-- This file is essentially the same as the second one, but without the ".fixed" file to allow the warnings to be tested. -->
+<div> 
+<% echo $var; %>
+<p>Some text <% echo $var; %> and some more text</p>
+<%= $var . ' and some more text to make sure the snippet works'; %>
+<p>Some text <%= $var %> and some more text</p>
+</div>

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -33,6 +33,8 @@ class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
 
         if ($aspTags === true) {
             $testFiles[] = $testFileBase.'2.inc';
+        } else {
+            $testFiles[] = $testFileBase.'3.inc';
         }
 
         return $testFiles;
@@ -92,10 +94,21 @@ class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getWarningList()
+    public function getWarningList($testFile='')
     {
+        if ($testFile === 'DisallowAlternativePHPTagsUnitTest.3.inc') {
+            return [
+                3 => 1,
+                4 => 1,
+                5 => 1,
+                6 => 1,
+            ];
+        }
+
         return [];
 
     }//end getWarningList()


### PR DESCRIPTION
The current unit tests did not test that the `warning`s were correctly being thrown when the `asp_tags` ini setting was set to `Off`.
This needs to be tested using a separate test file as the warnings cannot be auto-fixed, so the unit tests would fail if this was tested against unit test file 2.

This change in this commit ensures that the warnings are now also unit tested.

N.B.: The actual testing will only be done once PR #1784 has been merged!