### PR TITLE
Remove unused test file

### DIFF
--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.inc
@@ -1,6 +1,0 @@
-<div>
-<?php echo $var; ?>
-Some content here.
-<?= $var; ?>
-<? echo $var; ?>
-</div>


### PR DESCRIPTION
This file was replaced by the `DisallowShortOpenTagUnitTest.[1-3].inc` files and was already removed from the `package.xml` file.