### PR TITLE
fix(stdin) set non-blocking stream when cli stdin are used

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -365,6 +365,7 @@ class Config
         }
 
         $handle = fopen('php://stdin', 'r');
+        stream_set_blocking($handle, 0);
 
         // Check for content on STDIN.
         if ($this->stdin === true


### PR DESCRIPTION
Address issue #1788 
Sequel of #1490 

I believe the set non-blocking mode as been missed during the refactoring.
@arnested Could you confirm ?