### PR TITLE
PSR2/UseDeclaration: fix fixer conflict

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -192,9 +192,9 @@ class UseDeclarationSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // Ignore USE keywords inside closures.
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
-        if ($tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
+        // Ignore USE keywords inside closures and during live coding.
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($next === false || $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
             return true;
         }
 

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.1.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.1.inc
@@ -29,3 +29,10 @@ trait HelloWorld
 {
     use Hello, World;
 }
+
+$x = $foo ? function ($foo) use /* comment */ ($bar): int {
+    return 1;
+} : $bar;
+
+// Testcase must be on last line in the file.
+use


### PR DESCRIPTION
Another small PR in the series to fix fixer conflicts.

This fixes two minor issues in the `PSR2.Namespaces.UseDeclaration` sniff:
1. Bow out during live coding.
2. Improved check to bow out in case it's a closure `use` statement.

Includes unit tests.

I've committed the new unit tests separately to facilitate easy testing of the issue. Run `phpcbf` against the unit test commit to see the fixer conflict.