### PR TITLE
NonExecutableCodeSniff: fix undefined index notice

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -224,6 +224,11 @@ class NonExecutableCodeSniff implements Sniff
             }
         }//end for
 
+        if (isset($tokens[$start]) === false) {
+            // Live coding or parse error.
+            return;
+        }
+
         $lastLine = $tokens[$start]['line'];
         for ($i = ($start + 1); $i < $end; $i++) {
             if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true


### PR DESCRIPTION
When running the `Squiz.PHP.NonExecutableCode` sniff during live coding (or when the file has a parse error), it would throw an "undefined index" notice when encountering code like the below:
```php
function ABC() {
    return
```

This minor change prevents this.