### PR TITLE
Generic/OpeningBraceKernighanRitchie: minor efficiency fix

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -115,9 +115,9 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }//end if
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Function opening brace placement', 'same line');
         }//end if
-
-        $phpcsFile->recordMetric($stackPtr, 'Function opening brace placement', 'same line');
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($openingBrace + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openingBrace]['line']) {


### PR DESCRIPTION
No need to call the `recordMetric()` method again if the metric has already been recorded.