### PR TITLE
Squiz/LanguageConstructSpacing: fix fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -51,8 +51,9 @@ class LanguageConstructSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[($stackPtr + 1)]) === false) {
-            // Skip if there is no next token.
+        $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($nextToken === false) {
+            // Skip when at end of file.
             return;
         }
 


### PR DESCRIPTION
Small fix which improves on 14b9857876d88ba3ed77318b4c4e51391c16da2d in regards to disregarding this sniff when at the end of the file.

This prevents conflicts with the `Generic.Files.EndFileNewLine`/`Generic.Files.EndFileNoNewLine` sniffs.

Unit test case already exists.

To reproduce the issue, run the following command against `master`:
`phpcbf -p -s -vv ./src/Standards/Squiz/Tests/LanguageConstructSpacingUnitTest.inc --standard=Squiz`