### PR TITLE
Various comment sniffs: fix fixer conflicts

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1180,6 +1180,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyCatchCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.php" role="test" />

--- a/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -49,7 +49,16 @@ class DocCommentSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens       = $phpcsFile->getTokens();
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['comment_closer']) === false
+            || ($tokens[$tokens[$stackPtr]['comment_closer']]['content'] === ''
+            && $tokens[$stackPtr]['comment_closer'] === ($phpcsFile->numTokens - 1))
+        ) {
+            // Don't process an unfinished comment during live coding.
+            return;
+        }
+
         $commentStart = $stackPtr;
         $commentEnd   = $tokens[$stackPtr]['comment_closer'];
 

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
@@ -192,3 +192,5 @@
  */
 
 /**doc comment */
+
+/** No docblock close tag. Must be last test without new line.

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -76,7 +76,7 @@ class DocCommentAlignmentSniff implements Sniff
             T_VAR       => true,
         ];
 
-        if (isset($ignore[$tokens[$nextToken]['code']]) === false) {
+        if ($nextToken === false || isset($ignore[$tokens[$nextToken]['code']]) === false) {
             // Could be a file comment.
             $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if ($tokens[$prevToken]['code'] !== T_OPEN_TAG) {
@@ -96,6 +96,11 @@ class DocCommentAlignmentSniff implements Sniff
             }
 
             if ($tokens[$i]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+                if (trim($tokens[$i]['content']) === '') {
+                    // Don't process an unfinished docblock close tag during live coding.
+                    continue;
+                }
+
                 // Can't process the close tag if it is not the first thing on the line.
                 $prev = $phpcsFile->findPrevious(T_DOC_COMMENT_WHITESPACE, ($i - 1), $stackPtr, true);
                 if ($tokens[$prev]['line'] === $tokens[$i]['line']) {

--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -64,6 +64,14 @@ class FileCommentSniff implements Sniff
             return ($phpcsFile->numTokens + 1);
         }
 
+        if (isset($tokens[$commentStart]['comment_closer']) === false
+            || ($tokens[$tokens[$commentStart]['comment_closer']]['content'] === ''
+            && $tokens[$commentStart]['comment_closer'] === ($phpcsFile->numTokens - 1))
+        ) {
+            // Don't process an unfinished file comment during live coding.
+            return ($phpcsFile->numTokens + 1);
+        }
+
         $commentEnd = $tokens[$commentStart]['comment_closer'];
 
         $nextToken = $phpcsFile->findNext(

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.2.inc
@@ -1,0 +1,9 @@
+<?php
+/**
+ * File comment.
+ *
+ * @package    Package
+ * @subpackage Subpackage
+ * @author     Squiz Pty Ltd <products@squiz.net>
+ * @copyright  2010-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ *


### PR DESCRIPTION
Another small PR to deal with fixer conflicts.

When a docblock comment is unfinished and at the end of a file - typically found in live coding situations -, fixer conflicts would occur through a combination of the `Generic.Files.(No)Newline`, `Generic.Commenting.DocComment`, `Squiz.Commenting.DocCommentAlignment` and the `Squiz.Commenting.FileComment` sniffs.

The fixer conflicts can be reproduced by checking out the first commit, which just contains the tests demonstrating the issue, and running:
`phpcbf -p -s -vv ./src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc --standard=Squiz`
and
`phpcbf -p -s -vv ./src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.2.inc --standard=Squiz`

The changes made in the second commit basically just prevent the sniffs from throwing errors/fixing when no valid docblock closer tag is found.