### PR TITLE
PEAR/ScopeClosingBrace: fix fixer conflict

### DIFF
--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -137,8 +137,9 @@ class ScopeClosingBraceSniff implements Sniff
         }
 
         $fix = false;
-        if ($tokens[$stackPtr]['code'] === T_CASE
-            || $tokens[$stackPtr]['code'] === T_DEFAULT
+        if (($tokens[$stackPtr]['code'] === T_CASE
+            || $tokens[$stackPtr]['code'] === T_DEFAULT)
+            && $tokens[$scopeEnd]['code'] !== T_CLOSE_CURLY_BRACKET
         ) {
             // BREAK statements should be indented n spaces from the
             // CASE or DEFAULT statement.

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
@@ -89,7 +89,7 @@ switch ($httpResponseCode) {
 
 switch($i) {
 case 1: {
-    }
+}
 }
 
 switch ($httpResponseCode) {


### PR DESCRIPTION
Another small PR to fix a fixer conflict between the `PEAR.WhiteSpace.ScopeClosingBrace` and the `PEAR.WhiteSpace.ScopeIndent` (extended from `Generic.WhiteSpace.ScopeIndent`) sniffs.

If a `case` or `default` statement uses braces, the scope indent and scope closing brace would fight over where the brace should be placed.

The unit test file already contains a test case highlighting the issue.
https://github.com/squizlabs/PHP_CodeSniffer/blob/b55fd82f4f6335a519bd787703810551a2dfb9ad/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc#L88-L90
To reproduce the issue, run the following command on the `master` branch:
`phpcbf -p -s -vv ./src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc --standard=PEAR`

Note: this change *does* change the behaviour of the sniff in that particular case. If that's undesired, another solution will need to be found.