### PR TITLE
New `Generic.CodeAnalysis.EmptyPHPStatement` sniff

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -330,6 +330,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        </dir>
        <dir name="CodeAnalysis">
         <file baseinstalldir="PHP/CodeSniffer" name="AssignmentInConditionSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyPHPStatementSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStatementSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopShouldBeWhileLoopSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopWithTestFunctionCallSniff.php" role="php" />
@@ -449,6 +450,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
        <dir name="CodeAnalysis">
         <file baseinstalldir="PHP/CodeSniffer" name="AssignmentInConditionUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="AssignmentInConditionUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyPHPStatementUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyPHPStatementUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyPHPStatementUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStatementUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStatementUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopShouldBeWhileLoopUnitTest.inc" role="test" />

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Checks against empty PHP statements.
+ *
+ * - Check against two semi-colons with no executable code in between.
+ * - Check against an empty PHP open - close tag combination.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class EmptyPHPStatementSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [
+            T_SEMICOLON,
+            T_CLOSE_TAG,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        switch ($tokens[$stackPtr]['type']) {
+        // Detect `something();;`.
+        case 'T_SEMICOLON':
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+            if ($prevNonEmpty === false
+                || ($tokens[$prevNonEmpty]['code'] !== T_SEMICOLON
+                && $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG)
+            ) {
+                return;
+            }
+
+            $fix = $phpcsFile->addFixableWarning(
+                'Empty PHP statement detected: superfluous semi-colon.',
+                $stackPtr,
+                'SemicolonWithoutCodeDetected'
+            );
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+
+                if ($tokens[$prevNonEmpty]['code'] === T_OPEN_TAG) {
+                    // Check for superfluous whitespace after the semi-colon which will be
+                    // removed as the `<?php ` open tag token already contains whitespace,
+                    // either a space or a new line.
+                    if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                        $replacement = str_replace(' ', '', $tokens[($stackPtr + 1)]['content']);
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), $replacement);
+                    }
+                }
+
+                for ($i = $stackPtr; $i > $prevNonEmpty; $i--) {
+                    if ($tokens[$i]['code'] !== T_SEMICOLON
+                        && $tokens[$i]['code'] !== T_WHITESPACE
+                    ) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }//end if
+
+            break;
+
+        // Detect `<?php ? >`.
+        case 'T_CLOSE_TAG':
+            $prevNonEmpty = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+
+            if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG) {
+                return;
+            }
+
+            $fix = $phpcsFile->addFixableWarning(
+                'Empty PHP open/close tag combination detected.',
+                $prevNonEmpty,
+                'EmptyPHPOpenCloseTagsDetected'
+            );
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+
+                for ($i = $prevNonEmpty; $i <= $stackPtr; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+            break;
+
+        default:
+            // Deliberately left empty.
+            break;
+        }//end switch
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -55,7 +55,8 @@ class EmptyPHPStatementSniff implements Sniff
 
             if ($prevNonEmpty === false
                 || ($tokens[$prevNonEmpty]['code'] !== T_SEMICOLON
-                && $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG)
+                && $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG
+                && $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG_WITH_ECHO)
             ) {
                 return;
             }
@@ -68,7 +69,9 @@ class EmptyPHPStatementSniff implements Sniff
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
 
-                if ($tokens[$prevNonEmpty]['code'] === T_OPEN_TAG) {
+                if ($tokens[$prevNonEmpty]['code'] === T_OPEN_TAG
+                    || $tokens[$prevNonEmpty]['code'] === T_OPEN_TAG_WITH_ECHO
+                ) {
                     // Check for superfluous whitespace after the semi-colon which will be
                     // removed as the `<?php ` open tag token already contains whitespace,
                     // either a space or a new line.
@@ -90,14 +93,16 @@ class EmptyPHPStatementSniff implements Sniff
 
                 $phpcsFile->fixer->endChangeset();
             }//end if
-
             break;
 
         // Detect `<?php ? >`.
         case 'T_CLOSE_TAG':
             $prevNonEmpty = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
 
-            if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG) {
+            if ($prevNonEmpty === false
+                || ($tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG
+                && $tokens[$prevNonEmpty]['code'] !== T_OPEN_TAG_WITH_ECHO)
+            ) {
                 return;
             }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php
@@ -61,6 +61,17 @@ class EmptyPHPStatementSniff implements Sniff
                 return;
             }
 
+            if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
+                $nested     = $tokens[$stackPtr]['nested_parenthesis'];
+                $lastCloser = array_pop($nested);
+                if (isset($tokens[$lastCloser]['parenthesis_owner']) === true
+                    && $tokens[$tokens[$lastCloser]['parenthesis_owner']]['code'] === T_FOR
+                ) {
+                    // Empty for() condition.
+                    return;
+                }
+            }
+
             $fix = $phpcsFile->addFixableWarning(
                 'Empty PHP statement detected: superfluous semi-colon.',
                 $stackPtr,

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Test empty statement: two consecutive semicolons without executable code between them.
+ */
+function_call(); // OK.
+
+// The below examples are all bad.
+function_call();;
+
+function_call();
+;
+
+function_call();
+/* some comment */;
+
+function_call();
+/* some comment */     ;
+
+?>
+<input name="<?php ; something_else(); ?>" />
+<input name="<?php something_else(); ; ?>" />
+
+/*
+ * Test empty statement: no code between PHP open and close tag.
+ */
+<input name="<?php something_else() ?>" /> <!-- OK. -->
+<input name="<?php something_else(); ?>" /> <!-- OK. -->
+<input name="<?php /* comment */ ?>" /> <!-- OK. -->
+
+<input name="<?php ?>" /> <!-- Bad. -->
+
+<input name="<?php
+
+
+?>" /> <!-- Bad. -->
+
+<!--
+/*
+ * Test detecting & fixing a combination of the two above checks.
+ */
+-->
+<?php ; ?>
+
+<input name="<?php ; ?>" />

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Test empty statement: two consecutive semicolons without executable code between them.
+ * Test empty statement: two consecutive semi-colons without executable code between them.
  */
 function_call(); // OK.
 
@@ -48,3 +48,7 @@ function_call();
 <input name="<?= 'some text' ?>" /> <!-- OK. -->
 <input name="<?= ?>" /> <!-- Bad. -->
 <input name="<?= ; ?>" /> <!-- Bad. -->
+
+<?php
+// Guard against false positives for two consecutive semi-colons in a for statement.
+for ( $i = 0; ; $i++ ) {}

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc
@@ -42,4 +42,9 @@ function_call();
 -->
 <?php ; ?>
 
-<input name="<?php ; ?>" />
+<input name="<?php ; ?>" /> <!-- Bad. -->
+
+<!-- Tests with short open echo tag. -->
+<input name="<?= 'some text' ?>" /> <!-- OK. -->
+<input name="<?= ?>" /> <!-- Bad. -->
+<input name="<?= ; ?>" /> <!-- Bad. -->

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Test empty statement: two consecutive semicolons without executable code between them.
+ */
+function_call(); // OK.
+
+// The below examples are all bad.
+function_call();
+
+function_call();
+
+function_call();
+/* some comment */
+
+function_call();
+/* some comment */
+
+?>
+<input name="<?php something_else(); ?>" />
+<input name="<?php something_else(); ?>" />
+
+/*
+ * Test empty statement: no code between PHP open and close tag.
+ */
+<input name="<?php something_else() ?>" /> <!-- OK. -->
+<input name="<?php something_else(); ?>" /> <!-- OK. -->
+<input name="<?php /* comment */ ?>" /> <!-- OK. -->
+
+<input name="" /> <!-- Bad. -->
+
+<input name="" /> <!-- Bad. -->
+
+<!--
+/*
+ * Test detecting & fixing a combination of the two above checks.
+ */
+-->
+
+<input name="" />

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Test empty statement: two consecutive semicolons without executable code between them.
+ * Test empty statement: two consecutive semi-colons without executable code between them.
  */
 function_call(); // OK.
 
@@ -43,3 +43,7 @@ function_call();
 <input name="<?= 'some text' ?>" /> <!-- OK. -->
 <input name="" /> <!-- Bad. -->
 <input name="" /> <!-- Bad. -->
+
+<?php
+// Guard against false positives for two consecutive semi-colons in a for statement.
+for ( $i = 0; ; $i++ ) {}

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.inc.fixed
@@ -37,4 +37,9 @@ function_call();
  */
 -->
 
-<input name="" />
+<input name="" /> <!-- Bad. -->
+
+<!-- Tests with short open echo tag. -->
+<input name="<?= 'some text' ?>" /> <!-- OK. -->
+<input name="" /> <!-- Bad. -->
+<input name="" /> <!-- Bad. -->

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Unit test class for the EmptyStatement sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2017 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\CodeAnalysis;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class EmptyPHPStatementUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [
+            9  => 1,
+            12 => 1,
+            15 => 1,
+            18 => 1,
+            21 => 1,
+            22 => 1,
+            31 => 1,
+            33 => 1,
+            43 => 1,
+            45 => 1,
+        ];
+
+    }//end getWarningList()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyPHPStatementUnitTest.php
@@ -51,6 +51,8 @@ class EmptyPHPStatementUnitTest extends AbstractSniffUnitTest
             33 => 1,
             43 => 1,
             45 => 1,
+            49 => 1,
+            50 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
New sniff to detect superfluous semi-colons and empty PHP open-close tag combinations.

Includes an auto-fixer.

Fixes #1119 