### PR TITLE
Squiz/EmbeddedPhp: Allow for ignore comments

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -373,7 +373,7 @@ class EmbeddedPhpSniff implements Sniff
         if ($tokens[($closeTag - 1)]['code'] === T_WHITESPACE) {
             $trailingSpace = strlen($tokens[($closeTag - 1)]['content']);
         } else if (($tokens[($closeTag - 1)]['code'] === T_COMMENT
-            || $tokens[($closeTag - 1)]['code'] === T_PHPCS_IGNORE)
+            || isset(Tokens::$phpcsCommentTokens[$tokens[($closeTag - 1)]['code']]) === true)
             && substr($tokens[($closeTag - 1)]['content'], -1) === ' '
         ) {
             $trailingSpace = (strlen($tokens[($closeTag - 1)]['content']) - strlen(rtrim($tokens[($closeTag - 1)]['content'])));
@@ -387,7 +387,7 @@ class EmbeddedPhpSniff implements Sniff
                 if ($trailingSpace === 0) {
                     $phpcsFile->fixer->addContentBefore($closeTag, ' ');
                 } else if ($tokens[($closeTag - 1)]['code'] === T_COMMENT
-                    || $tokens[($closeTag - 1)]['code'] === T_PHPCS_IGNORE
+                    || isset(Tokens::$phpcsCommentTokens[$tokens[($closeTag - 1)]['code']]) === true
                 ) {
                     $phpcsFile->fixer->replaceToken(($closeTag - 1), rtrim($tokens[($closeTag - 1)]['content']).' ');
                 } else {

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -372,7 +372,8 @@ class EmbeddedPhpSniff implements Sniff
         $trailingSpace = 0;
         if ($tokens[($closeTag - 1)]['code'] === T_WHITESPACE) {
             $trailingSpace = strlen($tokens[($closeTag - 1)]['content']);
-        } else if ($tokens[($closeTag - 1)]['code'] === T_COMMENT
+        } else if (($tokens[($closeTag - 1)]['code'] === T_COMMENT
+            || $tokens[($closeTag - 1)]['code'] === T_PHPCS_IGNORE)
             && substr($tokens[($closeTag - 1)]['content'], -1) === ' '
         ) {
             $trailingSpace = (strlen($tokens[($closeTag - 1)]['content']) - strlen(rtrim($tokens[($closeTag - 1)]['content'])));
@@ -385,7 +386,9 @@ class EmbeddedPhpSniff implements Sniff
             if ($fix === true) {
                 if ($trailingSpace === 0) {
                     $phpcsFile->fixer->addContentBefore($closeTag, ' ');
-                } else if ($tokens[($closeTag - 1)]['code'] === T_COMMENT) {
+                } else if ($tokens[($closeTag - 1)]['code'] === T_COMMENT
+                    || $tokens[($closeTag - 1)]['code'] === T_PHPCS_IGNORE
+                ) {
                     $phpcsFile->fixer->replaceToken(($closeTag - 1), rtrim($tokens[($closeTag - 1)]['content']).' ');
                 } else {
                     $phpcsFile->fixer->replaceToken(($closeTag - 1), ' ');

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc
@@ -115,3 +115,5 @@ function foo()
 <?php /* translators: My sites label */ ?>
 <?php /* translators: My sites label */?>
 <?php /* translators: My sites label */      ?>
+
+<?php echo 'oops'; // phpcs:ignore Standard.Category.Sniff -- reason. ?>

--- a/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/EmbeddedPhpUnitTest.inc.fixed
@@ -115,3 +115,5 @@ function foo()
 <?php /* translators: My sites label */ ?>
 <?php /* translators: My sites label */ ?>
 <?php /* translators: My sites label */ ?>
+
+<?php echo 'oops'; // phpcs:ignore Standard.Category.Sniff -- reason. ?>

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -464,6 +464,19 @@ final class Tokens
     ];
 
     /**
+     * Tokens that are comments containing PHPCS instructions.
+     *
+     * @var array<int, int>
+     */
+    public static $phpcsCommentTokens = [
+        T_PHPCS_ENABLE           => T_PHPCS_ENABLE,
+        T_PHPCS_DISABLE          => T_PHPCS_DISABLE,
+        T_PHPCS_SET              => T_PHPCS_SET,
+        T_PHPCS_IGNORE           => T_PHPCS_IGNORE,
+        T_PHPCS_IGNORE_FILE      => T_PHPCS_IGNORE_FILE,
+    ];
+
+    /**
      * Tokens that represent strings.
      *
      * Note that T_STRINGS are NOT represented in this list.


### PR DESCRIPTION
This is basically the same fix as previously pulled & merged in #1554, but now to allow for `// phpcs:ignore` comments as they have their own token.

> The Squiz.PHP.EmbeddedPhp sniff will create a fixer conflict with itself when it encounters a // comment just before the PHP close tag.
> 
> The tokenizer will tokenize whitespace at the end of a // comment as part of the T_COMMENT token, so the fixer just keeps adding more spaces between the T_COMMENT and the T_CLOSE_TAG which in the next fixer round is then tokenized again as being part of the T_COMMENT resulting in the loop.