### PR TITLE
ValidVariableName sniffs: remove superfluous property setting

### DIFF
--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -16,16 +16,6 @@ use PHP_CodeSniffer\Files\File;
 class ValidVariableNameSniff extends AbstractVariableSniff
 {
 
-    /**
-     * Tokens to ignore so that we can find a DOUBLE_COLON.
-     *
-     * @var array
-     */
-    private $ignore = [
-        T_WHITESPACE,
-        T_COMMENT,
-    ];
-
 
     /**
      * Processes this test, when one of its tokens is encountered.

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -16,16 +16,6 @@ use PHP_CodeSniffer\Files\File;
 class ValidVariableNameSniff extends AbstractVariableSniff
 {
 
-    /**
-     * Tokens to ignore so that we can find a DOUBLE_COLON.
-     *
-     * @var array
-     */
-    private $ignore = [
-        T_WHITESPACE,
-        T_COMMENT,
-    ];
-
 
     /**
      * Processes this test, when one of its tokens is encountered.


### PR DESCRIPTION
Looks like the property is no longer used in either of these sniffs or the parent sniffs they extend.

A quick look at the history reveals that the properties were introduced when the sniffs were written in 2007, but it looks like the use of the property was already removed a few days later (still in 2007) and that the property was never used in a released version.

Removing the properties does not seem to have any negative effects. The unit tests still pass without the property and the sniffs do not throw errors about an "undefined property".