### PR TITLE
A phpcs:enable comment is not tokenized correctly if it is outside a phpcs:disable block

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -351,41 +351,42 @@ abstract class Tokenizer
                         $this->tokens[$i]['code']       = T_PHPCS_DISABLE;
                         $this->tokens[$i]['type']       = 'T_PHPCS_DISABLE';
                         $this->tokens[$i]['sniffCodes'] = $disabledSniffs;
-                    } else if ($ignoring !== null
-                        && substr($commentTextLower, 0, 12) === 'phpcs:enable'
-                    ) {
-                        $enabledSniffs = [];
+                    } else if (substr($commentTextLower, 0, 12) === 'phpcs:enable') {
+                        if ($ignoring !== null) {
+                            $enabledSniffs = [];
 
-                        $additionalText = substr($commentText, 13);
-                        if ($additionalText === false) {
-                            $ignoring = null;
-                        } else {
-                            $parts = explode(',', substr($commentText, 13));
-                            foreach ($parts as $sniffCode) {
-                                $sniffCode = trim($sniffCode);
-                                $enabledSniffs[$sniffCode] = true;
-                                if (isset($ignoring[$sniffCode]) === true) {
-                                    unset($ignoring[$sniffCode]);
+                            $additionalText = substr($commentText, 13);
+                            if ($additionalText === false) {
+                                $ignoring = null;
+                            } else {
+                                $parts = explode(',', substr($commentText, 13));
+                                foreach ($parts as $sniffCode) {
+                                    $sniffCode = trim($sniffCode);
+                                    $enabledSniffs[$sniffCode] = true;
+                                    if (isset($ignoring[$sniffCode]) === true) {
+                                        unset($ignoring[$sniffCode]);
+                                    }
+                                }
+
+                                if (empty($ignoring) === true) {
+                                    $ignoring = null;
                                 }
                             }
 
-                            if (empty($ignoring) === true) {
-                                $ignoring = null;
+                            if ($ownLine === true) {
+                                // Completely ignore the comment line.
+                                $this->ignoredLines[$this->tokens[$i]['line']] = ['all' => true];
+                            } else {
+                                // The comment is on the same line as the code it is ignoring,
+                                // so respect the new ignore rules.
+                                $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;
                             }
-                        }
 
-                        if ($ownLine === true) {
-                            // Completely ignore the comment line.
-                            $this->ignoredLines[$this->tokens[$i]['line']] = ['all' => true];
-                        } else {
-                            // The comment is on the same line as the code it is ignoring,
-                            // so respect the new ignore rules.
-                            $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;
-                        }
+                            $this->tokens[$i]['sniffCodes'] = $enabledSniffs;
+                        }//end if
 
-                        $this->tokens[$i]['code']       = T_PHPCS_ENABLE;
-                        $this->tokens[$i]['type']       = 'T_PHPCS_ENABLE';
-                        $this->tokens[$i]['sniffCodes'] = $enabledSniffs;
+                        $this->tokens[$i]['code'] = T_PHPCS_ENABLE;
+                        $this->tokens[$i]['type'] = 'T_PHPCS_ENABLE';
                     } else if (substr($commentTextLower, 0, 12) === 'phpcs:ignore') {
                         $ignoreRules = [];
 

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -1000,6 +1000,20 @@ class ErrorSuppressionTest extends TestCase
         $this->assertEquals(1, $numWarnings);
         $this->assertCount(1, $warnings);
 
+        // Ignore an enable before a disable.
+        $content = '<?php '.PHP_EOL.'// phpcs:enable Generic.PHP.NoSilencedErrors -- Because reasons'.PHP_EOL.'$var = @delete( $filename );'.PHP_EOL;
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors      = $file->getErrors();
+        $numErrors   = $file->getErrorCount();
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertCount(0, $errors);
+        $this->assertEquals(0, $numWarnings);
+        $this->assertCount(0, $warnings);
+
     }//end testCommenting()
 
 


### PR DESCRIPTION
Fixes #1825

Includes unit test.


The actual change is quite small, easiest to view by ignoring the indentation change: https://github.com/squizlabs/PHP_CodeSniffer/pull/1827/files?w=1