### PR TITLE
Squiz.WhiteSpace.SuperfluousWhiteSpace ignoreBlankLines property ignores whitespace after single line comments

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -192,6 +192,7 @@ class SuperfluousWhitespaceSniff implements Sniff
 
             // Ignore blank lines if required.
             if ($this->ignoreBlankLines === true
+                && $tokens[$stackPtr]['code'] === T_WHITESPACE
                 && $tokens[($stackPtr - 1)]['line'] !== $tokens[$stackPtr]['line']
             ) {
                 return;

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc
@@ -46,6 +46,8 @@ function myFunction2()
     
 }
 
+// Ordinary comment with extra whitespace at the end    
+
 // phpcs:set Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
 
 // Уберём из системных свойств все кроме информации об услугах

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.inc.fixed
@@ -42,6 +42,8 @@ function myFunction2()
     
 }
 
+// Ordinary comment with extra whitespace at the end
+
 // phpcs:set Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false
 
 // Уберём из системных свойств все кроме информации об услугах

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -39,7 +39,8 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                 23 => 1,
                 28 => 1,
                 33 => 1,
-                53 => 1,
+                49 => 1,
+                55 => 1,
             ];
             break;
         case 'SuperfluousWhitespaceUnitTest.1.js':


### PR DESCRIPTION
Setting `ignoreBlankLines` to `true`, would also cause the sniff to ignore single-line comments with superfluous whitespace at the end.

Includes unit test.