### PR TITLE
Generic/LineLength: ignore new PHPCS annotations for the metrics

### DIFF
--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -15,6 +15,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Files;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class LineLengthSniff implements Sniff
 {
@@ -106,6 +107,16 @@ class LineLengthSniff implements Sniff
             && $tokens[$stackPtr]['content'] === $phpcsFile->eolChar
         ) {
             $stackPtr--;
+        }
+
+        if (isset(Tokens::$phpcsCommentTokens[$tokens[$stackPtr]['code']]) === true) {
+            $prevNonWhiteSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+            if ($tokens[$stackPtr]['line'] !== $tokens[$prevNonWhiteSpace]['line']) {
+                // Ignore PHPCS annotation comments if they are on a line by themselves.
+                return;
+            }
+
+            unset($prevNonWhiteSpace);
         }
 
         $lineLength = ($tokens[$stackPtr]['column'] + $tokens[$stackPtr]['length'] - 1);

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.1.inc
@@ -74,3 +74,9 @@ $ab	= function ()	{ /* comment */ if ($foo === true) { return	(int) $foo; }  };
 	$ab	= function () { /* comment */ if ($foo === true) { return(int) $foo; }};
 	$ab	= function () { /* comment */ if ($foo === true) {	return(int) $foo; }};
 $ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab	=  	$ab;
+
+// PHPCS annotations on a line by themselves should be ignored for the metrics.
+// phpcs:enable Standard.Category.Sniff.ErrorCode1,Standard.Category.Sniff.ErrorCode2 -- for reasons ...
+
+// ... but not when combined with statements.
+$a = $b; // phpcs:ignore Standard.Category.Sniff.ErrorCode1,Standard.Category.Sniff.ErrorCode2 -- for reasons ...

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -48,6 +48,7 @@ class LineLengthUnitTest extends AbstractSniffUnitTest
                 31 => 1,
                 34 => 1,
                 45 => 1,
+                82 => 1,
             ];
             break;
         case 'LineLengthUnitTest.2.inc':


### PR DESCRIPTION
Ignore the new `// phpcs:` annotation comments completely when they are on a line by themselves.
Do not record metrics about lines only containing these type of comments.

Errors would not be thrown anyway as lines containing these comments are ignored when throwing errors. Still, this does save the sniff from executing the rest of the logic when its not necessary.

Includes unit test.