### PR TITLE
Squiz/CSS/Indentation: minor efficiency fix

### DIFF
--- a/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class IndentationSniff implements Sniff
 {
@@ -59,7 +60,9 @@ class IndentationSniff implements Sniff
         $indentLevel  = 0;
         $nestingLevel = 0;
         for ($i = 1; $i < $numTokens; $i++) {
-            if ($tokens[$i]['code'] === T_COMMENT) {
+            if ($tokens[$i]['code'] === T_COMMENT
+                || isset(Tokens::$phpcsCommentTokens[$tokens[$i]['code']]) === true
+            ) {
                 // Don't check the indent of comments.
                 continue;
             }

--- a/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.css
@@ -71,5 +71,9 @@ td {
         padding: 0 0 0 30px;
     }
 
+.WhitelistCommentIndentationShouldBeIgnored {
+/* phpcs:disable Standard.Category.Sniff -- for reasons. */
+}
+
 /* syntax error */
 --------------------------------------------- */

--- a/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/IndentationUnitTest.css.fixed
@@ -65,5 +65,9 @@ td {
     padding: 0 0 0 30px;
 }
 
+.WhitelistCommentIndentationShouldBeIgnored {
+/* phpcs:disable Standard.Category.Sniff -- for reasons. */
+}
+
 /* syntax error */
 --------------------------------------------- */


### PR DESCRIPTION
Treat the new `// phpcs:` comments in the same way as "ordinary" `T_COMMENT` tokens.
This makes the sniff more efficient by skipping the logic for errors which will not be reported anyway.

Includes unit test.