### PR TITLE
PSR2/SwitchDeclaration: bug fix - ignore PHPCS annotation tokens

### DIFF
--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -109,7 +109,8 @@ class SwitchDeclarationSniff implements Sniff
 
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($opener + 1), null, true);
                 if ($tokens[$next]['line'] === $tokens[$opener]['line']
-                    && $tokens[$next]['code'] === T_COMMENT
+                    && ($tokens[$next]['code'] === T_COMMENT
+                    || isset(Tokens::$phpcsCommentTokens[$tokens[$next]['code']]) === true)
                 ) {
                     // Skip comments on the same line.
                     $next = $phpcsFile->findNext(T_WHITESPACE, ($next + 1), null, true);

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -122,7 +122,7 @@ switch ($foo) {
         // some comment
         echo 'bar';
         break;
-    case 'baz': // other comment
+    case 'baz': // phpcs:ignore Standard.Category.Sniff
         echo 'baz';
         break;
     case 'boo':

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -126,7 +126,7 @@ switch ($foo) {
         // some comment
         echo 'bar';
         break;
-    case 'baz': // other comment
+    case 'baz': // phpcs:ignore Standard.Category.Sniff
         echo 'baz';
         break;
     case 'boo':


### PR DESCRIPTION
Treat the new `// phpcs:` comments in the same way as "ordinary" `T_COMMENT` tokens.

Includes adjusted unit test.

This fixes a bug where when a `// phpcs:ignore` comment is at the end of a line, it would be incorrectly "fixed" by moving it down a line, making the comment apply to a different line altogether.