### PR TITLE
PSR2/ClassDeclaration: bug fix - ignore PHPCS annotation tokens

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -429,7 +429,10 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
 
         // Check the closing brace is on it's own line, but allow
         // for comments like "//end class".
-        $nextContent = $phpcsFile->findNext([T_WHITESPACE, T_COMMENT], ($closeBrace + 1), null, true);
+        $ignoreTokens   = Tokens::$phpcsCommentTokens;
+        $ignoreTokens[] = T_WHITESPACE;
+        $ignoreTokens[] = T_COMMENT;
+        $nextContent    = $phpcsFile->findNext($ignoreTokens, ($closeBrace + 1), null, true);
         if ($tokens[$nextContent]['content'] !== $phpcsFile->eolChar
             && $tokens[$nextContent]['line'] === $tokens[$closeBrace]['line']
         ) {

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -158,3 +158,8 @@ class A extends B
     implements C
 {
 }
+
+class C2
+{
+
+} // phpcs:ignore Standard.Category.Sniff

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -156,3 +156,8 @@ class Base
 class A extends B implements C
 {
 }
+
+class C2
+{
+
+} // phpcs:ignore Standard.Category.Sniff


### PR DESCRIPTION
Treat the new `// phpcs:` comments in the same way as "ordinary" `T_COMMENT` tokens.

Includes unit test.

This fixes a bug where an error would be reported for a `// phpcs:` comment being on the same line as the class close brace.