### PR TITLE
Squiz/ClassDeclaration: bug fix - ignore PHPCS annotation tokens

### DIFF
--- a/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes;
 
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff as PSR2ClassDeclarationSniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
 {
@@ -108,7 +109,8 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
             // Ignore comments on the same lines as the brace.
             if ($tokens[$nextContent]['line'] === $tokens[$closeBrace]['line']
                 && ($tokens[$nextContent]['code'] === T_WHITESPACE
-                || $tokens[$nextContent]['code'] === T_COMMENT)
+                || $tokens[$nextContent]['code'] === T_COMMENT
+                || isset(Tokens::$phpcsCommentTokens[$tokens[$nextContent]['code']]) === true)
             ) {
                 continue;
             }

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -80,7 +80,7 @@ class   CorrectClassDeclaration
 class CorrectClassDeclaration extends CorrectClassDeclaration2 implements ICorrectClassDeclaration
 {
 
-}//end class
+} // phpcs:enable Standard.Category.Sniff
 
 class File implements \Zend_Auth_Storage_Interface,\Zend_Auth_Storage,  \Zend_Foo
 {

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -87,7 +87,7 @@ class CorrectClassDeclaration
 class CorrectClassDeclaration extends CorrectClassDeclaration2 implements ICorrectClassDeclaration
 {
 
-}//end class
+} // phpcs:enable Standard.Category.Sniff
 
 class File implements \Zend_Auth_Storage_Interface, \Zend_Auth_Storage, \Zend_Foo
 {


### PR DESCRIPTION
Treat the new `// phpcs:` comments in the same way as "ordinary" `T_COMMENT` tokens.

Includes adjusted unit test.

This fixes a bug where an error would be reported for a `// phpcs:` comment being on the same line as the class close brace, as well as the fixer for that error moving the `// phpcs:` comment, while it shouldn't.