### PR TITLE
Squiz/ControlStructureSpacing: bug fix - allow for PHPCS annotation tokens

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -238,7 +238,9 @@ class ControlStructureSpacingSniff implements Sniff
             true
         );
 
-        if ($tokens[$trailingContent]['code'] === T_COMMENT) {
+        if ($tokens[$trailingContent]['code'] === T_COMMENT
+            || isset(Tokens::$phpcsCommentTokens[$tokens[$trailingContent]['code']]) === true
+        ) {
             // Special exception for code where the comment about
             // an ELSE or ELSEIF is written between the control structures.
             $nextCode = $phpcsFile->findNext(
@@ -327,7 +329,8 @@ class ControlStructureSpacingSniff implements Sniff
                     true
                 );
 
-                if ($tokens[$trailingContent]['code'] === T_COMMENT
+                if (($tokens[$trailingContent]['code'] === T_COMMENT
+                    || isset(Tokens::$phpcsCommentTokens[$tokens[$trailingContent]['code']]) === true)
                     && $tokens[$trailingContent]['line'] === $tokens[$scopeCloser]['line']
                 ) {
                     $phpcsFile->fixer->addNewline($trailingContent);

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -234,6 +234,11 @@ if ($true) {
 }//end if
 echo 'hi';
 
+if ($true) {
+    echo 'hi 2';
+} // phpcs:enable Standard.Category.Sniff -- for reasons.
+echo 'hi';
+
 ?>
 <?php foreach($formset['Fieldset'] as $fieldset): ?>
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -228,6 +228,12 @@ if ($true) {
 
 echo 'hi';
 
+if ($true) {
+    echo 'hi 2';
+} // phpcs:enable Standard.Category.Sniff -- for reasons.
+
+echo 'hi';
+
 ?>
 <?php foreach($formset['Fieldset'] as $fieldset): ?>
     <?php foreach($fieldset['Field'] as $field):

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -54,8 +54,9 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
                 189 => 1,
                 222 => 1,
                 234 => 1,
-                238 => 1,
-                240 => 1,
+                239 => 1,
+                243 => 1,
+                245 => 1,
             ];
             break;
         case 'ControlStructureSpacingUnitTest.js':


### PR DESCRIPTION
Treat the new `// phpcs:` comments in the same way as "ordinary" `T_COMMENT` tokens.

Includes unit test.

Related to #1817, which was recently fixed in a7d4118b9ca880acd2b9a7d70b7861e9228756eb. This commit builds onto that fix.

Without the fix, the `NoLineAfterClose` error would not be reported when there is a `phpcs:` comment after a control structure close brace and the needed fix would not be applied.