### PR TITLE
Squiz/FunctionSpacing: bug fix - ignore PHPCS annotation tokens

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class FunctionSpacingSniff implements Sniff
 {
@@ -138,7 +139,9 @@ class FunctionSpacingSniff implements Sniff
             $currentLine = $tokens[$stackPtr]['line'];
 
             $prevContent = $phpcsFile->findPrevious(T_WHITESPACE, $prevLineToken, null, true);
-            if ($tokens[$prevContent]['code'] === T_COMMENT) {
+            if ($tokens[$prevContent]['code'] === T_COMMENT
+                || isset(Tokens::$phpcsCommentTokens[$tokens[$prevContent]['code']]) === true
+            ) {
                 // Ignore comments as they can have different spacing rules, and this
                 // isn't a proper function comment anyway.
                 return;

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -300,3 +300,8 @@ if ($foo) {
 // foo
 function foo() {
 }
+
+
+// phpcs:disable Standard.Category.Sniff -- for reasons.
+function bar() {
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -328,3 +328,8 @@ if ($foo) {
 // foo
 function foo() {
 }
+
+
+// phpcs:disable Standard.Category.Sniff -- for reasons.
+function bar() {
+}


### PR DESCRIPTION
Treat the new `// phpcs:` comments in the same way as "ordinary" `T_COMMENT` tokens.

Includes unit test.

Without this fix, the fixer would report an error for the spacing above the function and add two blank lines between the `// phpcs:` comment and the function declaration.
  