### PR TITLE
Squiz/CommentedOutCode: ignore PHPCS annotations + minor other fixes

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -160,15 +160,6 @@ class CommentedOutCodeSniff implements Sniff
 
         ini_set('error_reporting', $oldErrors);
 
-        $emptyTokens = [
-            T_WHITESPACE              => true,
-            T_STRING                  => true,
-            T_STRING_CONCAT           => true,
-            T_ENCAPSED_AND_WHITESPACE => true,
-            T_NONE                    => true,
-            T_COMMENT                 => true,
-        ];
-
         $numTokens = count($stringTokens);
 
         /*
@@ -197,6 +188,15 @@ class CommentedOutCodeSniff implements Sniff
         ) {
             return;
         }
+
+        $emptyTokens = [
+            T_WHITESPACE              => true,
+            T_STRING                  => true,
+            T_STRING_CONCAT           => true,
+            T_ENCAPSED_AND_WHITESPACE => true,
+            T_NONE                    => true,
+            T_COMMENT                 => true,
+        ];
 
         $numComment  = 0;
         $numPossible = 0;

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -122,6 +122,9 @@ class CommentedOutCodeSniff implements Sniff
                 $tokenContent = substr($tokenContent, 1);
             }
 
+            // Remove PHPCS annotations.
+            $tokenContent = preg_replace('`[@]?(?:phpcs:(?:enable|disable|set|ignore)|codingStandards(?:Ignore|Change)).*$`', '', $tokenContent);
+
             $content     .= $tokenContent.$phpcsFile->eolChar;
             $lastLineSeen = $tokens[$i]['line'];
         }//end for

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -78,11 +78,7 @@ class CommentedOutCodeSniff implements Sniff
             return;
         }
 
-        $content = '';
-        if ($phpcsFile->tokenizerType === 'PHP') {
-            $content = '<?php ';
-        }
-
+        $content      = '';
         $lastLineSeen = $tokens[$stackPtr]['line'];
         for ($i = $stackPtr; $i < $phpcsFile->numTokens; $i++) {
             if ($tokens[$i]['code'] === T_WHITESPACE) {
@@ -130,12 +126,6 @@ class CommentedOutCodeSniff implements Sniff
             $lastLineSeen = $tokens[$i]['line'];
         }//end for
 
-        $content = trim($content);
-
-        if ($phpcsFile->tokenizerType === 'PHP') {
-            $content .= ' ?>';
-        }
-
         // Quite a few comments use multiple dashes, equals signs etc
         // to frame comments and licence headers.
         $content = preg_replace('/[-=#*]{2,}/', '-', $content);
@@ -143,6 +133,16 @@ class CommentedOutCodeSniff implements Sniff
         // Random numbers sitting inside the content can throw parse errors
         // for invalid literals in PHP7+, so strip those.
         $content = preg_replace('/\d+/', '', $content);
+
+        $content = trim($content);
+
+        if ($content === '') {
+            return;
+        }
+
+        if ($phpcsFile->tokenizerType === 'PHP') {
+            $content = '<?php '.$content.' ?>';
+        }
 
         // Because we are not really parsing code, the tokenizer can throw all sorts
         // of errors that don't mean anything, so ignore them.

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -206,8 +206,8 @@ class CommentedOutCodeSniff implements Sniff
             if (isset($emptyTokens[$stringTokens[$i]['code']]) === true) {
                 // Looks like comment.
                 $numComment++;
-            } else if (in_array($stringTokens[$i]['code'], Tokens::$comparisonTokens) === true
-                || in_array($stringTokens[$i]['code'], Tokens::$arithmeticTokens) === true
+            } else if (isset(Tokens::$comparisonTokens[$stringTokens[$i]['code']]) === true
+                || isset(Tokens::$arithmeticTokens[$stringTokens[$i]['code']]) === true
                 || $stringTokens[$i]['code'] === T_GOTO_LABEL
             ) {
                 // Commented out HTML/XML and other docs contain a lot of these

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -122,7 +122,7 @@ class CommentedOutCodeSniff implements Sniff
 
         // Quite a few comments use multiple dashes, equals signs etc
         // to frame comments and licence headers.
-        $content = preg_replace('/[-=*]+/', '-', $content);
+        $content = preg_replace('/[-=#*]{2,}/', '-', $content);
 
         // Random numbers sitting inside the content can throw parse errors
         // for invalid literals in PHP7+, so strip those.

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
@@ -112,3 +112,15 @@ function myFunction( $param )
 	 *
 	 * }//end myFunction()
 	 */
+
+    /*
+     * function myFunction( $param )
+     * {
+     *  // phpcs:disable Standard.Category.Sniff -- for reasons.
+     *  if ( preg_match( '`[abc]`', $param ) > 0 ) {
+     *      do_something();
+     *  }
+     *  // phpcs:enable Standard.Category.Sniff -- for reasons.
+     *
+     * }//end myFunction()
+     */

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
@@ -87,3 +87,28 @@ function myFunction()
 // function ()
 
 // T_STRING is not a function call or not listed in _getFunctionListWithCallableArgument().
+
+	// function myFunction( $param )
+	// {
+	//    do_something();
+	// }//end myFunction()
+	//
+
+/*
+function myFunction( $param )
+{
+	// phpcs:disable Standard.Category.Sniff -- for reasons.
+	if ( preg_match( '`[abc]`', $param ) > 0 ) {
+		do_something();
+	}
+	// phpcs:enable Standard.Category.Sniff -- for reasons.
+
+}//end myFunction()
+*/
+
+	/*
+	 * function myFunction( $param ) // @phpcs:ignore Standard.Category.Sniff -- for reasons.
+	 * {
+	 *
+	 * }//end myFunction()
+	 */

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
@@ -32,7 +32,7 @@ if ($blah) {
 
 // Continue, as we're done with this token.
 
-/**
+/*
  * The listeners array.
  *
  * @var array(PHP_CodeSniffer_Sniff)
@@ -59,7 +59,7 @@ function myFunction()
 // | A comment block           |
 // *****************************
 
-/**
+/*
  * List of panels.
  *
  * XML structure:

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
@@ -124,3 +124,11 @@ function myFunction( $param )
      *
      * }//end myFunction()
      */
+
+    // function myFunction( $param )
+    // {
+          // phpcs:disable Standard.Category.Sniff -- for reasons.
+    //    do_something();
+          // phpcs:enable Standard.Category.Sniff -- for reasons.
+    // }//end myFunction()
+    //

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -55,6 +55,7 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
                 97  => 1,
                 109 => 1,
                 116 => 1,
+                128 => 1,
             ];
             break;
         case 'CommentedOutCodeUnitTest.css':

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -49,6 +49,7 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
                 8   => 1,
                 15  => 1,
                 19  => 1,
+                35  => 1,
                 87  => 1,
                 91  => 1,
                 97  => 1,

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -45,11 +45,14 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'CommentedOutCodeUnitTest.inc':
             return [
-                6  => 1,
-                8  => 1,
-                15 => 1,
-                19 => 1,
-                87 => 1,
+                6   => 1,
+                8   => 1,
+                15  => 1,
+                19  => 1,
+                87  => 1,
+                91  => 1,
+                97  => 1,
+                109 => 1,
             ];
             break;
         case 'CommentedOutCodeUnitTest.css':

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -54,6 +54,7 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
                 91  => 1,
                 97  => 1,
                 109 => 1,
+                116 => 1,
             ];
             break;
         case 'CommentedOutCodeUnitTest.css':


### PR DESCRIPTION
Another one in the series to make sure sniffs handle the new PHPCS annotations correctly.

PHPCS annotations in commented out code would be tokenized and would throw the "commented out" % off, making the sniff underreport commented out code.

This PR fixes that.

While reviewing the sniff to figure out how to fix this in the best way, I came across numerous other bugs and inefficiencies and have fixed each one in a separate commit.

Includes unit tests covering the bugs.

The PR looks bigger than it is. It will be easiest to review by looking at each commit separately.

-------
## Relevant commit details

### Bug fix (minor): Prevent parsing out valid code.

The regex used to parse out comment fencing was a little too overactive and would change the below commented out code:
```php
//eval('$var = 4;');
```
to
```php
//eval('$var - ;');
```

Now only real comment fencing for which this regex was intended will be replaced.

### Bug fix: Treat multi-line indented `//` comments as one

Multi-line comments are intended to be treated as one comment by this sniff.

Indented `//` style comments tokenize as `T_WHITESPACE` + `T_COMMENT`.
This meant that the compare for multi-line comments would fail for these and that each comment would be analyzed separately instead, causing false negatives.

Includes unit test.

### Efficiency fix (minor) - don't re-tokenize empty comments

Empty comments don't need to be re-tokenized and examined, so the sniff can bow out early in that case.

Covered by the existing unit tests on line 41 and 43 of the test case file.

### Fix two unit tests

As the sniff doesn't listen anymore to docblock comment tokens since 638f98d, these unit tests were no longer covering anything.

Changing these to `/* */` style comments re-activates the unit tests. This does change the result of the analysis for one of these two comments.

###  Efficiency fix (minor): use isset() rather than in_array() for improved efficiency

### Bug fix: ignore PHPCS annotations in comment blocks

The new PHPCS annotations could throw off the detection of commented out code.
Removing them before the comment is re-tokenized fixes that.



  