### PR TITLE
Squiz/MemberVarSpacing: document behaviour with PHPCS annotations

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
@@ -212,3 +212,37 @@ interface MyInterface
     public $var3 = 'value';
 
 }//end class
+
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacing 0
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacingBeforeFirst 0
+
+class phpcsCommentTest {
+
+
+    // phpcs:disable Standard.Category.Sniff
+
+    public $var1 = 'value';
+
+
+    // phpcs:enable Standard.Category.Sniff
+
+    public $var1 = 'value';
+
+}
+
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacing 1
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacingBeforeFirst 1
+
+class phpcsCommentTest {
+
+
+    // phpcs:disable Standard.Category.Sniff
+
+    public $var1 = 'value';
+
+
+    // phpcs:enable Standard.Category.Sniff
+
+    public $var1 = 'value';
+
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -207,3 +207,31 @@ interface MyInterface
     public $var3 = 'value';
 
 }//end class
+
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacing 0
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacingBeforeFirst 0
+
+class phpcsCommentTest {
+    // phpcs:disable Standard.Category.Sniff
+
+    public $var1 = 'value';
+    // phpcs:enable Standard.Category.Sniff
+
+    public $var1 = 'value';
+
+}
+
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacing 1
+// phpcs:set Squiz.WhiteSpace.MemberVarSpacing spacingBeforeFirst 1
+
+class phpcsCommentTest {
+
+    // phpcs:disable Standard.Category.Sniff
+
+    public $var1 = 'value';
+
+    // phpcs:enable Standard.Category.Sniff
+
+    public $var1 = 'value';
+
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -45,6 +45,10 @@ class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
             200 => 1,
             209 => 1,
             211 => 1,
+            224 => 1,
+            229 => 1,
+            241 => 1,
+            246 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Add unit tests to document the behaviour when PHPCS annotations are encountered.

This is basically for the `AfterComment` error. As that error is thrown on the line containing the comment, it is automatically ignored for the PHPCS annotations, so no sniff code adjustments were needed.