### PR TITLE
Generic/Todo & Fixme: minor efficiency fix

### DIFF
--- a/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -35,7 +35,7 @@ class FixmeSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$commentTokens;
+        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -34,7 +34,7 @@ class TodoSniff implements Sniff
      */
     public function register()
     {
-        return Tokens::$commentTokens;
+        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
 
     }//end register()
 


### PR DESCRIPTION
As "errors" in the PHPCS annotations will not be reported anyway, no need to examine them for these sniffs.