### PR TITLE
Generic/UpperCaseConstantName: bug fix - ignore PHPCS annotation tokens

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class UpperCaseConstantNameSniff implements Sniff
 {
@@ -61,29 +62,13 @@ class UpperCaseConstantNameSniff implements Sniff
 
         // If the next non-whitespace token after this token
         // is not an opening parenthesis then it is not a function call.
-        for ($openBracket = ($stackPtr + 1); $openBracket < $phpcsFile->numTokens; $openBracket++) {
-            if ($tokens[$openBracket]['code'] !== T_WHITESPACE) {
-                break;
-            }
-        }
-
-        if ($openBracket === $phpcsFile->numTokens) {
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($openBracket === false) {
             return;
         }
 
         if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
-            $functionKeyword = $phpcsFile->findPrevious(
-                [
-                    T_WHITESPACE,
-                    T_COMMA,
-                    T_COMMENT,
-                    T_STRING,
-                    T_NS_SEPARATOR,
-                ],
-                ($stackPtr - 1),
-                null,
-                true
-            );
+            $functionKeyword = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
             if ($tokens[$functionKeyword]['code'] !== T_CONST) {
                 return;

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
@@ -168,4 +168,8 @@ class Foo
     }
 }
 
-?>
+class ClassConstBowOutTest {
+	const /* comment */ abc = 1;
+	const // phpcs:ignore Standard.Category.Sniff
+	    some_constant = 2;
+}

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.php
@@ -26,11 +26,13 @@ class UpperCaseConstantNameUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            8  => 1,
-            10 => 1,
-            12 => 1,
-            14 => 1,
-            19 => 1,
+            8   => 1,
+            10  => 1,
+            12  => 1,
+            14  => 1,
+            19  => 1,
+            172 => 1,
+            174 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Treat the new `// phpcs:` comments in the same way as "ordinary" `T_COMMENT` tokens.

Includes unit test.

This fixes a bug where non-uppercase constants defined using the `const` keyword would not be reported.

It also fixes some outdated code. Looking at the history, originally this sniff also tried to detect _usage_ of non-uppercase constants.
As of commit 4af13118b1fedd89faadd78b9bccf858ce21dbc9 / October 2013, this is no longer the case and only definition of non-uppercase constants is reported.
It looks like both the sniff as well as the unit test case file still contains quite some code related to the old behaviour which could be further simplified, but that is outside the scope of this PR.