### PR TITLE
MultipleStatementAlignment: do not break on comments within arrays.

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -124,6 +124,22 @@ class MultipleStatementAlignmentSniff implements Sniff
                     continue;
                 }
 
+                // Skip past the content of arrays.
+                if ($tokens[$assign]['code'] === T_OPEN_SHORT_ARRAY
+                    && isset($tokens[$assign]['bracket_closer']) === true
+                ) {
+                    $assign = $lastCode = $tokens[$assign]['bracket_closer'];
+                    continue;
+                }
+
+                if ($tokens[$assign]['code'] === T_ARRAY
+                    && isset($tokens[$assign]['parenthesis_opener']) === true
+                    && isset($tokens[$tokens[$assign]['parenthesis_opener']]['parenthesis_closer']) === true
+                ) {
+                    $assign = $lastCode = $tokens[$tokens[$assign]['parenthesis_opener']]['parenthesis_closer'];
+                    continue;
+                }
+
                 // A blank line indicates that the assignment block has ended.
                 if (isset(Tokens::$emptyTokens[$tokens[$assign]['code']]) === false) {
                     if (($tokens[$assign]['line'] - $tokens[$lastCode]['line']) > 1) {

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -248,3 +248,20 @@ $loggerResult = $util->setLogger(new class {
     }
 });
 $foo          = 5;
+
+$foo = array(
+    'a' => 'b',
+);
+$barbar = 'bar';
+
+$foo = array(
+    // Some comment.
+    'a' => 'b',
+);
+$barbar = 'bar';
+
+$foo = [
+    // phpcs:ignore Standard.Category.Sniff.Code -- for reasons.
+    'a' => 'b',
+];
+$barbar = 'bar';

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -248,3 +248,20 @@ $loggerResult = $util->setLogger(new class {
     }
 });
 $foo          = 5;
+
+$foo    = array(
+    'a' => 'b',
+);
+$barbar = 'bar';
+
+$foo    = array(
+    // Some comment.
+    'a' => 'b',
+);
+$barbar = 'bar';
+
+$foo    = [
+    // phpcs:ignore Standard.Category.Sniff.Code -- for reasons.
+    'a' => 'b',
+];
+$barbar = 'bar';

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -79,6 +79,9 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
                 182 => 1,
                 206 => 1,
                 207 => 1,
+                252 => 1,
+                257 => 1,
+                263 => 1,
             ];
         break;
         case 'MultipleStatementAlignmentUnitTest.js':


### PR DESCRIPTION
Multi-line arrays interspersed with comments were treated differently than multi-line arrays without comments.

This aligns the behaviour of both to be the same.

Includes unit tests.