### PR TITLE
Travis: More stable solution for removing Xdebug when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
-  - if [[ $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != hhv* ]]; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   # Circumvent a bug in the travis HHVM image - ships with incompatible PHPUnit.
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer self-update; fi
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:~4.0; fi


### PR DESCRIPTION
Builds onto #1852

As per https://twitter.com/kelunik/status/954242454676475904

When newer images of PHP versions become available, Xdebug isn't always installed.
Using this little titbit, the builds won't break because of it.