### PR TITLE
Add function name on missing function doc comment

### DIFF
--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -61,7 +61,7 @@ class FunctionCommentSniff implements Sniff
         ) {
             $function = $phpcsFile->getDeclarationName($stackPtr);
             $phpcsFile->addError(
-                'Missing docblock for function "%s()"',
+                'Missing function doc comment for function "%s()"',
                 $stackPtr,
                 'Missing',
                 [$function]

--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -59,7 +59,8 @@ class FunctionCommentSniff implements Sniff
         if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
             && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
-            $phpcsFile->addError('Missing function doc comment', $stackPtr, 'Missing');
+            $function = $phpcsFile->getDeclarationName($stackPtr);
+            $phpcsFile->addError('Missing function doc comment: '.$function.'()', $stackPtr, 'Missing');
             $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'no');
             return;
         } else {

--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -60,7 +60,12 @@ class FunctionCommentSniff implements Sniff
             && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
             $function = $phpcsFile->getDeclarationName($stackPtr);
-            $phpcsFile->addError('Missing function doc comment: '.$function.'()', $stackPtr, 'Missing');
+            $phpcsFile->addError(
+                'Missing docblock for function "%s()"',
+                $stackPtr,
+                'Missing',
+                [$function]
+            );
             $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'no');
             return;
         } else {


### PR DESCRIPTION
### Old Error Messages

```
10 | ERROR | [ ] Missing function doc comment
20 | ERROR | [ ] Missing function doc comment
30 | ERROR | [ ] Missing function doc comment
```

### New Error Messages

```
10 | ERROR | [ ] Missing function doc comment: lorem()
20 | ERROR | [ ] Missing function doc comment: ipsum()
30 | ERROR | [ ] Missing function doc comment: dolor()
```

### Sample File

```
<?php

class Foo
{
    public function lorem()
    {
    }

    private function ipsum()
    {
    }
}

function dolor()
{
}
```