### PR TITLE
Add class name on missing class doc comment

### DIFF
--- a/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
@@ -56,7 +56,8 @@ class ClassCommentSniff extends FileCommentSniff
         if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
             && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
-            $phpcsFile->addError('Missing %s doc comment', $stackPtr, 'Missing', $errorData);
+            $errorData[] = $phpcsFile->getDeclarationName($stackPtr);
+            $phpcsFile->addError('Missing doc comment for %s %s', $stackPtr, 'Missing', $errorData);
             $phpcsFile->recordMetric($stackPtr, 'Class has doc comment', 'no');
             return;
         }

--- a/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
@@ -56,7 +56,8 @@ class ClassCommentSniff implements Sniff
         if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
             && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
-            $phpcsFile->addError('Missing class doc comment', $stackPtr, 'Missing');
+            $class = $phpcsFile->getDeclarationName($stackPtr);
+            $phpcsFile->addError('Missing doc comment for class %s', $stackPtr, 'Missing', [$class]);
             $phpcsFile->recordMetric($stackPtr, 'Class has doc comment', 'no');
             return;
         }


### PR DESCRIPTION
### Target

This pull-request modifies both PEAR and Squiz coding standards.

### Scenario

Normally, people define one class per file, in this case the name of the class may be redundant if the name of the file is the same. However, in cases where the developer is not adhering to this standard it may be helpful to know if all the classes contained in the same file have a proper DocBlock comment.

Also notice the _"Missing file doc comment"_ in the examples below. I will not submit a pull-request for this because adding the name of the file in front of the warning is really redundant considering that `phpcs` already prints the name of the file before the warning/error table.

The error message also follow the same format suggested [here](https://github.com/squizlabs/PHP_CodeSniffer/pull/1865#issuecomment-362099764).

### Old Error Messages

```
2 | ERROR | Missing file doc comment
3 | ERROR | Missing class doc comment
7 | ERROR | Missing class doc comment
```

### New Error Messages

```
2 | ERROR | Missing file doc comment
3 | ERROR | Missing doc comment for class Foo
7 | ERROR | Missing doc comment for class Bar
```

### Sample File

```
<?php

class Foo
{
}

class Bar
{
}
```