### PR TITLE
Add standards path resolution for files served over http(s).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/*
 /vendor/
 composer.lock
+/src/Standards/HttpCache/

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -156,7 +156,7 @@ class Ruleset
         foreach ($standardPaths as $standard) {
             // If rules are loaded over http, use caching.
             $urlInfo = parse_url($standard);
-            if ($urlInfo !== false && strpos($urlInfo['scheme'], 'http') === 0) {
+            if ($urlInfo !== false && array_key_exists('scheme', $urlInfo) === true && strpos($urlInfo['scheme'], 'http') === 0) {
                 $timeout  = 3;
                 $context  = stream_context_create(['http' => ['timeout' => $timeout]]);
                 $contents = @file_get_contents($standard, false, $context);

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -75,6 +75,11 @@ class Common
             return str_replace('/dev/fd', 'php://fd', $path);
         }
 
+        // Check for file served over http(s)
+        if (strpos($path, 'http://') === 0 || strpos($path, 'https://') === 0) {
+            return $path;
+        }
+
         // No extra work needed if this is not a phar file.
         if (self::isPharFile($path) === false) {
             return realpath($path);

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -75,7 +75,7 @@ class Common
             return str_replace('/dev/fd', 'php://fd', $path);
         }
 
-        // Check for file served over http(s)
+        // Check for file served over http(s).
         if (strpos($path, 'http://') === 0 || strpos($path, 'https://') === 0) {
             return $path;
         }

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -227,8 +227,9 @@ class Standards
             $standard = Common::realPath($standard);
 
             // If the file is served over HTTP, check if the file is available and is an XML file.
-            if (strpos($standard, 'http://') === 0 || strpos($standard, 'https://') === 0) {
-                if (strpos($standard, 'http://') === 0) {
+            $protocol = parse_url($standard, PHP_URL_SCHEME);
+            if ($protocol !== false && strpos($standard, 'http') === 0) {
+                if ($protocol !== 'https') {
                     echo 'NOTICE: HTTP is insecure. Use HTTPS, if available.', PHP_EOL;
                 }
 

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -228,6 +228,10 @@ class Standards
 
             // If the file is served over HTTP, check if the file is available and is an XML file.
             if (strpos($standard, 'http://') === 0 || strpos($standard, 'https://') === 0) {
+                if (strpos($standard, 'http://') === 0) {
+                    echo 'NOTICE: HTTP is insecure. Use HTTPS, if available.', PHP_EOL;
+                }
+
                 $headers = get_headers($standard);
                 foreach ($headers as $header) {
                     if (stripos($header, 'HTTP') === 0 && stripos($header, '200') === false) {

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -226,6 +226,22 @@ class Standards
             // standards directory.
             $standard = Common::realPath($standard);
 
+            // If the file is served over HTTP, check if the file is available and is an XML file.
+            if (strpos($standard, 'http://') === 0 || strpos($standard, 'https://') === 0) {
+                $headers = get_headers($standard);
+                foreach ($headers as $header) {
+                    if (stripos($header, 'HTTP') === 0 && stripos($header, '200') === false) {
+                        return false;
+                    }
+
+                    if (stripos($header, 'Content-Type') === 0 && stripos($header, 'application/xml') === false) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
             // Might be an actual ruleset file itUtil.
             // If it has an XML extension, let's at least try it.
             if (is_file($standard) === true


### PR DESCRIPTION
`Common::realpath()` passes through paths with an http(s) protocol.
`Standards::isInstalledStandard()` checks if the file exists and is an xml file for standards with an http(s) protocol.

This should resolve #1872 

I did not see any unit tests associated with these methods, so I didn't add any testing.