### PR TITLE
Improve testability of rulesets

### DIFF
--- a/tests/Standards/AllSniffs.php
+++ b/tests/Standards/AllSniffs.php
@@ -56,7 +56,7 @@ class AllSniffs
             $ignoreTestsForStandards = explode(',', $ignoreTestsForStandards);
         }
 
-        $installedStandards = Standards::getInstalledStandardDetails(true);
+        $installedStandards = self::getInstalledStandardDetails();
 
         foreach ($installedStandards as $standard => $details) {
             Autoload::addSearchPath($details['path'], $details['namespace']);
@@ -105,6 +105,19 @@ class AllSniffs
         return $suite;
 
     }//end suite()
+
+
+    /**
+     * Get the details of all coding standards installed.
+     *
+     * @return array
+     * @see    Standards::getInstalledStandardDetails()
+     */
+    protected static function getInstalledStandardDetails()
+    {
+        return Standards::getInstalledStandardDetails(true);
+
+    }//end getInstalledStandardDetails()
 
 
 }//end class


### PR DESCRIPTION
By extracting the retrieval of the installed standards a third party ruleset/sniff developer, me, can easily create an extension of `AllSniffs` that only runs the sniffs of the ruleset in question.

This simple extraction will prevent doing cli magic like `--filter` and allow full configurability in a `phpunit.xml`.

Adds to #1756