### PR TITLE
use json_encode in JSON reports to fix invalid outputs

### DIFF
--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -59,7 +59,7 @@ class Json implements Report
                     $messagesObject->column = $column;
                     $messagesObject->fixable = $fixable;
 
-                    $messages .= json_encode($messagesObject);
+                    $messages .= json_encode($messagesObject) . ",";
                 }//end foreach
             }//end foreach
         }//end foreach

--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -54,14 +54,12 @@ class Json implements Report
                         $fixable = 'true';
                     }
 
-                    $messages .= '{"message":"'.$error['message'].'",';
-                    $messages .= '"source":"'.$error['source'].'",';
-                    $messages .= '"severity":'.$error['severity'].',';
-                    $messages .= '"type":"'.$error['type'].'",';
-                    $messages .= '"line":'.$line.',';
-                    $messages .= '"column":'.$column.',';
-                    $messages .= '"fixable":'.$fixable;
-                    $messages .= '},';
+                    $messagesObject = (object) $error;
+                    $messagesObject->line = $line;
+                    $messagesObject->column = $column;
+                    $messagesObject->fixable = $fixable;
+
+                    $messages .= json_encode($messagesObject);
                 }//end foreach
             }//end foreach
         }//end foreach


### PR DESCRIPTION
I had issues with a sniffer, which use class names in the source. These class names had (not escaped) namespaces included. This make the json output invalid.

After looking at the code, I was wondering, why PHP_CodeSniffer doesn't use json_encode for this task.