### PR TITLE
AbstractVariableSniff: add list of PHP reserved variables

### DIFF
--- a/src/Sniffs/AbstractVariableSniff.php
+++ b/src/Sniffs/AbstractVariableSniff.php
@@ -24,6 +24,29 @@ abstract class AbstractVariableSniff extends AbstractScopeSniff
 
 
     /**
+     * List of PHP Reserved variables.
+     *
+     * Used by various naming convention sniffs.
+     *
+     * @var array
+     */
+    protected $phpReservedVars = [
+        '_SERVER'              => true,
+        '_GET'                 => true,
+        '_POST'                => true,
+        '_REQUEST'             => true,
+        '_SESSION'             => true,
+        '_ENV'                 => true,
+        '_COOKIE'              => true,
+        '_FILES'               => true,
+        'GLOBALS'              => true,
+        'http_response_header' => true,
+        'HTTP_RAW_POST_DATA'   => true,
+        'php_errormsg'         => true,
+    ];
+
+
+    /**
      * Constructs an AbstractVariableTest.
      */
     public function __construct()

--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -31,23 +31,8 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $tokens  = $phpcsFile->getTokens();
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
-        $phpReservedVars = [
-            '_SERVER',
-            '_GET',
-            '_POST',
-            '_REQUEST',
-            '_SESSION',
-            '_ENV',
-            '_COOKIE',
-            '_FILES',
-            'GLOBALS',
-            'http_response_header',
-            'HTTP_RAW_POST_DATA',
-            'php_errormsg',
-        ];
-
         // If it's a php reserved var, then its ok.
-        if (in_array($varName, $phpReservedVars) === true) {
+        if (isset($this->phpReservedVars[$varName]) === true) {
             return;
         }
 
@@ -170,25 +155,10 @@ class ValidVariableNameSniff extends AbstractVariableSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $phpReservedVars = [
-            '_SERVER',
-            '_GET',
-            '_POST',
-            '_REQUEST',
-            '_SESSION',
-            '_ENV',
-            '_COOKIE',
-            '_FILES',
-            'GLOBALS',
-            'http_response_header',
-            'HTTP_RAW_POST_DATA',
-            'php_errormsg',
-        ];
-
         if (preg_match_all('|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
             foreach ($matches[1] as $varName) {
                 // If it's a php reserved var, then its ok.
-                if (in_array($varName, $phpReservedVars) === true) {
+                if (isset($this->phpReservedVars[$varName]) === true) {
                     continue;
                 }
 

--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -31,23 +31,8 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $tokens  = $phpcsFile->getTokens();
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
-        $phpReservedVars = [
-            '_SERVER'              => true,
-            '_GET'                 => true,
-            '_POST'                => true,
-            '_REQUEST'             => true,
-            '_SESSION'             => true,
-            '_ENV'                 => true,
-            '_COOKIE'              => true,
-            '_FILES'               => true,
-            'GLOBALS'              => true,
-            'http_response_header' => true,
-            'HTTP_RAW_POST_DATA'   => true,
-            'php_errormsg'         => true,
-        ];
-
         // If it's a php reserved var, then its ok.
-        if (isset($phpReservedVars[$varName]) === true) {
+        if (isset($this->phpReservedVars[$varName]) === true) {
             return;
         }
 
@@ -182,25 +167,10 @@ class ValidVariableNameSniff extends AbstractVariableSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $phpReservedVars = [
-            '_SERVER',
-            '_GET',
-            '_POST',
-            '_REQUEST',
-            '_SESSION',
-            '_ENV',
-            '_COOKIE',
-            '_FILES',
-            'GLOBALS',
-            'http_response_header',
-            'HTTP_RAW_POST_DATA',
-            'php_errormsg',
-        ];
-
         if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
             foreach ($matches[1] as $varName) {
                 // If it's a php reserved var, then its ok.
-                if (in_array($varName, $phpReservedVars) === true) {
+                if (isset($this->phpReservedVars[$varName]) === true) {
                     continue;
                 }
 


### PR DESCRIPTION
Duplicate code removal.

The list of PHP reserved variables was up to now defined in four places in two separate sniffs.
Both these sniffs extend the `AbstractVariableSniff`, so it makes sense to define the list as a property of that sniff and to re-use it in the individual sniffs instead.

Also changes the array format in a way that the more efficient `isset()` can be used instead of `in_array()`.