### PR TITLE
PSR2/UseDeclaration: allow comments after the last USE statement

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -142,7 +142,7 @@ class UseDeclarationSniff implements Sniff
             return;
         }
 
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($end + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
 
         if ($next === false || $tokens[$next]['code'] === T_CLOSE_TAG) {
             return;

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.8.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.8.inc
@@ -1,0 +1,4 @@
+<?php
+use Foo\Bar; //comment
+
+// This should pass.


### PR DESCRIPTION
Resolves #1891