### PR TITLE
Prove regression from #1893

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -137,13 +137,15 @@ class UseDeclarationSniff implements Sniff
             return;
         }
 
-        $end         = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
-        $nextComment = $phpcsFile->findNext(T_COMMENT, ($end + 1));
+        $end = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
+        $candidateComment = $end;
 
-        // The end of the line is allowed to be a comment as well as a semi colon.
-        if ($nextComment !== false && $tokens[$nextComment]['line'] === $tokens[$end]['line']) {
-            $end = $nextComment;
-        }
+        do {
+            $nextComment      = $candidateComment;
+            $candidateComment = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextComment + 1));
+        } while ($candidateComment !== false && $tokens[$candidateComment]['line'] === $tokens[$end]['line']);
+
+        $end = $nextComment;
 
         if ($end === false) {
             return;

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -142,7 +142,7 @@ class UseDeclarationSniff implements Sniff
             return;
         }
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($end + 1), null, true);
 
         if ($next === false || $tokens[$next]['code'] === T_CLOSE_TAG) {
             return;

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -138,17 +138,32 @@ class UseDeclarationSniff implements Sniff
         }
 
         $end = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
-        $candidateComment = $end;
-
-        do {
-            $nextComment      = $candidateComment;
-            $candidateComment = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextComment + 1));
-        } while ($candidateComment !== false && $tokens[$candidateComment]['line'] === $tokens[$end]['line']);
-
-        $end = $nextComment;
-
         if ($end === false) {
             return;
+        }
+
+        // Find either the start of the next line or the beginning of the next statement,
+        // whichever comes first.
+        for ($end = ++$end; $end < $phpcsFile->numTokens; $end++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$end]['code']]) === false) {
+                break;
+            }
+
+            if ($tokens[$end]['column'] === 1) {
+                // Reached the next line.
+                break;
+            }
+        }
+
+        --$end;
+
+        if (($tokens[$end]['code'] === T_COMMENT
+            || isset(Tokens::$phpcsCommentTokens[$tokens[$end]['code']]) === true)
+            && substr($tokens[$end]['content'], 0, 2) === '/*'
+            && substr($tokens[$end]['content'], -2) !== '*/'
+        ) {
+            // Multi-line block comments are not allowed as trailing comment after a use statement.
+            --$end;
         }
 
         $next = $phpcsFile->findNext(T_WHITESPACE, ($end + 1), null, true);

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -137,7 +137,14 @@ class UseDeclarationSniff implements Sniff
             return;
         }
 
-        $end = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
+        $end         = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
+        $nextComment = $phpcsFile->findNext(T_COMMENT, ($end + 1));
+
+        // The end of the line is allowed to be a comment as well as a semi colon.
+        if ($nextComment !== false && $tokens[$nextComment]['line'] === $tokens[$end]['line']) {
+            $end = $nextComment;
+        }
+
         if ($end === false) {
             return;
         }

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.10.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.10.inc
@@ -1,0 +1,8 @@
+<?php
+use Foo\Bar; // trailing comment
+// This should fail.
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.10.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.10.inc.fixed
@@ -1,0 +1,9 @@
+<?php
+use Foo\Bar; // trailing comment
+
+// This should fail.
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc
@@ -1,0 +1,2 @@
+<?php
+use Foo\Bar; class Baz {}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.11.inc.fixed
@@ -1,0 +1,4 @@
+<?php
+use Foo\Bar; 
+
+class Baz {}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc
@@ -1,0 +1,9 @@
+<?php
+use Foo\Bar; /*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.12.inc.fixed
@@ -1,0 +1,11 @@
+<?php
+use Foo\Bar; 
+
+/*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc
@@ -1,0 +1,10 @@
+<?php
+use Foo\Bar; // trailing comment
+/*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.13.inc.fixed
@@ -1,0 +1,11 @@
+<?php
+use Foo\Bar; // trailing comment
+
+/*
+ * This multi-line comment shouldn't be allowed here.
+ */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc
@@ -1,0 +1,8 @@
+<?php
+use Foo\Bar; // trailing comment
+/* phpcs:ignore Standard.Category.Sniff -- for reasons */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.14.inc.fixed
@@ -1,0 +1,9 @@
+<?php
+use Foo\Bar; // trailing comment
+
+/* phpcs:ignore Standard.Category.Sniff -- for reasons */
+
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.8.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.8.inc
@@ -2,3 +2,7 @@
 use Foo\Bar; //comment
 
 // This should pass.
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.8.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.8.inc
@@ -1,5 +1,5 @@
 <?php
-use Foo\Bar; //comment
+use Foo\Bar;
 
 // This should pass.
 class Baz

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.9.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.9.inc
@@ -1,0 +1,8 @@
+<?php
+use Foo\Bar; // trailing comment
+
+// This should pass.
+class Baz
+{
+
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -49,6 +49,8 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
                 18 => 1,
                 19 => 1,
             ];
+        case 'UseDeclarationUnitTest.10.inc':
+            return [2 => 1];
         default:
             return [];
         }//end switch

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -50,6 +50,10 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
                 19 => 1,
             ];
         case 'UseDeclarationUnitTest.10.inc':
+        case 'UseDeclarationUnitTest.11.inc':
+        case 'UseDeclarationUnitTest.12.inc':
+        case 'UseDeclarationUnitTest.13.inc':
+        case 'UseDeclarationUnitTest.14.inc':
             return [2 => 1];
         default:
             return [];


### PR DESCRIPTION
see #1898 

The test that was merged with #1893 didn't actually test that lines after a user statement weren't blank as PHPCS would determine this to be the end of the file due to lack of class declaration or other valid code lines.