### PR TITLE
Fixed PHPCS annotations in multi-line tab-indented comments + not ignoring whole line for phpcs:set

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -320,8 +320,11 @@ abstract class Tokenizer
                     }
 
                     if (substr($commentTextLower, 0, 9) === 'phpcs:set') {
-                        // Ignore standards for lines that change sniff settings.
-                        $this->ignoredLines[$this->tokens[$i]['line']] = true;
+                        // Ignore standards for complete lines that change sniff settings.
+                        if ($ownLine === true) {
+                            $this->ignoredLines[$this->tokens[$i]['line']] = true;
+                        }
+
                         $this->tokens[$i]['code'] = T_PHPCS_SET;
                         $this->tokens[$i]['type'] = 'T_PHPCS_SET';
                     } else if (substr($commentTextLower, 0, 16) === 'phpcs:ignorefile') {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -255,7 +255,7 @@ abstract class Tokenizer
                     ) {
                         $ignoring = ['all' => true];
                         if ($ownLine === true) {
-                            $this->ignoredLines[$this->tokens[$i]['line']] = ['all' => true];
+                            $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;
                         }
                     } else if ($ignoring !== null
                         && strpos($commentText, '@codingStandardsIgnoreEnd') !== false
@@ -272,7 +272,7 @@ abstract class Tokenizer
                     ) {
                         $ignoring = ['all' => true];
                         if ($ownLine === true) {
-                            $this->ignoredLines[$this->tokens[$i]['line']]       = ['all' => true];
+                            $this->ignoredLines[$this->tokens[$i]['line']]       = $ignoring;
                             $this->ignoredLines[($this->tokens[$i]['line'] + 1)] = $ignoring;
                         } else {
                             $this->ignoredLines[$this->tokens[$i]['line']] = $ignoring;

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -228,8 +228,8 @@ abstract class Tokenizer
                 || $this->tokens[$i]['code'] === T_DOC_COMMENT_TAG
                 || ($inTests === true && $this->tokens[$i]['code'] === T_INLINE_HTML))
             ) {
-                $commentText      = ltrim($this->tokens[$i]['content'], ' /*');
-                $commentText      = rtrim($commentText, " */\r\n");
+                $commentText      = ltrim($this->tokens[$i]['content'], " \t/*");
+                $commentText      = rtrim($commentText, " */\t\r\n");
                 $commentTextLower = strtolower($commentText);
                 if (strpos($commentText, '@codingStandards') !== false) {
                     // If this comment is the only thing on the line, it tells us

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -92,7 +92,7 @@ class ErrorSuppressionTest extends TestCase
         $this->assertCount(0, $errors);
 
         // Process with block comment suppression.
-        $content = '<?php '.PHP_EOL.'/* phpcs:disable */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/* phpcs:disable */';
+        $content = '<?php '.PHP_EOL.'/* phpcs:disable */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/* phpcs:enable */';
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 
@@ -852,7 +852,7 @@ class ErrorSuppressionTest extends TestCase
         $this->assertEquals(0, $numWarnings);
         $this->assertCount(0, $warnings);
 
-        // Suppress wrong catergory using docblocks.
+        // Suppress wrong category using docblocks.
         $content = '<?php '.PHP_EOL.'/**
         '.PHP_EOL.' * phpcs:disable Generic.Files'.PHP_EOL.' */ '.PHP_EOL.'//TODO: write some code';
         $file    = new DummyFile($content, $ruleset, $config);

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -51,6 +51,16 @@ class ErrorSuppressionTest extends TestCase
         $this->assertEquals(0, $numErrors);
         $this->assertCount(0, $errors);
 
+        // Process with multi-line inline comment suppression, tab-indented.
+        $content = '<?php '.PHP_EOL."\t".'// For reasons'.PHP_EOL."\t".'// phpcs:disable'.PHP_EOL."\t".'$var = FALSE;'.PHP_EOL."\t".'// phpcs:enable';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertCount(0, $errors);
+
         // Process with inline @ comment suppression.
         $content = '<?php '.PHP_EOL.'// @phpcs:disable'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'// @phpcs:enable';
         $file    = new DummyFile($content, $ruleset, $config);
@@ -91,8 +101,48 @@ class ErrorSuppressionTest extends TestCase
         $this->assertEquals(0, $numErrors);
         $this->assertCount(0, $errors);
 
+        // Process with multi-line block comment suppression.
+        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' phpcs:disable'.PHP_EOL.' */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/*'.PHP_EOL.' phpcs:enable'.PHP_EOL.' */';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertCount(0, $errors);
+
+        // Process with multi-line block comment suppression, each line starred.
+        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' * phpcs:disable'.PHP_EOL.' */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/*'.PHP_EOL.' * phpcs:enable'.PHP_EOL.' */';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertCount(0, $errors);
+
+        // Process with multi-line block comment suppression, tab-indented.
+        $content = '<?php '.PHP_EOL."\t".'/*'.PHP_EOL."\t".' * phpcs:disable'.PHP_EOL."\t".' */'.PHP_EOL."\t".'$var = FALSE;'.PHP_EOL."\t".'/*'.PHP_EOL.' * phpcs:enable'.PHP_EOL.' */';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertCount(0, $errors);
+
         // Process with block comment suppression (deprecated syntax).
         $content = '<?php '.PHP_EOL.'/* @codingStandardsIgnoreStart */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/* @codingStandardsIgnoreEnd */';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(0, $numErrors);
+        $this->assertCount(0, $errors);
+
+        // Process with multi-line block comment suppression (deprecated syntax).
+        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' @codingStandardsIgnoreStart'.PHP_EOL.' */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/*'.PHP_EOL.' @codingStandardsIgnoreEnd'.PHP_EOL.' */';
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 
@@ -311,6 +361,26 @@ class ErrorSuppressionTest extends TestCase
 
          // Process with @ suppression on line before.
         $content = '<?php '.PHP_EOL.'// @phpcs:ignore'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(1, $numErrors);
+        $this->assertCount(1, $errors);
+
+        // Process with suppression on line before.
+        $content = '<?php '.PHP_EOL.'/* phpcs:ignore */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $errors    = $file->getErrors();
+        $numErrors = $file->getErrorCount();
+        $this->assertEquals(1, $numErrors);
+        $this->assertCount(1, $errors);
+
+         // Process with @ suppression on line before.
+        $content = '<?php '.PHP_EOL.'/* @phpcs:ignore */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 
@@ -614,8 +684,28 @@ class ErrorSuppressionTest extends TestCase
         $this->assertEquals(0, $numWarnings);
         $this->assertCount(0, $warnings);
 
+        // Process with a multi-line block comment suppression.
+        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' phpcs:ignoreFile'.PHP_EOL.' */'.PHP_EOL.'//TODO: write some code';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertCount(0, $warnings);
+
         // Process with a block comment suppression (deprecated syntax).
         $content = '<?php '.PHP_EOL.'/* @codingStandardsIgnoreFile */'.PHP_EOL.'//TODO: write some code';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $warnings    = $file->getWarnings();
+        $numWarnings = $file->getWarningCount();
+        $this->assertEquals(0, $numWarnings);
+        $this->assertCount(0, $warnings);
+
+        // Process with a multi-line block comment suppression (deprecated syntax).
+        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' @codingStandardsIgnoreFile'.PHP_EOL.' */'.PHP_EOL.'//TODO: write some code';
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 


### PR DESCRIPTION
This PR should go into `3.2.3` as it fixes two bugs in how the tokenizer deals with the new PHPCS annotations.

This PR will be easiest to review by looking at each commit individually.

**Bug 1**:
PHPCS annotations in tab-indented multi-line block comments were not recognized nor tokenized correctly.

Includes extensive unit tests.

**Bug 2**:
A `phpcs:set` would always cause the whole line to be ignored, even when its used as an end-comment.

As `phpcs:set` annotations are not covered in the unit test file, I wasn't sure were to add the tests for this.

**Other**:
While staring at the code I saw a few minor other optimizations/typos, those have been fixed in separate commits.