### PR TITLE
PEAR/MultiLineCondition: bug fix - deal correctly with PHPCS annotations

### DIFF
--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -179,7 +179,7 @@ class MultiLineConditionSniff implements Sniff
                 }
 
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, $i, null, true);
-                if ($next !== $closeBracket) {
+                if ($next !== $closeBracket && $tokens[$next]['line'] === $tokens[$i]['line']) {
                     if (isset(Tokens::$booleanOperators[$tokens[$next]['code']]) === false) {
                         $error = 'Each line in a multi-line IF statement must begin with a boolean operator';
                         $fix   = $phpcsFile->addFixableError($error, $i, 'StartWithBoolean');

--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -117,7 +117,9 @@ class MultiLineConditionSniff implements Sniff
                     if ($fix === true) {
                         // Account for a comment at the end of the line.
                         $next = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), null, true);
-                        if ($tokens[$next]['code'] !== T_COMMENT) {
+                        if ($tokens[$next]['code'] !== T_COMMENT
+                            && isset(Tokens::$phpcsCommentTokens[$tokens[$next]['code']]) === false
+                        ) {
                             $phpcsFile->fixer->addNewlineBefore($closeBracket);
                         } else {
                             $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
@@ -144,7 +146,9 @@ class MultiLineConditionSniff implements Sniff
                     $expectedIndent = ($statementIndent + $this->indent);
                 }//end if
 
-                if ($tokens[$i]['code'] === T_COMMENT) {
+                if ($tokens[$i]['code'] === T_COMMENT
+                    || isset(Tokens::$phpcsCommentTokens[$tokens[$i]['code']]) === true
+                ) {
                     $prevLine = $tokens[$i]['line'];
                     continue;
                 }

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.inc
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.inc
@@ -188,3 +188,64 @@ if ($a
         ?>
     <?php endif; ?>
 <?php endforeach; ?>
+<?php
+
+if ($IPP->errorCode() == 401 || // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    $IPP->errorCode() == 3200)  /*
+                                   phpcs:ignore Standard.Category.Sniff -- for reasons.
+                                 */
+{
+    return false;
+}
+
+if ($IPP->errorCode() == 401 || // phpcs:disable Standard.Category.Sniff -- for reasons.
+    $IPP->errorCode() == 3200)  // phpcs:enable
+{
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    || $IPP->errorCode() == 3200
+) {
+    return false;
+}
+
+    if ($IPP->errorCode() == 401 ||
+    /*
+     * phpcs:disable Standard.Category.Sniff -- for reasons.
+     */
+    $IPP->errorCode() == 3200
+    ) {
+        return false;
+    }
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode() == 3200
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode()
+        === 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode()
+        // A comment.
+        === 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode()
+        // phpcs:ignore Standard.Category.Sniff -- for reasons.
+        === 'someverylongexpectedoutput'
+) {
+    return false;
+}

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.inc.fixed
@@ -185,3 +185,63 @@ if ($a
         ?>
     <?php endif; ?>
 <?php endforeach; ?>
+<?php
+
+if ($IPP->errorCode() == 401  // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    || $IPP->errorCode() == 3200  /*
+                                   phpcs:ignore Standard.Category.Sniff -- for reasons.
+                                 */
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401  // phpcs:disable Standard.Category.Sniff -- for reasons.
+    || $IPP->errorCode() == 3200  // phpcs:enable
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    || $IPP->errorCode() == 3200
+) {
+    return false;
+}
+
+    if ($IPP->errorCode() == 401 
+        /*
+     * phpcs:disable Standard.Category.Sniff -- for reasons.
+     */
+        || $IPP->errorCode() == 3200
+    ) {
+        return false;
+    }
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode() == 3200
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode()    === 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode()
+    // A comment.
+    === 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if ($IPP->errorCode() == 401
+    || $IPP->errorCode()
+        // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    === 'someverylongexpectedoutput'
+) {
+    return false;
+}

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.js
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.js
@@ -177,3 +177,75 @@ if (a
     )) {
     return false;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+if (foo == 401 || // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    bar == 3200)  /*
+                     phpcs:ignore Standard.Category.Sniff -- for reasons.
+                   */
+{
+    return false;
+}
+
+if (foo == 401 || // phpcs:disable Standard.Category.Sniff -- for reasons.
+    bar == 3200)  // phpcs:enable
+{
+    return false;
+}
+
+if (IPP.errorCode() == 401
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    || IPP.errorCode() == 3200
+) {
+    return false;
+}
+
+    if (foo == 401 ||
+    /*
+	 * phpcs:disable Standard.Category.Sniff -- for reasons.
+	 */
+    bar == 3200
+    ) {
+        return false;
+    }
+
+if (IPP.errorCode() == 401
+    || IPP.errorCode() == 3200
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+) {
+    return false;
+}
+
+if (foo == 401
+    || bar
+        == 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if (IPP.errorCode() == 401
+    || bar
+        // A comment.
+        == 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if (foo == 401
+    || IPP.errorCode()
+        // phpcs:ignore Standard.Category.Sniff -- for reasons.
+        == 'someverylongexpectedoutput'
+) {
+    return false;
+}

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.js.fixed
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.js.fixed
@@ -174,3 +174,74 @@ if (a
 ) {
     return false;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+if (foo == 401  // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    || bar == 3200  /*
+                     phpcs:ignore Standard.Category.Sniff -- for reasons.
+                   */
+) {
+    return false;
+}
+
+if (foo == 401  // phpcs:disable Standard.Category.Sniff -- for reasons.
+    || bar == 3200  // phpcs:enable
+) {
+    return false;
+}
+
+if (IPP.errorCode() == 401
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    || IPP.errorCode() == 3200
+) {
+    return false;
+}
+
+    if (foo == 401 
+        /*
+	 * phpcs:disable Standard.Category.Sniff -- for reasons.
+	 */
+        || bar == 3200
+    ) {
+        return false;
+    }
+
+if (IPP.errorCode() == 401
+    || IPP.errorCode() == 3200
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+) {
+    return false;
+}
+
+if (foo == 401
+    || bar    == 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if (IPP.errorCode() == 401
+    || bar
+    // A comment.
+    == 'someverylongexpectedoutput'
+) {
+    return false;
+}
+
+if (foo == 401
+    || IPP.errorCode()
+        // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    == 'someverylongexpectedoutput'
+) {
+    return false;
+}

--- a/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
+++ b/src/Standards/PEAR/Tests/ControlStructures/MultiLineConditionUnitTest.php
@@ -54,6 +54,14 @@ class MultiLineConditionUnitTest extends AbstractSniffUnitTest
             153 => 2,
             168 => 1,
             177 => 1,
+            194 => 2,
+            202 => 2,
+            215 => 1,
+            218 => 2,
+            232 => 2,
+            239 => 1,
+            240 => 2,
+            248 => 2,
         ];
 
         if ($testFile === 'MultiLineConditionUnitTest.inc') {


### PR DESCRIPTION
Another one in the series to fix the sniffs to deal correctly with the new PHPCS annotations. Three more sniffs to go.

This PR should be tagged for the `3.2.3` release,

To review the PR, please look at the individual commits.

This PR fixes three issues in the `PEAR.ControlStructures.MultiLineCondition` sniff when it encountered PHPCS annotations within multi-line conditions:
1. It didn't allow for trailing PHPCS annotations.
2. When PHPCS annotations were encountered within a multi-line condition, it could occur that the same `StartWithBoolean` error would be thrown twice for the same line.
3. When a condition was spread out across multiple lines interspersed with comments and/or PHPCS annotations, the fixer would remove the comments.

Includes extensive unit tests.

The PR can be tested by checking out the first commit (unit tests) and running both `phpcs` as well as `phpcbf` against it to see the identified bugs in practice.