### PR TITLE
CommentedOutCode: ignore small comments and annotations from other tools

### DIFF
--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
@@ -132,3 +132,13 @@ function myFunction( $param )
           // phpcs:enable Standard.Category.Sniff -- for reasons.
     // }//end myFunction()
     //
+
+echo 'something'; // @codeCoverageIgnore
+echo 'something'; // @codeCoverageIgnoreStart
+echo 'something'; // @SuppressWarnings(PHPMD.UnusedLocalVariable)
+
+// Ok!
+
+/* Go! */
+
+// ISO-639-3

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -56,6 +56,7 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
                 109 => 1,
                 116 => 1,
                 128 => 1,
+                138 => 1,
             ];
             break;
         case 'CommentedOutCodeUnitTest.css':


### PR DESCRIPTION
This implements option 3 and 5 as discussed in #1910:
* Ignore comments which only consist of a silence operator + one alphanumeric word.
    This will prevent false positives on most (not all) ignore annotations from other tools.
* Ignore comments which result in only two or less non-whitespace tokens.
    This will prevent false positives on `// Ok!` type of comments.

    To implement this, I've elected to remove the open/close tags from the token array of the retokenized comment to prevent having to make the calculations more complicated.

Includes additional unit tests.

Fixes #1910
Fixes #1912