### PR TITLE
Fix fatal 'class already declared' errors when using external standards

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -76,7 +76,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
                 if (strpos(__DIR__, 'phar://') !== 0
                     && file_exists(__DIR__.'/../../autoload.php') === true
                 ) {
-                    self::$composerAutoloader = include __DIR__.'/../../autoload.php';
+                    self::$composerAutoloader = include_once __DIR__.'/../../autoload.php';
                     if (self::$composerAutoloader instanceof \Composer\Autoload\ClassLoader) {
                         self::$composerAutoloader->unregister();
                         self::$composerAutoloader->register();
@@ -164,7 +164,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
             $interfaces = get_declared_interfaces();
             $traits     = get_declared_traits();
 
-            include $path;
+            include_once $path;
 
             $className  = null;
             $newClasses = array_reverse(array_diff(get_declared_classes(), $classes));

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -313,7 +313,7 @@ class Runner
 
         // Include bootstrap files.
         foreach ($this->config->bootstrap as $bootstrap) {
-            include $bootstrap;
+            include_once $bootstrap;
         }
 
         if ($this->config->stdin === true) {


### PR DESCRIPTION
I've seen similar issues now in several external standards, where people are receiving a `Cannot declare class Standard\Sniffs\Category\SomethingSniff, because the name is already in use` error.

I've not been able to reproduce the issues, but noticed that - at least in some of the cases - this involved external sniffs which extend other external sniffs and use a `use` statement for the parent sniff.

I suspect that the fact that I cannot reproduce this, may be due to sniffs not loading in a predefined order, but depending on when the directive to include the sniff/standard is encountered in the ruleset.

I imagine that if a child sniff is included first and a parent sniff second, this causes the fatal error (though I haven't been able to reproduce it that way either).

Using `include_once` instead of `include` for typical class based files should solve this problem.

To that end, I've reviewed all uses of `include/require` in PHPCS and the three addressed in this PR are the result of that review.