### PR TITLE
Generic/MultipleStatementAlignment: fix bug/list syntax before assignment operator

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -116,30 +116,6 @@ class MultipleStatementAlignmentSniff implements Sniff
 
         for ($assign = $stackPtr; $assign < $phpcsFile->numTokens; $assign++) {
             if (isset($find[$tokens[$assign]['code']]) === false) {
-                if ($tokens[$assign]['code'] === T_CLOSURE
-                    || $tokens[$assign]['code'] === T_ANON_CLASS
-                ) {
-                    $assign   = $tokens[$assign]['scope_closer'];
-                    $lastCode = $assign;
-                    continue;
-                }
-
-                // Skip past the content of arrays.
-                if ($tokens[$assign]['code'] === T_OPEN_SHORT_ARRAY
-                    && isset($tokens[$assign]['bracket_closer']) === true
-                ) {
-                    $assign = $lastCode = $tokens[$assign]['bracket_closer'];
-                    continue;
-                }
-
-                if ($tokens[$assign]['code'] === T_ARRAY
-                    && isset($tokens[$assign]['parenthesis_opener']) === true
-                    && isset($tokens[$tokens[$assign]['parenthesis_opener']]['parenthesis_closer']) === true
-                ) {
-                    $assign = $lastCode = $tokens[$tokens[$assign]['parenthesis_opener']]['parenthesis_closer'];
-                    continue;
-                }
-
                 // A blank line indicates that the assignment block has ended.
                 if (isset(Tokens::$emptyTokens[$tokens[$assign]['code']]) === false) {
                     if (($tokens[$assign]['line'] - $tokens[$lastCode]['line']) > 1) {
@@ -163,10 +139,6 @@ class MultipleStatementAlignmentSniff implements Sniff
                     }
                 }//end if
 
-                continue;
-            } else if ($assign !== $stackPtr && $tokens[$assign]['line'] === $lastLine) {
-                // Skip multiple assignments on the same line. We only need to
-                // try and align the first assignment.
                 continue;
             }//end if
 
@@ -264,6 +236,10 @@ class MultipleStatementAlignmentSniff implements Sniff
 
             $lastLine   = $tokens[$assign]['line'];
             $prevAssign = $assign;
+
+            // Skip past the value assignment.
+            $assign   = ($phpcsFile->findEndOfStatement($assign) - 1);
+            $lastCode = $assign;
         }//end for
 
         if (empty($assignments) === true) {

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -265,3 +265,19 @@ $foo = [
     'a' => 'b',
 ];
 $barbar = 'bar';
+
+// Issue #1922 - allow for lists before the assignment operator.
+public function buildForm(FormBuilderInterface $builder, array $options)
+{
+    $transformer = new ContractTransformer($options['contracts']);
+    $types       = ['support.contact.question' => ContactData::QUESTION];
+
+    [$important, $questions, $incidents, $requests] = $this->createContractBuckets($options['contracts']);
+}
+
+public function buildForm(FormBuilderInterface $builder, array $options)
+{
+    $transformer                                    = new ContractTransformer($options['contracts']);
+    $types                                          = ['support.contact.question' => ContactData::QUESTION];
+    [$important, $questions, $incidents, $requests] = $this->createContractBuckets($options['contracts']);
+}

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -265,3 +265,19 @@ $foo    = [
     'a' => 'b',
 ];
 $barbar = 'bar';
+
+// Issue #1922 - allow for lists before the assignment operator.
+public function buildForm(FormBuilderInterface $builder, array $options)
+{
+    $transformer = new ContractTransformer($options['contracts']);
+    $types       = ['support.contact.question' => ContactData::QUESTION];
+
+    [$important, $questions, $incidents, $requests] = $this->createContractBuckets($options['contracts']);
+}
+
+public function buildForm(FormBuilderInterface $builder, array $options)
+{
+    $transformer                                    = new ContractTransformer($options['contracts']);
+    $types                                          = ['support.contact.question' => ContactData::QUESTION];
+    [$important, $questions, $incidents, $requests] = $this->createContractBuckets($options['contracts']);
+}


### PR DESCRIPTION
This simplifies the fixes which were previously committed to fix #1870 and #1848, which were released in `3.2.3`.

Both those fixes try to prevent the sniff getting confused over (potentially) multi-line value assignments, such as closures and arrays.

The simplification removes the previously added code in favour of skipping to the end of a statement as soon as an assignment operator has been found.

This might also make the sniff marginally faster as the tokens between the assignment operator and the end of the statement will no longer be examined.

N.B.: The reason for going one back from the end of the assignment (line 241), is that otherwise the code addressing the issue covered by the unit test on line 220 / added in commit 579d39cac3163bdf05ce1b50a7e470acd452735b would not be triggered, leading to incorrect results.

Fixes #1922

Side-note: I think it would be a good idea to add unit tests for the `File::findEndOfStatement()` method.