### PR TITLE
Generic opening brace placement sniffs incorrectly move PHPCS annotations

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -127,7 +127,9 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, "$metricType opening brace placement", 'same line');
         }//end if
 
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($openingBrace + 1), null, true);
+        $ignore   = Tokens::$phpcsCommentTokens;
+        $ignore[] = T_WHITESPACE;
+        $next     = $phpcsFile->findNext($ignore, ($openingBrace + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openingBrace]['line']) {
             if ($next === $tokens[$stackPtr]['scope_closer']
                 || $tokens[$next]['code'] === T_CLOSE_TAG

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc
@@ -201,3 +201,23 @@ function myFunction($a, $lot, $of, $params)
     : array {
     return null;
 }
+
+function myFunction($a, $lot, $of, $params) { // comment
+    return null;
+}
+
+function myFunction($a, $lot, $of, $params)
+    : array { // comment
+    return null;
+}
+
+function myFunction($a, $lot, $of, $params)
+    : array { // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    return null;
+}
+
+function myFunction($a, $lot, $of, $params)
+    : array
+{ // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    return null;
+}

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc.fixed
@@ -213,3 +213,28 @@ function myFunction($a, $lot, $of, $params)
 {
     return null;
 }
+
+function myFunction($a, $lot, $of, $params) 
+{
+ // comment
+    return null;
+}
+
+function myFunction($a, $lot, $of, $params)
+    : array 
+{
+ // comment
+    return null;
+}
+
+function myFunction($a, $lot, $of, $params)
+    : array  // phpcs:ignore Standard.Category.Sniff -- for reasons.
+{
+    return null;
+}
+
+function myFunction($a, $lot, $of, $params)
+    : array
+{ // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    return null;
+}

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
@@ -52,6 +52,9 @@ class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffUnitTest
             176 => 1,
             196 => 1,
             201 => 1,
+            205 => 2,
+            210 => 2,
+            215 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc
@@ -203,3 +203,8 @@ function myFunction($a, $lot, $of, $params)
 {
     return null;
 }
+
+function myFunction($a, $lot, $of, $params)
+    : array { // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    return null;
+}

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc.fixed
@@ -188,7 +188,11 @@ function myFunction($a, $lot, $of, $params)
 }
 
 function myFunction($a, $lot, $of, $params)
-    : array {
- // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    : array { // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    return null;
+}
+
+function myFunction($a, $lot, $of, $params)
+    : array { // phpcs:ignore Standard.Category.Sniff -- for reasons.
     return null;
 }


### PR DESCRIPTION
As discussed in #1931, moving a trailing `phpcs:ignore` annotation to the next line changes its meaning, which is what currently happens when the `ContentAfterBrace` error is triggered by one of the new PHPCS annotations in the `Generic.Functions.OpeningFunctionBraceKernighanRitchie` and `Generic.Functions.OpeningFunctionBraceBsdAllman` sniffs.

For the `Generic.Functions.OpeningFunctionBraceBsdAllman` sniff, this also impacts the fixer of the `BraceOnSameLine` errror which could also move the comment down.

This PR fixes that.

For this fix, I've chosen to ignore *all* the PHPCS annotations, not just the `phpcs:ignore` one. If so desired, I can change the PR to only make an exception for a trailing `phpcs:ignore` comment and to move `phpcs:disable/enable/set` comments to the next line, just like "normal" comments.

Includes unit tests.