### PR TITLE
phpcs:set annotations do not cause the line they are on to be ignored

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -162,15 +162,15 @@ class SuperfluousWhitespaceSniff implements Sniff
                 ) {
                     return;
                 }
-
-                if ($phpcsFile->fixer->enabled === true) {
-                    $prev     = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-                    $stackPtr = ($prev + 1);
-                }
             }//end if
 
             $fix = $phpcsFile->addFixableError('Additional whitespace found at end of file', $stackPtr, 'EndFile');
             if ($fix === true) {
+                if ($phpcsFile->tokenizerType !== 'PHP') {
+                    $prev     = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+                    $stackPtr = ($prev + 1);
+                }
+
                 $phpcsFile->fixer->beginChangeset();
                 for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
                     $phpcsFile->fixer->replaceToken($i, '');

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -322,7 +322,7 @@ abstract class Tokenizer
                     if (substr($commentTextLower, 0, 9) === 'phpcs:set') {
                         // Ignore standards for complete lines that change sniff settings.
                         if ($ownLine === true) {
-                            $this->ignoredLines[$this->tokens[$i]['line']] = true;
+                            $this->ignoredLines[$this->tokens[$i]['line']] = ['all' => true];
                         }
 
                         $this->tokens[$i]['code'] = T_PHPCS_SET;


### PR DESCRIPTION
### Tokenizer: minor bug fix

The ignore setting for PHPCS annotations on their own line uses `['all' => true]` everywhere else, except for the `phpcs:set` annotation.

This has now been made consistent.

----
### SuperfluousWhitespace: fix fixer bug

The change in the tokenizer exposed a bug in the `Squiz.WhiteSpace.SuperfluousWhitespace` sniff, where if the last non-whitespace token in a file is a PHPCS annotation, the fixer would not kick in.

Moving the fixer start token determination for JS/CSS files into the fixer code block, fixes this.