### PR TITLE
Improve Tokenizer::replaceTabsInToken performance

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -467,7 +467,7 @@ abstract class Tokenizer
             }
         }
 
-        if (str_replace("\t", '', $token['content']) === '') {
+        if (rtrim($token['content'], "\t") === '') {
             // String only contains tabs, so we can shortcut the process.
             $numTabs = strlen($token['content']);
 


### PR DESCRIPTION
I actually profiled and micro-benchmarked this line. I found that rtrim() is by far the fastest when applied on real-life content, 10 times faster than str_replace() and 2 times faster than ltrim(). Why? Because real-life code typically contains way more strings that are not exclusively made of whitespace. This check needs to be fast for these non-whitespace cases. Furthermore, if a string contains whitespace, that's typically not at the end of the string. rtrim() immediately stops doing anything in this case, while ltrim() needs to trim all tabs from the beginning of the string first, and str_replace() needs to replace all tabs, even tabs in the middle of the string that are not relevant for this check.

So this change is all about bailing out as early as possible.