### PR TITLE
Allow requesting a custom report using the report name or FQN

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -218,6 +218,18 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
 
 
         /**
+         * Retrieve the namespaces and paths registered by external standards.
+         *
+         * @return array
+         */
+        public static function getSearchPaths()
+        {
+            return self::$searchPaths;
+
+        }//end getSearchPaths()
+
+
+        /**
          * Gets the class name for the given file path.
          *
          * @param string $path The name of the file.


### PR DESCRIPTION
This allows for external standards to provide portable custom reports while installed in an arbitrary directory.

* The external standard has to make sure it includes an `<autoload>` directive in the ruleset and sort out the loading of the custom report classes through a `spl_autoload_register()`-ed autoloader.
* The name of the custom report class can be provided either on the command line using `--report=...` or via the ruleset using `<arg name="report" value=".."/>`.
* The name of the custom report class can be either the Fully Qualified report class name òr the standard relative class name (i.e. without the top-level namespace for the standard).
    - The FQN does not have to be prefixed with an `\`, but things will work just fine if it is.
    - If just the class name is provided, PHPCS will try to find the report in any of the namespaces as registered by the installed standards.
    - If the report class is not found in any of these, a `DeepExitException` will be thrown.

So, as an example, let's take an external standard with the following ruleset.xml file:
```xml
<?xml version="1.0"?>
<ruleset name="MyStandard" namespace="MyStandard\CS">
    <autoload>./../autoload-bootstrap.php</autoload>
    <rule ref="MyStandard"/>
</ruleset>
```

... which would provide a custom report class `MyStandard\CS\Custom` and an autoloader which would load the custom report

... an end-user could now request the custom report using any of the following names either from the command-line or from their own custom ruleset:
* `\MyStandard\CS\Custom`
* `MyStandard\CS\Custom`
* `\Custom`
* `Custom`

Existing functionality such as requesting several reports in one go `--report=source,Custom` and writing the report to a file using `--report-file=./path/to/file.txt` will work with this new feature as well.

Fixes #1942