### PR TITLE
Avoid calling Config::__get() in a loop

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -160,8 +160,8 @@ abstract class Tokenizer
         }
 
         $checkAnnotations = $this->config->annotations;
-        $encoding = $this->config->encoding;
-        $tabWidthIsZero = $this->config->tabWidth === 0;
+        $encoding         = $this->config->encoding;
+        $tabWidth         = $this->config->tabWidth;
 
         $this->tokensWithTabs = [
             T_WHITESPACE               => true,
@@ -185,7 +185,7 @@ abstract class Tokenizer
                 // There are no tabs in the tokens we know the length of.
                 $length      = $this->knownLengths[$this->tokens[$i]['code']];
                 $currColumn += $length;
-            } else if ($tabWidthIsZero
+            } else if ($tabWidth === 0
                 || isset($this->tokensWithTabs[$this->tokens[$i]['code']]) === false
                 || strpos($this->tokens[$i]['content'], "\t") === false
             ) {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -160,6 +160,8 @@ abstract class Tokenizer
         }
 
         $checkAnnotations = $this->config->annotations;
+        $encoding = $this->config->encoding;
+        $tabWidthIsZero = $this->config->tabWidth === 0;
 
         $this->tokensWithTabs = [
             T_WHITESPACE               => true,
@@ -183,7 +185,7 @@ abstract class Tokenizer
                 // There are no tabs in the tokens we know the length of.
                 $length      = $this->knownLengths[$this->tokens[$i]['code']];
                 $currColumn += $length;
-            } else if ($this->config->tabWidth === 0
+            } else if ($tabWidthIsZero
                 || isset($this->tokensWithTabs[$this->tokens[$i]['code']]) === false
                 || strpos($this->tokens[$i]['content'], "\t") === false
             ) {
@@ -192,7 +194,7 @@ abstract class Tokenizer
                     // Not using the default encoding, so take a bit more care.
                     $oldLevel = error_reporting();
                     error_reporting(0);
-                    $length = iconv_strlen($this->tokens[$i]['content'], $this->config->encoding);
+                    $length = iconv_strlen($this->tokens[$i]['content'], $encoding);
                     error_reporting($oldLevel);
 
                     if ($length === false) {


### PR DESCRIPTION
I was surprised to see the impact this minor optimization does have. In the example run I profiled Config::__get() was called about 88,000 times, and these calls accounted for about 4.6% of the total runtime.

With this optimization applied Config::__get() is now called 5,000 times, and these calls now account for 0.3% of the total runtime.

Yes, I'm talking total runtime. This means a run of 20 seconds total will be about a second faster.

Before:
![image](https://user-images.githubusercontent.com/6576639/37710783-fd48f878-2d0e-11e8-96b3-00f54be9e7a7.png)

After:
![image](https://user-images.githubusercontent.com/6576639/37710810-16399d06-2d0f-11e8-85bc-62ccae46cf36.png)