### PR TITLE
Avoid calling File::hasCondition() twice

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -219,8 +219,7 @@ class SuperfluousWhitespaceSniff implements Sniff
                 Check for multiple blank lines in a function.
             */
 
-            if (($phpcsFile->hasCondition($stackPtr, T_FUNCTION) === true
-                || $phpcsFile->hasCondition($stackPtr, T_CLOSURE) === true)
+            if (($phpcsFile->hasCondition($stackPtr, [T_FUNCTION, T_CLOSURE]) === true)
                 && $tokens[($stackPtr - 1)]['line'] < $tokens[$stackPtr]['line']
                 && $tokens[($stackPtr - 2)]['line'] === $tokens[($stackPtr - 1)]['line']
             ) {


### PR DESCRIPTION
This does not have a measurable effect on runtime, but immensely reduces the number of calls to this function. In the run I profiled hasCondition() was called about 18,000 times before and 10,000 times after this patch. The total runtime for these calls went from 1.3% to 1.1%.

Note there are a few more sniffs where the exact same optimization can be applied.