### PR TITLE
Squiz/MemberVarScope: fix handling of multi-line properties

### DIFF
--- a/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
@@ -27,23 +27,16 @@ class MemberVarScopeSniff extends AbstractVariableSniff
      */
     protected function processMemberVar(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
+        $tokens     = $phpcsFile->getTokens();
+        $properties = $phpcsFile->getMemberProperties($stackPtr);
 
-        $modifier = null;
-        for ($i = ($stackPtr - 1); $i > 0; $i--) {
-            if ($tokens[$i]['line'] < $tokens[$stackPtr]['line']) {
-                break;
-            } else if (isset(Tokens::$scopeModifiers[$tokens[$i]['code']]) === true) {
-                $modifier = $i;
-                break;
-            }
+        if ($properties['scope_specified'] !== false) {
+            return;
         }
 
-        if ($modifier === null) {
-            $error = 'Scope modifier not specified for member variable "%s"';
-            $data  = [$tokens[$stackPtr]['content']];
-            $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
-        }
+        $error = 'Scope modifier not specified for member variable "%s"';
+        $data  = [$tokens[$stackPtr]['content']];
+        $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
 
     }//end processMemberVar()
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
@@ -53,4 +53,16 @@ class MyClass {
 
         $var = null;
     }
+
+    public $mCounter, $mSearchUser, $mSearchPeriodStart, $mSearchPeriodEnd,
+    $mTestFilter;
+
+    protected $mCounter,
+        $mSearchUser,
+        $mSearchPeriodStart,
+        $mSearchPeriodEnd,
+        $mTestFilter;
+
+    var $mCounter, $mSearchUser,
+        $mSearchPeriodStart;
 }

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -32,6 +32,8 @@ class MemberVarScopeUnitTest extends AbstractSniffUnitTest
             33 => 1,
             39 => 1,
             41 => 1,
+            66 => 2,
+            67 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This fix builds upon the earlier fix in PR #1715, which improved the handling of group property declarations for the `File::getMemberProperties()` method.

This sniff now just defers to the `File::getMemberProperties()` method to determine whether the visibility of a property has been set.

Includes additional unit tests.

Fixes #1963