### PR TITLE
SquizMultiLineFunctionDeclaration: fix bug when param has trailing comment/PHPCS annotation

### DIFF
--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -179,7 +179,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
                 continue;
             }
 
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
             if ($tokens[$next]['line'] === $tokens[$i]['line']) {
                 $error = 'Multi-line '.$type.' declarations must define one parameter per line';
                 $fix   = $phpcsFile->addFixableError($error, $next, $errorPrefix.'OneParamPerLine');

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc
@@ -161,3 +161,19 @@ function foo(
     $param3,
 ) : SomeClass {
 }
+
+// Issue 1959.
+function __construct(
+    $foo,   // This is foo
+    $bar
+) {}
+
+function __construct(
+    $foo /* this is foo */,
+    $bar // this is bar
+) {}
+
+function __construct(
+    $foo,   // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    $bar
+) {}

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
@@ -173,3 +173,19 @@ function foo(
     $param3,
 ) : SomeClass {
 }
+
+// Issue 1959.
+function __construct(
+    $foo,   // This is foo
+    $bar
+) {}
+
+function __construct(
+    $foo /* this is foo */,
+    $bar // this is bar
+) {}
+
+function __construct(
+    $foo,   // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    $bar
+) {}


### PR DESCRIPTION
Very easy fix ;-)
Includes unit tests.
Should also solve any issues this particular check in the sniff has/had with trailing PHPCS annotations.

_Note: this sniff most likely does still have an issue with PHPCS annotations when fixing an incorrect multi-line function declaration._

Fixes #1959