### PR TITLE
Replace slow Tokens::tokenName() with define()

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1146,7 +1146,7 @@ class PHP extends Tokenizer
                 as T_HASHBANG while PHP proper uses T_INLINE_HTML.
             */
 
-            if ($tokenIsArray === true && defined('T_HASHBANG') && $token[0] === T_HASHBANG) {
+            if ($tokenIsArray === true && defined('T_HASHBANG') === true && $token[0] === T_HASHBANG) {
                 $finalTokens[$newStackPtr] = [
                     'content' => $token[1],
                     'code'    => T_INLINE_HTML,

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1146,7 +1146,7 @@ class PHP extends Tokenizer
                 as T_HASHBANG while PHP proper uses T_INLINE_HTML.
             */
 
-            if ($tokenIsArray === true && Util\Tokens::tokenName($token[0]) === 'T_HASHBANG') {
+            if ($tokenIsArray === true && defined('T_HASHBANG') && $token[0] === T_HASHBANG) {
                 $finalTokens[$newStackPtr] = [
                     'content' => $token[1],
                     'code'    => T_INLINE_HTML,


### PR DESCRIPTION
I actually profiled this and found Tokens::tokenName() is called hundreds of thousands of times here. Even if the method implementation appears to be trivial, it is expensive. The line touched in this patch always converts the same integer constant to a string, and compares the string then. In the profile run I did this line alone accounts for 3% of the total runtime. PHPs define() is much faster, even if called as often as it is the case here.