### PR TITLE
Added coveralls configuration - generate Code Coverage report

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+.coveralls.yml export-ignore
 .travis.yml export-ignore
 package.xml export-ignore
 phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .idea/*
 /vendor/
 composer.lock
+clover.xml
+coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 language: php
 dist: trusty
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 matrix:
   fast_finish: true
   include:
@@ -14,6 +18,7 @@ matrix:
     - php: 7.0
       env: CUSTOM_INI=1
     - php: 7.1
+      env: TEST_COVERAGE=true
     - php: 7.2
     - php: nightly
     - php: hhvm
@@ -24,11 +29,15 @@ matrix:
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
-  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.' ; fi
   # Circumvent a bug in the travis HHVM image - ships with incompatible PHPUnit.
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer self-update; fi
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:~4.0; fi
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer install; fi
+
+install:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev --no-interaction php-coveralls/php-coveralls ; fi
+  - travis_retry composer update
+  - stty cols 120 && composer show
 
 before_script:
   - if [[ $CUSTOM_INI == "1" && ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then phpenv config-add php5-testingConfig.ini; fi
@@ -36,10 +45,12 @@ before_script:
 
 script:
   - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then php bin/phpcs --config-set php_path php; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then phpunit tests/AllTests.php; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then vendor/bin/phpunit tests/AllTests.php; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; else vendor/bin/phpunit ; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
   - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* && $TRAVIS_PHP_VERSION != "nightly" ]]; then pear package-validate package.xml; fi
   - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
   - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* ]]; then php scripts/build-phar.php; fi
   - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* ]]; then php phpcs.phar; fi
+
+after_script:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 PHP\_CodeSniffer is a set of two PHP scripts; the main `phpcs` script that tokenizes PHP, JavaScript and CSS files to detect violations of a defined coding standard, and a second `phpcbf` script to automatically correct coding standard violations. PHP\_CodeSniffer is an essential development tool that ensures your code remains clean and consistent.
 
-[![Build Status](https://travis-ci.org/squizlabs/PHP_CodeSniffer.svg?branch=phpcs-fixer)](https://travis-ci.org/squizlabs/PHP_CodeSniffer) [![Code consistency](http://squizlabs.github.io/PHP_CodeSniffer/analysis/squizlabs/PHP_CodeSniffer/grade.svg)](http://squizlabs.github.io/PHP_CodeSniffer/analysis/squizlabs/PHP_CodeSniffer) [![Join the chat at https://gitter.im/squizlabs/PHP_CodeSniffer](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/squizlabs/PHP_CodeSniffer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/squizlabs/PHP_CodeSniffer.svg?branch=phpcs-fixer)](https://travis-ci.org/squizlabs/PHP_CodeSniffer)
+[![Coverage Status](https://coveralls.io/repos/github/squizlabs/PHP_CodeSniffer/badge.svg?branch=master)](https://coveralls.io/github/squizlabs/PHP_CodeSniffer?branch=master)
+[![Code consistency](http://squizlabs.github.io/PHP_CodeSniffer/analysis/squizlabs/PHP_CodeSniffer/grade.svg)](http://squizlabs.github.io/PHP_CodeSniffer/analysis/squizlabs/PHP_CodeSniffer)
+[![Join the chat at https://gitter.im/squizlabs/PHP_CodeSniffer](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/squizlabs/PHP_CodeSniffer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Requirements
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,4 +5,13 @@
             <file>tests/AllTests.php</file>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory>src/Standards/*/Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
It would be nice to have Code Coverage report with the repository. I'm adding here integration with coveralls, but we can use any other service - whatever you prefer.