### PR TITLE
Tokenizer does not change heredoc to nowdoc token if the start tag contains spaces

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -651,7 +651,7 @@ class PHP extends Tokenizer
                 // Check if this is actually a nowdoc and use a different token
                 // to help the sniffs.
                 $nowdoc = false;
-                if ($token[1][3] === "'") {
+                if (preg_match('/<<<\s*\'/', $token[1]) === true) {
                     $finalTokens[$newStackPtr]['code'] = T_START_NOWDOC;
                     $finalTokens[$newStackPtr]['type'] = 'T_START_NOWDOC';
                     $nowdoc = true;


### PR DESCRIPTION
`<<< 'EOF'` is a valid nowdoc start tag (there could be more than one space, or even tab ...)