### PR TITLE
Process doc tags when short description is missing

### DIFF
--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
@@ -197,6 +197,13 @@
  */
 
 /**
+ *
+ * @param  int    $number
+ * @param  string $text
+ * @return something
+ */
+
+/**
  * étude des ...
  */
 

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js
@@ -197,6 +197,13 @@
  */
 
 /**
+ *
+ * @param  int    $number
+ * @param  string $text
+ * @return something
+ */
+
+/**
  * étude des ...
  */
 

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -49,8 +49,8 @@ class DocCommentUnitTest extends AbstractSniffUnitTest
             95  => 1,
             156 => 1,
             158 => 1,
-            170 => 3,
-            171 => 3,
+            170 => 4,
+            171 => 4,
             179 => 1,
             183 => 1,
             184 => 2,
@@ -59,8 +59,10 @@ class DocCommentUnitTest extends AbstractSniffUnitTest
             187 => 2,
             193 => 1,
             196 => 1,
-            200 => 1,
-            203 => 4,
+            199 => 1,
+            203 => 1,
+            207 => 1,
+            210 => 4,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Fixes issue #1989 

In the existing code, when the short description was missing, then ``DocCommentSniff`` ``process()`` would return immediately. The parsing of the tag problems comes later, and so that did not happen.

With this PR, the various problems related to the description lines put inside an ``else`` of the ``Check for a comment description`` ``if`` statement - so that they are only processed if there is at least a description found. The "early" return is removed. This allows the code to continue, examining matters related to tags.