### PR TITLE
Fixed counting elements in array in if statements

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -352,9 +352,9 @@ class File
                         $start   = strpos($commentText, '@codingStandardsChangeSetting');
                         $comment = substr($commentText, ($start + 30));
                         $parts   = explode(' ', $comment);
-                        if ($parts >= 3) {
+                        if (count($parts) >= 3) {
                             $sniffParts = explode('.', $parts[0]);
-                            if ($sniffParts >= 3) {
+                            if (count($sniffParts) >= 3) {
                                 // If the sniff code is not known to us, it has not been registered in this run.
                                 // But don't throw an error as it could be there for a different standard to use.
                                 if (isset($this->ruleset->sniffCodes[$parts[0]]) === true) {
@@ -388,9 +388,9 @@ class File
 
                     // Need to maintain case here, to get the correct sniff code.
                     $parts = explode(' ', substr($commentText, 10));
-                    if ($parts >= 3) {
+                    if (count($parts) >= 3) {
                         $sniffParts = explode('.', $parts[0]);
-                        if ($sniffParts >= 3) {
+                        if (count($sniffParts) >= 3) {
                             // If the sniff code is not known to us, it has not been registered in this run.
                             // But don't throw an error as it could be there for a different standard to use.
                             if (isset($this->ruleset->sniffCodes[$parts[0]]) === true) {


### PR DESCRIPTION
`explode` function returns array and we should count number of elements in that array.
Comparison `ARR >= 3` always returns `true`.

Code (https://3v4l.org/NkdIT):
```php
var_dump([] >= 3);
var_dump([1] >= 3);
var_dump([1, 2] >= 3);
var_dump([1, 2, 3] >= 3);
var_dump([1, 2, 3, 4] >= 3);
```

Results:
```
bool(true)
bool(true)
bool(true)
bool(true)
bool(true)
```

