### PR TITLE
Generic.Formatting.MultipleStatementAlignment does see PHP close tag as end of statement block

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -147,6 +147,11 @@ class MultipleStatementAlignmentSniff implements Sniff
                     break;
                 }
 
+                if ($tokens[$assign]['code'] === T_CLOSE_TAG) {
+                    // Breaking out of PHP ends the assignment block.
+                    break;
+                }
+
                 if ($tokens[$assign]['code'] === T_OPEN_SHORT_ARRAY
                     && isset($tokens[$assign]['bracket_closer']) === true
                 ) {

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -373,3 +373,17 @@ $foo = [
 $abc = 'something';
 if ($foo) {}
 $defghi = 'longer something';
+
+		public function get_location_details( $location_id, $atts ) {
+			$coords_lat  = 'abc';
+			$coords_long = 'def';
+			?>
+
+			<div>
+				<?php
+				$location       = 'ghi';
+				$other_location = 'jkl';
+				?>
+			</div>
+			<?php
+		}

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -373,3 +373,17 @@ $foo = [
 $abc = 'something';
 if ($foo) {}
 $defghi = 'longer something';
+
+		public function get_location_details( $location_id, $atts ) {
+			$coords_lat  = 'abc';
+			$coords_long = 'def';
+			?>
+
+			<div>
+				<?php
+				$location       = 'ghi';
+				$other_location = 'jkl';
+				?>
+			</div>
+			<?php
+		}


### PR DESCRIPTION
The case where PHP and HTML is mixed was not taken into account by the sniff up to now.

Includes unit test.