### PR TITLE
3.3.0: Generic/LowerCaseType: allow for nullable types and more

### DIFF
--- a/src/Standards/Generic/Docs/PHP/LowerCaseTypeStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/LowerCaseTypeStandard.xml
@@ -1,17 +1,17 @@
 <documentation title="Lowercase PHP Types">
     <standard>
     <![CDATA[
-    All PHP types used for type hints and return types should be lowercase.
+    All PHP types used for parameter type and return type declarations should be lowercase.
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: Lowercase types used.">
+        <code title="Valid: Lowercase type declarations used.">
         <![CDATA[
 function myFunction(int $foo) : string {
 }
         ]]>
         </code>
-        <code title="Invalid: Non-lowercase types used.">
+        <code title="Invalid: Non-lowercase type declarations used.">
         <![CDATA[
 function myFunction(<em>Int</em> $foo) : <em>STRING</em> {
 }

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -88,12 +88,14 @@ class LowerCaseTypeSniff implements Sniff
         $props = $phpcsFile->getMethodProperties($stackPtr);
 
         // Strip off potential nullable indication.
-        $returnType = ltrim($props['return_type'], '?');
+        $returnType      = ltrim($props['return_type'], '?');
+        $returnTypeLower = strtolower($returnType);
+
         if ($returnType !== ''
-            && isset($phpTypes[strtolower($returnType)]) === true
+            && isset($phpTypes[$returnTypeLower]) === true
         ) {
             // A function return type.
-            if (strtolower($returnType) !== $returnType) {
+            if ($returnTypeLower !== $returnType) {
                 if ($returnType === strtoupper($returnType)) {
                     $phpcsFile->recordMetric($stackPtr, 'PHP type case', 'upper');
                 } else {
@@ -103,13 +105,13 @@ class LowerCaseTypeSniff implements Sniff
                 $error = 'PHP return type declarations must be lowercase; expected "%s" but found "%s"';
                 $token = $props['return_type_token'];
                 $data  = [
-                    strtolower($returnType),
+                    $returnTypeLower,
                     $returnType,
                 ];
 
                 $fix = $phpcsFile->addFixableError($error, $token, 'ReturnTypeFound', $data);
                 if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken($token, strtolower($tokens[$token]['content']));
+                    $phpcsFile->fixer->replaceToken($token, $returnTypeLower);
                 }
             } else {
                 $phpcsFile->recordMetric($stackPtr, 'PHP type case', 'lower');
@@ -117,15 +119,20 @@ class LowerCaseTypeSniff implements Sniff
         }//end if
 
         $params = $phpcsFile->getMethodParameters($stackPtr);
+        if (empty($params) === true) {
+            return;
+        }
+
         foreach ($params as $param) {
             // Strip off potential nullable indication.
-            $typeHint = ltrim($param['type_hint'], '?');
+            $typeHint      = ltrim($param['type_hint'], '?');
+            $typeHintLower = strtolower($typeHint);
 
             if ($typeHint !== ''
-                && isset($phpTypes[strtolower($typeHint)]) === true
+                && isset($phpTypes[$typeHintLower]) === true
             ) {
                 // A function return type.
-                if (strtolower($typeHint) !== $typeHint) {
+                if ($typeHintLower !== $typeHint) {
                     if ($typeHint === strtoupper($typeHint)) {
                         $phpcsFile->recordMetric($stackPtr, 'PHP type case', 'upper');
                     } else {
@@ -135,13 +142,13 @@ class LowerCaseTypeSniff implements Sniff
                     $error = 'PHP parameter type declarations must be lowercase; expected "%s" but found "%s"';
                     $token = $param['type_hint_token'];
                     $data  = [
-                        strtolower($typeHint),
+                        $typeHintLower,
                         $typeHint,
                     ];
 
                     $fix = $phpcsFile->addFixableError($error, $token, 'ParamTypeFound', $data);
                     if ($fix === true) {
-                        $phpcsFile->fixer->replaceToken($token, strtolower($tokens[$token]['content']));
+                        $phpcsFile->fixer->replaceToken($token, $typeHintLower);
                     }
                 } else {
                     $phpcsFile->recordMetric($stackPtr, 'PHP type case', 'lower');

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -54,13 +54,13 @@ class LowerCaseTypeSniff implements Sniff
                     $phpcsFile->recordMetric($stackPtr, 'PHP type case', 'mixed');
                 }
 
-                $error = 'PHP types must be lowercase; expected "%s" but found "%s"';
+                $error = 'PHP type casts must be lowercase; expected "%s" but found "%s"';
                 $data  = [
                     strtolower($tokens[$stackPtr]['content']),
                     $tokens[$stackPtr]['content'],
                 ];
 
-                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'TypeCastFound', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken($stackPtr, strtolower($tokens[$stackPtr]['content']));
                 }
@@ -98,13 +98,13 @@ class LowerCaseTypeSniff implements Sniff
                     $phpcsFile->recordMetric($stackPtr, 'PHP type case', 'mixed');
                 }
 
-                $error = 'PHP types must be lowercase; expected "%s" but found "%s"';
+                $error = 'PHP return type declarations must be lowercase; expected "%s" but found "%s"';
                 $data  = [
                     strtolower($returnType),
                     $returnType,
                 ];
 
-                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'ReturnTypeFound', $data);
                 if ($fix === true) {
                     $token = $props['return_type_token'];
                     $phpcsFile->fixer->replaceToken($token, strtolower($tokens[$token]['content']));
@@ -128,13 +128,13 @@ class LowerCaseTypeSniff implements Sniff
                         $phpcsFile->recordMetric($stackPtr, 'PHP type case', 'mixed');
                     }
 
-                    $error = 'PHP types must be lowercase; expected "%s" but found "%s"';
+                    $error = 'PHP parameter type declarations must be lowercase; expected "%s" but found "%s"';
                     $data  = [
                         strtolower($typeHint),
                         $typeHint,
                     ];
 
-                    $fix = $phpcsFile->addFixableError($error, $stackPtr, 'Found', $data);
+                    $fix = $phpcsFile->addFixableError($error, $stackPtr, 'ParamTypeFound', $data);
                     if ($fix === true) {
                         $token = $param['type_hint_token'];
                         $phpcsFile->fixer->replaceToken($token, strtolower($tokens[$token]['content']));

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -101,14 +101,14 @@ class LowerCaseTypeSniff implements Sniff
                 }
 
                 $error = 'PHP return type declarations must be lowercase; expected "%s" but found "%s"';
+                $token = $props['return_type_token'];
                 $data  = [
                     strtolower($returnType),
                     $returnType,
                 ];
 
-                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'ReturnTypeFound', $data);
+                $fix = $phpcsFile->addFixableError($error, $token, 'ReturnTypeFound', $data);
                 if ($fix === true) {
-                    $token = $props['return_type_token'];
                     $phpcsFile->fixer->replaceToken($token, strtolower($tokens[$token]['content']));
                 }
             } else {
@@ -133,14 +133,14 @@ class LowerCaseTypeSniff implements Sniff
                     }
 
                     $error = 'PHP parameter type declarations must be lowercase; expected "%s" but found "%s"';
+                    $token = $param['type_hint_token'];
                     $data  = [
                         strtolower($typeHint),
                         $typeHint,
                     ];
 
-                    $fix = $phpcsFile->addFixableError($error, $stackPtr, 'ParamTypeFound', $data);
+                    $fix = $phpcsFile->addFixableError($error, $token, 'ParamTypeFound', $data);
                     if ($fix === true) {
-                        $token = $param['type_hint_token'];
                         $phpcsFile->fixer->replaceToken($token, strtolower($tokens[$token]['content']));
                     }
                 } else {

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -73,6 +73,7 @@ class LowerCaseTypeSniff implements Sniff
 
         $phpTypes = [
             'self'     => true,
+            'parent'   => true,
             'array'    => true,
             'callable' => true,
             'bool'     => true,
@@ -80,6 +81,8 @@ class LowerCaseTypeSniff implements Sniff
             'int'      => true,
             'string'   => true,
             'iterable' => true,
+            'void'     => true,
+            'object'   => true,
         ];
 
         $props      = $phpcsFile->getMethodProperties($stackPtr);

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -85,8 +85,10 @@ class LowerCaseTypeSniff implements Sniff
             'object'   => true,
         ];
 
-        $props      = $phpcsFile->getMethodProperties($stackPtr);
-        $returnType = $props['return_type'];
+        $props = $phpcsFile->getMethodProperties($stackPtr);
+
+        // Strip off potential nullable indication.
+        $returnType = ltrim($props['return_type'], '?');
         if ($returnType !== ''
             && isset($phpTypes[strtolower($returnType)]) === true
         ) {
@@ -116,7 +118,9 @@ class LowerCaseTypeSniff implements Sniff
 
         $params = $phpcsFile->getMethodParameters($stackPtr);
         foreach ($params as $param) {
-            $typeHint = $param['type_hint'];
+            // Strip off potential nullable indication.
+            $typeHint = ltrim($param['type_hint'], '?');
+
             if ($typeHint !== ''
                 && isset($phpTypes[strtolower($typeHint)]) === true
             ) {

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -27,3 +27,7 @@ $foo = function (int $a, Callable $b) :INT{};
 $foo = function (BOOL $a, float $b) use ($foo) : INT {};
 $foo = function (Foo $a, Foo\Bar $b) use ($foo) : \Foo\Bar {};
 $foo = function (bool $a, callable $b) use ($foo) : Bar {};
+
+class Testing {
+    public function TestThis(SELF $a, obJect $b, Parent $c) : VOID {}
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -31,3 +31,14 @@ $foo = function (bool $a, callable $b) use ($foo) : Bar {};
 class Testing {
     public function TestThis(SELF $a, obJect $b, Parent $c) : VOID {}
 }
+
+function foo(
+    ?Float $a,
+    ? String $b,
+    ?ITERABLE $c,
+    ?	Object $d,
+    ?Foo\Bar $e
+) : ?Foo\Bar {}
+
+$foo = function (?Int $a, ?    Callable $b)
+    :?INT{};

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -27,3 +27,7 @@ $foo = function (int $a, callable $b) :int{};
 $foo = function (bool $a, float $b) use ($foo) : int {};
 $foo = function (Foo $a, Foo\Bar $b) use ($foo) : \Foo\Bar {};
 $foo = function (bool $a, callable $b) use ($foo) : Bar {};
+
+class Testing {
+    public function TestThis(self $a, object $b, parent $c) : void {}
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -31,3 +31,14 @@ $foo = function (bool $a, callable $b) use ($foo) : Bar {};
 class Testing {
     public function TestThis(self $a, object $b, parent $c) : void {}
 }
+
+function foo(
+    ?float $a,
+    ? string $b,
+    ?iterable $c,
+    ?	object $d,
+    ?Foo\Bar $e
+) : ?Foo\Bar {}
+
+$foo = function (?int $a, ?    callable $b)
+    :?int{};

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -38,6 +38,12 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             26 => 2,
             27 => 2,
             32 => 4,
+            36 => 1,
+            37 => 1,
+            38 => 1,
+            39 => 1,
+            43 => 2,
+            44 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -37,6 +37,7 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             25 => 1,
             26 => 2,
             27 => 2,
+            32 => 4,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This PR ports over various things which were already covered by PR #1685, but not (yet) covered by the new `Generic.PHP.LowerCaseType` sniff.

@gsherwood As the `Generic.PHP.LowerCaseType` sniff is new to PHPCS 3.3.0, it would be advisable to merge this PR before releasing PHPCS 3.3.0.

All significant changes are accompanied by unit tests.

## Commits:

### Generic/LowerCaseType: add missing types

* `parent` is a valid type declaration and has been supported since the beginning, though only properly since PHP 5.2.
* `void` was added in PHP 7.1 (return type only).
* `object` was added in PHP 7.2.

### Generic/LowerCaseType: have unique error messages and codes

Differentiate the error messages and error codes to enable modular usage of the sniff.

### Generic/LowerCaseType: allow for nullable parameter and return type declarations

### Generic/LowerCaseType: indicate the precise line of the error

For (long) multi-line function declarations, it will be more helpful throwing the error on the line where the error actually occurs instead of on the line of the function keyword.

### Generic/LowerCaseType: various efficiency fixes

* Bow out early if there are no function parameters.
* No need to execute the exact same function call multiple times.

### Generic/LowerCaseType: minor terminology fix