### PR TITLE
Drop HHVM testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,30 +16,23 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: nightly
-    - php: hhvm
 
   allow_failures:
     - php: nightly
-    - php: hhvm
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-  # Circumvent a bug in the travis HHVM image - ships with incompatible PHPUnit.
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer self-update; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:~4.0; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer install; fi
 
 before_script:
   - if [[ $CUSTOM_INI == "1" && ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then phpenv config-add php5-testingConfig.ini; fi
   - if [[ $CUSTOM_INI == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then phpenv config-add php7-testingConfig.ini; fi
 
 script:
-  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then php bin/phpcs --config-set php_path php; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then phpunit tests/AllTests.php; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then vendor/bin/phpunit tests/AllTests.php; fi
+  - php bin/phpcs --config-set php_path php
+  - phpunit tests/AllTests.php
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
-  - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* && $TRAVIS_PHP_VERSION != "nightly" ]]; then pear package-validate package.xml; fi
+  - if [[ $CUSTOM_INI != "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then pear package-validate package.xml; fi
   - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
-  - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* ]]; then php scripts/build-phar.php; fi
-  - if [[ $CUSTOM_INI != "1" &&  $TRAVIS_PHP_VERSION != hhv* ]]; then php phpcs.phar; fi
+  - if [[ $CUSTOM_INI != "1" ]]; then php scripts/build-phar.php; fi
+  - if [[ $CUSTOM_INI != "1" ]]; then php phpcs.phar; fi

--- a/src/Config.php
+++ b/src/Config.php
@@ -394,12 +394,6 @@ class Config
             }
         }//end if
 
-        if (defined('PHP_CODESNIFFER_IN_TESTS') === true && defined('HHVM_VERSION') === true) {
-            // HHVM 3.25+ wont let us re-open STDIN after it is closed.
-            // So don't close it.
-            return;
-        }
-
         fclose($handle);
 
     }//end __construct()

--- a/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -61,7 +61,7 @@ class SyntaxSniff implements Sniff
         }
 
         $fileName = escapeshellarg($phpcsFile->getFilename());
-        $cmd      = escapeshellcmd($this->phpPath)." -l $fileName 2>&1";
+        $cmd      = escapeshellcmd($this->phpPath)." -l -d display_errors=1 -d error_prepend_string='' $fileName 2>&1";
         $output   = shell_exec($cmd);
         $matches  = [];
         if (preg_match('/^.*error:(.*) in .* on line ([0-9]+)/m', trim($output), $matches) === 1) {

--- a/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -61,14 +61,9 @@ class SyntaxSniff implements Sniff
         }
 
         $fileName = escapeshellarg($phpcsFile->getFilename());
-        if (defined('HHVM_VERSION') === false) {
-            $cmd = escapeshellcmd($this->phpPath)." -l -d display_errors=1 -d error_prepend_string='' $fileName 2>&1";
-        } else {
-            $cmd = escapeshellcmd($this->phpPath)." -l $fileName 2>&1";
-        }
-
-        $output  = shell_exec($cmd);
-        $matches = [];
+        $cmd      = escapeshellcmd($this->phpPath)." -l $fileName 2>&1";
+        $output   = shell_exec($cmd);
+        $matches  = [];
         if (preg_match('/^.*error:(.*) in .* on line ([0-9]+)/m', trim($output), $matches) === 1) {
             $error = trim($matches[1]);
             $line  = (int) $matches[2];

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -25,6 +25,7 @@ class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
     protected function getTestFiles($testFileBase)
     {
         $testFiles = [$testFileBase.'1.inc'];
+        $testFiles[] = $testFileBase.'2.inc';
 
         return $testFiles;
 

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -24,7 +24,7 @@ class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
      */
     protected function getTestFiles($testFileBase)
     {
-        $testFiles = [$testFileBase.'1.inc'];
+        $testFiles   = [$testFileBase.'1.inc'];
         $testFiles[] = $testFileBase.'2.inc';
 
         return $testFiles;

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -26,12 +26,6 @@ class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
     {
         $testFiles = [$testFileBase.'1.inc'];
 
-        // HHVM doesn't tokenize any of the file after a git
-        // merge conflict, so only run this check on non-HHVM versions.
-        if (defined('HHVM_VERSION') === false) {
-            $testFiles[] = $testFileBase.'2.inc';
-        }
-
         return $testFiles;
 
     }//end getTestFiles()

--- a/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/DisallowLongArraySyntaxUnitTest.php
@@ -16,23 +16,6 @@ class DisallowLongArraySyntaxUnitTest extends AbstractSniffUnitTest
 
 
     /**
-     * Get a list of all test files to check.
-     *
-     * @param string $testFileBase The base path that the unit tests files will have.
-     *
-     * @return string[]
-     */
-    protected function getTestFiles($testFileBase)
-    {
-        $testFiles   = [$testFileBase.'1.inc'];
-        $testFiles[] = $testFileBase.'2.inc';
-
-        return $testFiles;
-
-    }//end getTestFiles()
-
-
-    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value

--- a/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNewlineUnitTest.php
@@ -31,12 +31,7 @@ class EndFileNewlineUnitTest extends AbstractSniffUnitTest
         case 'EndFileNewlineUnitTest.3.inc':
         case 'EndFileNewlineUnitTest.3.js':
         case 'EndFileNewlineUnitTest.3.css':
-            return [2 => 1];
         case 'EndFileNewlineUnitTest.4.inc':
-            // HHVM just removes the entire comment token, as if it was never there.
-            if (defined('HHVM_VERSION') === true) {
-                return [];
-            }
             return [2 => 1];
         default:
             return [];

--- a/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/EndFileNoNewlineUnitTest.php
@@ -35,19 +35,10 @@ class EndFileNoNewlineUnitTest extends AbstractSniffUnitTest
             return [3 => 1];
         case 'EndFileNoNewlineUnitTest.2.css':
         case 'EndFileNoNewlineUnitTest.2.js':
+        case 'EndFileNoNewlineUnitTest.6.inc':
             return [2 => 1];
         case 'EndFileNoNewlineUnitTest.5.inc':
-            // HHVM just removes the entire comment token, as if it was never there.
-            if (defined('HHVM_VERSION') === true) {
-                return [1 => 1];
-            }
             return [];
-        case 'EndFileNoNewlineUnitTest.6.inc':
-            // HHVM just removes the entire comment token, as if it was never there.
-            if (defined('HHVM_VERSION') === true) {
-                return [1 => 1];
-            }
-            return [2 => 1];
         default:
             return [];
         }//end switch

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -43,18 +43,6 @@ class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
 
 
     /**
-     * Skip this test on HHVM.
-     *
-     * @return bool Whether to skip this test.
-     */
-    protected function shouldSkipTest()
-    {
-        return defined('HHVM_VERSION');
-
-    }//end shouldSkipTest()
-
-
-    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -25,8 +25,13 @@ class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
     protected function getTestFiles($testFileBase)
     {
         $testFiles   = [$testFileBase.'1.inc'];
+
         $option      = (boolean) ini_get('short_open_tag');
-        $testFiles[] = $testFileBase.'3.inc';
+        if ($option === true) {
+            $testFiles[] = $testFileBase.'2.inc';
+        } else {
+            $testFiles[] = $testFileBase.'3.inc';
+        }
 
         return $testFiles;
 

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -24,9 +24,9 @@ class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
      */
     protected function getTestFiles($testFileBase)
     {
-        $testFiles   = [$testFileBase.'1.inc'];
+        $testFiles = [$testFileBase.'1.inc'];
 
-        $option      = (boolean) ini_get('short_open_tag');
+        $option = (boolean) ini_get('short_open_tag');
         if ($option === true) {
             $testFiles[] = $testFileBase.'2.inc';
         } else {

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -24,14 +24,9 @@ class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
      */
     protected function getTestFiles($testFileBase)
     {
-        $testFiles = [$testFileBase.'1.inc'];
-
-        $option = (boolean) ini_get('short_open_tag');
-        if ($option === true || defined('HHVM_VERSION') === true) {
-            $testFiles[] = $testFileBase.'2.inc';
-        } else {
-            $testFiles[] = $testFileBase.'3.inc';
-        }
+        $testFiles   = [$testFileBase.'1.inc'];
+        $option      = (boolean) ini_get('short_open_tag');
+        $testFiles[] = $testFileBase.'3.inc';
 
         return $testFiles;
 

--- a/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/EndFileNewlineUnitTest.php
@@ -32,13 +32,8 @@ class EndFileNewlineUnitTest extends AbstractSniffUnitTest
         case 'EndFileNewlineUnitTest.3.inc':
         case 'EndFileNewlineUnitTest.6.inc':
         case 'EndFileNewlineUnitTest.7.inc':
-            return [2 => 1];
         case 'EndFileNewlineUnitTest.9.inc':
         case 'EndFileNewlineUnitTest.10.inc':
-            // HHVM just removes the entire comment token, as if it was never there.
-            if (defined('HHVM_VERSION') === true) {
-                return [];
-            }
             return [2 => 1];
         default:
             return [];

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -41,12 +41,6 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
                 28 => 2,
                 32 => 2,
             ];
-        case 'FileCommentUnitTest.3.inc':
-            // HHVM just removes the entire comment token, as if it was never there.
-            if (defined('HHVM_VERSION') === true) {
-                return [1 => 1];
-            }
-            return [];
         default:
             return [];
         }//end switch


### PR DESCRIPTION
HHVM LTS 3.24 is the last version to support PHP 5 compatibility
the third paragraph of the announcement states "HHVM will not aim to target PHP7" and further down "We do not intend to be the runtime of choice for folks with pure PHP7 code." (HHVM will only support HACK going forward)
https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html