### PR TITLE
PEAR/ValidFunctionName: fix uninitialized string offset error

### DIFF
--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -232,6 +232,7 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
         if ($packagePart !== '') {
             // Check that each new word starts with a capital.
             $nameBits = explode('_', $packagePart);
+            $nameBits = array_filter($nameBits);
             foreach ($nameBits as $bit) {
                 if ($bit{0} !== strtoupper($bit{0})) {
                     $newPackagePart = '';

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -229,3 +229,5 @@ $a new class {
     function __myFunction() {}
     function __my_function() {}
 }
+
+function send_system_email__to_user($body, $recipient){}

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -138,6 +138,7 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
             227 => 1,
             229 => 1,
             230 => 2,
+            233 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
When a function name would contain more than one subsequent underscore, the `explode()` call will create entries containing an empty string in the `$nameBits` array.

The proposed fix will remove those empty entries before testing each `$bit`.
([`array_filter()` called without callback](http://php.net/manual/en/function.array-filter.php#example-6090) will remove everything which after juggling would evaluate to `false`).

**Note:** The resulting suggested `$newName` for the function will no longer contain a double underscore either.

If it would be desired to allow the double underscore, the alternative would be to change the `if ($bit{0} !== strtoupper($bit{0}))` condition to `if ($bit !== '' && $bit{0} !== strtoupper($bit{0}))`. This would also require an adjustment in the inner loop which creates the new package name.

Includes unit test.

Fixes #2027