### PR TITLE
Squiz.Scope.MemberVarScope throws fatal error when a property is found in an interface

### DIFF
--- a/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php
@@ -30,7 +30,7 @@ class MemberVarScopeSniff extends AbstractVariableSniff
         $tokens     = $phpcsFile->getTokens();
         $properties = $phpcsFile->getMemberProperties($stackPtr);
 
-        if ($properties['scope_specified'] !== false) {
+        if ($properties === [] || $properties['scope_specified'] !== false) {
             return;
         }
 

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.inc
@@ -66,3 +66,7 @@ class MyClass {
     var $mCounter, $mSearchUser,
         $mSearchPeriodStart;
 }
+
+interface Base {
+    protected $anonymous;
+}

--- a/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MemberVarScopeUnitTest.php
@@ -49,7 +49,7 @@ class MemberVarScopeUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [];
+        return [71 => 1];
 
     }//end getWarningList()
 


### PR DESCRIPTION
[Fixer conflicts series PR]

Encountered this fatal error when running the `Squiz` standard over the `Squiz` tests files.

The error can be reproduced on `master` by running `phpcs -p -s ./src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.inc --standard=Squiz --sniffs=Squiz.Scope.MemberVarScope`

```
Fatal error: Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Undefined index: scope_specified in /PHPCS/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php on line 33 in /PHPCS/src/Runner.php on line 562

PHP_CodeSniffer\Exceptions\RuntimeException: Undefined index: scope_specified in /PHPCS/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php on line 33 in /PHPCS/src/Runner.php on line 562

Call Stack:
    0.0000     349528   1. {main}() \PHP_CodeSniffer\bin\phpcbf:0
    0.0050     511904   2. PHP_CodeSniffer\Runner->runPHPCBF() /PHPCS/bin/phpcbf:18
    0.7440    5897360   3. PHP_CodeSniffer\Runner->run() /PHPCS/src/Runner.php:193
    0.7720    6565784   4. PHP_CodeSniffer\Runner->processFile() /PHPCS/src/Runner.php:394
    1.6731    7023360   5. PHP_CodeSniffer\Reporter->cacheFileReport() /PHPCS/src/Runner.php:611
    1.6731    7041328   6. PHP_CodeSniffer\Reports\Cbf->generateFileReport() /PHPCS/src/Reporter.php:284
    1.6731    7024896   7. PHP_CodeSniffer\Fixer->fixFile() /PHPCS/src/Reports/Cbf.php:48
    1.6981    7048032   8. PHP_CodeSniffer\Files\LocalFile->process() /PHPCS/src/Fixer.php:174
    1.6981    7048032   9. PHP_CodeSniffer\Files\LocalFile->process() /PHPCS/src/Files/LocalFile.php:91
    1.9421    7421832  10. PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MemberVarScopeSniff->process() /PHPCS/src/Files/File.php:490
    1.9421    7421832  11. PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MemberVarScopeSniff->processTokenWithinScope() /PHPCS/src/Sniffs/AbstractScopeSniff.php:138
    1.9421    7422104  12. PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MemberVarScopeSniff->processMemberVar() /PHPCS/src/Sniffs/AbstractVariableSniff.php:145
    1.9421    7422544  13. PHP_CodeSniffer\Runner->handleErrors() /PHPCS/src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php:33
```

Includes unit test to safeguard against this in the future.