### PR TITLE
 PSR2/UseDeclaration: fix runaway fixer and more

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1236,6 +1236,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="UseDeclarationUnitTest.14.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="UseDeclarationUnitTest.14.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="UseDeclarationUnitTest.15.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="UseDeclarationUnitTest.16.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="UseDeclarationUnitTest.16.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="UseDeclarationUnitTest.17.inc" role="test" />
        </dir>
       </dir>
       <file baseinstalldir="PHP/CodeSniffer" name="ruleset.xml" role="php" />

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -61,86 +61,91 @@ class UseDeclarationSniff implements Sniff
             && $tokens[$next]['code'] !== T_SEMICOLON
             && $tokens[$next]['code'] !== T_CLOSE_TAG
         ) {
-            $error = 'There must be one USE keyword per declaration';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'MultipleDeclarations');
-            if ($fix === true) {
-                if ($tokens[$next]['code'] === T_COMMA) {
-                    $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar.'use ');
-                } else {
-                    $baseUse           = rtrim($phpcsFile->getTokensAsString($stackPtr, ($next - $stackPtr)));
-                    $closingCurly      = $phpcsFile->findNext(T_CLOSE_USE_GROUP, ($next + 1));
-                    $lastNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($closingCurly - 1), null, true);
+            $error        = 'There must be one USE keyword per declaration';
+            $closingCurly = $phpcsFile->findNext(T_CLOSE_USE_GROUP, ($next + 1));
+            if ($closingCurly === false) {
+                // Parse error or live coding. Not auto-fixable.
+                $phpcsFile->addError($error, $stackPtr, 'MultipleDeclarations');
+            } else {
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'MultipleDeclarations');
+                if ($fix === true) {
+                    if ($tokens[$next]['code'] === T_COMMA) {
+                        $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar.'use ');
+                    } else {
+                        $baseUse           = rtrim($phpcsFile->getTokensAsString($stackPtr, ($next - $stackPtr)));
+                        $lastNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($closingCurly - 1), null, true);
 
-                    $phpcsFile->fixer->beginChangeset();
+                        $phpcsFile->fixer->beginChangeset();
 
-                    // Remove base use statement.
-                    for ($i = $stackPtr; $i <= $next; $i++) {
-                        $phpcsFile->fixer->replaceToken($i, '');
-                    }
-
-                    if (preg_match('`^[\r\n]+$`', $tokens[($next + 1)]['content']) === 1) {
-                        $phpcsFile->fixer->replaceToken(($next + 1), '');
-                    }
-
-                    // Convert grouped use statements into full use statements.
-                    do {
-                        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
-                        if ($next === false) {
-                            // Group use statement with trailing comma after last item.
-                            break;
-                        }
-
-                        $nonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($next - 1), null, true);
-                        for ($i = ($nonWhitespace + 1); $i < $next; $i++) {
-                            if (preg_match('`^[\r\n]+$`', $tokens[$i]['content']) === 1) {
-                                // Preserve new lines.
-                                continue;
-                            }
-
+                        // Remove base use statement.
+                        for ($i = $stackPtr; $i <= $next; $i++) {
                             $phpcsFile->fixer->replaceToken($i, '');
                         }
 
-                        if ($tokens[$next]['code'] === T_CONST || $tokens[$next]['code'] === T_FUNCTION) {
-                            $phpcsFile->fixer->addContentBefore($next, 'use ');
-                            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
-                            $phpcsFile->fixer->addContentBefore($next, str_replace('use ', '', $baseUse));
-                        } else {
-                            $phpcsFile->fixer->addContentBefore($next, $baseUse);
+                        if (preg_match('`^[\r\n]+$`', $tokens[($next + 1)]['content']) === 1) {
+                            $phpcsFile->fixer->replaceToken(($next + 1), '');
                         }
 
-                        $next = $phpcsFile->findNext(T_COMMA, ($next + 1), $closingCurly);
-                        if ($next !== false) {
-                            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
-                            if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['line'] === $tokens[$next]['line']) {
-                                $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($nextNonEmpty - 1), $next, true);
-                                if ($prevNonWhitespace === $next) {
-                                    $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar);
+                        // Convert grouped use statements into full use statements.
+                        do {
+                            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
+                            if ($next === false) {
+                                // Group use statement with trailing comma after last item.
+                                break;
+                            }
+
+                            $nonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($next - 1), null, true);
+                            for ($i = ($nonWhitespace + 1); $i < $next; $i++) {
+                                if (preg_match('`^[\r\n]+$`', $tokens[$i]['content']) === 1) {
+                                    // Preserve new lines.
+                                    continue;
+                                }
+
+                                $phpcsFile->fixer->replaceToken($i, '');
+                            }
+
+                            if ($tokens[$next]['code'] === T_CONST || $tokens[$next]['code'] === T_FUNCTION) {
+                                $phpcsFile->fixer->addContentBefore($next, 'use ');
+                                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
+                                $phpcsFile->fixer->addContentBefore($next, str_replace('use ', '', $baseUse));
+                            } else {
+                                $phpcsFile->fixer->addContentBefore($next, $baseUse);
+                            }
+
+                            $next = $phpcsFile->findNext(T_COMMA, ($next + 1), $closingCurly);
+                            if ($next !== false) {
+                                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
+                                if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['line'] === $tokens[$next]['line']) {
+                                    $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($nextNonEmpty - 1), $next, true);
+                                    if ($prevNonWhitespace === $next) {
+                                        $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar);
+                                    } else {
+                                        $phpcsFile->fixer->replaceToken($next, ';');
+                                        $phpcsFile->fixer->addNewline($prevNonWhitespace);
+                                    }
                                 } else {
+                                    // Last item with trailing comma or next item already on new line.
                                     $phpcsFile->fixer->replaceToken($next, ';');
-                                    $phpcsFile->fixer->addNewline($prevNonWhitespace);
                                 }
                             } else {
-                                // Last item with trailing comma or next item already on new line.
-                                $phpcsFile->fixer->replaceToken($next, ';');
+                                // Last item without trailing comma.
+                                $phpcsFile->fixer->addContent($lastNonWhitespace, ';');
                             }
-                        } else {
-                            // Last item without trailing comma.
-                            $phpcsFile->fixer->addContent($lastNonWhitespace, ';');
+                        } while ($next !== false);
+
+                        // Remove closing curly,semi-colon and any whitespace between last child and closing curly.
+                        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingCurly + 1), null, true);
+                        if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
+                            // Parse error, forgotten semi-colon.
+                            $next = $closingCurly;
                         }
-                    } while ($next !== false);
 
-                    // Remove closing curly,semi-colon and any whitespace between last child and closing curly.
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingCurly + 1), null, true);
-                    if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
-                        // Parse error, forgotten semi-colon.
-                        $next = $closingCurly;
-                    }
+                        for ($i = ($lastNonWhitespace + 1); $i <= $next; $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
 
-                    for ($i = ($lastNonWhitespace + 1); $i <= $next; $i++) {
-                        $phpcsFile->fixer->replaceToken($i, '');
-                    }
-
-                    $phpcsFile->fixer->endChangeset();
+                        $phpcsFile->fixer->endChangeset();
+                    }//end if
                 }//end if
             }//end if
         }//end if

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -81,8 +81,8 @@ class UseDeclarationSniff implements Sniff
                     do {
                         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
 
-                        $whitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($next - 1), null, true);
-                        for ($i = ($whitespace + 1); $i < $next; $i++) {
+                        $nonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($next - 1), null, true);
+                        for ($i = ($nonWhitespace + 1); $i < $next; $i++) {
                             $phpcsFile->fixer->replaceToken($i, '');
                         }
 
@@ -103,9 +103,9 @@ class UseDeclarationSniff implements Sniff
                     $phpcsFile->fixer->replaceToken($closingCurly, '');
 
                     // Remove any trailing whitespace.
-                    $next       = $phpcsFile->findNext(T_SEMICOLON, $closingCurly);
-                    $whitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($closingCurly - 1), null, true);
-                    for ($i = ($whitespace + 1); $i < $next; $i++) {
+                    $next          = $phpcsFile->findNext(T_SEMICOLON, $closingCurly);
+                    $nonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($closingCurly - 1), null, true);
+                    for ($i = ($nonWhitespace + 1); $i < $next; $i++) {
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
 

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -61,17 +61,21 @@ class UseDeclarationSniff implements Sniff
             && $tokens[$next]['code'] !== T_SEMICOLON
             && $tokens[$next]['code'] !== T_CLOSE_TAG
         ) {
-            $error        = 'There must be one USE keyword per declaration';
-            $closingCurly = $phpcsFile->findNext(T_CLOSE_USE_GROUP, ($next + 1));
-            if ($closingCurly === false) {
-                // Parse error or live coding. Not auto-fixable.
-                $phpcsFile->addError($error, $stackPtr, 'MultipleDeclarations');
-            } else {
+            $error = 'There must be one USE keyword per declaration';
+
+            if ($tokens[$next]['code'] === T_COMMA) {
                 $fix = $phpcsFile->addFixableError($error, $stackPtr, 'MultipleDeclarations');
                 if ($fix === true) {
-                    if ($tokens[$next]['code'] === T_COMMA) {
-                        $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar.'use ');
-                    } else {
+                    $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar.'use ');
+                }
+            } else {
+                $closingCurly = $phpcsFile->findNext(T_CLOSE_USE_GROUP, ($next + 1));
+                if ($closingCurly === false) {
+                    // Parse error or live coding. Not auto-fixable.
+                    $phpcsFile->addError($error, $stackPtr, 'MultipleDeclarations');
+                } else {
+                    $fix = $phpcsFile->addFixableError($error, $stackPtr, 'MultipleDeclarations');
+                    if ($fix === true) {
                         $baseUse           = rtrim($phpcsFile->getTokensAsString($stackPtr, ($next - $stackPtr)));
                         $lastNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($closingCurly - 1), null, true);
 

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -130,7 +130,12 @@ class UseDeclarationSniff implements Sniff
                     } while ($next !== false);
 
                     // Remove closing curly,semi-colon and any whitespace between last child and closing curly.
-                    $next = $phpcsFile->findNext(T_SEMICOLON, $closingCurly);
+                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($closingCurly + 1), null, true);
+                    if ($next === false || $tokens[$next]['code'] !== T_SEMICOLON) {
+                        // Parse error, forgotten semi-colon.
+                        $next = $closingCurly;
+                    }
+
                     for ($i = ($lastNonWhitespace + 1); $i <= $next; $i++) {
                         $phpcsFile->fixer->replaceToken($i, '');
                     }

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -179,9 +179,16 @@ class UseDeclarationSniff implements Sniff
             return;
         }
 
-        $end = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
+        $end = $phpcsFile->findNext([T_SEMICOLON, T_CLOSE_USE_GROUP, T_CLOSE_TAG], ($stackPtr + 1));
         if ($end === false) {
             return;
+        }
+
+        if ($tokens[$end]['code'] === T_CLOSE_USE_GROUP) {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+            if ($tokens[$nextNonEmpty]['code'] === T_SEMICOLON) {
+                $end = $nextNonEmpty;
+            }
         }
 
         // Find either the start of the next line or the beginning of the next statement,

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.16.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.16.inc
@@ -1,0 +1,11 @@
+<?php
+use Vendor\Package\SomeNamespace\{
+    SubnamespaceOne\ClassA,
+    SubnamespaceOne\ClassB,
+}
+
+class Test {
+	public function __construct() {
+		$var = 1;
+	}
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.16.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.16.inc.fixed
@@ -1,0 +1,9 @@
+<?php
+use Vendor\Package\SomeNamespace\SubnamespaceOne\ClassA;
+use Vendor\Package\SomeNamespace\SubnamespaceOne\ClassB;
+
+class Test {
+	public function __construct() {
+		$var = 1;
+	}
+}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.17.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.17.inc
@@ -1,0 +1,3 @@
+<?php
+use UnfinishedGroup\NotFixable {
+	ClassT,

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc
@@ -17,7 +17,3 @@ use function Grouped\Functions\ { func_k };
 use function foo\math\{ sin, cos, cosh };
 use const foo\math\{ PI, E, GAMMA, GOLDEN_RATIO };
 use foo\math\{ Math, const PI, function sin, function cos, function cosh };
-
-class PHP7 {
-
-}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc
@@ -17,3 +17,31 @@ use function Grouped\Functions\ { func_k };
 use function foo\math\{ sin, cos, cosh };
 use const foo\math\{ PI, E, GAMMA, GOLDEN_RATIO };
 use foo\math\{ Math, const PI, function sin, function cos, function cosh };
+
+use Grouped\TrailingComma\ {
+    ClassL,
+    const ConstM,
+    function func_n,
+    ClassO as O,
+};
+
+use function foo\math\trailingcomma\no\whitespace\{sin,cos,cosh,};
+
+use function foo\math\multipleonnewline\{
+	sin, cos, /* comment */ cosh
+};
+
+// phpcs:disable Standard.Cat.Sniff -- for reasons.
+use Grouped\TrailingCommaWithCommentsAndAnnotations\ {
+    // A comment.
+    ClassP,
+    /* Another comment. */
+    const ConstQ, // A trailing comment.
+
+    function func_r, // phpcs:ignore Standard.Cat.Sniff -- for reasons.
+    // phpcs:ignore Standard.Cat.Sniff -- for reasons.
+    ClassS as S,
+    // Some other comment.
+};
+
+// phpcs:enable

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc.fixed
@@ -26,3 +26,31 @@ use const foo\math\PI;
 use function foo\math\sin;
 use function foo\math\cos;
 use function foo\math\cosh;
+
+use Grouped\TrailingComma\ClassL;
+use const Grouped\TrailingComma\ConstM;
+use function Grouped\TrailingComma\func_n;
+use Grouped\TrailingComma\ClassO as O;
+
+use function foo\math\trailingcomma\no\whitespace\sin;
+use function foo\math\trailingcomma\no\whitespace\cos;
+use function foo\math\trailingcomma\no\whitespace\cosh;
+
+use function foo\math\multipleonnewline\sin;
+use function foo\math\multipleonnewline\cos; /* comment */
+use function foo\math\multipleonnewline\cosh;
+
+// phpcs:disable Standard.Cat.Sniff -- for reasons.
+    // A comment.
+use Grouped\TrailingCommaWithCommentsAndAnnotations\ClassP;
+    /* Another comment. */
+use const Grouped\TrailingCommaWithCommentsAndAnnotations\ConstQ; // A trailing comment.
+
+use function Grouped\TrailingCommaWithCommentsAndAnnotations\func_r; // phpcs:ignore Standard.Cat.Sniff -- for reasons.
+    // phpcs:ignore Standard.Cat.Sniff -- for reasons.
+use Grouped\TrailingCommaWithCommentsAndAnnotations\ClassS as S;
+
+    // Some other comment.
+
+
+// phpcs:enable

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.5.inc.fixed
@@ -26,7 +26,3 @@ use const foo\math\PI;
 use function foo\math\sin;
 use function foo\math\cos;
 use function foo\math\cosh;
-
-class PHP7 {
-
-}

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -48,12 +48,18 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
                 17 => 1,
                 18 => 1,
                 19 => 1,
+                21 => 1,
+                28 => 1,
+                30 => 1,
+                35 => 1,
             ];
         case 'UseDeclarationUnitTest.10.inc':
         case 'UseDeclarationUnitTest.11.inc':
         case 'UseDeclarationUnitTest.12.inc':
         case 'UseDeclarationUnitTest.13.inc':
         case 'UseDeclarationUnitTest.14.inc':
+        case 'UseDeclarationUnitTest.16.inc':
+        case 'UseDeclarationUnitTest.17.inc':
             return [2 => 1];
         case 'UseDeclarationUnitTest.15.inc':
             return [


### PR DESCRIPTION
[Fixer conflicts series PR]

**Note**: This PR will be easiest to review by looking at the individual commits.

## Summary of the fixes made:

### Fix handling of group use statements with trailing commas

As of PHP 7.2 grouped use statements can have trailing comma's after the last child statement.
Ref: https://wiki.php.net/rfc/list-syntax-trailing-commas

The sniff's fixer did not take this into account up to now and would cause a run-away fixer run which wouldn't stop until PHP ran out of memory.

This has now been fixed.

Also:
While fixing this I also looked into how comments and PHPCS annotations were handled and have adjusted the code for improved fixing of the whitespace between `use` statements without interferring with the comments/annotations.

### Defensive coding improvement [1]

Prevent accidentally removing code between a group use statement with a forgotten semi-colon (parse error) and the next statement which ends in a semi-colon.

### Defensive coding improvement [2]

Prevent auto-fixing unfinished/unclosed group use statements.

**Note**: This commit is smaller than it looks. Viewing the files with `?w=1` (ignoring whitespace changes) will show the real changes.

### Defensive coding improvement [3]

Prevent throwing an incorrect error for `SpaceAfterLastUse` when the semi-colon is missing after the group use close brace.

## Testing this PR

Initially check out commit https://github.com/squizlabs/PHP_CodeSniffer/commit/60c30eec8b14c5e5ec1fd46af25ae12e02af53dd

Running the below command will demonstrate the run-away fixer:
`phpcbf -p -s ./src/Standards/PSR2/Tests/NameSpaces/UseDeclarationUnitTest.5.inc --standard=PSR2 --sniffs=PSR2.NameSpaces.UseDeclaration -vv`

Next, check out commit https://github.com/squizlabs/PHP_CodeSniffer/commit/d6f4dd886276fa49dbcee51cdd3bafadc60edb68

Running the below commands will demonstrate the reason for commit https://github.com/squizlabs/PHP_CodeSniffer/commit/b9ee2653d760562768ca35bf146e67a70df338c3 and https://github.com/squizlabs/PHP_CodeSniffer/commit/f0ff546ee41d50691f1e9b3c3820614c973548e1:
`phpcbf -p -s ./src/Standards/PSR2/Tests/NameSpaces/UseDeclarationUnitTest.16.inc --standard=PSR2 --sniffs=PSR2.NameSpaces.UseDeclaration -vv`

Running the below command will demonstrate the reason for commit https://github.com/squizlabs/PHP_CodeSniffer/commit/ac76e74666659fc60c3bfd259e15336eef3b9525:
`phpcbf -p -s ./src/Standards/PSR2/Tests/NameSpaces/UseDeclarationUnitTest.17.inc --standard=PSR2 --sniffs=PSR2.NameSpaces.UseDeclaration -vv`