### PR TITLE
Squiz/FunctionSpacing: fix fixer conflict - ignore function at start of embedded PHP

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -68,6 +68,16 @@ class FunctionSpacingSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        $tokens           = $phpcsFile->getTokens();
+        $previousNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($previousNonEmpty !== false
+            && $tokens[$previousNonEmpty]['code'] === T_OPEN_TAG
+            && $tokens[$previousNonEmpty]['line'] !== 1
+        ) {
+            // Ignore functions at the start of an embedded PHP block.
+            return;
+        }
+
         // If the ruleset has only overriden the spacing property, use
         // that value for all spacing rules.
         if ($this->rulesetProperties === null) {
@@ -88,8 +98,7 @@ class FunctionSpacingSniff implements Sniff
             }
         }
 
-        $tokens        = $phpcsFile->getTokens();
-        $this->spacing = (int) $this->spacing;
+        $this->spacing            = (int) $this->spacing;
         $this->spacingBeforeFirst = (int) $this->spacingBeforeFirst;
         $this->spacingAfterLast   = (int) $this->spacingAfterLast;
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -355,3 +355,10 @@ $util->setLogger(new class {
     private function b(){}
     protected function c(){}
 });
+
+?>
+
+<?php
+function functionInEmbeddedPHP() {
+
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -398,3 +398,10 @@ $util->setLogger(new class {
     protected function c(){}
 
 });
+
+?>
+
+<?php
+function functionInEmbeddedPHP() {
+
+}


### PR DESCRIPTION
[Fixer conflicts series PR]

Fixer conflict can be reproduced by running the below command against `master`:
`phpcbf -p -s ./src/Standards/Generic/Tests/Files/LineEndingsUnitTest.inc --standard=Squiz`

Basically, the `Squiz.WhiteSpace.FunctionSpacing` sniff demands 2 blank lines between functions, while the `Squiz.PHP.EmbeddedPHP` sniff demands no blank lines at the start of an embedded PHP block, which causes a fixer conflict if a function is declared at the top of an embedded PHP block.

To fix this, I've given precedence to the `EmbeddedPHP` sniff - i.e. no blank lines between the PHP open tag and the start of the function declaration -.
The `FunctionSpacing` will now ignore functions at the start of an embedded PHP block.

Includes unit test.

----

Side-note: the docblock at the top of the sniff actually states `Checks the separation between methods in a class or interface.`, but the sniff does not actually check if the function it is examining is within a class or an interface.
Adding that check could be considered an alternative solution for the fixer conflict, but would change the existing behaviour of the sniff significantly.