### PR TITLE
Squiz/OperatorSpacing: fix fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -220,11 +220,22 @@ class OperatorSpacingSniff implements Sniff
                     $operator,
                     $found,
                 ];
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
-                if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+
+                $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+                if ($nextNonWhitespace !== false
+                    && isset(Tokens::$commentTokens[$tokens[$nextNonWhitespace]['code']]) === true
+                    && $found === 'newline'
+                ) {
+                    // Don't auto-fix when it's a comment or PHPCS annotation on a new line as
+                    // it causes fixer conflicts and can cause the meaning of annotations to change.
+                    $phpcsFile->addError($error, $stackPtr, 'SpacingAfter', $data);
+                } else {
+                    $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                    }
                 }
-            }
+            }//end if
         }//end if
 
     }//end process()

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -235,3 +235,17 @@ $x = $foo ? function ($foo) use /* comment */ ($bar): int {
 $x = !$foo ? $bar : function (): int {
     return 1;
 };
+
+$a =
+    // Comment.
+    [
+        'a',
+        'b',
+    ];
+
+$a =
+// phpcs:ignore Standard.Category.Sniff -- for reasons.
+[
+    'a',
+    'b',
+];

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -229,3 +229,17 @@ $x = $foo ? function ($foo) use /* comment */ ($bar): int {
 $x = !$foo ? $bar : function (): int {
     return 1;
 };
+
+$a =
+    // Comment.
+    [
+        'a',
+        'b',
+    ];
+
+$a =
+// phpcs:ignore Standard.Category.Sniff -- for reasons.
+[
+    'a',
+    'b',
+];

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -94,6 +94,8 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                 199 => 1,
                 200 => 1,
                 201 => 2,
+                239 => 1,
+                246 => 1,
             ];
             break;
         case 'OperatorSpacingUnitTest.js':


### PR DESCRIPTION
[Fixer conflicts series PR]

Fixer conflict can be reproduced by running the below command against `master`:
`phpcbf -p -s ./src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc --standard=Squiz`

When there is a comment after an operator, the `Squiz.Commenting.PostStatementComment` sniff and the `Squiz.WhiteSpace.OperatorSpacing` sniffs would conflict, with the `PostStatementComment` sniff demanding a new line and the `OperatorSpacing` sniff demanding exactly one space.

Along the same lines, if the next content is a PHPCS annotation on the next line, moving the annotation to be on the same line as the operator could change its meaning.

I've chosen to fix this by throwing the error, but blocking auto-fixing when the next thing after the operator is a comment/annotation and the whitespace found is a new line.

Includes unit test.