### PR TITLE
Squiz/SuperfluousWhitespace: recognize unicode whitespace at start/end of file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1721,6 +1721,12 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.1.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.2.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.3.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.3.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.4.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.4.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.5.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.5.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.1.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.1.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SuperfluousWhitespaceUnitTest.1.js" role="test" />

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -95,17 +95,20 @@ class SuperfluousWhitespaceSniff implements Sniff
                     return;
                 }
 
+                $beforeOpen = '';
+
                 for ($i = ($stackPtr - 1); $i >= 0; $i--) {
                     // If we find something that isn't inline html then there is something previous in the file.
                     if ($tokens[$i]['type'] !== 'T_INLINE_HTML') {
                         return;
                     }
 
-                    // If we have ended up with inline html make sure it isn't just whitespace.
-                    $tokenContent = trim($tokens[$i]['content']);
-                    if ($tokenContent !== '') {
-                        return;
-                    }
+                    $beforeOpen .= $tokens[$i]['content'];
+                }
+
+                // If we have ended up with inline html make sure it isn't just whitespace.
+                if (preg_match('`^[\pZ\s]+$`u', $beforeOpen) !== 1) {
+                    return;
                 }
             }//end if
 
@@ -129,6 +132,8 @@ class SuperfluousWhitespaceSniff implements Sniff
                     return;
                 }
 
+                $afterClose = '';
+
                 for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
                     // If we find something that isn't inline HTML then there
                     // is more to the file.
@@ -136,12 +141,12 @@ class SuperfluousWhitespaceSniff implements Sniff
                         return;
                     }
 
-                    // If we have ended up with inline html make sure it
-                    // isn't just whitespace.
-                    $tokenContent = trim($tokens[$i]['content']);
-                    if (empty($tokenContent) === false) {
-                        return;
-                    }
+                    $afterClose .= $tokens[$i]['content'];
+                }
+
+                // If we have ended up with inline html make sure it isn't just whitespace.
+                if (preg_match('`^[\pZ\s]+$`u', $afterClose) !== 1) {
+                    return;
                 }
             } else {
                 // The last token is always the close tag inserted when tokenized

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.3.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.3.inc
@@ -1,0 +1,14 @@
+           
+
+		    	
+
+
+<?php
+
+// This should throw an error - mixed: spaces, tabs, new lines.
+
+?>
+           
+
+		    	
+

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.3.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.3.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+
+// This should throw an error - mixed: spaces, tabs, new lines.
+
+?>

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.4.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.4.inc
@@ -1,0 +1,4 @@
+ <?php
+
+// This should throw an error - single space before open tag, tab + space after closing tag.
+?>	 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.4.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.4.inc.fixed
@@ -1,0 +1,4 @@
+<?php
+
+// This should throw an error - single space before open tag, tab + space after closing tag.
+?>

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.5.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.5.inc
@@ -1,0 +1,5 @@
+ <?php
+
+// This should throw an error - unicode space before open tag and after close tag.
+?> 
+ 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.5.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.5.inc.fixed
@@ -1,0 +1,4 @@
+<?php
+
+// This should throw an error - unicode space before open tag and after close tag.
+?>

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -49,6 +49,19 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                 8 => 1,
             ];
             break;
+        case 'SuperfluousWhitespaceUnitTest.3.inc':
+            return [
+                6  => 1,
+                10 => 1,
+            ];
+            break;
+        case 'SuperfluousWhitespaceUnitTest.4.inc':
+        case 'SuperfluousWhitespaceUnitTest.5.inc':
+            return [
+                1 => 1,
+                4 => 1,
+            ];
+            break;
         case 'SuperfluousWhitespaceUnitTest.1.js':
             return [
                 1  => 1,


### PR DESCRIPTION
As unicode regexes can be even more expensive than regular regexes, I've moved the check for non-whitespace out of the loop.

Includes unit tests. The `5` file is the one with unicode. The other ones are just more confirmation that the sniff works as expected.

Fixes #2038