### PR TITLE
Generic/FunctionCallArgumentSpacing: fix fixer conflict

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -115,10 +115,19 @@ class FunctionCallArgumentSpacingSniff implements Sniff
                         $error = 'Space found before comma in function call';
                         $fix   = $phpcsFile->addFixableError($error, $nextSeparator, 'SpaceBeforeComma');
                         if ($fix === true) {
-                            $phpcsFile->fixer->replaceToken(($nextSeparator - 1), '');
+                            $phpcsFile->fixer->beginChangeset();
+
+                            if ($tokens[$prev]['line'] !== $tokens[$nextSeparator]['line']) {
+                                $phpcsFile->fixer->addContent($prev, ',');
+                                $phpcsFile->fixer->replaceToken($nextSeparator, '');
+                            } else {
+                                $phpcsFile->fixer->replaceToken(($nextSeparator - 1), '');
+                            }
+
+                            $phpcsFile->fixer->endChangeset();
                         }
-                    }
-                }
+                    }//end if
+                }//end if
 
                 if ($tokens[($nextSeparator + 1)]['code'] !== T_WHITESPACE) {
                     $error = 'No space found after comma in function call';

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
@@ -123,3 +123,13 @@ $obj->{$var}($foo,$bar);
         echo $a, $b, $c, $d;
     };
 })('a','b')('c','d');
+
+my_function_call(
+    'a'
+    /* Comment */
+    ,'b'
+    , 'c' // Comment.
+    ,'d'
+    ,'e' // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    , 'f'
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
@@ -123,3 +123,13 @@ $obj->{$var}($foo, $bar);
         echo $a, $b, $c, $d;
     };
 })('a', 'b')('c', 'd');
+
+my_function_call(
+    'a',
+    /* Comment */
+    'b',
+     'c', // Comment.
+    'd',
+    'e', // phpcs:ignore Standard.Category.Sniff -- for reasons.
+     'f'
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -47,6 +47,11 @@ class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
             115 => 1,
             119 => 1,
             125 => 2,
+            130 => 2,
+            131 => 1,
+            132 => 2,
+            133 => 2,
+            134 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
[Fixer conflicts series PR]

This PR addresses a fixer conflict between the `Generic.Functions.FunctionCallArgumentSpacing` and the `PEAR.Functions.FunctionCallSignature` sniffs when these sniffs encounter a multi-line function call.

The fixer conflict can be reproduced by running:
`phpcbf -p -s ./test.php --standard=PEAR --sniffs=Generic.Functions.FunctionCallArgumentSpacing,PEAR.Functions.FunctionCallSignature`
against the following code:
```php
my_function_call(
    'a'
    /* Comment */
    ,'b'
    , 'c' // Comment.
    ,'d'
    ,'e' // phpcs:ignore Standard.Category.Sniff -- for reasons.
    , 'f'
);
```

If given half a chance, the fixer in the `Generic.Functions.FunctionCallArgumentSpacing` sniff would change multi-line function calls to single-line.

This PR fixes this.

Includes unit tests