### PR TITLE
Create NoSpaceAfterNotSniff

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterNotSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterNotSniff.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Ensures there is no space after a NOT operator.
+ *
+ * @author    Gabriel Caruso <carusogabriel34@gmail.com>
+ * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class NoSpaceAfterNotSniff implements Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [T_BOOLEAN_NOT];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+            return;
+        }
+
+        $error = 'A NOT operator must not be followed by a space';
+        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceFound');
+
+        if ($fix === true) {
+            $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.inc
@@ -1,0 +1,10 @@
+<?php
+if (! $foo !== $bar) {
+    return !$bar;
+}
+
+$foo = ! (1 === 3);
+
+$baz = function () {
+    return !  $bar;
+};

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.inc.fixed
@@ -1,0 +1,10 @@
+<?php
+if (!$foo !== $bar) {
+    return !$bar;
+}
+
+$foo = !(1 === 3);
+
+$baz = function () {
+    return !$bar;
+};

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.js
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.js
@@ -1,0 +1,10 @@
+
+if (! foo !== bar) {
+    return !bar;
+}
+
+foo = ! (1 === 3);
+
+baz = => {
+    return !  bar;
+};

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.js.fixed
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.js.fixed
@@ -1,0 +1,10 @@
+
+if (!foo !== bar) {
+    return !bar;
+}
+
+foo = !(1 === 3);
+
+baz = => {
+    return !bar;
+};

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterNotUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Unit test class for the SpaceAfterNot sniff.
+ *
+ * @author    Gabriel Caruso <carusogabriel34@gmail.com>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class NoSpaceAfterNotUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            2 => 1,
+            6 => 1,
+            9 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Hello there :wave: 

Recently, while trying to recreate the Symfony CS with PHPCS, I couldn't found a Sniff to forbid whitespaces after the not operator `!`.

Ref: https://symfony.com/doc/current/contributing/code/standards.html#structure

As my first Sniff PR, here we have it :smile: 