### PR TITLE
Reports/Summary: sort files based on directory

### DIFF
--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -95,6 +95,27 @@ class Summary implements Report
             $maxLength = max($maxLength, $fileLen);
         }
 
+        uksort(
+            $reportFiles,
+            function ($keyA, $keyB) {
+                $pathPartsA = explode(DIRECTORY_SEPARATOR, $keyA);
+                $pathPartsB = explode(DIRECTORY_SEPARATOR, $keyB);
+
+                do {
+                    $partA = array_shift($pathPartsA);
+                    $partB = array_shift($pathPartsB);
+                } while ($partA === $partB && empty($pathPartsA) === false && empty($pathPartsB) === false);
+
+                if (empty($pathPartsA) === false && empty($pathPartsB) === true) {
+                    return 1;
+                } else if (empty($pathPartsA) === true && empty($pathPartsB) === false) {
+                    return -1;
+                } else {
+                    return strcasecmp($partA, $partB);
+                }
+            }
+        );
+
         $width = min($width, ($maxLength + 21));
         $width = max($width, 70);
 


### PR DESCRIPTION
The original sort order of the file names in the summary report was alphabetic and did not take subdirectories into account.

This could result in a list like:
```
dir/afile/subdir/file.php
dir/afile.php
dir/b/subdir/file.php
dir/cfile.php
```

The change proposed in this PR sorts the file names in a way that the directory layout is taken into account, so the above list would now display as:
```
dir/afile.php
dir/cfile.php
dir/afile/subdir/file.php
dir/b/subdir/file.php
```