### PR TITLE
Reports/Source: sort sources on count and source

### DIFF
--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -158,8 +158,14 @@ class Source implements Report
 
         $width = max($width, 70);
 
-        asort($sources);
-        $sources = array_reverse($sources);
+        // Sort the data based on counts and source code.
+        $sourceCodes = array_keys($sources);
+        $counts      = [];
+        foreach ($sources as $source => $data) {
+            $counts[$source] = $data['count'];
+        }
+
+        array_multisort($counts, SORT_DESC, $sourceCodes, SORT_ASC, SORT_NATURAL, $sources);
 
         echo PHP_EOL."\033[1mPHP CODE SNIFFER VIOLATION SOURCE SUMMARY\033[0m".PHP_EOL;
         echo str_repeat('-', $width).PHP_EOL."\033[1m";


### PR DESCRIPTION
The original sort order of the sources in the source report was based on the error/warning count alone.
This would make the resulting order for errors with the same count unpredictable and different on each run, making it more difficult to compare between runs.

The change proposed in this PR sorts the list first on the error/warning count and secondary on the source code, stabilizing the sort order.