### PR TITLE
Fix AbstractArraySniff Indexing

### DIFF
--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -76,8 +76,9 @@ abstract class AbstractArraySniff implements Sniff
             $lastToken = $stackPtr;
         }
 
-        $keyUsed = false;
-        $indices = [];
+        $findComma = false;
+        $keyUsed   = false;
+        $indices   = [];
 
         for ($checkToken = ($stackPtr + 1); $checkToken <= $lastArrayToken; $checkToken++) {
             // Skip bracketed statements, like function calls.
@@ -94,7 +95,9 @@ abstract class AbstractArraySniff implements Sniff
                 || $tokens[$checkToken]['code'] === T_CLOSURE
             ) {
                 // Let subsequent calls of this test handle nested arrays.
-                if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {
+                if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW
+                    && $findComma === false
+                ) {
                     $indices[] = ['value_start' => $checkToken];
                     $lastToken = $checkToken;
                 }
@@ -110,7 +113,9 @@ abstract class AbstractArraySniff implements Sniff
 
                 $checkToken = $phpcsFile->findNext(T_WHITESPACE, ($checkToken + 1), null, true);
                 $lastToken  = $checkToken;
+
                 if ($tokens[$checkToken]['code'] !== T_COMMA) {
+                    $findComma = true;
                     $checkToken--;
                 }
 
@@ -148,7 +153,9 @@ abstract class AbstractArraySniff implements Sniff
                     continue;
                 }
 
-                if ($keyUsed === false) {
+                if ($findComma === true) {
+                    $findComma = false;
+                } else if ($keyUsed === false) {
                     $valueContent = $phpcsFile->findNext(
                         Tokens::$emptyTokens,
                         ($lastToken + 1),

--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -163,7 +163,9 @@ abstract class AbstractArraySniff implements Sniff
                         true
                     );
 
-                    $indices[] = ['value_start' => $valueContent];
+                    if ($valueContent !== false) {
+                        $indices[] = ['value_start' => $valueContent];
+                    }
                 }
 
                 $lastToken = $checkToken;

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
@@ -56,3 +56,15 @@ $var = [
         2 => 'two',
     /* three */ 3 => 'three',
     ];
+
+$var = [
+    ['one'] +
+    ['two'] +
+    ['three']
+];
+
+$var = [
+    ['one']
+    + ['two']
+    + ['three']
+];

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
@@ -57,3 +57,15 @@ $var = [
   2 => 'two',
   /* three */ 3 => 'three',
 ];
+
+$var = [
+  ['one'] +
+    ['two'] +
+    ['three']
+];
+
+$var = [
+  ['one']
+    + ['two']
+    + ['three']
+];

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -37,6 +37,8 @@ class ArrayIndentUnitTest extends AbstractSniffUnitTest
             56 => 1,
             57 => 1,
             58 => 1,
+            61 => 1,
+            67 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
While implementing some custom sniffs on top of `PHP_CodeSniffer\SniffsAbstractArraySniff`, it appeared that there were some issues with the data being provided to `processMultiLineArray()` and `processSingleLineArray()`.

The two changes in this PR should resolve the odd behaviors found in the test cases detailed below. The first is to ensure that once a value has been found, nothing else should be added as a value until a comma or the end of the array is found. The second change is to avoid adding an index on the end of the list when reaching the end of an array with no comma.

The only test case that could be verified with the available tests was **Array Concatenation Array**. The others are more visible when doing single line arrays, for which there is no testing support in the suite.

# Test Cases

The following are cases that I was able to find as returning odd results.

## Empty Array

Even though there are no values in the array, an index gets added with a bool (instead of an int) index. The index should probably not be here.

``` php
// Array
[]

// $indices
array(1) {
  [0]=>
  array(1) {
    ["value_start"]=>
    bool(false)
  }
}
```

## Empty Value Array

Even though there is one value in the array, an extra index gets added with a bool (instead of an int) index. The extra index should probably not be here.

``` php
// String Array
['']
// Array Array
[[]]

// $indices
array(2) {
  [0]=>
  array(1) {
    ["value_start"]=>
    int(1214)
  }
  [1]=>
  array(1) {
    ["value_start"]=>
    bool(false)
  }
}
```

## Operation as Value Array

Even though there is one value in the array, an extra index gets added. The extra index should probably not be here.

``` php
// Array
[['value' => $badValue] + $this->getDefaultArray()]

// $indices
array(2) {
  [0]=>
  array(1) {
    ["value_start"]=>
    int(699)
  }
  [1]=>
  array(1) {
    ["value_start"]=>
    int(709)
  }
}
```

## Array Values Array

Even though there are three values in the wrapping array, an extra index gets added. The extra index should probably not be here.

``` php
// Array
[[1], 2, [3]]

// Indices
array(4) {
  [0]=>
  array(1) {
    ["value_start"]=>
    int(107)
  }
  [1]=>
  array(1) {
    ["value_start"]=>
    int(112)
  }
  [2]=>
  array(1) {
    ["value_start"]=>
    int(115)
  }
  [3]=>
  array(1) {
    ["value_start"]=>
    bool(false)
  }
}
```

## Array Concatenation Array

Even though there is one value in the wrapping array, three extra indices get added. The extra indices should probably not be here.

``` php
// Array
$var = [
    ['one'] +
    ['two'] +
    ['three']
];

// Indices
array(4) {
  [0]=>
  array(1) {
    ["value_start"]=>
    int(319)
  }
  [1]=>
  array(1) {
    ["value_start"]=>
    int(326)
  }
  [2]=>
  array(1) {
    ["value_start"]=>
    int(332)
  }
  [3]=>
  array(1) {
    ["value_start"]=>
    bool(false)
  }
}

```