### PR TITLE
Fix compatibility with PHP 7.3/nightly

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1408,7 +1408,7 @@ class File
                 // If it's null, then there must be no parameters for this
                 // method.
                 if ($currVar === null) {
-                    continue;
+                    continue 2;
                 }
 
                 $vars[$paramCount]            = [];

--- a/src/Tokenizers/CSS.php
+++ b/src/Tokenizers/CSS.php
@@ -390,7 +390,7 @@ class CSS extends PHP
 
                     // Needs to be in the format "url(" for it to be a URL.
                     if ($finalTokens[$x]['code'] !== T_OPEN_PARENTHESIS) {
-                        continue;
+                        continue 2;
                     }
 
                     // Make sure the content isn't empty.
@@ -401,7 +401,7 @@ class CSS extends PHP
                     }
 
                     if ($finalTokens[$y]['code'] === T_CLOSE_PARENTHESIS) {
-                        continue;
+                        continue 2;
                     }
 
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -743,7 +743,7 @@ abstract class Tokenizer
                 }
                 break;
             default:
-                continue;
+                continue 2;
             }//end switch
         }//end for
 


### PR DESCRIPTION
As of PHP 7.3, using `continue` to target a `switch` control structure will throw an `E_WARNING`.

Applying `continue` to a `switch` is equivalent to using `break` and more often than not, a `continue` targeting a higher level control structure is actually intended.

To target the higher level control structure, a numeric argument has to be passed to `continue`.

Refs:
* http://php.net/manual/en/control-structures.continue.php
* https://github.com/php/php-src/pull/3364
* https://wiki.php.net/rfc/continue_on_switch_deprecation

This change has been recently committed to PHP itself and will break the build against `nightly` for the current `master` already.
See: https://travis-ci.org/jrfnl/PHP_CodeSniffer/jobs/401533444 (this branch, but without commits, so equal to the current PHPCS `master`).

This PR fixes the instances of this in PHPCS so [the build against `nightly` will pass again](https://travis-ci.org/jrfnl/PHP_CodeSniffer/jobs/401536827).

Notes:
* All these switches are nested in other control structures, but end the switch at the scope closer of the outer control structure, so using `break` in these cases is equivalent to using `continue 2`.

---
FYI: The [PHPCompatibility](https://github.com/wimg/PHPCompatibility) standard will include a sniff to detect this in the near future. This PR is the result of some tests I've been running on the WIP PHPCompatibility sniff :wink: 