### PR TITLE
added errors attribute with value zero to junit report testsuites

### DIFF
--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -39,6 +39,7 @@ class Junit implements Report
 
         $out->startElement('testsuite');
         $out->writeAttribute('name', $report['filename']);
+        $out->writeAttribute('errors', 0);
 
         if (count($report['messages']) === 0) {
             $out->writeAttribute('tests', 1);


### PR DESCRIPTION
'errors' attribute is required by xunit jenkins plugin (that's weird cause junit itself seems to define that parameter optional). Still it would be good to have PHP_CodeSniffer junit xml report compatible with Jenkins xunit plugin.

https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd