### PR TITLE
Unit test runner: ignore `bak` files

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -81,7 +81,7 @@ abstract class AbstractSniffUnitTest extends TestCase
         foreach ($di as $file) {
             $path = $file->getPathname();
             if (substr($path, 0, strlen($testFileBase)) === $testFileBase) {
-                if ($path !== $testFileBase.'php' && substr($path, -5) !== 'fixed') {
+                if ($path !== $testFileBase.'php' && substr($path, -5) !== 'fixed' && substr($path, -4) !== '.bak') {
                     $testFiles[] = $path;
                 }
             }


### PR DESCRIPTION
Just a pet peeve.

Some IDE/code editors create `.bak` files when a file has been edited which cause the unit test runs to fail as these files would be tested as if they were intentional test case files.

This minor fix prevents this from happening.