### PR TITLE
Squiz.WhiteSpace.FunctionSpacing is removing indents from the start of functions when fixing

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -306,11 +306,15 @@ class FunctionSpacingSniff implements Sniff
                 } else {
                     $nextContent = $phpcsFile->findNext(T_WHITESPACE, ($nextSpace + 1), null, true);
                     $phpcsFile->fixer->beginChangeset();
-                    for ($i = $nextSpace; $i < ($nextContent - 1); $i++) {
+                    for ($i = $nextSpace; $i < $nextContent; $i++) {
+                        if ($tokens[$i]['line'] === $tokens[$nextContent]['line']) {
+                            $phpcsFile->fixer->addContentBefore($i, str_repeat($phpcsFile->eolChar, $requiredSpacing));
+                            break;
+                        }
+
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
 
-                    $phpcsFile->fixer->replaceToken($i, str_repeat($phpcsFile->eolChar, $requiredSpacing));
                     $phpcsFile->fixer->endChangeset();
                 }
             }//end if

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -302,7 +302,7 @@ class FunctionSpacingSniff implements Sniff
 
                 if ($foundLines < $requiredSpacing) {
                     $padding = str_repeat($phpcsFile->eolChar, ($requiredSpacing - $foundLines));
-                    $phpcsFile->fixer->addContent($nextSpace, $padding);
+                    $phpcsFile->fixer->addContentBefore($nextSpace, $padding);
                 } else {
                     $nextContent = $phpcsFile->findNext(T_WHITESPACE, ($nextSpace + 1), null, true);
                     $phpcsFile->fixer->beginChangeset();

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -362,3 +362,34 @@ $util->setLogger(new class {
 function functionInEmbeddedPHP() {
 
 }
+
+// Make sure the indentation for the function comment does not get removed.
+class MyClass
+{
+
+    protected $tag = '';
+
+
+
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func1() {}
+
+}//end class
+
+class MyClass
+{
+
+
+
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func1() {}
+
+}//end class

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -393,3 +393,21 @@ class MyClass
     function func1() {}
 
 }//end class
+
+class MyClass
+{
+    // Unrelated comment.
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func1() {}
+    // phpcs:disable Standard.Category.Sniff -- for reasons.
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func2() {}
+}//end class

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -405,3 +405,30 @@ $util->setLogger(new class {
 function functionInEmbeddedPHP() {
 
 }
+
+// Make sure the indentation for the function comment does not get removed.
+class MyClass
+{
+
+    protected $tag = '';
+
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func1() {}
+
+}//end class
+
+class MyClass
+{
+
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func1() {}
+
+}//end class

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -432,3 +432,25 @@ class MyClass
     function func1() {}
 
 }//end class
+
+class MyClass
+{
+    // Unrelated comment.
+
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func1() {}
+
+    // phpcs:disable Standard.Category.Sniff -- for reasons.
+
+    /**
+     * Function comment.
+     *
+     * @return boolean
+     */
+    function func2() {}
+
+}//end class

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -60,6 +60,8 @@ class FunctionSpacingUnitTest extends AbstractSniffUnitTest
             354 => 2,
             355 => 1,
             356 => 1,
+            379 => 1,
+            393 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -62,6 +62,8 @@ class FunctionSpacingUnitTest extends AbstractSniffUnitTest
             356 => 1,
             379 => 1,
             393 => 1,
+            405 => 2,
+            412 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
When too many blank lines are found before a function, the `Before/BeforeFirst` fixer would unnecessarily also remove the indentation of the `$nextContent` line, meaning that this sniff would **always** need to be accompanied by one or more sniffs to fix the indentation again.

As this sniff is about blank lines between functions, not about indentation, I consider this a bug.

This minor change fixes it.

Includes unit tests demonstrating the issue.