### PR TITLE
[PSR12] Add return type sniff

### DIFF
--- a/src/Standards/Generic/Docs/Functions/ReturnTypeDeclarationStandard.xml
+++ b/src/Standards/Generic/Docs/Functions/ReturnTypeDeclarationStandard.xml
@@ -1,0 +1,27 @@
+<documentation title="Return Type Declaration">
+    <standard>
+        <![CDATA[
+        Return type declarations are optional, and have a specified amount of spaces between the function's closing parenthesis and colon, and a
+        specified amount of spaces between the colon and the return type.
+        The default is zero spaces between closing parenthesis and colon and one space between colon and return type.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Zero spaces between closing parenthesis and colon, one space between colon and return type.">
+            <![CDATA[
+function fooFunction()<em>: string</em>
+{
+...
+}
+        ]]>
+        </code>
+        <code title="Invalid: One space between closing parenthesis and colon, zero spaces between colon and return type.">
+            <![CDATA[
+function fooFunction()<em> :string</em>
+{
+ ...
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/Functions/ReturnTypeDeclarationSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/ReturnTypeDeclarationSniff.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Checks for return type declarations if the spacing between a function's closing parenthesis,
+ * colon, and return type is correct
+ *
+ * @author    Arent van Korlaar <avkorlaar@hostnet.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Functions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ReturnTypeDeclarationSniff implements Sniff
+{
+
+    /**
+     * Number of spaces between the function's closing parenthesis and colon.
+     *
+     * @var integer
+     */
+    public $numSpacesClosingParenthesisColon = 0;
+
+    /**
+     * Number of spaces between the colon and the return type.
+     *
+     * @var integer
+     */
+    public $numSpacesColonReturnType = 1;
+
+    /**
+     * Ignore new lines when true
+     *
+     * @var boolean
+     */
+    public $ignoreNewLines = false;
+
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION,
+            T_CLOSURE,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $closingParenthesisPosition = $this->getClosingParenthesis($phpcsFile, $tokens, $stackPtr);
+        $endPosition = $this->getCharacterAfterReturnTypeDeclaration($phpcsFile, $tokens, $stackPtr);
+
+        $tokensToFind = [
+            T_COLON,
+            T_RETURN_TYPE,
+            T_WHITESPACE,
+        ];
+
+        $closingParenthesisColonSpacing = $colonReturnTypeSpacing = $acc = '';
+
+        $nextSeparator = $closingParenthesisPosition;
+        while (($nextSeparator = $phpcsFile->findNext($tokensToFind, ($nextSeparator + 1), $endPosition)) !== false) {
+            if ($tokens[$nextSeparator]['code'] === T_COLON) {
+                $closingParenthesisColonSpacing = $acc;
+                $acc           = '';
+                $colonPosition = $nextSeparator;
+            } else if ($tokens[$nextSeparator]['code'] === T_RETURN_TYPE) {
+                $colonReturnTypeSpacing = $acc;
+                $acc = '';
+                $returnTypePosition = $nextSeparator;
+            } else {
+                $acc = $acc.$tokens[($nextSeparator)]['content'];
+            }
+        }
+
+        if (isset($colonPosition) === false || isset($returnTypePosition) === false) {
+            // No return type declaration found, so nothing to sniff.
+            return;
+        }
+
+        if ($this->ignoreNewLines === true) {
+            $closingParenthesisColonSpacing = preg_replace("/[\n\r]/", "", $closingParenthesisColonSpacing);
+            $colonReturnTypeSpacing         = preg_replace("/[\n\r]/", "", $colonReturnTypeSpacing);
+        }
+
+        $configuredSpacesClosingParenthesisColon = str_repeat(' ', $this->numSpacesClosingParenthesisColon);
+        $configuredSpacesColonReturnType         = str_repeat(' ', $this->numSpacesColonReturnType);
+
+        if ($closingParenthesisColonSpacing === $configuredSpacesClosingParenthesisColon
+            && $colonReturnTypeSpacing === $configuredSpacesColonReturnType
+        ) {
+            // The spacing is ok.
+            return;
+        }
+
+        $errorMessage = sprintf(
+            "Expected \")%s:%sreturntype\";found \")%s:%sreturntype\"",
+            $configuredSpacesClosingParenthesisColon,
+            $configuredSpacesColonReturnType,
+            $closingParenthesisColonSpacing,
+            $colonReturnTypeSpacing
+        );
+
+        $errorMessage = str_replace("\r\n", '\n', $errorMessage);
+        $errorMessage = str_replace("\n", '\n', $errorMessage);
+        $errorMessage = str_replace("\r", '\r', $errorMessage);
+        $errorMessage = str_replace("\t", '\t', $errorMessage);
+        $errorMessage = str_replace('EOL', '\n', $errorMessage);
+
+        if ($phpcsFile->addFixableError($errorMessage, $stackPtr, 'ReturnTypeDeclarationSpacing') === false) {
+            return;
+        }
+
+        if ($closingParenthesisColonSpacing !== $configuredSpacesClosingParenthesisColon) {
+            $this->fixSpacing(
+                $phpcsFile,
+                $tokens,
+                $configuredSpacesClosingParenthesisColon,
+                $closingParenthesisPosition,
+                $colonPosition
+            );
+        }
+
+        if ($colonReturnTypeSpacing !== $configuredSpacesColonReturnType) {
+            $this->fixSpacing(
+                $phpcsFile,
+                $tokens,
+                $configuredSpacesColonReturnType,
+                $colonPosition,
+                $returnTypePosition
+            );
+        }
+
+    }//end process()
+
+
+    /**
+     * Get the position of a function's closing parenthesis within the
+     * token stack.
+     *
+     * @param File  $phpcsFile The file being scanned.
+     * @param array $tokens    Token stack for this file
+     * @param int   $stackPtr  The position of the current token
+     *                         in the stack passed in $tokens.
+     *
+     * @return int position within the token stack
+     */
+    private function getClosingParenthesis(File $phpcsFile, array $tokens, $stackPtr)
+    {
+        $closingParenthesis = $tokens[$stackPtr]['parenthesis_closer'];
+
+        // In case the function is a closure, the closing parenthesis
+        // may be positioned after a use language construct.
+        if ($tokens[$stackPtr]['code'] === T_CLOSURE) {
+            $use = $phpcsFile->findNext(T_USE, ($closingParenthesis + 1), $tokens[$stackPtr]['scope_opener']);
+            if ($use !== false) {
+                $openBracket        = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($use + 1));
+                $closingParenthesis = $tokens[$openBracket]['parenthesis_closer'];
+            }
+        }
+
+        return $closingParenthesis;
+
+    }//end getClosingParenthesis()
+
+
+    /**
+     * Get the position of first character after the return type declaration
+     * within the token stack.
+     * This can be an opening brace, or, in case of an interface,
+     * a semicolon.
+     *
+     * @param File  $phpcsFile The file being scanned.
+     * @param array $tokens    Token stack for this file
+     * @param int   $stackPtr  The position of the current token
+     *                         in the stack passed in $tokens.
+     *
+     * @return int position within the token stack
+     */
+    private function getCharacterAfterReturnTypeDeclaration(File $phpcsFile, array $tokens, $stackPtr)
+    {
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            $endPosition = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
+        } else {
+            $endPosition = $tokens[$stackPtr]['scope_opener'];
+        }
+
+        return $endPosition;
+
+    }//end getCharacterAfterReturnTypeDeclaration()
+
+
+    /**
+     * Fix the spacing to the required spacing between start and end
+     *
+     * @param File   $phpcsFile       The file being scanned.
+     * @param array  $tokens          Token stack for this file
+     * @param string $requiredSpacing Required spacing between start and end
+     * @param int    $start           Position of the start in the token stack
+     * @param int    $end             Position of the end in the token stack
+     *
+     * @return void
+     */
+    private function fixSpacing(File $phpcsFile, $tokens, $requiredSpacing, $start, $end)
+    {
+        // Currently there is no spacing, but spacing should be added.
+        if (($start + 1) === $end && empty($requiredSpacing) === false) {
+            $phpcsFile->fixer->addContent(
+                $start,
+                $requiredSpacing
+            );
+
+            return;
+        }
+
+        // There is a variable amount of spacing. Remove spacing, and insert the required spacing.
+        for ($i = ($start + 1); $i < $end; $i++) {
+            if ($tokens[$i]['code'] === T_WHITESPACE) {
+                if ($this->ignoreNewLines === true
+                    && isset($tokens[$i]['content']) === true
+                    && preg_match("/[\n\r]/", $tokens[$i]['content']) === 1
+                ) {
+                    continue;
+                }
+
+                if (($i + 1) === $end) {
+                    $phpcsFile->fixer->replaceToken($i, $requiredSpacing);
+                    break;
+                } else {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+            }
+        }
+
+    }//end fixSpacing()
+
+
+}//end class

--- a/src/Standards/Generic/Sniffs/Functions/ReturnTypeDeclarationSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/ReturnTypeDeclarationSniff.php
@@ -70,7 +70,7 @@ class ReturnTypeDeclarationSniff implements Sniff
 
         $tokensToFind = [
             T_COLON,
-            T_RETURN_TYPE,
+            T_STRING,
             T_WHITESPACE,
         ];
 
@@ -82,7 +82,7 @@ class ReturnTypeDeclarationSniff implements Sniff
                 $closingParenthesisColonSpacing = $acc;
                 $acc           = '';
                 $colonPosition = $nextSeparator;
-            } else if ($tokens[$nextSeparator]['code'] === T_RETURN_TYPE) {
+            } else if ($tokens[$nextSeparator]['code'] === T_STRING) {
                 $colonReturnTypeSpacing = $acc;
                 $acc = '';
                 $returnTypePosition = $nextSeparator;

--- a/src/Standards/Generic/Sniffs/Functions/ReturnTypeDeclarationSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/ReturnTypeDeclarationSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Functions;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class ReturnTypeDeclarationSniff implements Sniff
 {
@@ -125,7 +126,18 @@ class ReturnTypeDeclarationSniff implements Sniff
         $errorMessage = str_replace("\t", '\t', $errorMessage);
         $errorMessage = str_replace('EOL', '\n', $errorMessage);
 
-        if ($phpcsFile->addFixableError($errorMessage, $stackPtr, 'ReturnTypeDeclarationSpacing') === false) {
+        // Ensure we don't affect inline comments when automatically fixing.
+        $find    = Tokens::$phpcsCommentTokens;
+        $find[]  = T_COMMENT;
+        $comment = $phpcsFile->findNext($find, $closingParenthesisPosition, $endPosition);
+        if ($comment === false) {
+            $fix = $phpcsFile->addFixableError($errorMessage, $stackPtr, 'ReturnTypeDeclarationSpacing');
+        } else {
+            $fix = false;
+            $phpcsFile->addError($errorMessage, $stackPtr, 'ReturnTypeDeclarationSpacing');
+        }
+
+        if ($fix === false) {
             return;
         }
 

--- a/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc
@@ -219,5 +219,31 @@ namespace ReturnTypeVariations
     {
         return;
     };
-}
 
+    $func = function() use($a):
+    string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+
+    $func = function() use($a): // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    string
+    {
+        return;
+    };
+
+    $func = function() use($a):string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+
+    $func = function() use($a) :string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+
+    $func = function() use($a) : string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+}

--- a/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc
@@ -1,0 +1,223 @@
+<?php
+// Shameless copy from:
+// https://gist.githubusercontent.com/michaelcullum/c025f3870c9ea1dd2668/raw/0b6bec832b1bb30689e2271d4e931ddfba378718/returnTypesSpacing.php
+
+// Chosen approach is to consider the closing parameter bracket and
+// colon look visually as one character so no space between parenthesis and colon
+// and have a preceding space before the type declaration. Demonstrated in method
+// named `this()`
+
+class ReturnTypeVariations
+{
+    public function this(): string
+    {
+        return;
+    }
+
+    public function func() :string
+    {
+        return;
+    }
+
+    public function func() : string
+    {
+        return;
+    }
+
+    public function func():string
+    {
+        return;
+    }
+
+    public function func()
+    :string{
+        return;
+    }
+
+    public function func()
+    :string {
+        return;
+    }
+
+    public function func()
+    : string {
+        return;
+    }
+
+    public function func()
+    :string
+    {
+        return;
+    }
+
+    public function func()
+    : string
+    {
+        return;
+    }
+
+    public function func():
+    string
+    {
+        return;
+    }
+
+    public function func()
+    {
+        return;
+    }
+}
+
+public function this(): string
+{
+    return;
+}
+
+public function func() :string
+{
+    return;
+}
+
+public function func() : string
+{
+    return;
+}
+
+public function func():string
+{
+    return;
+}
+
+public function func()
+:string{
+    return;
+}
+
+public function func()
+:string {
+    return;
+}
+
+public function func()
+: string {
+    return;
+}
+
+public function func()
+:string
+{
+    return;
+}
+
+public function func()
+: string
+{
+    return;
+}
+
+public function func():
+string
+{
+    return;
+}
+
+public function func()
+{
+    return;
+}
+
+interface ReturnTypeVariations
+{
+    public function this(): string;
+
+    public function func() :string;
+
+    public function func() : string;
+
+    public function func():string;
+
+    public function func()
+    :string;
+
+    public function func()
+    :string ;
+
+    public function func()
+    : string ;
+
+    public function func()
+    :string
+    ;
+
+    public function func()
+    : string
+    ;
+
+    public function func():
+    string
+    ;
+
+    public function func();
+}
+
+namespace ReturnTypeVariations
+{
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a) :string
+    {
+        return;
+    };
+
+    $func = function() use($a) : string
+    {
+        return;
+    };
+
+    $func = function() use($a):string
+    {
+        return;
+    };
+
+    $func = function() use($a)
+    :string{
+        return;
+    };
+
+    $func = function() use($a)
+    :string {
+        return;
+    };
+
+    $func = function() use($a)
+    : string {
+        return;
+    };
+
+    $func = function() use($a)
+    :string
+    {
+        return;
+    };
+
+    $func = function() use($a)
+    : string
+    {
+        return;
+    };
+
+    $func = function() use($a):
+    string
+    {
+        return;
+    };
+
+    $func = function() use($a)
+    {
+        return;
+    };
+}
+

--- a/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc.fixed
@@ -195,5 +195,31 @@ namespace ReturnTypeVariations
     {
         return;
     };
-}
 
+    $func = function() use($a):
+    string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+
+    $func = function() use($a): // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    string
+    {
+        return;
+    };
+
+    $func = function() use($a):string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+
+    $func = function() use($a) :string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+
+    $func = function() use($a) : string // phpcs:ignore Standard.Category.Sniff -- for reasons.
+    {
+        return;
+    };
+}

--- a/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.inc.fixed
@@ -1,0 +1,199 @@
+<?php
+// Shameless copy from:
+// https://gist.githubusercontent.com/michaelcullum/c025f3870c9ea1dd2668/raw/0b6bec832b1bb30689e2271d4e931ddfba378718/returnTypesSpacing.php
+
+// Chosen approach is to consider the closing parameter bracket and
+// colon look visually as one character so no space between parenthesis and colon
+// and have a preceding space before the type declaration. Demonstrated in method
+// named `this()`
+
+class ReturnTypeVariations
+{
+    public function this(): string
+    {
+        return;
+    }
+
+    public function func(): string
+    {
+        return;
+    }
+
+    public function func(): string
+    {
+        return;
+    }
+
+    public function func(): string
+    {
+        return;
+    }
+
+    public function func(): string{
+        return;
+    }
+
+    public function func(): string {
+        return;
+    }
+
+    public function func(): string {
+        return;
+    }
+
+    public function func(): string
+    {
+        return;
+    }
+
+    public function func(): string
+    {
+        return;
+    }
+
+    public function func(): string
+    {
+        return;
+    }
+
+    public function func()
+    {
+        return;
+    }
+}
+
+public function this(): string
+{
+    return;
+}
+
+public function func(): string
+{
+    return;
+}
+
+public function func(): string
+{
+    return;
+}
+
+public function func(): string
+{
+    return;
+}
+
+public function func(): string{
+    return;
+}
+
+public function func(): string {
+    return;
+}
+
+public function func(): string {
+    return;
+}
+
+public function func(): string
+{
+    return;
+}
+
+public function func(): string
+{
+    return;
+}
+
+public function func(): string
+{
+    return;
+}
+
+public function func()
+{
+    return;
+}
+
+interface ReturnTypeVariations
+{
+    public function this(): string;
+
+    public function func(): string;
+
+    public function func(): string;
+
+    public function func(): string;
+
+    public function func(): string;
+
+    public function func(): string ;
+
+    public function func(): string ;
+
+    public function func(): string
+    ;
+
+    public function func(): string
+    ;
+
+    public function func(): string
+    ;
+
+    public function func();
+}
+
+namespace ReturnTypeVariations
+{
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a): string{
+        return;
+    };
+
+    $func = function() use($a): string {
+        return;
+    };
+
+    $func = function() use($a): string {
+        return;
+    };
+
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a): string
+    {
+        return;
+    };
+
+    $func = function() use($a)
+    {
+        return;
+    };
+}
+

--- a/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Unit test class for the ReturnTypeDeclaration sniff.
+ *
+ * @author    Arent van Korlaar <avkorlaar@hostnet.nl>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            17  => 1,
+            22  => 1,
+            27  => 1,
+            32  => 1,
+            37  => 1,
+            42  => 1,
+            47  => 1,
+            53  => 1,
+            59  => 1,
+            76  => 1,
+            81  => 1,
+            86  => 1,
+            91  => 1,
+            96  => 1,
+            101 => 1,
+            106 => 1,
+            112 => 1,
+            118 => 1,
+            133 => 1,
+            135 => 1,
+            137 => 1,
+            139 => 1,
+            142 => 1,
+            145 => 1,
+            148 => 1,
+            152 => 1,
+            156 => 1,
+            170 => 1,
+            175 => 1,
+            180 => 1,
+            185 => 1,
+            190 => 1,
+            195 => 1,
+            200 => 1,
+            206 => 1,
+            212 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/ReturnTypeDeclarationUnitTest.php
@@ -62,6 +62,11 @@ class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
             200 => 1,
             206 => 1,
             212 => 1,
+            223 => 1,
+            229 => 1,
+            235 => 1,
+            240 => 1,
+            245 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -181,6 +181,7 @@
     <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
 
     <!-- When you have a return type declaration present there MUST be one space after the colon followed by the type declaration. The colon and declaration MUST be on the same line as the argument list closing parentheses with no spaces between the two characters. -->
+    <rule ref="Generic.Functions.ReturnTypeDeclaration"/>
 
     <!-- In nullable type declarations there MUST NOT be a space between the question mark and the type. -->
 


### PR DESCRIPTION
Following on from the amazing work done by @akvankorlaar in #1219 this PR:
* Updates it to handle the breaking change from 1f55125d76385c48a36801628d40be1f482cf7ac
* Changes the auto-fixer to prevent it from affecting inline comments (pointed out by @jrfnl and @gsherwood)
* Add some tests for inline comments
* Defines it as part of PSR-12