### PR TITLE
Report info: minor sorting improvement

### DIFF
--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -123,7 +123,7 @@ class Info implements Report
 
                 echo "$metric:".PHP_EOL;
 
-                ksort($values);
+                ksort($values, SORT_NATURAL);
                 arsort($values);
 
                 $percentPrefixWidth = 0;


### PR DESCRIPTION
Just realized that I hadn't added this to the previous PR #2103 yet.

As the metric keys may be numeric, the `SORT_NATURAL` flag (introduced in PHP 5.4) will ensure that numbers with equal counts will be sorted properly, i.e.:
Without this these would be sorted like:
```
1  => 10 (... %)
12 => 10 (... %)
2  => 10 (... %)
```
Now they will be sorted like so:
```
1  => 10 (... %)
2  => 10 (... %)
12 => 10 (... %)
```