### PR TITLE
Squiz.PHP.DisallowMultipleAssignments false positive in while loop conditions

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -52,6 +52,18 @@ class DisallowMultipleAssignmentsSniff implements Sniff
             }
         }
 
+        // Ignore assignments in WHILE loop conditions.
+        if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
+            $nested = $tokens[$stackPtr]['nested_parenthesis'];
+            foreach ($nested as $opener => $closer) {
+                if (isset($tokens[$opener]['parenthesis_owner']) === true
+                    && $tokens[$tokens[$opener]['parenthesis_owner']]['code'] === T_WHILE
+                ) {
+                    return;
+                }
+            }
+        }
+
         /*
             The general rule is:
             Find an equal sign and go backwards along the line. If you hit an
@@ -122,10 +134,10 @@ class DisallowMultipleAssignmentsSniff implements Sniff
 
         // Ignore the first part of FOR loops as we are allowed to
         // assign variables there even though the variable is not the
-        // first thing on the line. Also ignore WHILE loops.
+        // first thing on the line.
         if ($tokens[$varToken]['code'] === T_OPEN_PARENTHESIS && isset($tokens[$varToken]['parenthesis_owner']) === true) {
             $owner = $tokens[$varToken]['parenthesis_owner'];
-            if ($tokens[$owner]['code'] === T_FOR || $tokens[$owner]['code'] === T_WHILE) {
+            if ($tokens[$owner]['code'] === T_FOR) {
                 return;
             }
         }

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
@@ -56,3 +56,9 @@ $obj->$classVar = $prefix.'-'.$type;
 $closureWithDefaultParamter = function(array $testArray=array()) {};
 ?>
 <?php $var = false; ?>
+
+<?php
+
+while ( ( $csvdata = fgetcsv( $handle, 2000, $separator ) ) !== false ) {
+	// Do something.
+}


### PR DESCRIPTION
A variable assignment in the condition of a `while` loop may well be enclosed in additional parenthesis to prevent issues with operator precedence when comparing the assigned value within the same condition.

Example:
```php
while ( ( $csvdata = fgetcsv( $handle, 2000, $separator ) ) !== false ) {}
```

Previously only the lowest level `parenthesis_owner` would be examined to determine whether or not to report this as an error. Now, for `while` loops only, the parenthesis owners of all nested parenthesis will be examined.

Examining them early on in the sniff as the rest of the logic is superfluous if the assignment should be ignored anyway.

Includes unit test.