### PR TITLE
Generic/NoSilencedErrors: improve the usefulness of the error message

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -53,12 +53,22 @@ class NoSilencedErrorsSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        // Prepare the "Found" string to display.
+        $contextLength  = 4;
+        $endOfStatement = $phpcsFile->findEndOfStatement($stackPtr, T_COMMA);
+        if (($endOfStatement - $stackPtr) < $contextLength) {
+            $contextLength = ($endOfStatement - $stackPtr);
+        }
+
+        $found = $phpcsFile->getTokensAsString($stackPtr, $contextLength);
+        $found = str_replace(["\t", "\n", "\r"], ' ', $found).'...';
+
         if ($this->error === true) {
-            $error = 'Silencing errors is forbidden';
-            $phpcsFile->addError($error, $stackPtr, 'Forbidden');
+            $error = 'Silencing errors is forbidden. Found: %s';
+            $phpcsFile->addError($error, $stackPtr, 'Forbidden', [$found]);
         } else {
-            $error = 'Silencing errors is discouraged';
-            $phpcsFile->addWarning($error, $stackPtr, 'Discouraged');
+            $error = 'Silencing errors is discouraged. Found: %s';
+            $phpcsFile->addWarning($error, $stackPtr, 'Discouraged', [$found]);
         }
 
     }//end process()


### PR DESCRIPTION
... by showing a snippet of the context in which the error silence operator was found.