### PR TITLE
File::findExtendedClassName() doesn't support nested classes

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2377,12 +2377,12 @@ class File
             return false;
         }
 
-        if (isset($this->tokens[$stackPtr]['scope_closer']) === false) {
+        if (isset($this->tokens[$stackPtr]['scope_opener']) === false) {
             return false;
         }
 
-        $classCloserIndex = $this->tokens[$stackPtr]['scope_closer'];
-        $extendsIndex     = $this->findNext(T_EXTENDS, $stackPtr, $classCloserIndex);
+        $classOpenerIndex = $this->tokens[$stackPtr]['scope_opener'];
+        $extendsIndex     = $this->findNext(T_EXTENDS, $stackPtr, $classOpenerIndex);
         if (false === $extendsIndex) {
             return false;
         }
@@ -2393,7 +2393,7 @@ class File
             T_WHITESPACE,
         ];
 
-        $end  = $this->findNext($find, ($extendsIndex + 1), $classCloserIndex, true);
+        $end  = $this->findNext($find, ($extendsIndex + 1), ($classOpenerIndex + 1), true);
         $name = $this->getTokensAsString(($extendsIndex + 1), ($end - $extendsIndex - 1));
         $name = trim($name);
 

--- a/tests/Core/File/FindExtendedClassNameTest.inc
+++ b/tests/Core/File/FindExtendedClassNameTest.inc
@@ -22,3 +22,11 @@ interface testInterfaceThatExtendsInterface extends testFECNInterface{}
 
 /* testInterfaceThatExtendsFQCNInterface */
 interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\Core\File\testFECNInterface{}
+
+/* testNestedExtendedClass */
+class testFECNNestedExtendedClass {
+	public function someMethod() {
+		/* testNestedExtendedAnonClass */
+		$anon = new class extends testFECNAnonClass {};
+	}
+}

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -191,4 +191,49 @@ class FindExtendedClassNameTest extends TestCase
     }//end testExtendedNamespacedInterface()
 
 
+    /**
+     * Test a non-extended class with a nested class which does extend another class.
+     *
+     * @return void
+     */
+    public function testNestedExtendedClass()
+    {
+        $start = ($this->phpcsFile->numTokens - 1);
+        $class = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testNestedExtendedClass */'
+        );
+
+        $found = $this->phpcsFile->findExtendedClassName(($class + 2));
+        $this->assertFalse($found);
+
+    }//end testNestedExtendedClass()
+
+
+    /**
+     * Test a nested anonymous class that extends a named class.
+     *
+     * @return void
+     */
+    public function testNestedExtendedAnonClass()
+    {
+        $start = ($this->phpcsFile->numTokens - 1);
+        $class = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            '/* testNestedExtendedAnonClass */'
+        );
+        $class = $this->phpcsFile->findNext(T_ANON_CLASS, ($class + 1));
+
+        $found = $this->phpcsFile->findExtendedClassName($class);
+        $this->assertSame('testFECNAnonClass', $found);
+
+    }//end testNestedExtendedAnonClass()
+
+
 }//end class


### PR DESCRIPTION
The method used the class scope closer to end searches, which meant that a non-extended class which contained a nested extended class would return the extended class name of the nested class, instead of `false`.

Switching this to the scope opener, fixes this.

Included unit tests.