### PR TITLE
File: add new `File::findExtendedInterfaceNames()` utility method

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -80,6 +80,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="FindEndOfStatementTest.php" role="test" />
       <file baseinstalldir="" name="FindExtendedClassNameTest.inc" role="test" />
       <file baseinstalldir="" name="FindExtendedClassNameTest.php" role="test" />
+      <file baseinstalldir="" name="FindExtendedInterfaceNamesTest.inc" role="test" />
+      <file baseinstalldir="" name="FindExtendedInterfaceNamesTest.php" role="test" />
       <file baseinstalldir="" name="FindImplementedInterfaceNamesTest.inc" role="test" />
       <file baseinstalldir="" name="FindImplementedInterfaceNamesTest.php" role="test" />
       <file baseinstalldir="" name="GetMemberPropertiesTest.inc" role="test" />

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -16,6 +16,7 @@ require_once 'IsCamelCapsTest.php';
 require_once 'ErrorSuppressionTest.php';
 require_once 'File/FindEndOfStatementTest.php';
 require_once 'File/FindExtendedClassNameTest.php';
+require_once 'File/FindExtendedInterfaceNamesTest.php';
 require_once 'File/FindImplementedInterfaceNamesTest.php';
 require_once 'File/GetMemberPropertiesTest.php';
 require_once 'File/GetMethodParametersTest.php';
@@ -50,6 +51,7 @@ class AllTests
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\ErrorSuppressionTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindEndOfStatementTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindExtendedClassNameTest');
+        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindExtendedInterfaceNamesTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindImplementedInterfaceNamesTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMemberPropertiesTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodParametersTest');

--- a/tests/Core/File/FindExtendedInterfaceNamesTest.inc
+++ b/tests/Core/File/FindExtendedInterfaceNamesTest.inc
@@ -1,0 +1,31 @@
+<?php
+/* @codingStandardsIgnoreFile */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+interface testFEINInterface2 {}
+
+/* testInterface */
+interface testFEINInterface {}
+
+/* testExtendedInterface */
+interface testFEINExtendedInterface extends testFEINInterface {}
+
+/* testMultiExtendedInterface */
+interface testFEINMultiExtendedInterface extends testFEINInterface, testFEINInterface2 {}
+
+/* testNamespacedInterface */
+interface testFEINNamespacedInterface extends \PHP_CodeSniffer\Tests\Core\File\testFEINInterface {}
+
+/* testMultiNamespacedInterface */
+interface testFEINMultiNamespacedInterface extends \PHP_CodeSniffer\Tests\Core\File\testFEINInterface, \PHP_CodeSniffer\Tests\Core\File\testFEINInterface2 {}
+
+/* testMultiExtendedInterfaceWithComment */
+interface testFEINMultiExtendedInterface
+	extends
+		/* a comment */
+		testFEINInterface,
+		\PHP_CodeSniffer\Tests /* comment */ \Core \ File \testFEINInterface2,
+		\testFEINInterface3 /* comment */
+{
+}

--- a/tests/Core/File/FindExtendedInterfaceNamesTest.php
+++ b/tests/Core/File/FindExtendedInterfaceNamesTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:findExtendedInterfaceNames method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Files\DummyFile;
+use PHPUnit\Framework\TestCase;
+
+class FindExtendedInterfaceNamesTest extends TestCase
+{
+
+    /**
+     * The \PHP_CodeSniffer\Files\File object containing parsed contents of the test case file.
+     *
+     * @var \PHP_CodeSniffer\Files\File
+     */
+    private $phpcsFile;
+
+
+    /**
+     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
+     *
+     * Methods used for these tests can be found in a test case file in the same
+     * directory and with the same name, using the .inc extension.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $config            = new Config();
+        $config->standards = ['Generic'];
+
+        $ruleset = new Ruleset($config);
+
+        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
+        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
+        $this->phpcsFile->process();
+
+    }//end setUp()
+
+
+    /**
+     * Clean up after finished test.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->phpcsFile);
+
+    }//end tearDown()
+
+
+    /**
+     * Test retrieving the names of the interfaces being extended by another interface.
+     *
+     * @param string $identifier Comment which preceeds the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @dataProvider dataExtendedInterface
+     *
+     * @return void
+     */
+    public function testFindExtendedInterfaceNames($identifier, $expected)
+    {
+        $start     = ($this->phpcsFile->numTokens - 1);
+        $delim     = $this->phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            $identifier
+        );
+        $interface = $this->phpcsFile->findNext(T_INTERFACE, ($delim + 1));
+
+        $result = $this->phpcsFile->findExtendedInterfaceNames($interface);
+        $this->assertSame($expected, $result);
+
+    }//end testFindExtendedInterfaceNames()
+
+
+    /**
+     * Data provider for the FindExtendedInterfaceNames test.
+     *
+     * @see testFindExtendedInterfaceNames()
+     *
+     * @return array
+     */
+    public function dataExtendedInterface()
+    {
+        return [
+            [
+                '/* testInterface */',
+                false,
+            ],
+            [
+                '/* testExtendedInterface */',
+                ['testFEINInterface'],
+            ],
+            [
+                '/* testMultiExtendedInterface */',
+                [
+                    'testFEINInterface',
+                    'testFEINInterface2',
+                ],
+            ],
+            [
+                '/* testNamespacedInterface */',
+                ['\PHP_CodeSniffer\Tests\Core\File\testFEINInterface'],
+            ],
+            [
+                '/* testMultiNamespacedInterface */',
+                [
+                    '\PHP_CodeSniffer\Tests\Core\File\testFEINInterface',
+                    '\PHP_CodeSniffer\Tests\Core\File\testFEINInterface2',
+                ],
+            ],
+            [
+                '/* testMultiExtendedInterfaceWithComment */',
+                [
+                    'testFEINInterface',
+                    '\PHP_CodeSniffer\Tests\Core\File\testFEINInterface2',
+                    '\testFEINInterface3',
+                ],
+            ],
+        ];
+
+    }//end dataExtendedInterface()
+
+
+}//end class


### PR DESCRIPTION
As I've just looked at the `findExtendedClassName()` method again for PR #2127, I remembered that @SenseException reported another issue with it a while back via Twitter: https://twitter.com/SenseException/status/997988691468484609.

Summary: interfaces can extend more than one interface (in contrast to classes) and the `findExtendedClassName()` method does not allow for that.
See: http://php.net/manual/en/language.oop5.interfaces.php#example-208

To allow for this from within the existing `findExtendedClassName()` method would change the function signature from `@return string|false` to `@return string|array|false`, thus breaking the API.

So, instead, I've elected to add a new `File::findExtendedInterfaceNames()` method and to recommend using that method for interfaces in the documentation of the `findExtendedClassName()` method .

As the logic needed for these two methods, as well as for the `findImplementedInterfaces()` method, is basically the same, I've extracted the logic out to a private `File::examineObjectDeclarationSignature()` method which is now called by all three functions to DRY out the code.

Includes dedicated unit tests for the new method.