### PR TITLE
FindImplementedInterfaceNamesTest: Remove redundant line

### DIFF
--- a/tests/Core/File/FindImplementedInterfaceNamesTest.inc
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.inc
@@ -3,7 +3,6 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-\PHP_CodeSniffer\Tests\Core\File\testFECNClass
 interface testFIINInterface2 {}
 
 /* testInterface */


### PR DESCRIPTION
Looks like this line was copied/pasted at some point, but has no function in this test file, so removing it.