### PR TITLE
Adds InconsistentReturnSniff

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class InconsistentReturnSniff implements Sniff
 {
 
+
     /**
      * Returns an array of tokens this test wants to listen for.
      *
@@ -23,10 +24,10 @@ class InconsistentReturnSniff implements Sniff
      */
     public function register()
     {
-        return [
-            T_FUNCTION
-        ];
-    }
+        return [T_FUNCTION];
+
+    }//end register()
+
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -37,20 +38,19 @@ class InconsistentReturnSniff implements Sniff
      *
      * @return void
      */
-    public function process( File $phpcsFile, $stackPtr )
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         $returnCount = 0;
         $funcLevel   = $tokens[$stackPtr]['level'];
 
-        if (empty($tokens[$stackPtr]['scope_opener'])) {
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
             return;
         }
 
         $markerPtr = $tokens[$stackPtr]['scope_opener'];
         while (($markerPtr = $phpcsFile->findNext([ T_RETURN, T_THROW ], ($markerPtr + 1), $tokens[$stackPtr]['scope_closer'])) !== false) {
-
             $nextPtr = $phpcsFile->findNext(T_WHITESPACE, ($markerPtr + 1), null, true);
             if ($tokens[$nextPtr]['code'] === T_SEMICOLON) {
                 return;
@@ -70,7 +70,7 @@ class InconsistentReturnSniff implements Sniff
 
                 if ($code === T_SWITCH) {
                     $casePtr = $phpcsFile->findPrevious([ T_CASE, T_DEFAULT ], $markerPtr);
-                    if ($casePtr && $tokens[$casePtr]['code'] === T_DEFAULT) {
+                    if ($casePtr !== false && $tokens[$casePtr]['code'] === T_DEFAULT) {
                         $markerLevel--;
                     }
                 }
@@ -80,16 +80,18 @@ class InconsistentReturnSniff implements Sniff
                 $returnCount++;
             }
 
-            if ($markerLevel == $funcLevel + 1) {
+            if ($markerLevel === ($funcLevel + 1)) {
                 return;
             }
-        }
+        }//end while
 
-        if ($returnCount == 0) {
+        if ($returnCount === 0) {
             return;
         }
 
-		$phpcsFile->addWarning("Not all paths through function return a value or throw exception.", $stackPtr, 'NotAllReturn');
-    }
+        $phpcsFile->addWarning("Not all paths through function return a value or throw exception.", $stackPtr, 'NotAllReturn');
 
-}
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
@@ -61,8 +61,9 @@ class InconsistentReturnSniff implements Sniff
                     continue 2;
                 }
 
-                if ($code === T_CATCH) {
+                if ($code === T_CATCH || $code === T_ELSE) {
                     $markerLevel--;
+                    continue;
                 }
 
                 if ($code === T_SWITCH) {

--- a/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
@@ -13,84 +13,83 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Functions;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
-class InconsistentReturnSniff implements Sniff {
+class InconsistentReturnSniff implements Sniff
+{
 
-	/**
-	 * Returns an array of tokens this test wants to listen for.
-	 *
-	 * @return array
-	 */
-	public function register() {
-		return [
-			T_FUNCTION
-		];
-	}
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION
+        ];
+    }
 
-	/**
-	 * Processes this test, when one of its tokens is encountered.
-	 *
-	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-	 * @param int                         $stackPtr  The position of the current token
-	 *                                               in the stack passed in $tokens.
-	 *
-	 * @return void
-	 */
-	public function process( File $phpcsFile, $stackPtr ) {
-		$tokens = $phpcsFile->getTokens();
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process( File $phpcsFile, $stackPtr )
+    {
+        $tokens = $phpcsFile->getTokens();
 
-		$returnCount = 0;
-		$funcLevel   = $tokens[$stackPtr]['level'];
+        $returnCount = 0;
+        $funcLevel   = $tokens[$stackPtr]['level'];
 
-		if( empty($tokens[$stackPtr]['scope_opener']) ) {
-			return;
-		}
+        if (empty($tokens[$stackPtr]['scope_opener'])) {
+            return;
+        }
 
-		$markerPtr = $tokens[$stackPtr]['scope_opener'];
-		for( ; ; ) {
-			$markerPtr = $phpcsFile->findNext([ T_RETURN, T_THROW ], $markerPtr + 1, $tokens[$stackPtr]['scope_closer']);
-			if( !$markerPtr ) {
-				break;
-			}
+        $markerPtr = $tokens[$stackPtr]['scope_opener'];
+        while (($markerPtr = $phpcsFile->findNext([ T_RETURN, T_THROW ], ($markerPtr + 1), $tokens[$stackPtr]['scope_closer'])) !== false) {
 
-			$nextPtr = $phpcsFile->findNext(T_WHITESPACE, $markerPtr + 1, null, true);
-			if( $tokens[$nextPtr]['code'] === T_SEMICOLON ) {
-				return;
-			}
+            $nextPtr = $phpcsFile->findNext(T_WHITESPACE, ($markerPtr + 1), null, true);
+            if ($tokens[$nextPtr]['code'] === T_SEMICOLON) {
+                return;
+            }
 
-			$markers[] = $markerPtr;
+            $markers[] = $markerPtr;
 
-			$markerLevel = $tokens[$markerPtr]['level'];
-			foreach( $tokens[$markerPtr]['conditions'] as $point => $code ) {
-				if( ($code === T_FUNCTION || $code === T_CLOSURE) && $point > $stackPtr ) {
-					continue 2;
-				}
+            $markerLevel = $tokens[$markerPtr]['level'];
+            foreach ($tokens[$markerPtr]['conditions'] as $point => $code) {
+                if (($code === T_FUNCTION || $code === T_CLOSURE) && $point > $stackPtr) {
+                    continue 2;
+                }
 
-				if( $code === T_CATCH ) {
-					$markerLevel--;
-				}
+                if ($code === T_CATCH) {
+                    $markerLevel--;
+                }
 
-				if( $code === T_SWITCH ) {
-					$casePtr = $phpcsFile->findPrevious([ T_CASE, T_DEFAULT ], $markerPtr);
-					if( $casePtr && $tokens[$casePtr]['code'] === T_DEFAULT ) {
-						$markerLevel--;
-					}
-				}
-			}
+                if ($code === T_SWITCH) {
+                    $casePtr = $phpcsFile->findPrevious([ T_CASE, T_DEFAULT ], $markerPtr);
+                    if ($casePtr && $tokens[$casePtr]['code'] === T_DEFAULT) {
+                        $markerLevel--;
+                    }
+                }
+            }
 
-			if( $tokens[$markerPtr]['code'] === T_RETURN ) {
-				$returnCount++;
-			}
+            if ($tokens[$markerPtr]['code'] === T_RETURN) {
+                $returnCount++;
+            }
 
-			if( $markerLevel == $funcLevel + 1 ) {
-				return;
-			}
-		}
+            if ($markerLevel == $funcLevel + 1) {
+                return;
+            }
+        }
 
-		if( $returnCount == 0 ) {
-			return;
-		}
+        if ($returnCount == 0) {
+            return;
+        }
 
-		$phpcsFile->addWarning("Not all paths through function return or throw exception.", $stackPtr, 'NotAllReturn');
-	}
+		$phpcsFile->addWarning("Not all paths through function return a value or throw exception.", $stackPtr, 'NotAllReturn');
+    }
 
 }

--- a/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Ensures that all function paths return
+ *
+ * @author    Jesse G. Donat <donatj@gmail.com>
+ * @copyright 2009-2014 Jesse G. Donat
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Functions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class InconsistentReturnSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return [
+			T_FUNCTION
+		];
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$returnCount = 0;
+		$funcLevel   = $tokens[$stackPtr]['level'];
+
+		if( empty($tokens[$stackPtr]['scope_opener']) ) {
+			return;
+		}
+
+		$markerPtr = $tokens[$stackPtr]['scope_opener'];
+		for( ; ; ) {
+			$markerPtr = $phpcsFile->findNext([ T_RETURN, T_THROW ], $markerPtr + 1, $tokens[$stackPtr]['scope_closer']);
+			if( !$markerPtr ) {
+				break;
+			}
+
+			$nextPtr = $phpcsFile->findNext(T_WHITESPACE, $markerPtr + 1, null, true);
+			if( $tokens[$nextPtr]['code'] === T_SEMICOLON ) {
+				return;
+			}
+
+			$markers[] = $markerPtr;
+
+			$markerLevel = $tokens[$markerPtr]['level'];
+			foreach( $tokens[$markerPtr]['conditions'] as $point => $code ) {
+				if( ($code === T_FUNCTION || $code === T_CLOSURE) && $point > $stackPtr ) {
+					continue 2;
+				}
+
+				if( $code === T_CATCH ) {
+					$markerLevel--;
+				}
+
+				if( $code === T_SWITCH ) {
+					$casePtr = $phpcsFile->findPrevious([ T_CASE, T_DEFAULT ], $markerPtr);
+					if( $casePtr && $tokens[$casePtr]['code'] === T_DEFAULT ) {
+						$markerLevel--;
+					}
+				}
+			}
+
+			if( $tokens[$markerPtr]['code'] === T_RETURN ) {
+				$returnCount++;
+			}
+
+			if( $markerLevel == $funcLevel + 1 ) {
+				return;
+			}
+		}
+
+		if( $returnCount == 0 ) {
+			return;
+		}
+
+		$phpcsFile->addWarning("Not all paths through function return or throw exception.", $stackPtr, 'NotAllReturn');
+	}
+
+}

--- a/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
@@ -41,13 +41,12 @@ class InconsistentReturnSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-
-        $returnCount = 0;
-        $funcLevel   = $tokens[$stackPtr]['level'];
-
         if (isset($tokens[$stackPtr]['scope_opener']) === false) {
             return;
         }
+
+        $returnCount = 0;
+        $funcLevel   = $tokens[$stackPtr]['level'];
 
         $markerPtr = $tokens[$stackPtr]['scope_opener'];
         while (($markerPtr = $phpcsFile->findNext([ T_RETURN, T_THROW ], ($markerPtr + 1), $tokens[$stackPtr]['scope_closer'])) !== false) {
@@ -55,8 +54,6 @@ class InconsistentReturnSniff implements Sniff
             if ($tokens[$nextPtr]['code'] === T_SEMICOLON) {
                 return;
             }
-
-            $markers[] = $markerPtr;
 
             $markerLevel = $tokens[$markerPtr]['level'];
             foreach ($tokens[$markerPtr]['conditions'] as $point => $code) {

--- a/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
@@ -4,7 +4,7 @@
  * Ensures that all function paths return
  *
  * @author    Jesse G. Donat <donatj@gmail.com>
- * @copyright 2009-2014 Jesse G. Donat
+ * @copyright 2018 Jesse G. Donat
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/InconsistentReturnSniff.php
@@ -24,7 +24,7 @@ class InconsistentReturnSniff implements Sniff
      */
     public function register()
     {
-        return [T_FUNCTION];
+        return [T_FUNCTION, T_CLOSURE];
 
     }//end register()
 

--- a/src/Standards/Generic/Tests/Functions/InconsistentReturnUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/InconsistentReturnUnitTest.inc
@@ -1,0 +1,81 @@
+<?php
+
+// Good
+function foo() {
+	// no return
+}
+
+// Bad - only returns within if
+function bar(){
+	if(false) {
+		return "ok";
+	}
+}
+
+// Bad - only returns within if
+$x = function($foo) {
+	if($foo) {
+		return $foo;
+	}
+};
+
+// Good - throws or returns
+$x = function($foo) {
+	if($foo) {
+		return $foo;
+	}
+
+	throw new \Exception;
+};
+
+// Bad - returns with a switch
+function($foo) {
+	switch($foo) {
+		case "a":
+			return 1;
+		case "b":
+			return 2;
+	}
+}
+
+// Good
+function($foo) {
+	switch($foo) {
+		case "a":
+			return 1;
+		case "b":
+			return 2;
+		default:
+			return 0;
+	}
+}
+
+// Good, throws exception at root
+function($foo) {
+	switch($foo) {
+		case "a":
+			return 1;
+		case "b":
+			return 2;
+	}
+
+	throw new \Exception;
+}
+
+// Bad - only returns within an else
+function($foo) {
+	if($a) {
+
+	}else{
+		return 2;
+	}
+}
+
+// Bad - only returns value within an else
+function($foo) {
+	if($a) {
+		return;
+	}else{
+		return 2;
+	}
+}

--- a/src/Standards/Generic/Tests/Functions/InconsistentReturnUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/InconsistentReturnUnitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Unit test class for the InconsistentReturn sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class InconsistentReturnUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [
+            9  => 1,
+            16 => 1,
+            32 => 1,
+            70 => 1,
+            75 => 1,
+        ];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
I am looking to see if there is any interest in this Sniff I wrote and have been using in my personal code.  I am quite open to any feedback.

Adds a sniff to detect when not all code paths within a function return / throw.

For example:

```php
function foo($bar) {
    if($bar) {
        return true;
    }
}
```

It correctly handles return/throws from Switch `default`'s as well as `catch`'s

If there is interest in my sniff I will **very happily** add tests to back it up.