### PR TITLE
Filters: New `GitStaged` filter

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -127,6 +127,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
      <file baseinstalldir="PHP/CodeSniffer" name="ExactMatch.php" role="php" />
      <file baseinstalldir="PHP/CodeSniffer" name="Filter.php" role="php" />
      <file baseinstalldir="PHP/CodeSniffer" name="GitModified.php" role="php" />
+     <file baseinstalldir="PHP/CodeSniffer" name="GitStaged.php" role="php" />
     </dir>
     <dir name="Generators">
      <file baseinstalldir="PHP/CodeSniffer" name="Generator.php" role="php" />

--- a/src/Filters/GitStaged.php
+++ b/src/Filters/GitStaged.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * A filter to only include files that have been staged for commit in a Git repository.
+ *
+ * This filter is the ideal companion for your pre-commit git hook.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2018 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Filters;
+
+use PHP_CodeSniffer\Util;
+
+class GitStaged extends ExactMatch
+{
+
+
+    /**
+     * Get a list of blacklisted file paths.
+     *
+     * @return array
+     */
+    protected function getBlacklist()
+    {
+        return [];
+
+    }//end getBlacklist()
+
+
+    /**
+     * Get a list of whitelisted file paths.
+     *
+     * @return array
+     */
+    protected function getWhitelist()
+    {
+        $modified = [];
+
+        $cmd    = 'git diff --cached --name-only -- '.escapeshellarg($this->basedir);
+        $output = [];
+        exec($cmd, $output);
+
+        $basedir = $this->basedir;
+        if (is_dir($basedir) === false) {
+            $basedir = dirname($basedir);
+        }
+
+        foreach ($output as $path) {
+            $path = Util\Common::realpath($path);
+            do {
+                $modified[$path] = true;
+                $path            = dirname($path);
+            } while ($path !== $basedir);
+        }
+
+        return $modified;
+
+    }//end getWhitelist()
+
+
+}//end class

--- a/src/Filters/GitStaged.php
+++ b/src/Filters/GitStaged.php
@@ -49,6 +49,11 @@ class GitStaged extends ExactMatch
 
         foreach ($output as $path) {
             $path = Util\Common::realpath($path);
+            if ($path === false) {
+                // Skip deleted files.
+                continue;
+            }
+
             do {
                 $modified[$path] = true;
                 $path            = dirname($path);


### PR DESCRIPTION
With the new file added in this commit, a new filter becomes available which can be used in a `pre-commit` git hook, as in:
```bash
phpcs --filter=gitstaged
```
... to only examine the files which you are about to commit.