### PR TITLE
Squiz/CommentedOutCode: fix false positive + false negative

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -75,6 +75,10 @@ class CommentedOutCodeSniff implements Sniff
 
         $lastCommentBlockToken = $stackPtr;
         for ($i = $stackPtr; $i < $phpcsFile->numTokens; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false) {
+                break;
+            }
+
             if ($tokens[$i]['code'] === T_WHITESPACE) {
                 continue;
             }
@@ -84,9 +88,18 @@ class CommentedOutCodeSniff implements Sniff
                 continue;
             }
 
-            if ($tokens[$stackPtr]['code'] !== $tokens[$i]['code']
-                || ($lastLineSeen + 1) < $tokens[$i]['line']
+            if ($commentStyle === 'line'
+                && ($lastLineSeen + 1) <= $tokens[$i]['line']
+                && strpos($tokens[$i]['content'], '/*') === 0
             ) {
+                // First non-whitespace token on a new line is start of a different style comment.
+                break;
+            }
+
+            if ($commentStyle === 'line'
+                && ($lastLineSeen + 1) < $tokens[$i]['line']
+            ) {
+                // Blank line breaks a '//' style comment block.
                 break;
             }
 
@@ -96,6 +109,7 @@ class CommentedOutCodeSniff implements Sniff
             */
 
             $tokenContent = trim($tokens[$i]['content']);
+            $break        = false;
 
             if ($commentStyle === 'line') {
                 if (substr($tokenContent, 0, 2) === '//') {
@@ -116,6 +130,7 @@ class CommentedOutCodeSniff implements Sniff
 
                 if (substr($tokenContent, -2) === '*/') {
                     $tokenContent = substr($tokenContent, 0, -2);
+                    $break        = true;
                 }
 
                 if (substr($tokenContent, 0, 1) === '*') {
@@ -127,6 +142,11 @@ class CommentedOutCodeSniff implements Sniff
             $lastLineSeen = $tokens[$i]['line'];
 
             $lastCommentBlockToken = $i;
+
+            if ($break === true) {
+                // Closer of a block comment found.
+                break;
+            }
         }//end for
 
         // Ignore typical warning suppression annotations from other tools.

--- a/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php
@@ -130,7 +130,7 @@ class CommentedOutCodeSniff implements Sniff
         }//end for
 
         // Ignore typical warning suppression annotations from other tools.
-        if (preg_match('`^\s*@[A-Za-z]+\s*$`', $content) === 1) {
+        if (preg_match('`^\s*@[A-Za-z()\._-]+\s*$`', $content) === 1) {
             return ($lastCommentBlockToken + 1);
         }
 

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.inc
@@ -142,3 +142,17 @@ echo 'something'; // @SuppressWarnings(PHPMD.UnusedLocalVariable)
 /* Go! */
 
 // ISO-639-3
+
+			// But override with a different text if any.
+			/*
+			$id = intval( str_replace( 'hook_name', '', $order_method['method_id'] ) );
+			if ( ! empty( $id ) ) {
+				$info_text = get_post_meta( $location_id, 'meta_name' );
+
+				if ( ! empty( $info_text ) ) {
+					$text = $info_text;
+				}
+
+			}
+			*/
+			// function() { $a = $b; };

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -56,6 +56,8 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
                 109 => 1,
                 116 => 1,
                 128 => 1,
+                147 => 1,
+                158 => 1,
             ];
             break;
         case 'CommentedOutCodeUnitTest.css':

--- a/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/CommentedOutCodeUnitTest.php
@@ -56,7 +56,6 @@ class CommentedOutCodeUnitTest extends AbstractSniffUnitTest
                 109 => 1,
                 116 => 1,
                 128 => 1,
-                138 => 1,
             ];
             break;
         case 'CommentedOutCodeUnitTest.css':


### PR DESCRIPTION
### Squiz/CommentedOutCode: fix false positive for PHPMD suppression annotation

Updated the regex used to detect annotations from other tools, to also allow for PHPMD suppression annotations.

This gets rid of the false positive on unit test case file line 138.

Depending on end-user reports, the regex can be improved further.

### Squiz/CommentedOutCode: fix false negative

After the changes I made in PR #1839, this code now added to the unit test case file was incorrectly no longer recognized as commented out code.

This PR further iterates on the previous changes and implements the following:
* Treat a line comment followed by a block comment (and visa versa) as two separate comments.
* Allow for blank lines within block comments, but not within line comment blocks.

