### PR TITLE
Include traits in ClassFileName and DuplicateClassName

### DIFF
--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -52,6 +52,7 @@ class DuplicateClassNameSniff implements Sniff
         $findTokens = [
             T_CLASS,
             T_INTERFACE,
+            T_TRAIT,
             T_NAMESPACE,
             T_CLOSE_TAG,
         ];

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.1.inc
@@ -3,6 +3,9 @@ class MyClass {}
 class YourClass {}
 interface MyInterface {}
 interface YourInterface {}
+trait MyTrait {}
+trait YourTrait {}
 class MyClass {}
 interface MyInterface {}
+trait MyTrait {}
 ?>

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.2.inc
@@ -1,4 +1,5 @@
 <?php
 class MyClass {}
 interface MyInterface {}
+trait MyTrait {}
 ?>

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -45,14 +45,16 @@ class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'DuplicateClassNameUnitTest.1.inc':
             return [
-                6 => 1,
-                7 => 1,
+                8  => 1,
+                9  => 1,
+                10 => 1,
             ];
             break;
         case 'DuplicateClassNameUnitTest.2.inc':
             return [
                 2 => 1,
                 3 => 1,
+                4 => 1,
             ];
             break;
         case 'DuplicateClassNameUnitTest.5.inc':

--- a/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
@@ -22,7 +22,7 @@ class MethodDeclarationSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct([T_CLASS, T_INTERFACE], [T_FUNCTION]);
+        parent::__construct([T_CLASS, T_INTERFACE, T_TRAIT], [T_FUNCTION]);
 
     }//end __construct()
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
@@ -15,3 +15,28 @@ class MyClass
     static protected final abstract function myFunction();
     public function _() {}
 }
+
+interface MyInterface
+{
+    function _myFunction();
+    function __myFunction();
+    public static function myFunction();
+    static public function myFunction();
+    public function _();
+}
+
+trait MyTrait
+{
+    function _myFunction() {}
+    private function myFunction() {}
+    function __myFunction() {}
+    public static function myFunction() {}
+    static public function myFunction() {}
+    final public function myFunction() {}
+    public final function myFunction() {}
+    abstract private function myFunction();
+    private abstract function myFunction();
+    final public static function myFunction() {}
+    static protected final abstract function myFunction();
+    public function _() {}
+}

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
@@ -15,3 +15,28 @@ class MyClass
     abstract final protected static function myFunction();
     public function _() {}
 }
+
+interface MyInterface
+{
+    function _myFunction();
+    function __myFunction();
+    public static function myFunction();
+    public static function myFunction();
+    public function _();
+}
+
+trait MyTrait
+{
+    function _myFunction() {}
+    private function myFunction() {}
+    function __myFunction() {}
+    public static function myFunction() {}
+    public static function myFunction() {}
+    final public function myFunction() {}
+    final public function myFunction() {}
+    abstract private function myFunction();
+    abstract private function myFunction();
+    final public static function myFunction() {}
+    abstract final protected static function myFunction();
+    public function _() {}
+}

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -30,6 +30,11 @@ class MethodDeclarationUnitTest extends AbstractSniffUnitTest
             11 => 1,
             13 => 1,
             15 => 3,
+            24 => 1,
+            34 => 1,
+            36 => 1,
+            38 => 1,
+            40 => 3,
         ];
 
     }//end getErrorList()
@@ -45,7 +50,11 @@ class MethodDeclarationUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [5 => 1];
+        return [
+            5  => 1,
+            21 => 1,
+            30 => 1,
+        ];
 
     }//end getWarningList()
 

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -26,6 +26,7 @@ class ClassFileNameSniff implements Sniff
         return [
             T_CLASS,
             T_INTERFACE,
+            T_TRAIT,
         ];
 
     }//end register()

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
@@ -3,12 +3,20 @@
 
 // Valid class name (matching filename).
 class ClassFileNameUnitTest {}
+interface ClassFileNameUnitTest {}
+trait ClassFileNameUnitTest {}
 
 
 // Invalid filename matching class name (case sensitive).
 class classFileNameUnitTest {}
 class classfilenameunittest {}
 class CLASSFILENAMEUNITTEST {}
+interface classFileNameUnitTest {}
+interface classfilenameunittest {}
+interface CLASSFILENAMEUNITTEST {}
+trait classFileNameUnitTest {}
+trait classfilenameunittest {}
+trait CLASSFILENAMEUNITTEST {}
 
 
 // Invalid non-filename matching class names.
@@ -16,6 +24,14 @@ class CompletelyWrongClassName {}
 class ClassFileNameUnitTestExtra {}
 class ClassFileNameUnitTestInc {}
 class ExtraClassFileNameUnitTest {}
+interface CompletelyWrongClassName {}
+interface ClassFileNameUnitTestExtra {}
+interface ClassFileNameUnitTestInc {}
+interface ExtraClassFileNameUnitTest {}
+trait CompletelyWrongClassName {}
+trait ClassFileNameUnitTestExtra {}
+trait ClassFileNameUnitTestInc {}
+trait ExtraClassFileNameUnitTest {}
 
 
 ?>

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -26,13 +26,27 @@ class ClassFileNameUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            9  => 1,
-            10 => 1,
             11 => 1,
+            12 => 1,
+            13 => 1,
+            14 => 1,
             15 => 1,
             16 => 1,
             17 => 1,
             18 => 1,
+            19 => 1,
+            23 => 1,
+            24 => 1,
+            25 => 1,
+            26 => 1,
+            27 => 1,
+            28 => 1,
+            29 => 1,
+            30 => 1,
+            31 => 1,
+            32 => 1,
+            33 => 1,
+            34 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Was expecting to see traits follow the same rules.