### PR TITLE
PSR2.Namespaces.UseDeclaration does not properly fix "use function" and "use const" statements

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -66,7 +66,18 @@ class UseDeclarationSniff implements Sniff
             if ($tokens[$next]['code'] === T_COMMA) {
                 $fix = $phpcsFile->addFixableError($error, $stackPtr, 'MultipleDeclarations');
                 if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar.'use ');
+                    switch ($tokens[($stackPtr + 2)]['content']) {
+                    case 'const':
+                        $baseUse = 'use const';
+                        break;
+                    case 'function':
+                        $baseUse = 'use function';
+                        break;
+                    default:
+                        $baseUse = 'use';
+                    }
+
+                    $phpcsFile->fixer->replaceToken($next, ';'.$phpcsFile->eolChar.$baseUse);
                 }
             } else {
                 $closingCurly = $phpcsFile->findNext(T_CLOSE_USE_GROUP, ($next + 1));

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.2.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.2.inc
@@ -3,6 +3,8 @@ namespace MyProject;
 
 use  BarClass as Bar;
 use My\Full\Classname as Another, My\Full\NSname;
+use function My\Full\functionname as somefunction, My\Full\otherfunction;
+use const My\Full\constantname as someconstant, My\Full\otherconstant;
 
 
 namespace AnotherProject;

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.2.inc.fixed
@@ -4,6 +4,10 @@ namespace MyProject;
 use BarClass as Bar;
 use My\Full\Classname as Another;
 use My\Full\NSname;
+use function My\Full\functionname as somefunction;
+use function My\Full\otherfunction;
+use const My\Full\constantname as someconstant;
+use const My\Full\otherconstant;
 
 
 namespace AnotherProject;

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.php
@@ -32,7 +32,9 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
             return [
                 4  => 1,
                 5  => 1,
-                10 => 2,
+                6  => 1,
+                7  => 1,
+                12 => 2,
             ];
         case 'UseDeclarationUnitTest.3.inc':
             return [


### PR DESCRIPTION
Currently works correctly with curly braces, but turns function and constant uses into classes.