### PR TITLE
Support PHP 7.3

### DIFF
--- a/CodeSniffer/File.php
+++ b/CodeSniffer/File.php
@@ -1763,7 +1763,7 @@ class PHP_CodeSniffer_File
                 }
                 break;
             default:
-                continue;
+                continue 2;
             }//end switch
         }//end for
 
@@ -2880,7 +2880,7 @@ class PHP_CodeSniffer_File
                 // If it's null, then there must be no parameters for this
                 // method.
                 if ($currVar === null) {
-                    continue;
+                    continue 2;
                 }
 
                 $vars[$paramCount]            = array();


### PR DESCRIPTION
As per https://wiki.php.net/rfc/continue_on_switch_deprecation the use of `continue` is deprecate in switch statements and should use either break or continue 2.