### PR TITLE
Report/Summary: minor usability improvement

### DIFF
--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -159,9 +159,10 @@ class Summary implements Report
             echo 'S';
         }
 
-        echo ' WERE FOUND IN '.$totalFiles.' FILE';
-        if ($totalFiles !== 1) {
-            echo 'S';
+        if ($totalFiles === 1) {
+            echo ' WERE FOUND IN '.$totalFiles.' FILE';
+        } else {
+            echo ' WERE FOUND IN '.count($reportFiles).' OUT OF '.$totalFiles.' FILES';
         }
 
         echo "\033[0m";


### PR DESCRIPTION
The "Totals" line at the bottom of the `Summary` report shows the number of files scanned:
```
A TOTAL OF 76 ERRORS AND 0 WARNINGS WERE FOUND IN 188 FILES
```

However, the actual report only lists the files in which errors or warnings were found, which is often a lot less than the total number of files scanned, causing a disconnect between the content of the report and the "Totals" line.

This PR changes the "Totals" line to include the number of files in which errors/warnings were found, like so:
```
A TOTAL OF 76 ERRORS AND 0 WARNINGS WERE FOUND IN 10 OUT OF 188 FILES
```