### PR TITLE
Fixer: very minor efficiency fix

### DIFF
--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -351,7 +351,7 @@ class Fixer
         }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-            $bt    = debug_backtrace();
+            $bt    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
             $sniff = $bt[1]['class'];
             $line  = $bt[0]['line'];
 
@@ -480,7 +480,7 @@ class Fixer
         }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-            $bt = debug_backtrace();
+            $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
             if ($bt[1]['class'] === 'PHP_CodeSniffer\Fixer') {
                 $sniff = $bt[2]['class'];
                 $line  = $bt[1]['line'];
@@ -592,7 +592,7 @@ class Fixer
         }
 
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-            $bt = debug_backtrace();
+            $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
             if ($bt[1]['class'] === 'PHP_CodeSniffer\Fixer') {
                 $sniff = $bt[2]['class'];
                 $line  = $bt[1]['line'];


### PR DESCRIPTION
Since PHP 5.3.6, `debug_backtrace()` can be called with the `DEBUG_BACKTRACE_IGNORE_ARGS` option.
By default, `debug_backtrace()` when called from within a function will provide access to the parameters passed to the function.
Using the `DEBUG_BACKTRACE_IGNORE_ARGS` option, it won't and as the `args` index from the resulting backtrace arrays is not used in the `Fixer` anyway, using that option should lower the memory usage a tiny bit.

Ref: http://php.net/manual/en/function.debug-backtrace.php