### PR TITLE
New Generic.WhiteSpace.IncrementDecrementSpacing sniff

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Verifies spacing between variables and increment/decrement operators.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2018 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class IncrementDecrementSpacingSniff implements Sniff
+{
+
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            T_DEC,
+            T_INC,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenName = 'increment';
+        if ($tokens[$stackPtr]['code'] === T_DEC) {
+            $tokenName = 'decrement';
+        }
+
+        // Is this a pre-increment/decrement ?
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty !== false
+            && (($phpcsFile->tokenizerType === 'PHP' && $tokens[$nextNonEmpty]['code'] === T_VARIABLE)
+            || ($phpcsFile->tokenizerType === 'JS' && $tokens[$nextNonEmpty]['code'] === T_STRING))
+        ) {
+            if ($nextNonEmpty === ($stackPtr + 1)) {
+                $phpcsFile->recordMetric($stackPtr, 'Spacing between in/decrementor and variable', 0);
+                return;
+            }
+
+            $spaces            = 0;
+            $fixable           = true;
+            $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+            if ($nextNonWhitespace !== $nextNonEmpty) {
+                $fixable = false;
+                $spaces  = 'comment';
+            } else {
+                if ($tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']) {
+                    $spaces = 'newline';
+                } else {
+                    $spaces = $tokens[($stackPtr + 1)]['length'];
+                }
+            }
+
+            $phpcsFile->recordMetric($stackPtr, 'Spacing between in/decrementor and variable', $spaces);
+
+            $error     = 'Expected no spaces between the %s operator and %s; %s found';
+            $errorCode = 'SpaceAfter'.ucfirst($tokenName);
+            $data      = [
+                $tokenName,
+                $tokens[$nextNonEmpty]['content'],
+                $spaces,
+            ];
+
+            if ($fixable === false) {
+                $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+                return;
+            }
+
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($stackPtr + 1); $i < $nextNonEmpty; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+
+            return;
+        }//end if
+
+        // Is this a post-increment/decrement ?
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($prevNonEmpty !== false
+            && (($phpcsFile->tokenizerType === 'PHP' && $tokens[$prevNonEmpty]['code'] === T_VARIABLE)
+            || ($phpcsFile->tokenizerType === 'JS' && $tokens[$prevNonEmpty]['code'] === T_STRING))
+        ) {
+            if ($prevNonEmpty === ($stackPtr - 1)) {
+                $phpcsFile->recordMetric($stackPtr, 'Spacing between in/decrementor and variable', 0);
+                return;
+            }
+
+            $spaces            = 0;
+            $fixable           = true;
+            $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+            if ($prevNonWhitespace !== $prevNonEmpty) {
+                $fixable = false;
+                $spaces  = 'comment';
+            } else {
+                if ($tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']) {
+                    $spaces = 'newline';
+                } else {
+                    $spaces = $tokens[($stackPtr - 1)]['length'];
+                }
+            }
+
+            $phpcsFile->recordMetric($stackPtr, 'Spacing between in/decrementor and variable', $spaces);
+
+            $error     = 'Expected no spaces between %s and the %s operator; %s found';
+            $errorCode = 'SpaceAfter'.ucfirst($tokenName);
+            $data      = [
+                $tokens[$prevNonEmpty]['content'],
+                $tokenName,
+                $spaces,
+            ];
+
+            if ($fixable === false) {
+                $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+                return;
+            }
+
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($stackPtr - 1); $prevNonEmpty < $i; $i--) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc
@@ -1,0 +1,17 @@
+<?php
+
+$i = 10;
+--$i;
+-- $i;
+-- /*comment*/ $i;
+++$i;
+++ 
+   $i;
+++/*comment*/$i;
+
+$i--;
+$i        --;
+$i /*comment*/ --;
+$i++;
+$i ++;
+$i /*comment*/ ++;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.inc.fixed
@@ -1,0 +1,16 @@
+<?php
+
+$i = 10;
+--$i;
+--$i;
+-- /*comment*/ $i;
+++$i;
+++$i;
+++/*comment*/$i;
+
+$i--;
+$i--;
+$i /*comment*/ --;
+$i++;
+$i++;
+$i /*comment*/ ++;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.js
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.js
@@ -1,0 +1,17 @@
+var i;
+
+i = 10;
+--i;
+-- i;
+-- /*comment*/ i;
+++i;
+++
+   i;
+++/*comment*/i;
+
+i--;
+i        --;
+i /*comment*/ --;
+i++;
+i ++;
+i /*comment*/ ++;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.js.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.js.fixed
@@ -1,0 +1,16 @@
+var i;
+
+i = 10;
+--i;
+--i;
+-- /*comment*/ i;
+++i;
+++i;
+++/*comment*/i;
+
+i--;
+i--;
+i /*comment*/ --;
+i++;
+i++;
+i /*comment*/ ++;

--- a/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/IncrementDecrementSpacingUnitTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Unit test class for the IncrementDecrementSpacing sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2018 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class IncrementDecrementSpacingUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @param string $testFile The name of the file being tested.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList($testFile='IncrementDecrementSpacingUnitTest.inc')
+    {
+        switch ($testFile) {
+        case 'IncrementDecrementSpacingUnitTest.inc':
+        case 'IncrementDecrementSpacingUnitTest.js':
+            return [
+                5  => 1,
+                6  => 1,
+                8  => 1,
+                10 => 1,
+                13 => 1,
+                14 => 1,
+                16 => 1,
+                17 => 1,
+            ];
+
+        default:
+            return [];
+        }//end switch
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
New sniff to check that there are no spaces (or comments) between an incrementor/decrementor and the variable it applies to.

The sniff can examine both PHP as well as JS files for this, though I suspect there may be some false positive reports for JS at some point as `T_STRING` is quite a generic token to check for.

Includes unit tests.
Includes auto-fixer.
Includes code-consistency metrics.

I've made a conscious decision to not make the number of spaces accepted between the in/decrementor and the variable configurable as it is a widely accepted convention that there should be no spaces between them.
If it would be so desired, I can add a public property to make this configurable.

Fixes #2172