### PR TITLE
Ignore BOM in Generic.Files.InlineHTML and Generic.PHP.CharacterBeforePHPOpeningTag

### DIFF
--- a/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/InlineHTMLSniff.php
@@ -15,6 +15,19 @@ use PHP_CodeSniffer\Files\File;
 class InlineHTMLSniff implements Sniff
 {
 
+    /**
+     * List of supported BOM definitions.
+     *
+     * Use encoding names as keys and hex BOM representations as values.
+     *
+     * @var array
+     */
+    protected $bomDefinitions = [
+        'UTF-8'       => 'efbbbf',
+        'UTF-16 (BE)' => 'feff',
+        'UTF-16 (LE)' => 'fffe',
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -39,6 +52,16 @@ class InlineHTMLSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        // Allow a byte-order mark.
+        $tokens = $phpcsFile->getTokens();
+        foreach ($this->bomDefinitions as $bomName => $expectedBomHex) {
+            $bomByteLength = (strlen($expectedBomHex) / 2);
+            $htmlBomHex    = bin2hex(substr($tokens[0]['content'], 0, $bomByteLength));
+            if ($htmlBomHex === $expectedBomHex && strlen($tokens[0]['content']) === $bomByteLength) {
+                return;
+            }
+        }
+
         // Ignore shebang lines.
         $tokens = $phpcsFile->getTokens();
         if (substr($tokens[$stackPtr]['content'], 0, 2) === '#!') {

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.6.inc
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.6.inc
@@ -1,0 +1,2 @@
+﻿<?php
+echo 'foo';

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.7.inc
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.7.inc
@@ -1,0 +1,2 @@
+﻿foo<?php
+echo 'foo';

--- a/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/InlineHTMLUnitTest.php
@@ -34,6 +34,9 @@ class InlineHTMLUnitTest extends AbstractSniffUnitTest
         case 'InlineHTMLUnitTest.4.inc':
             return [1 => 1];
             break;
+        case 'InlineHTMLUnitTest.7.inc':
+            return [1 => 1];
+            break;
         default:
             return [];
             break;

--- a/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/PHP/CharacterBeforePHPOpeningTagUnitTest.3.inc
@@ -1,0 +1,3 @@
+﻿<?php
+
+//some code


### PR DESCRIPTION
Having a BOM currently triggers `Generic.Files.InlineHTML` and `Generic.PHP.CharacterBeforePHPOpeningTag`, duplicating `Generic.Files.ByteOrderMark`. This causes them to ignore it.