### PR TITLE
Build/Travis: validate rulesets against XSD and check code style consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.0
-      env: CUSTOM_INI=1
+      env: CUSTOM_INI=1 XMLLINT=1
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
     - php: 7.1
     - php: 7.2
     - php: 7.3
@@ -22,6 +26,7 @@ matrix:
     - php: nightly
 
 before_install:
+  - export XMLLINT_INDENT="    "
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
@@ -37,3 +42,16 @@ script:
   - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php scripts/build-phar.php; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php phpcs.phar; fi
+  # Validate the xml ruleset files.
+  # @link http://xmlsoft.org/xmllint.html
+  - if [[ $XMLLINT == "1" ]]; then xmllint --noout --schema phpcs.xsd ./src/Standards/*/ruleset.xml; fi
+  # Check the code-style consistency of the xml files.
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./phpcs.xml.dist <(xmllint --format "./phpcs.xml.dist"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/Generic/ruleset.xml <(xmllint --format "./src/Standards/Generic/ruleset.xml"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/MySource/ruleset.xml <(xmllint --format "./src/Standards/MySource/ruleset.xml"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PEAR/ruleset.xml <(xmllint --format "./src/Standards/PEAR/ruleset.xml"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PSR1/ruleset.xml <(xmllint --format "./src/Standards/PSR1/ruleset.xml"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PSR2/ruleset.xml <(xmllint --format "./src/Standards/PSR2/ruleset.xml"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PSR12/ruleset.xml <(xmllint --format "./src/Standards/PSR12/ruleset.xml"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/Squiz/ruleset.xml <(xmllint --format "./src/Standards/Squiz/ruleset.xml"); fi
+  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/Zend/ruleset.xml <(xmllint --format "./src/Standards/Zend/ruleset.xml"); fi

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,8 +11,8 @@
     <exclude-pattern>*/Standards/*/Tests/*\.(inc|css|js)</exclude-pattern>
 
     <arg name="basepath" value="."/>
-    <arg name="colors" />
-    <arg name="parallel" value="75" />
+    <arg name="colors"/>
+    <arg name="parallel" value="75"/>
     <arg value="np"/>
 
     <!-- Don't hide tokenizer exceptions -->
@@ -22,40 +22,40 @@
 
     <!-- Include the whole PEAR standard -->
     <rule ref="PEAR">
-        <exclude name="PEAR.NamingConventions.ValidFunctionName" />
-        <exclude name="PEAR.NamingConventions.ValidVariableName" />
-        <exclude name="PEAR.Commenting.ClassComment" />
-        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
-        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag" />
-        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
-        <exclude name="PEAR.Commenting.FileComment.MissingVersion" />
-        <exclude name="PEAR.Commenting.InlineComment" />
+        <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
+        <exclude name="PEAR.NamingConventions.ValidVariableName"/>
+        <exclude name="PEAR.Commenting.ClassComment"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
+        <exclude name="PEAR.Commenting.InlineComment"/>
     </rule>
 
     <!-- Include some sniffs from other standards that don't conflict with PEAR -->
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
-    <rule ref="Squiz.Arrays.ArrayDeclaration" />
-    <rule ref="Squiz.Commenting.ClosingDeclarationComment" />
-    <rule ref="Squiz.ControlStructures.ControlSignature" />
-    <rule ref="Squiz.ControlStructures.ElseIfDeclaration" />
-    <rule ref="Squiz.Commenting.BlockComment" />
-    <rule ref="Squiz.Commenting.DocCommentAlignment" />
-    <rule ref="Squiz.Commenting.EmptyCatchComment" />
-    <rule ref="Squiz.Commenting.InlineComment" />
-    <rule ref="Squiz.Commenting.LongConditionClosingComment" />
-    <rule ref="Squiz.Commenting.PostStatementComment" />
-    <rule ref="Squiz.Commenting.VariableComment" />
-    <rule ref="Squiz.Formatting.OperatorBracket" />
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing" />
-    <rule ref="Squiz.Operators.ComparisonOperatorUsage" />
-    <rule ref="Squiz.PHP.DisallowInlineIf" />
-    <rule ref="Squiz.Scope.MethodScope" />
-    <rule ref="Squiz.Strings.ConcatenationSpacing" />
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing" />
-    <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace" />
-    <rule ref="Squiz.WhiteSpace.FunctionSpacing" />
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing" />
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace" />
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+    <rule ref="Squiz.Arrays.ArrayDeclaration"/>
+    <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
+    <rule ref="Squiz.ControlStructures.ControlSignature"/>
+    <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
+    <rule ref="Squiz.Commenting.BlockComment"/>
+    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
+    <rule ref="Squiz.Commenting.EmptyCatchComment"/>
+    <rule ref="Squiz.Commenting.InlineComment"/>
+    <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
+    <rule ref="Squiz.Commenting.PostStatementComment"/>
+    <rule ref="Squiz.Commenting.VariableComment"/>
+    <rule ref="Squiz.Formatting.OperatorBracket"/>
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
+    <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
+    <rule ref="Squiz.Scope.MethodScope"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
+    <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace"/>
+    <rule ref="Squiz.WhiteSpace.FunctionSpacing"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Commenting.Todo"/>
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>
@@ -77,7 +77,7 @@
         </properties>
     </rule>
 
-     <!-- We use custom indent rules for arrays -->
+    <!-- We use custom indent rules for arrays -->
     <rule ref="Generic.Arrays.ArrayIndent"/>
     <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
         <severity>0</severity>
@@ -93,7 +93,7 @@
     </rule>
 
     <!-- Check var names, but we don't want leading underscores for private vars -->
-    <rule ref="Squiz.NamingConventions.ValidVariableName" />
+    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
     <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
         <severity>0</severity>
     </rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHP_CodeSniffer">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>The coding standard for PHP_CodeSniffer itself.</description>
 
     <file>autoload.php</file>

--- a/src/Standards/Generic/ruleset.xml
+++ b/src/Standards/Generic/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
-<ruleset name="Generic">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Generic" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
  <description>A collection of generic sniffs. This standard is not designed to be used to check code.</description>
 </ruleset>

--- a/src/Standards/Generic/ruleset.xml
+++ b/src/Standards/Generic/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Generic" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
- <description>A collection of generic sniffs. This standard is not designed to be used to check code.</description>
+    <description>A collection of generic sniffs. This standard is not designed to be used to check code.</description>
 </ruleset>

--- a/src/Standards/MySource/ruleset.xml
+++ b/src/Standards/MySource/ruleset.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MySource" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
- <description>The MySource coding standard builds on the Squiz coding standard. Currently used for MySource Mini development.</description>
+    <description>The MySource coding standard builds on the Squiz coding standard. Currently used for MySource Mini development.</description>
 
- <exclude-pattern>*/Tests/*</exclude-pattern>
- <exclude-pattern>*/Oven/*</exclude-pattern>
- <exclude-pattern>*/data/*</exclude-pattern>
- <exclude-pattern>*/jquery.js</exclude-pattern>
- <exclude-pattern>*/jquery.*.js</exclude-pattern>
- <exclude-pattern>*/viper/*</exclude-pattern>
- <exclude-pattern>DALConf.inc</exclude-pattern>
+    <exclude-pattern>*/Tests/*</exclude-pattern>
+    <exclude-pattern>*/Oven/*</exclude-pattern>
+    <exclude-pattern>*/data/*</exclude-pattern>
+    <exclude-pattern>*/jquery.js</exclude-pattern>
+    <exclude-pattern>*/jquery.*.js</exclude-pattern>
+    <exclude-pattern>*/viper/*</exclude-pattern>
+    <exclude-pattern>DALConf.inc</exclude-pattern>
 
- <!-- Include the whole Squiz standard except FunctionComment, which we override -->
- <rule ref="Squiz">
-  <exclude name="Squiz.Commenting.FunctionComment"/>
- </rule>
+    <!-- Include the whole Squiz standard except FunctionComment, which we override -->
+    <rule ref="Squiz">
+        <exclude name="Squiz.Commenting.FunctionComment"/>
+    </rule>
 
 </ruleset>

--- a/src/Standards/MySource/ruleset.xml
+++ b/src/Standards/MySource/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="MySource">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MySource" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
  <description>The MySource coding standard builds on the Squiz coding standard. Currently used for MySource Mini development.</description>
 
  <exclude-pattern>*/Tests/*</exclude-pattern>

--- a/src/Standards/PEAR/ruleset.xml
+++ b/src/Standards/PEAR/ruleset.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PEAR" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
- <description>The PEAR coding standard.</description>
+    <description>The PEAR coding standard.</description>
 
- <!-- Include some additional sniffs from the Generic standard -->
- <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
- <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
- <rule ref="Generic.PHP.LowerCaseConstant"/>
- <rule ref="Generic.PHP.DisallowShortOpenTag"/>
- <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
- <rule ref="Generic.Commenting.DocComment"/>
- <rule ref="Squiz.Commenting.DocCommentAlignment"/>
+    <!-- Include some additional sniffs from the Generic standard -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
+    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
+    <rule ref="Generic.Commenting.DocComment"/>
+    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
 
- <!-- Lines can be 85 chars long, but never show errors -->
- <rule ref="Generic.Files.LineLength">
-  <properties>
-   <property name="lineLimit" value="85"/>
-   <property name="absoluteLineLimit" value="0"/>
-  </properties>
- </rule>
+    <!-- Lines can be 85 chars long, but never show errors -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="85"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
+    </rule>
 
- <!-- Use Unix newlines -->
- <rule ref="Generic.Files.LineEndings">
-  <properties>
-   <property name="eolChar" value="\n"/>
-  </properties>
- </rule>
+    <!-- Use Unix newlines -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n"/>
+        </properties>
+    </rule>
 
- <!-- This message is not required as spaces are allowed for alignment -->
- <rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
-  <severity>0</severity>
- </rule>
+    <!-- This message is not required as spaces are allowed for alignment -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
+        <severity>0</severity>
+    </rule>
 
- <!-- Use warnings for inline control structures -->
- <rule ref="Generic.ControlStructures.InlineControlStructure">
-  <properties>
-   <property name="error" value="false"/>
-  </properties>
- </rule>
+    <!-- Use warnings for inline control structures -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure">
+        <properties>
+            <property name="error" value="false"/>
+        </properties>
+    </rule>
 
 </ruleset>

--- a/src/Standards/PEAR/ruleset.xml
+++ b/src/Standards/PEAR/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PEAR">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PEAR" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
  <description>The PEAR coding standard.</description>
 
  <!-- Include some additional sniffs from the Generic standard -->

--- a/src/Standards/PSR1/ruleset.xml
+++ b/src/Standards/PSR1/ruleset.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PSR1" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
- <description>The PSR1 coding standard.</description>
+    <description>The PSR1 coding standard.</description>
 
- <!-- 2. Files -->
+    <!-- 2. Files -->
 
- <!-- 2.1. PHP Tags -->
+    <!-- 2.1. PHP Tags -->
 
- <!-- PHP code MUST use the long <?php ?> tags or the short-echo <?= ?> tags; it MUST NOT use the other tag variations. -->
- <rule ref="Generic.PHP.DisallowShortOpenTag"/>
- <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
-  <severity>0</severity>
- </rule>
+    <!-- PHP code MUST use the long <?php ?> tags or the short-echo <?= ?> tags; it MUST NOT use the other tag variations. -->
+    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+    <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
+        <severity>0</severity>
+    </rule>
 
- <!-- 2.2. Character Encoding -->
+    <!-- 2.2. Character Encoding -->
 
- <!-- PHP code MUST use only UTF-8 without BOM. -->
- <rule ref="Generic.Files.ByteOrderMark"/>
+    <!-- PHP code MUST use only UTF-8 without BOM. -->
+    <rule ref="Generic.Files.ByteOrderMark"/>
 
- <!-- 2.3. Side Effects -->
+    <!-- 2.3. Side Effects -->
 
- <!-- A file SHOULD declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it SHOULD execute logic with side effects, but SHOULD NOT do both. -->
- <!-- checked in Files/SideEffectsSniff -->
+    <!-- A file SHOULD declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it SHOULD execute logic with side effects, but SHOULD NOT do both. -->
+    <!-- checked in Files/SideEffectsSniff -->
 
- <!-- 3. Namespace and Class Names -->
+    <!-- 3. Namespace and Class Names -->
 
- <!-- Namespaces and classes MUST follow PSR-0.
-      This means each class is in a file by itself, and is in a namespace of at least one level: a top-level vendor name. -->
- <!-- checked in Classes/ClassDeclarationSniff -->
+    <!-- Namespaces and classes MUST follow PSR-0.
+         This means each class is in a file by itself, and is in a namespace of at least one level: a top-level vendor name. -->
+    <!-- checked in Classes/ClassDeclarationSniff -->
 
- <!-- Class names MUST be declared in StudlyCaps. -->
- <rule ref="Squiz.Classes.ValidClassName"/>
+    <!-- Class names MUST be declared in StudlyCaps. -->
+    <rule ref="Squiz.Classes.ValidClassName"/>
 
- <!-- 4. Class Constants, Properties, and Methods -->
+    <!-- 4. Class Constants, Properties, and Methods -->
 
- <!-- 4.1. Constants -->
+    <!-- 4.1. Constants -->
 
- <!-- Class constants MUST be declared in all upper case with underscore separators. -->
- <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+    <!-- Class constants MUST be declared in all upper case with underscore separators. -->
+    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
 
- <!-- 4.3. Methods -->
+    <!-- 4.3. Methods -->
 
- <!-- Method names MUST be declared in camelCase(). -->
- <!-- checked in Methods/CamelCapsMethodNameSniff -->
+    <!-- Method names MUST be declared in camelCase(). -->
+    <!-- checked in Methods/CamelCapsMethodNameSniff -->
 
 </ruleset>

--- a/src/Standards/PSR1/ruleset.xml
+++ b/src/Standards/PSR1/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PSR1">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PSR1" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
  <description>The PSR1 coding standard.</description>
 
  <!-- 2. Files -->

--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -214,8 +214,8 @@
     The closing brace MUST be on the next line after the body
     The body of each structure MUST be enclosed by braces. This standardizes how the structures look, and reduces the likelihood of introducing errors as new lines get added to the body. -->
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>

--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PSR12">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PSR12" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
     <description>The PSR-12 coding standard.</description>
     <arg name="tab-width" value="4"/>
 

--- a/src/Standards/PSR2/ruleset.xml
+++ b/src/Standards/PSR2/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PSR2">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PSR2" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
  <description>The PSR-2 coding standard.</description>
  <arg name="tab-width" value="4"/>
 

--- a/src/Standards/PSR2/ruleset.xml
+++ b/src/Standards/PSR2/ruleset.xml
@@ -1,201 +1,201 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PSR2" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
- <description>The PSR-2 coding standard.</description>
- <arg name="tab-width" value="4"/>
+    <description>The PSR-2 coding standard.</description>
+    <arg name="tab-width" value="4"/>
 
- <!-- 2. General -->
+    <!-- 2. General -->
 
- <!-- 2.1 Basic Coding Standard -->
+    <!-- 2.1 Basic Coding Standard -->
 
- <!-- Include the whole PSR-1 standard -->
- <rule ref="PSR1"/>
+    <!-- Include the whole PSR-1 standard -->
+    <rule ref="PSR1"/>
 
- <!-- 2.2 Files -->
+    <!-- 2.2 Files -->
 
- <!-- All PHP files MUST use the Unix LF (linefeed) line ending. -->
- <rule ref="Generic.Files.LineEndings">
-  <properties>
-   <property name="eolChar" value="\n"/>
-  </properties>
- </rule>
+    <!-- All PHP files MUST use the Unix LF (linefeed) line ending. -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n"/>
+        </properties>
+    </rule>
 
- <!-- All PHP files MUST end with a single blank line. -->
- <!-- checked in Files/EndFileNewlineSniff -->
+    <!-- All PHP files MUST end with a single blank line. -->
+    <!-- checked in Files/EndFileNewlineSniff -->
 
- <!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
- <!-- checked in Files/ClosingTagSniff -->
+    <!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
+    <!-- checked in Files/ClosingTagSniff -->
 
- <!-- 2.3 Lines -->
+    <!-- 2.3 Lines -->
 
- <!-- The soft limit on line length MUST be 120 characters; automated style checkers MUST warn but MUST NOT error at the soft limit. -->
- <rule ref="Generic.Files.LineLength">
-  <properties>
-   <property name="lineLimit" value="120"/>
-   <property name="absoluteLineLimit" value="0"/>
-  </properties>
- </rule>
+    <!-- The soft limit on line length MUST be 120 characters; automated style checkers MUST warn but MUST NOT error at the soft limit. -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
+    </rule>
 
- <!-- There MUST NOT be trailing whitespace at the end of non-blank lines. -->
- <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-  <properties>
-   <property name="ignoreBlankLines" value="true"/>
-  </properties>
- </rule>
- <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
-  <severity>0</severity>
- </rule>
- <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
-  <severity>0</severity>
- </rule>
- <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
-  <severity>0</severity>
- </rule>
+    <!-- There MUST NOT be trailing whitespace at the end of non-blank lines. -->
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+        <severity>0</severity>
+    </rule>
 
- <!-- There MUST NOT be more than one statement per line. -->
- <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+    <!-- There MUST NOT be more than one statement per line. -->
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 
- <!-- 2.4 Indenting -->
+    <!-- 2.4 Indenting -->
 
- <!-- Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting. -->
- <rule ref="Generic.WhiteSpace.ScopeIndent">
-  <properties>
-   <property name="ignoreIndentationTokens" type="array">
-    <element value="T_COMMENT"/>
-    <element value="T_DOC_COMMENT_OPEN_TAG"/>
-   </property>
-  </properties>
- </rule>
- <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
+    <!-- Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting. -->
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="ignoreIndentationTokens" type="array">
+                <element value="T_COMMENT"/>
+                <element value="T_DOC_COMMENT_OPEN_TAG"/>
+            </property>
+        </properties>
+    </rule>
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
 
- <!-- 2.5 Keywords and True/False/Null -->
+    <!-- 2.5 Keywords and True/False/Null -->
 
- <!-- PHP keywords MUST be in lower case. -->
- <rule ref="Generic.PHP.LowerCaseKeyword"/>
+    <!-- PHP keywords MUST be in lower case. -->
+    <rule ref="Generic.PHP.LowerCaseKeyword"/>
 
- <!-- The PHP constants true, false, and null MUST be in lower case. -->
- <rule ref="Generic.PHP.LowerCaseConstant"/>
+    <!-- The PHP constants true, false, and null MUST be in lower case. -->
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
 
- <!-- 3. Namespace and Use Declarations -->
+    <!-- 3. Namespace and Use Declarations -->
 
- <!-- When present, there MUST be one blank line after the namespace declaration. -->
- <!-- checked in Namespaces/NamespaceDeclarationSniff -->
+    <!-- When present, there MUST be one blank line after the namespace declaration. -->
+    <!-- checked in Namespaces/NamespaceDeclarationSniff -->
 
- <!-- When present, all use declarations MUST go after the namespace declaration.
-      There MUST be one use keyword per declaration.
-      There MUST be one blank line after the use block. -->
- <!-- checked in Namespaces/UseDeclarationSniff -->
+    <!-- When present, all use declarations MUST go after the namespace declaration.
+         There MUST be one use keyword per declaration.
+         There MUST be one blank line after the use block. -->
+    <!-- checked in Namespaces/UseDeclarationSniff -->
 
- <!-- 4. Classes, Properties, and Methods -->
+    <!-- 4. Classes, Properties, and Methods -->
 
- <!-- 4.1. Extends and Implements -->
+    <!-- 4.1. Extends and Implements -->
 
- <!-- The extends and implements keywords MUST be declared on the same line as the class name.
-      The opening brace for the class go MUST go on its own line; the closing brace for the class MUST go on the next line after the body.
-      Lists of implements MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one interface per line. -->
- <!-- checked in Classes/ClassDeclarationSniff -->
+    <!-- The extends and implements keywords MUST be declared on the same line as the class name.
+         The opening brace for the class go MUST go on its own line; the closing brace for the class MUST go on the next line after the body.
+         Lists of implements MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one interface per line. -->
+    <!-- checked in Classes/ClassDeclarationSniff -->
 
- <!-- 4.2. Properties -->
+    <!-- 4.2. Properties -->
 
- <!-- Visibility MUST be declared on all properties.
-      The var keyword MUST NOT be used to declare a property.
-      There MUST NOT be more than one property declared per statement.
-      Property names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility. -->
- <!-- checked in Classes/PropertyDeclarationSniff -->
+    <!-- Visibility MUST be declared on all properties.
+         The var keyword MUST NOT be used to declare a property.
+         There MUST NOT be more than one property declared per statement.
+         Property names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility. -->
+    <!-- checked in Classes/PropertyDeclarationSniff -->
 
- <!-- 4.3 Methods -->
+    <!-- 4.3 Methods -->
 
- <!-- Visibility MUST be declared on all methods. -->
- <rule ref="Squiz.Scope.MethodScope"/>
- <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
+    <!-- Visibility MUST be declared on all methods. -->
+    <rule ref="Squiz.Scope.MethodScope"/>
+    <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
 
- <!-- Method names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility. -->
- <!-- checked in Methods/MethodDeclarationSniff -->
+    <!-- Method names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility. -->
+    <!-- checked in Methods/MethodDeclarationSniff -->
 
- <!-- Method names MUST NOT be declared with a space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. -->
- <!-- checked in Methods/FunctionClosingBraceSniff -->
- <rule ref="Squiz.Functions.FunctionDeclaration"/>
- <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
+    <!-- Method names MUST NOT be declared with a space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. -->
+    <!-- checked in Methods/FunctionClosingBraceSniff -->
+    <rule ref="Squiz.Functions.FunctionDeclaration"/>
+    <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
 
- <!-- 4.4 Method Arguments -->
+    <!-- 4.4 Method Arguments -->
 
- <!-- In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma. -->
- <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
-  <properties>
-   <property name="equalsSpacing" value="1"/>
-  </properties>
- </rule>
- <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint">
-  <severity>0</severity>
- </rule>
+    <!-- In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma. -->
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint">
+        <severity>0</severity>
+    </rule>
 
- <!-- Method arguments with default values MUST go at the end of the argument list. -->
- <rule ref="PEAR.Functions.ValidDefaultValue"/>
+    <!-- Method arguments with default values MUST go at the end of the argument list. -->
+    <rule ref="PEAR.Functions.ValidDefaultValue"/>
 
- <!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
- <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
+    <!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
 
- <!-- 4.5 abstract, final, and static -->
+    <!-- 4.5 abstract, final, and static -->
 
- <!-- When present, the abstract and final declarations MUST precede the visibility declaration.
-      When present, the static declaration MUST come after the visibility declaration. -->
- <!-- checked in Methods/MethodDeclarationSniff -->
+    <!-- When present, the abstract and final declarations MUST precede the visibility declaration.
+         When present, the static declaration MUST come after the visibility declaration. -->
+    <!-- checked in Methods/MethodDeclarationSniff -->
 
- <!-- 4.6 Method and Function Calls -->
+    <!-- 4.6 Method and Function Calls -->
 
- <!-- When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis, there MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. -->
- <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
- <rule ref="PSR2.Methods.FunctionCallSignature.SpaceAfterCloseBracket">
-  <severity>0</severity>
- </rule>
- <rule ref="PSR2.Methods.FunctionCallSignature.OpeningIndent">
-  <severity>0</severity>
- </rule>
+    <!-- When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis, there MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
+         Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+    <rule ref="PSR2.Methods.FunctionCallSignature.SpaceAfterCloseBracket">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.OpeningIndent">
+        <severity>0</severity>
+    </rule>
 
- <!-- 5. Control Structures -->
+    <!-- 5. Control Structures -->
 
- <!-- The general style rules for control structures are as follows:
- There MUST be one space after the control structure keyword
- There MUST NOT be a space after the opening parenthesis
- There MUST NOT be a space before the closing parenthesis
- There MUST be one space between the closing parenthesis and the opening brace
- The structure body MUST be indented once
- The closing brace MUST be on the next line after the body -->
- <rule ref="Squiz.ControlStructures.ControlSignature"/>
- <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
- <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
- <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
- <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
- <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
- <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
- <!-- checked in ControlStructures/ControlStructureSpacingSniff -->
+    <!-- The general style rules for control structures are as follows:
+         There MUST be one space after the control structure keyword
+         There MUST NOT be a space after the opening parenthesis
+         There MUST NOT be a space before the closing parenthesis
+         There MUST be one space between the closing parenthesis and the opening brace
+         The structure body MUST be indented once
+         The closing brace MUST be on the next line after the body -->
+    <rule ref="Squiz.ControlStructures.ControlSignature"/>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
+    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
+    <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
+    <!-- checked in ControlStructures/ControlStructureSpacingSniff -->
 
- <!-- exclude this message as it is already checked Generic.PHP.LowerCaseKeyword -->
- <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.AsNotLower">
-  <severity>0</severity>
- </rule>
+    <!-- exclude this message as it is already checked Generic.PHP.LowerCaseKeyword -->
+    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.AsNotLower">
+        <severity>0</severity>
+    </rule>
 
- <!-- The body of each structure MUST be enclosed by braces. This standardizes how the structures look, and reduces the likelihood of introducing errors as new lines get added to the body. -->
- <rule ref="Generic.ControlStructures.InlineControlStructure"/>
+    <!-- The body of each structure MUST be enclosed by braces. This standardizes how the structures look, and reduces the likelihood of introducing errors as new lines get added to the body. -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
- <!-- 5.1. if, elseif, else -->
+    <!-- 5.1. if, elseif, else -->
 
- <!-- The keyword elseif SHOULD be used instead of else if so that all control keywords look like single words. -->
- <!-- checked in ControlStructures/ElseIfDeclarationSniff -->
+    <!-- The keyword elseif SHOULD be used instead of else if so that all control keywords look like single words. -->
+    <!-- checked in ControlStructures/ElseIfDeclarationSniff -->
 
- <!-- 5.2. switch, case -->
+    <!-- 5.2. switch, case -->
 
- <!-- The case statement MUST be indented once from switch, and the break keyword (or other terminating keyword) MUST be indented at the same level as the case body. There MUST be a comment such as // no break when fall-through is intentional in a non-empty case body. -->
- <!-- checked in ControlStructures/SwitchDeclarationSniff -->
+    <!-- The case statement MUST be indented once from switch, and the break keyword (or other terminating keyword) MUST be indented at the same level as the case body. There MUST be a comment such as // no break when fall-through is intentional in a non-empty case body. -->
+    <!-- checked in ControlStructures/SwitchDeclarationSniff -->
 
- <!-- 6. Closures -->
+    <!-- 6. Closures -->
 
- <!-- Closures MUST be declared with a space after the function keyword, and a space before and after the use keyword.
- The opening brace MUST go on the same line, and the closing brace MUST go on the next line following the body.
- There MUST NOT be a space after the opening parenthesis of the argument list or variable list, and there MUST NOT be a space before the closing parenthesis of the argument list or variable list.
- In the argument list and variable list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
- Closure arguments with default values MUST go at the end of the argument list.
- Argument lists and variable lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument or variable per line.
- When the ending list (whether or arguments or variables) is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
- <!-- checked in Squiz.Functions.MultiLineFunctionDeclaration -->
+    <!-- Closures MUST be declared with a space after the function keyword, and a space before and after the use keyword.
+         The opening brace MUST go on the same line, and the closing brace MUST go on the next line following the body.
+         There MUST NOT be a space after the opening parenthesis of the argument list or variable list, and there MUST NOT be a space before the closing parenthesis of the argument list or variable list.
+         In the argument list and variable list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.
+         Closure arguments with default values MUST go at the end of the argument list.
+         Argument lists and variable lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument or variable per line.
+         When the ending list (whether or arguments or variables) is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+    <!-- checked in Squiz.Functions.MultiLineFunctionDeclaration -->
 </ruleset>

--- a/src/Standards/Squiz/ruleset.xml
+++ b/src/Standards/Squiz/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Squiz">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Squiz" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
     <description>The Squiz coding standard.</description>
 
     <!-- Include some specific sniffs -->

--- a/src/Standards/Zend/ruleset.xml
+++ b/src/Standards/Zend/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Zend">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Zend" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
  <description>A coding standard based on an early Zend Framework coding standard. Note that this standard is out of date.</description>
 
  <!-- Include some sniffs from all around the place -->

--- a/src/Standards/Zend/ruleset.xml
+++ b/src/Standards/Zend/ruleset.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Zend" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
- <description>A coding standard based on an early Zend Framework coding standard. Note that this standard is out of date.</description>
+    <description>A coding standard based on an early Zend Framework coding standard. Note that this standard is out of date.</description>
 
- <!-- Include some sniffs from all around the place -->
- <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
- <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
- <rule ref="Generic.PHP.DisallowShortOpenTag"/>
- <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
- <rule ref="PEAR.Classes.ClassDeclaration"/>
- <rule ref="PEAR.ControlStructures.ControlSignature"/>
- <rule ref="PEAR.Functions.FunctionCallSignature"/>
- <rule ref="PEAR.Functions.ValidDefaultValue"/>
- <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
- <rule ref="Squiz.Functions.GlobalFunction"/>
+    <!-- Include some sniffs from all around the place -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
+    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
+    <rule ref="PEAR.Classes.ClassDeclaration"/>
+    <rule ref="PEAR.ControlStructures.ControlSignature"/>
+    <rule ref="PEAR.Functions.FunctionCallSignature"/>
+    <rule ref="PEAR.Functions.ValidDefaultValue"/>
+    <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
+    <rule ref="Squiz.Functions.GlobalFunction"/>
 
- <!-- Lines can be 80 chars long, show errors at 120 chars -->
- <rule ref="Generic.Files.LineLength">
-  <properties>
-   <property name="lineLimit" value="80"/>
-   <property name="absoluteLineLimit" value="120"/>
-  </properties>
- </rule>
+    <!-- Lines can be 80 chars long, show errors at 120 chars -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="80"/>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+    </rule>
 
- <!-- Use Unix newlines -->
- <rule ref="Generic.Files.LineEndings">
-  <properties>
-   <property name="eolChar" value="\n"/>
-  </properties>
- </rule>
+    <!-- Use Unix newlines -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n"/>
+        </properties>
+    </rule>
 
 </ruleset>


### PR DESCRIPTION
## Commit summary

### Build: lint the XML rulesets and check for consistent code style

Notes:
* Runs only once per build as the results are independent of the PHP version.
* Indent is set at four spaces as per commit 232f7da .
* I've elected to add this check to the smallest (fastest) build, so the build time will be spread more evenly.
* Not linting the PHPCS native ruleset as it's being run anyway, so is automatically checked.

### Add the XSD schema tags to the XML rulesets

### Clean the XML ruleset files/consistent code style 