### PR TITLE
PEAR.Functions.FunctionCallSignature incorrect error when encountering trailing PHPCS annotation

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -546,7 +546,7 @@ class FunctionCallSignatureSniff implements Sniff
             // If we are within an argument we should be ignoring commas
             // as these are not signaling the end of an argument.
             if ($inArg === false && $tokens[$i]['code'] === T_COMMA) {
-                $next = $phpcsFile->findNext([T_WHITESPACE, T_COMMENT], ($i + 1), $closeBracket, true);
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), $closeBracket, true);
                 if ($next === false) {
                     continue;
                 }

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
@@ -390,8 +390,29 @@ $deprecated_functions = [
 
 $deprecated_functions = [
     'the_category_ID'
-         => function_call( // 7 spaces, not 8. This is the problem line.
+         => function_call( // 9 spaces, not 8. This is the problem line.
         $a,
         $b
     ),
 ];
+
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments false
+
+printf(
+    '<select name="%1$s" id="%2$s">%3$s</select>',
+    $obj->getName(), // Trailing comment.
+    $obj->getID(), // phpcs:ignore Standard.Category.SniffName -- for reasons.
+    $option
+);
+
+// Handling of PHP 7.3 trailing comma's.
+functionCall($args, $foo,);
+functionCall(
+    $args, $foo,
+);
+functionCall(
+    $args,
+    $foo,
+);
+
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments true

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
@@ -403,8 +403,30 @@ $deprecated_functions = [
 
 $deprecated_functions = [
     'the_category_ID'
-        => function_call( // 7 spaces, not 8. This is the problem line.
+        => function_call( // 9 spaces, not 8. This is the problem line.
             $a,
             $b
         ),
 ];
+
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments false
+
+printf(
+    '<select name="%1$s" id="%2$s">%3$s</select>',
+    $obj->getName(), // Trailing comment.
+    $obj->getID(), // phpcs:ignore Standard.Category.SniffName -- for reasons.
+    $option
+);
+
+// Handling of PHP 7.3 trailing comma's.
+functionCall($args, $foo,);
+functionCall(
+    $args,
+    $foo,
+);
+functionCall(
+    $args,
+    $foo,
+);
+
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments true

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -111,6 +111,7 @@ class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
             394 => 1,
             395 => 1,
             396 => 1,
+            411 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
When `$allowMultipleArguments` is set to false and the sniff would encounter a trailing PHPCS annotation in a function call, it would incorrectly throw a _"Only one argument is allowed per line in a multi-line function call"_ error.

The sniff did handle normal trailing comments correctly, so only needed a minimal adjustment to allow for the PHPCS annotations.

Additional notes:
* This commit also adds a few unit test cases using trailing comma's in function calls - as allowed per PHP 7.3 - to confirm that the sniff handles these correctly and safeguard this for the future.
* Also includes a minor unit test case documentation fix.