### PR TITLE
Bugfixes for 6 sniffs / `processTokensWithinScope()` vs nested classes

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -98,6 +98,16 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
      */
     protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
+        $tokens = $phpcsFile->getTokens();
+
+        // Determine if this is a function which needs to be examined.
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
+            return;
+        }
+
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
         if ($methodName === null) {
             // Ignore closures.
@@ -105,11 +115,18 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
         }
 
         $className = $phpcsFile->getDeclarationName($currScope);
+        if (isset($className) === false) {
+            $className = '[Anonymous Class]';
+        }
+
         $errorData = [$className.'::'.$methodName];
+
+        $methodNameLc = strtolower($methodName);
+        $classNameLc  = strtolower($className);
 
         // Is this a magic method. i.e., is prefixed with "__" ?
         if (preg_match('|^__[^_]|', $methodName) !== 0) {
-            $magicPart = strtolower(substr($methodName, 2));
+            $magicPart = substr($methodNameLc, 2);
             if (isset($this->magicMethods[$magicPart]) === true
                 || isset($this->methodsDoubleUnderscore[$magicPart]) === true
             ) {
@@ -121,12 +138,12 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
         }
 
         // PHP4 constructors are allowed to break our rules.
-        if ($methodName === $className) {
+        if ($methodNameLc === $classNameLc) {
             return;
         }
 
         // PHP4 destructors are allowed to break our rules.
-        if ($methodName === '_'.$className) {
+        if ($methodNameLc === '_'.$classNameLc) {
             return;
         }
 

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
@@ -147,3 +147,17 @@ $a = new class {
     function __my_function() {}
 
 };
+
+class Nested {
+    public function getAnonymousClass() {
+        return new class() {
+            public function nested_function() {}
+            function __something() {}
+        };
+    }
+}
+
+abstract class My_Class {
+    public function my_class() {}
+    public function _MY_CLASS() {}
+}

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -61,6 +61,8 @@ class CamelCapsFunctionNameUnitTest extends AbstractSniffUnitTest
             144 => 1,
             146 => 1,
             147 => 2,
+            154 => 1,
+            155 => 1,
         ];
 
         return $errors;

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -70,6 +70,16 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
      */
     protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
+        $tokens = $phpcsFile->getTokens();
+
+        // Determine if this is a function which needs to be examined.
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
+            return;
+        }
+
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
         if ($methodName === null) {
             // Ignore closures.
@@ -77,11 +87,18 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
         }
 
         $className = $phpcsFile->getDeclarationName($currScope);
+        if (isset($className) === false) {
+            $className = '[Anonymous Class]';
+        }
+
         $errorData = [$className.'::'.$methodName];
+
+        $methodNameLc = strtolower($methodName);
+        $classNameLc  = strtolower($className);
 
         // Is this a magic method. i.e., is prefixed with "__" ?
         if (preg_match('|^__[^_]|', $methodName) !== 0) {
-            $magicPart = strtolower(substr($methodName, 2));
+            $magicPart = substr($methodNameLc, 2);
             if (isset($this->magicMethods[$magicPart]) === true) {
                 return;
             }
@@ -91,12 +108,12 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
         }
 
         // PHP4 constructors are allowed to break our rules.
-        if ($methodName === $className) {
+        if ($methodNameLc === $classNameLc) {
             return;
         }
 
         // PHP4 destructors are allowed to break our rules.
-        if ($methodName === '_'.$className) {
+        if ($methodNameLc === '_'.$classNameLc) {
             return;
         }
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -205,3 +205,18 @@ $a = new class {
 };
 
 function send_system_email__to_user($body, $recipient){}
+
+class Nested {
+    public function getAnonymousClass() {
+        return new class() {
+            public function nested_function() {}
+            function __something() {}
+            private function something() {}
+        };
+    }
+}
+
+abstract class My_Class {
+    public function my_class() {}
+    public function _MY_CLASS() {}
+}

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -119,6 +119,9 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
             203 => 1,
             204 => 2,
             207 => 2,
+            212 => 1,
+            213 => 1,
+            214 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
+++ b/src/Standards/PSR1/Sniffs/Methods/CamelCapsMethodNameSniff.php
@@ -29,6 +29,16 @@ class CamelCapsMethodNameSniff extends GenericCamelCapsFunctionNameSniff
      */
     protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
+        $tokens = $phpcsFile->getTokens();
+
+        // Determine if this is a function which needs to be examined.
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
+            return;
+        }
+
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
         if ($methodName === null) {
             // Ignore closures.
@@ -49,6 +59,10 @@ class CamelCapsMethodNameSniff extends GenericCamelCapsFunctionNameSniff
         if ($testName !== '' &&  Common::isCamelCaps($testName, false, true, false) === false) {
             $error     = 'Method name "%s" is not in camel caps format';
             $className = $phpcsFile->getDeclarationName($currScope);
+            if (isset($className) === false) {
+                $className = '[Anonymous Class]';
+            }
+
             $errorData = [$className.'::'.$methodName];
             $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps', $errorData);
             $phpcsFile->recordMetric($stackPtr, 'CamelCase method name', 'no');

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.inc
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.inc
@@ -70,4 +70,12 @@ function ___tripleUnderscore() {} // Ok.
 class triple {
     public function ___tripleUnderscore() {} // Ok.
 }
-?>
+
+class Nested {
+    public function getAnonymousClass() {
+        return new class() {
+            public function nested_function() {}
+        };
+    }
+}
+

--- a/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
+++ b/src/Standards/PSR1/Tests/Methods/CamelCapsMethodNameUnitTest.php
@@ -35,6 +35,7 @@ class CamelCapsMethodNameUnitTest extends AbstractSniffUnitTest
             21 => 1,
             25 => 1,
             26 => 1,
+            77 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
@@ -22,7 +22,7 @@ class MethodDeclarationSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct([T_CLASS, T_INTERFACE, T_TRAIT], [T_FUNCTION]);
+        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION]);
 
     }//end __construct()
 
@@ -39,6 +39,14 @@ class MethodDeclarationSniff extends AbstractScopeSniff
     protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
         $tokens = $phpcsFile->getTokens();
+
+        // Determine if this is a function which needs to be examined.
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
+            return;
+        }
 
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
         if ($methodName === null) {

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
@@ -40,3 +40,27 @@ trait MyTrait
     static protected final abstract function myFunction();
     public function _() {}
 }
+
+$a = new class()
+{
+    function _myFunction() {}
+    private function myFunction() {}
+    function __myFunction() {}
+    public static function myFunction() {}
+    static public function myFunction() {}
+    final public function myFunction() {}
+    public final function myFunction() {}
+    abstract private function myFunction();
+    private abstract function myFunction();
+    final public static function myFunction() {}
+    static protected final abstract function myFunction();
+    public function _() {}
+}
+
+class Nested_Function {
+    public function getAnonymousClass() {
+        return new class() {
+			static private final function _nested_function() {}
+        };
+    }
+}

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
@@ -40,3 +40,27 @@ trait MyTrait
     abstract final protected static function myFunction();
     public function _() {}
 }
+
+$a = new class()
+{
+    function _myFunction() {}
+    private function myFunction() {}
+    function __myFunction() {}
+    public static function myFunction() {}
+    public static function myFunction() {}
+    final public function myFunction() {}
+    final public function myFunction() {}
+    abstract private function myFunction();
+    abstract private function myFunction();
+    final public static function myFunction() {}
+    abstract final protected static function myFunction();
+    public function _() {}
+}
+
+class Nested_Function {
+    public function getAnonymousClass() {
+        return new class() {
+			final private static function _nested_function() {}
+        };
+    }
+}

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -35,6 +35,11 @@ class MethodDeclarationUnitTest extends AbstractSniffUnitTest
             36 => 1,
             38 => 1,
             40 => 3,
+            50 => 1,
+            52 => 1,
+            54 => 1,
+            56 => 3,
+            63 => 2,
         ];
 
     }//end getErrorList()
@@ -54,6 +59,8 @@ class MethodDeclarationUnitTest extends AbstractSniffUnitTest
             5  => 1,
             21 => 1,
             30 => 1,
+            46 => 1,
+            63 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
@@ -22,7 +22,7 @@ class MethodScopeSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct([T_CLASS, T_INTERFACE, T_TRAIT], [T_FUNCTION]);
+        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION]);
 
     }//end __construct()
 
@@ -40,14 +40,17 @@ class MethodScopeSniff extends AbstractScopeSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $methodName = $phpcsFile->getDeclarationName($stackPtr);
-        if ($methodName === null) {
-            // Ignore closures.
+        // Determine if this is a function which needs to be examined.
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
             return;
         }
 
-        if ($phpcsFile->hasCondition($stackPtr, T_FUNCTION) === true) {
-            // Ignore nested functions.
+        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($methodName === null) {
+            // Ignore closures.
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -22,7 +22,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct([T_CLASS], [T_FUNCTION]);
+        parent::__construct([T_CLASS, T_TRAIT, T_ANON_CLASS], [T_FUNCTION]);
 
     }//end __construct()
 
@@ -40,6 +40,14 @@ class StaticThisUsageSniff extends AbstractScopeSniff
     public function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
         $tokens = $phpcsFile->getTokens();
+
+        // Determine if this is a function which needs to be examined.
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
+            return;
+        }
 
         // Ignore abstract functions.
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
@@ -32,3 +32,11 @@ trait Trait_Test {
 	private function func1() {}
 	protected function func1() {}
 }
+
+class Nested {
+    public function getAnonymousClass() {
+        return new class() {
+            function __something() {}
+        };
+    }
+}

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -28,6 +28,7 @@ class MethodScopeUnitTest extends AbstractSniffUnitTest
         return [
             6  => 1,
             30 => 1,
+            39 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -54,4 +54,25 @@ class MyClass
             }
         };
     }
+
+    public function getAnonymousClass() {
+        return new class() {
+			public static function something() {
+				$this->doSomething();
+            }
+        };
+    }
+}
+
+trait MyTrait {
+	public static function myFunc() {
+		$this->doSomething();
+	}
+}
+
+$b = new class()
+{
+	public static function myFunc() {
+		$this->doSomething();
+	}
 }

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -31,6 +31,9 @@ class StaticThisUsageUnitTest extends AbstractSniffUnitTest
             9  => 1,
             14 => 1,
             20 => 1,
+            61 => 1,
+            69 => 1,
+            76 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
These fixes are all loosely related to and inspired by the test case provided in #2178 and fixed via #2182.

There were a number of other sniffs using the `AbstractScopeSniff` as a basis which would throw the same error twice for functions nested in anonymous classes.

I've reviewed most of these now and have fixed them in separate commits.

All fixes include unit tests.

The reasoning and solution used is the same as previously applied in #2182 for the `Generic.NamingConventions.ConstructorName` sniff.

> Turns out the `processTokensWithinScope()` method gets called for each whitelisted scope a `T_FUNCTION` token exists in.
>
> In effect, this means that the first time it gets called for the `nested_function()` method, it is because it is within the scope of the `Nested` class, the second time the function gets called, it is for the method being in the scope of the anonymous class.
>
> The fix I've now applied checks that the scope for which the method is called is actually the deepest scope first and bows out if it's not.

## Commit summary

### `Generic.NamingConventions.CamelCapsFunctionName`
* Fixed: Sniff would throw the same error twice for functions in nested classes.
* UX fix: For methods in anonymous classes, the error message would read `Public method name "::nested_function" is not in camel caps format` which could be considered confusing.
    I've changed this to now read: `Public method name "[Anonymous Class]::nested_function" is not in camel caps format`
* Class and method names in PHP are case _in_sensitive. While the sniff took that into account for the magic methods, it did not when checking for PHP4 style constructors/destructors.
     This has now been fixed by lowercasing both the class name as well as the function name before comparing them.

### `PEAR.NamingConventions.ValidFunctionName`
* Fixed: Sniff would throw the same error twice for functions in nested classes.
* UX fix: For methods in anonymous classes, the error message would read `Method name "::nested_function" ....` which could be considered confusing.
    I've changed this to now read: `Method name "[Anonymous Class]::nested_function" ....`
* Class and method names in PHP are case _in_sensitive. While the sniff took that into account for the magic methods, it did not when checking for PHP4 style constructors/destructors.
     This has now been fixed by lowercasing both the class name as well as the function name before comparing them.

### `PSR1.Methods.CamelCapsMethodName`
* Fixed: Sniff would throw the same error twice for functions in nested classes.
* UX fix: For methods in anonymous classes, the error message would read `Method name "::nested_function" ...` which could be considered confusing.
    I've changed this to now read: `Method name "[Anonymous Class]::nested_function" ...`

### `PSR2.Methods.MethodDeclaration`
* Enhancement: added support for anonymous classes while preventing the double error issue.

### `Squiz.Scope.MethodScope`
* Enhancement: added support for anonymous classes.
* Fixed: bug where nested structures would not be examined.

### `Squiz.Scope.StaticThisUsage`
* Enhancement: added support for anonymous classes and traits while preventing the double error issue.

