### PR TITLE
Generic/LanguageConstructSpacing: bug fix / don't fix spacing namespace operator

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php
@@ -11,7 +11,8 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Util\Common;
+use PHP_CodeSniffer\Util\Tokens;
 
 class LanguageConstructSpacingSniff implements Sniff
 {
@@ -68,6 +69,14 @@ class LanguageConstructSpacingSniff implements Sniff
         }
 
         $content = $tokens[$stackPtr]['content'];
+        if ($tokens[$stackPtr]['code'] === T_NAMESPACE) {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_NS_SEPARATOR) {
+                // Namespace keyword used as operator, not as the language construct.
+                return;
+            }
+        }
+
         if ($tokens[$stackPtr]['code'] === T_YIELD_FROM
             && strtolower($content) !== 'yield from'
         ) {
@@ -87,7 +96,7 @@ class LanguageConstructSpacingSniff implements Sniff
             }
 
             $error = 'Language constructs must be followed by a single space; expected 1 space between YIELD FROM found "%s"';
-            $data  = [Util\Common::prepareForOutput($found)];
+            $data  = [Common::prepareForOutput($found)];
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'IncorrectYieldFrom', $data);
             if ($fix === true) {
                 preg_match('/yield/i', $found, $yield);
@@ -113,7 +122,7 @@ class LanguageConstructSpacingSniff implements Sniff
             $content = $tokens[($stackPtr + 1)]['content'];
             if ($content !== ' ') {
                 $error = 'Language constructs must be followed by a single space; expected 1 space but found "%s"';
-                $data  = [Util\Common::prepareForOutput($content)];
+                $data  = [Common::prepareForOutput($content)];
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'IncorrectSingle', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc
@@ -49,8 +49,11 @@ namespace MyClass;
 namespace    MyClass;
 namespace MyNamespace\MyClass;
 namespace    MyNamespace\MyClass;
+
+// Namespace operator, not language construct.
+namespace\MyNamespace\MyClass;
 namespace \MyNamespace\MyClass;
-namespace    \MyNamespace\MyClass;
+namespace   /*comment*/  \MyNamespace\MyClass;
 
 use MyClass;
 use    MyClass;

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.inc.fixed
@@ -45,8 +45,11 @@ namespace MyClass;
 namespace MyClass;
 namespace MyNamespace\MyClass;
 namespace MyNamespace\MyClass;
+
+// Namespace operator, not language construct.
+namespace\MyNamespace\MyClass;
 namespace \MyNamespace\MyClass;
-namespace \MyNamespace\MyClass;
+namespace   /*comment*/  \MyNamespace\MyClass;
 
 use MyClass;
 use MyClass;

--- a/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/LanguageConstructSpacingUnitTest.php
@@ -44,14 +44,13 @@ class LanguageConstructSpacingUnitTest extends AbstractSniffUnitTest
             46 => 2,
             49 => 1,
             51 => 1,
-            53 => 1,
-            56 => 1,
-            58 => 1,
-            60 => 1,
-            64 => 1,
+            59 => 1,
+            61 => 1,
+            63 => 1,
             67 => 1,
-            68 => 1,
-            72 => 1,
+            70 => 1,
+            71 => 1,
+            75 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The sniff should only address the spacing after the `namespace` keyword when used as a language construct, not when it is used as an operator.

For more details, see issue #2194.

Fixes #2194