### PR TITLE
File::getTokensAsString(): prevent endless loop

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1911,6 +1911,14 @@ class File
      */
     public function getTokensAsString($start, $length, $origContent=false)
     {
+        if (is_int($start) === false || isset($this->tokens[$start]) === false) {
+            throw new RuntimeException('The $start position for getTokensAsString() must exist in the token stack.');
+        }
+
+        if (is_int($length) === false || $length <= 0) {
+            return '';
+        }
+
         $str = '';
         $end = ($start + $length);
         if ($end > $this->numTokens) {


### PR DESCRIPTION
As discussed in issue #2042, this adds an exception to the `File::getTokensAsString()` method for when the value of the `$start` parameter is invalid.

As for the `$length` parameter, I've chosen to just bow out early in that case.

Note: I've tested adding an exception for the `$length` parameter as well, but that would actually give issues with at least one existing PHPCS native sniff, so this is the more elegant solution.

The existing issue is with the function call on line 309 of the `AbstractPatternSniff` in combination with the `PEAR.ControlStructures.ControlSignature` sniff. I haven't looked into that issue any deeper though.

Fixes #2042