### PR TITLE
Squiz.WhiteSpace.OperatorSpacing throws error for negative index when using curly braces for string access

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -332,6 +332,7 @@ class OperatorSpacingSniff implements Sniff
                 T_INLINE_THEN         => true,
                 T_INLINE_ELSE         => true,
                 T_CASE                => true,
+                T_OPEN_CURLY_BRACKET  => true,
             ];
 
             if (isset($invalidTokens[$tokens[$prev]['code']]) === true) {

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -256,3 +256,7 @@ $foo = is_array($bar) ? array_map(
     ) : $bar;
 
 function bar(): array {}
+
+if ($line{-1} === ':') {
+    $line = substr($line, 0, -1);
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -250,3 +250,7 @@ $foo = is_array($bar) ? array_map(
     ) : $bar;
 
 function bar(): array {}
+
+if ($line{-1} === ':') {
+    $line = substr($line, 0, -1);
+}


### PR DESCRIPTION
Adding T_OPEN_CURLY_BRACKET to the list of tokens that indicate that the following token does not
belong to an arithmetic operation.
e.g. `$myString{-1}`

See https://secure.php.net/manual/en/language.types.string.php#language.types.string.substr