### PR TITLE
Generic.NamingConventions.CamelCapsFunctionName not ignoring SoapClient __getCookies() method

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -48,17 +48,18 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
      * @var array
      */
     protected $methodsDoubleUnderscore = [
-        'soapcall'               => true,
-        'getlastrequest'         => true,
-        'getlastresponse'        => true,
-        'getlastrequestheaders'  => true,
-        'getlastresponseheaders' => true,
-        'getfunctions'           => true,
-        'gettypes'               => true,
         'dorequest'              => true,
+        'getcookies'             => true,
+        'getfunctions'           => true,
+        'getlastrequest'         => true,
+        'getlastrequestheaders'  => true,
+        'getlastresponse'        => true,
+        'getlastresponseheaders' => true,
+        'gettypes'               => true,
         'setcookie'              => true,
         'setlocation'            => true,
         'setsoapheaders'         => true,
+        'soapcall'               => true,
     ];
 
     /**

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
@@ -147,3 +147,7 @@ $a = new class {
     function __my_function() {}
 
 };
+
+class FooBar extends \SoapClient {
+    public function __getCookies() {}
+}


### PR DESCRIPTION
The list of `$methodsDoubleUnderscore` from the SoapClient extension was missing the `__getCookies()` method.

Ref: http://php.net/manual/en/class.soapclient.php

Includes unit test.

Includes ordering the list in alphabetic order.