### PR TITLE
PSR2.Methods.MethodDeclaration gets confused over comments between modifier keywords

### DIFF
--- a/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/MethodDeclarationSniff.php
@@ -57,9 +57,8 @@ class MethodDeclarationSniff extends AbstractScopeSniff
         $abstract   = 0;
         $final      = 0;
 
-        $find   = Tokens::$methodPrefixes;
-        $find[] = T_WHITESPACE;
-        $prev   = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+        $find = (Tokens::$methodPrefixes + Tokens::$emptyTokens);
+        $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
 
         $prefix = $stackPtr;
         while (($prefix = $phpcsFile->findPrevious(Tokens::$methodPrefixes, ($prefix - 1), $prev)) !== false) {

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
@@ -6,12 +6,12 @@ class MyClass
     private function myFunction() {}
     function __myFunction() {}
     public static function myFunction() {}
-    static public function myFunction() {}
+    static public /*comment*/ function myFunction() {}
     final public function myFunction() {}
-    public final function myFunction() {}
+    public /*comment*/ final function myFunction() {}
     abstract private function myFunction();
-    private abstract function myFunction();
-    final public static function myFunction() {}
+    private /*comment*/ abstract function myFunction();
+    final public /*comment*/ static function myFunction() {}
     static protected final abstract function myFunction();
     public function _() {}
 }
@@ -32,11 +32,11 @@ trait MyTrait
     function __myFunction() {}
     public static function myFunction() {}
     static public function myFunction() {}
-    final public function myFunction() {}
+    final /*comment*/ public function myFunction() {}
     public final function myFunction() {}
     abstract private function myFunction();
     private abstract function myFunction();
     final public static function myFunction() {}
-    static protected final abstract function myFunction();
+    static /*comment*/ protected final abstract function myFunction();
     public function _() {}
 }

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
@@ -6,12 +6,12 @@ class MyClass
     private function myFunction() {}
     function __myFunction() {}
     public static function myFunction() {}
-    public static function myFunction() {}
+    public static /*comment*/ function myFunction() {}
     final public function myFunction() {}
-    final public function myFunction() {}
+    final public /*comment*/ function myFunction() {}
     abstract private function myFunction();
-    abstract private function myFunction();
-    final public static function myFunction() {}
+    abstract private /*comment*/ function myFunction();
+    final public /*comment*/ static function myFunction() {}
     abstract final protected static function myFunction();
     public function _() {}
 }
@@ -32,11 +32,11 @@ trait MyTrait
     function __myFunction() {}
     public static function myFunction() {}
     public static function myFunction() {}
-    final public function myFunction() {}
+    final /*comment*/ public function myFunction() {}
     final public function myFunction() {}
     abstract private function myFunction();
     abstract private function myFunction();
     final public static function myFunction() {}
-    abstract final protected static function myFunction();
+    /*comment*/ abstract final protected static function myFunction();
     public function _() {}
 }


### PR DESCRIPTION
The `PSR2.Methods.MethodDeclaration` sniff would get unnecessarily confused over comments between the modifier keywords.

This minor changes fixes that.

Includes (adjusted) unit tests demonstrating the issue.