### PR TITLE
FUNCTION and CONST in use groups being tokenised as T_FUNCTION and T_CONST

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -119,7 +119,7 @@ class UseDeclarationSniff implements Sniff
                                 $phpcsFile->fixer->replaceToken($i, '');
                             }
 
-                            if ($tokens[$next]['code'] === T_CONST || $tokens[$next]['code'] === T_FUNCTION) {
+                            if ($tokens[$next]['content'] === 'const' || $tokens[$next]['content'] === 'function') {
                                 $phpcsFile->fixer->addContentBefore($next, 'use ');
                                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
                                 $phpcsFile->fixer->addContentBefore($next, str_replace('use ', '', $baseUse));

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -2,7 +2,7 @@
 /**
 * Comment
 */
-
+use Foo\{function bar, const BAZ};
 
 include $blah;
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -2,7 +2,7 @@
 /**
 * Comment
 */
-
+use Foo\{function bar, const BAZ};
 
 include $blah;
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1389,7 +1389,7 @@ class PHP extends Tokenizer
                 // and T_CONST.
                 if (($newToken['code'] === T_FUNCTION
                     || $newToken['code'] === T_CONST)
-                    && $finalTokens[$lastNotEmptyToken]['code'] === T_USE
+                    && ($finalTokens[$lastNotEmptyToken]['code'] === T_USE || $insideUseGroup === true)
                 ) {
                     $newToken['code'] = T_STRING;
                     $newToken['type'] = 'T_STRING';


### PR DESCRIPTION
Added example to the test for `Squiz.WhiteSpace.FunctionSpacing` which has a problem with this (refs https://github.com/libero/php-coding-standard/pull/30).