### PR TITLE
File::getMemberProperties() is recognizing method params as properties

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1656,6 +1656,18 @@ class File
             }
         }
 
+        // Make sure it's not a method parameter.
+        if (empty($this->tokens[$stackPtr]['nested_parenthesis']) === false) {
+            $parenthesis = array_keys($this->tokens[$stackPtr]['nested_parenthesis']);
+            $deepestOpen = array_pop($parenthesis);
+            if ($deepestOpen > $ptr
+                && isset($this->tokens[$deepestOpen]['parenthesis_owner']) === true
+                && $this->tokens[$this->tokens[$deepestOpen]['parenthesis_owner']]['code'] === T_FUNCTION
+            ) {
+                throw new TokenizerException('$stackPtr is not a class member var');
+            }
+        }
+
         $valid = [
             T_PUBLIC    => T_PUBLIC,
             T_PRIVATE   => T_PRIVATE,

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -117,3 +117,21 @@ $globalVariable = true;
 
 /* testNotAVariable */
 return;
+
+$a = ( $foo == $bar ? new stdClass() :
+	new class() {
+		/* testNestedProperty 1 */
+		public $var = true;
+
+		/* testNestedMethodParam 1 */
+		public function something($var = false) {}
+	}
+);
+
+function_call( 'param', new class {
+	/* testNestedProperty 2 */
+	public $year = 2017;
+
+	/* testNestedMethodParam 2 */
+	public function __construct( $open, $post_id ) {}
+}, 10, 2 );

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -302,6 +302,22 @@ class GetMemberPropertiesTest extends TestCase
                 '/* testInterfaceProperty */',
                 [],
             ],
+            [
+                '/* testNestedProperty 1 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
+            [
+                '/* testNestedProperty 2 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                ],
+            ],
         ];
 
     }//end dataGetMemberProperties()
@@ -346,9 +362,12 @@ class GetMemberPropertiesTest extends TestCase
     public function dataNotClassProperty()
     {
         return [
+            ['/* testMethodParam */'],
             ['/* testImportedGlobal */'],
             ['/* testLocalVariable */'],
             ['/* testGlobalVariable */'],
+            ['/* testNestedMethodParam 1 */'],
+            ['/* testNestedMethodParam 2 */'],
         ];
 
     }//end dataNotClassProperty()


### PR DESCRIPTION
Method parameters were recognized as if they were class properties.

Looks like I already included an initial unit test case for this in #1715, but that case was not being tested.
The change in this PR should fix the issue, activates the existing unit test and adds some extra as well.