### PR TITLE
Tokenizer: fix binary cast recognition with inside parentheses whitespace

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1567,6 +1567,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        </dir>
        <dir name="WhiteSpace">
         <file baseinstalldir="PHP/CodeSniffer" name="CastSpacingUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="CastSpacingUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="CastSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ControlStructureSpacingUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ControlStructureSpacingUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc
@@ -4,4 +4,6 @@ $var = ( int ) $var2;
 $var = (int ) $var2;
 $var = ( int) $var2;
 $var = (	int	) $var2;
-?>
+
+$var = (binary) $var2;
+$var = (   binary   ) $var2;

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.inc.fixed
@@ -1,0 +1,9 @@
+<?php
+$var = (int) $var2;
+$var = (int) $var2;
+$var = (int) $var2;
+$var = (int) $var2;
+$var = (int) $var2;
+
+$var = (binary) $var2;
+$var = (binary) $var2;

--- a/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/CastSpacingUnitTest.php
@@ -30,6 +30,7 @@ class CastSpacingUnitTest extends AbstractSniffUnitTest
             4 => 1,
             5 => 1,
             6 => 1,
+            9 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -655,7 +655,7 @@ class PHP extends Tokenizer
 
             if ($tokenIsArray === true
                 && $token[0] === T_STRING_CAST
-                && strtolower($token[1]) === '(binary)'
+                && preg_match('`^\(\s*binary\s*\)$`i', $token[1]) === 1
             ) {
                 $finalTokens[$newStackPtr] = [
                     'code'    => T_BINARY_CAST,


### PR DESCRIPTION
As reported in [my last comment](https://github.com/squizlabs/PHP_CodeSniffer/issues/1574#issuecomment-435278428) on the original issue #1574, the fix to the tokenizer does not take whitespace inside of the binary cast parentheses into account.

This PR fixes this.

It also adds a unit test which will guard against regressions to the `Squiz.WhiteSpace.CastSpacing` sniff.

As that sniff did not have a `fixed` file, while it _does_ in actual fact contain a fixer, the `.fixed` file has also been added.