### PR TITLE
Binary cast change / add some additional unit tests

### DIFF
--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.inc
@@ -43,3 +43,9 @@ $var = (object)  $var2;
 $var = (unset) $var2;
 $var = (unset)$var2;
 $var = (unset)  $var2;
+
+$var = b"binary $foo";
+$var = b"binary string";
+$var = b'binary string';
+$var = (binary) $string;
+$var = (binary)$string;

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.inc.fixed
@@ -43,3 +43,9 @@ $var = (object)$var2;
 $var = (unset)$var2;
 $var = (unset)$var2;
 $var = (unset)$var2;
+
+$var = b"binary $foo";
+$var = b"binary string";
+$var = b'binary string';
+$var = (binary)$string;
+$var = (binary)$string;

--- a/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/NoSpaceAfterCastUnitTest.php
@@ -48,6 +48,7 @@ class NoSpaceAfterCastUnitTest extends AbstractSniffUnitTest
             41 => 1,
             43 => 1,
             45 => 1,
+            50 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -42,3 +42,6 @@ function foo(
 
 $foo = function (?Int $a, ?    Callable $b)
     :?INT{};
+
+$var = (BInARY) $string;
+$var = (binary)$string;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -42,3 +42,6 @@ function foo(
 
 $foo = function (?int $a, ?    callable $b)
     :?int{};
+
+$var = (binary) $string;
+$var = (binary)$string;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -44,6 +44,7 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             39 => 1,
             43 => 2,
             44 => 1,
+            46 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -275,6 +275,7 @@ class OperatorBracketSniff implements Sniff
             T_DNUMBER                  => true,
             T_STRING                   => true,
             T_CONSTANT_ENCAPSED_STRING => true,
+            T_DOUBLE_QUOTED_STRING     => true,
             T_WHITESPACE               => true,
             T_NS_SEPARATOR             => true,
             T_THIS                     => true,

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
@@ -165,3 +165,5 @@ $a = 2 * ${x} - ${minus};
 $foo = $bar ?? $baz ?? '';
 
 $foo = $myString{-1};
+
+$value = (binary) $blah + b"binary $foo";

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
@@ -165,3 +165,5 @@ $a = 2 * ${x} - ${minus};
 $foo = ($bar ?? $baz ?? '');
 
 $foo = $myString{-1};
+
+$value = ((binary) $blah + b"binary $foo");

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -65,6 +65,7 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
                 161 => 1,
                 163 => 2,
                 165 => 2,
+                169 => 1,
             ];
             break;
         case 'OperatorBracketUnitTest.js':


### PR DESCRIPTION
This PR adds some additional unit tests dealing with binary casts to various sniffs which look for the `$castTokens`.

It includes a very minor fix for the `Squiz.Formatting.OperatorBracket` sniff  when - no matter how unlikely - the sniff is triggered in combination with a `b"something $foo"` syntax.

Related to #1574 and https://github.com/squizlabs/PHP_CodeSniffer/commit/f36eecf11e97576f7d0860741dfbe73b7e7a7fcc