### PR TITLE
New `Generic.Formatting.SpaceBeforeCast` sniff

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Ensures there is a single space before cast tokens.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class SpaceBeforeCastSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Tokens::$castTokens;
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['column'] === 1) {
+            return;
+        }
+
+        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
+            $error = 'A cast statement must be preceded by a single space';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpace');
+            if ($fix === true) {
+                $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
+            }
+
+            $phpcsFile->recordMetric($stackPtr, 'Spacing before cast statement', 0);
+            return;
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Spacing before cast statement', $tokens[($stackPtr - 1)]['length']);
+
+        if ($tokens[($stackPtr - 1)]['column'] !== 1 && $tokens[($stackPtr - 1)]['length'] !== 1) {
+            $error = 'A cast statement must be preceded by a single space';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'TooMuchSpace');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc
@@ -1,0 +1,65 @@
+<?php
+
+$a = $a+(bool) $b;
+$a = function_call((bool) $b);
+if ((bool) $a ===(bool) $b) {}
+
+$var = (int) $var2;
+$var =(int) $var2;
+$var =     (int) $var2;
+
+$var = (integer) $var2;
+$var =(integer) $var2;
+$var =    (integer) $var2;
+
+$var = (string) $var2;
+$var =(string) $var2;
+$var =	 (string) $var2;
+
+$var = (float) $var2;
+$var =(float) $var2;
+$var =			 (float) $var2;
+
+$var = (double) $var2;
+$var =(double) $var2;
+$var =  (double) $var2;
+
+$var = (real) $var2;
+$var =(real) $var2;
+$var =    (real) $var2;
+
+$var = (array) $var2;
+$var =(array) $var2;
+$var =   (array) $var2;
+
+$var = (bool) $var2;
+$var =(bool) $var2;
+$var =    (bool) $var2;
+
+$var = (boolean) $var2;
+$var =(boolean) $var2;
+$var =  (boolean) $var2;
+
+$var = (object) $var2;
+$var =(object) $var2;
+$var =  (object) $var2;
+
+$var = (unset) $var2;
+$var =(unset) $var2;
+$var =   (unset) $var2;
+
+$var = b"binary $foo";
+$var =b"binary string";
+$var =   b'binary string';
+$var = (binary) $string;
+$var =(binary) $string;
+$var =    (binary) $string;
+
+$var = array(
+	(bool) $a,
+	array(
+        (int) $b,
+	),
+);
+
+(bool) $a ? echo $b : echo $c;

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.inc.fixed
@@ -1,0 +1,65 @@
+<?php
+
+$a = $a+ (bool) $b;
+$a = function_call( (bool) $b);
+if ( (bool) $a === (bool) $b) {}
+
+$var = (int) $var2;
+$var = (int) $var2;
+$var = (int) $var2;
+
+$var = (integer) $var2;
+$var = (integer) $var2;
+$var = (integer) $var2;
+
+$var = (string) $var2;
+$var = (string) $var2;
+$var = (string) $var2;
+
+$var = (float) $var2;
+$var = (float) $var2;
+$var = (float) $var2;
+
+$var = (double) $var2;
+$var = (double) $var2;
+$var = (double) $var2;
+
+$var = (real) $var2;
+$var = (real) $var2;
+$var = (real) $var2;
+
+$var = (array) $var2;
+$var = (array) $var2;
+$var = (array) $var2;
+
+$var = (bool) $var2;
+$var = (bool) $var2;
+$var = (bool) $var2;
+
+$var = (boolean) $var2;
+$var = (boolean) $var2;
+$var = (boolean) $var2;
+
+$var = (object) $var2;
+$var = (object) $var2;
+$var = (object) $var2;
+
+$var = (unset) $var2;
+$var = (unset) $var2;
+$var = (unset) $var2;
+
+$var = b"binary $foo";
+$var = b"binary string";
+$var = b'binary string';
+$var = (binary) $string;
+$var = (binary) $string;
+$var = (binary) $string;
+
+$var = array(
+	(bool) $a,
+	array(
+        (int) $b,
+	),
+);
+
+(bool) $a ? echo $b : echo $c;

--- a/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceBeforeCastUnitTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Unit test class for the SpaceBeforeCast sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Formatting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class SpaceBeforeCastUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            3  => 1,
+            4  => 1,
+            5  => 2,
+            8  => 1,
+            9  => 1,
+            12 => 1,
+            13 => 1,
+            16 => 1,
+            17 => 1,
+            20 => 1,
+            21 => 1,
+            24 => 1,
+            25 => 1,
+            28 => 1,
+            29 => 1,
+            32 => 1,
+            33 => 1,
+            36 => 1,
+            37 => 1,
+            40 => 1,
+            41 => 1,
+            44 => 1,
+            45 => 1,
+            48 => 1,
+            49 => 1,
+            52 => 1,
+            53 => 1,
+            55 => 1,
+            56 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
... which verifies that there is exactly one space before a type cast.

Sister-sniff to the `Generic.Formatting.SpaceAfterCast` sniff.

Depending on the coding-standard in which this sniff is included, this sniff may throw "duplicate" messages, i.e. given `$a =(bool) $b;`, a lot of coding standards will throw an error already demanding a space after the assignment operator.
All the same, type casts can be used in all sorts of code constructs, so there may well be situations in which the preceding token would not trigger an error, in which case, this sniff becomes relevant.

Notes:
* If the preceding whitespace is indentation, the sniff bows out.
* If the type cast is at the start of line, the sniff bows out.

Includes unit tests.