### PR TITLE
PSR2/PropertyDeclaration: add modifier order error + fixing

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1066,6 +1066,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDeclarationUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDeclarationUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="PropertyDeclarationUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="PropertyDeclarationUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="PropertyDeclarationUnitTest.php" role="test" />
        </dir>
        <dir name="ControlStructures">

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -39,7 +39,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         // for this, but also only process the first property in the list so we don't
         // repeat errors.
         $find = Tokens::$scopeModifiers;
-        $find = array_merge($find, [T_VARIABLE, T_VAR, T_SEMICOLON]);
+        $find = array_merge($find, [T_VARIABLE, T_VAR, T_SEMICOLON, T_OPEN_CURLY_BRACKET]);
         $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1));
         if ($tokens[$prev]['code'] === T_VARIABLE) {
             return;
@@ -51,17 +51,53 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         }
 
         $next = $phpcsFile->findNext([T_VARIABLE, T_SEMICOLON], ($stackPtr + 1));
-        if ($tokens[$next]['code'] === T_VARIABLE) {
+        if ($next !== false && $tokens[$next]['code'] === T_VARIABLE) {
             $error = 'There must not be more than one property declared per statement';
             $phpcsFile->addError($error, $stackPtr, 'Multiple');
         }
 
-        $modifier = $phpcsFile->findPrevious(Tokens::$scopeModifiers, $stackPtr);
-        if (($modifier === false) || ($tokens[$modifier]['line'] !== $tokens[$stackPtr]['line'])) {
+        try {
+            $propertyInfo = $phpcsFile->getMemberProperties($stackPtr);
+            if (empty($propertyInfo) === true) {
+                return;
+            }
+        } catch (Exception $e) {
+            // Turns out not to be a property after all.
+            return;
+        }
+
+        if ($propertyInfo['scope_specified'] === false) {
             $error = 'Visibility must be declared on property "%s"';
             $data  = [$tokens[$stackPtr]['content']];
             $phpcsFile->addError($error, $stackPtr, 'ScopeMissing', $data);
         }
+
+        if ($propertyInfo['scope_specified'] === true && $propertyInfo['is_static'] === true) {
+            $scopePtr  = $phpcsFile->findPrevious(Tokens::$scopeModifiers, ($stackPtr - 1));
+            $staticPtr = $phpcsFile->findPrevious(T_STATIC, ($stackPtr - 1));
+            if ($scopePtr < $staticPtr) {
+                return;
+            }
+
+            $error = 'The static declaration must come after the visibility declaration';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'StaticBeforeVisibility');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+
+                for ($i = ($scopePtr + 1); $scopePtr < $stackPtr; $i++) {
+                    if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->replaceToken($scopePtr, '');
+                $phpcsFile->fixer->addContentBefore($staticPtr, $propertyInfo['scope'].' ');
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }//end if
 
     }//end processMemberVar()
 

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
@@ -35,9 +35,8 @@ class ABC {
     public static $propA;
     protected static $propB;
     private static $propC;
-    static public $propD;
-    static
-        protected
-            $propE;
-    static private    /*comment*/   $propF;
+    public static $propD;
+    protected static
+        $propE;
+    private static /*comment*/   $propF;
 }

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -29,8 +29,13 @@ class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
             7  => 1,
             9  => 2,
             10 => 1,
-            16 => 1,
+            11 => 1,
             17 => 1,
+            18 => 1,
+            23 => 1,
+            38 => 1,
+            41 => 1,
+            42 => 1,
         ];
 
     }//end getErrorList()
@@ -47,9 +52,9 @@ class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            12 => 1,
             13 => 1,
             14 => 1,
+            15 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
IMO the feature request made in #2198 is unequivocally covered by PSR2 (emphasis in the quote is mine):

> Visibility MUST be declared on all **_properties_** and methods; `abstract` and `final` MUST be declared before the visibility; `static` MUST be declared after the visibility.
Ref: https://www.php-fig.org/psr/psr-2/#1-overview

With that in mind, I've adjusted the `PSR2.Classes.PropertyDeclaration` sniff to include a check for the modifier keyword order.

Includes unit tests.

Notes:
* As the sniff didn't have any fixers up to now, I've added a `.fixed` file.
* The fixer tries to gracefully handle any comments found between the keywords and the property variable.
* The sniff now defers to the `File::getMemberProperties()` method for the information on whether scope (and static) is specified.
    This also fixes a bug where the visibility was incorrectly not recognized as present when it was declared on another line. See unit test on line 22.
* Added a unit test to cover PHP4 style static properties and documented an intentional parse error in the test case file.
* Additionally, this PR contains some minor defensive coding improvements to the sniff.

Fixes #2198