### PR TITLE
Add support for multiline indenting to ObjectOperatorIndentSniff

### DIFF
--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -22,6 +22,13 @@ class ObjectOperatorIndentSniff implements Sniff
      */
     public $indent = 4;
 
+    /**
+     * Indicates whether multilevel indenting is allowed.
+     *
+     * @var boolean
+     */
+    public $multilevel = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -71,12 +78,12 @@ class ObjectOperatorIndentSniff implements Sniff
             }
         }
 
-        $requiredIndent = 0;
-        if ($i >= 0 && $tokens[$i]['code'] === T_WHITESPACE) {
-            $requiredIndent = strlen($tokens[$i]['content']);
+        $baseIndent = 0;
+        if ($i >= 0 && $tokens[$i]['code'] === \T_WHITESPACE) {
+            $baseIndent = \strlen($tokens[$i]['content']);
         }
 
-        $requiredIndent += $this->indent;
+        $baseIndent += $this->indent;
 
         // Determine the scope of the original object operator.
         $origBrackets = null;
@@ -95,6 +102,8 @@ class ObjectOperatorIndentSniff implements Sniff
         if ($tokens[$stackPtr]['line'] > $tokens[$start]['line']) {
             $next = $stackPtr;
         }
+
+        $previousIndent = $baseIndent;
 
         while ($next !== false) {
             // Make sure it is in the same scope, otherwise don't check indent.
@@ -121,22 +130,34 @@ class ObjectOperatorIndentSniff implements Sniff
                         $foundIndent = 0;
                     }
 
-                    if ($foundIndent !== $requiredIndent) {
+                    $minIndent      = $previousIndent;
+                    $maxIndent      = $previousIndent;
+                    $expectedIndent = $previousIndent;
+
+                    if ($this->multilevel === true) {
+                        $minIndent      = \max(($previousIndent - $this->indent), $baseIndent);
+                        $maxIndent      = ($previousIndent + $this->indent);
+                        $expectedIndent = \min(\max($foundIndent, $minIndent), $maxIndent);
+                    }
+
+                    if ($foundIndent < $minIndent || $foundIndent > $maxIndent) {
                         $error = 'Object operator not indented correctly; expected %s spaces but found %s';
                         $data  = [
-                            $requiredIndent,
+                            $expectedIndent,
                             $foundIndent,
                         ];
 
                         $fix = $phpcsFile->addFixableError($error, $next, 'Incorrect', $data);
                         if ($fix === true) {
-                            $spaces = str_repeat(' ', $requiredIndent);
+                            $spaces = str_repeat(' ', $expectedIndent);
                             if ($foundIndent === 0) {
                                 $phpcsFile->fixer->addContentBefore($next, $spaces);
                             } else {
                                 $phpcsFile->fixer->replaceToken(($next - 1), $spaces);
                             }
                         }
+                    } else {
+                        $previousIndent = $foundIndent;
                     }
                 }//end if
 

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -156,9 +156,9 @@ class ObjectOperatorIndentSniff implements Sniff
                                 $phpcsFile->fixer->replaceToken(($next - 1), $spaces);
                             }
                         }
-                    } else {
-                        $previousIndent = $foundIndent;
                     }
+
+                    $previousIndent = $expectedIndent;
                 }//end if
 
                 // It cant be the last thing on the line either.

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
@@ -80,3 +80,5 @@ $someObject
 ->endSomething()
 ->doSomething(23, 42)
 ->endEverything();
+
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
@@ -71,3 +71,12 @@ someclass::one()
 (new someclass())->one()
     ->two()
         ->three();
+
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel true
+
+$someObject
+    ->startSomething()
+                    ->someOtherFunc(23, 42)
+->endSomething()
+->doSomething(23, 42)
+->endEverything();

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
@@ -80,3 +80,5 @@ $someObject
     ->endSomething()
     ->doSomething(23, 42)
     ->endEverything();
+
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
@@ -71,3 +71,12 @@ someclass::one()
 (new someclass())->one()
     ->two()
     ->three();
+
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel true
+
+$someObject
+    ->startSomething()
+        ->someOtherFunc(23, 42)
+    ->endSomething()
+    ->doSomething(23, 42)
+    ->endEverything();

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -38,6 +38,10 @@ class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
             65 => 1,
             69 => 1,
             73 => 1,
+            79 => 1,
+            80 => 1,
+            81 => 1,
+            82 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This PR adds supports for multilevel indenting to the amazing sniff `ObjectOperatorIndentSniff` created by @gsherwood.

Multilevel indenting contributes to improve code readability in long chained method calls. This convention is [widely used by Symfony in configuration definitions](https://symfony.com/doc/current/components/config/definition.html#variable-nodes):

```php
$rootNode
    ->children()
        ->booleanNode('auto_connect')
            ->defaultTrue()
        ->end()
        ->scalarNode('default_connection')
            ->defaultValue('default')
        ->end()
    ->end()
;
```

The option `multilevel` allows enabling/disabled the new behavior, which is disabled by default to be backward compatible with previous versions.

The sniff can automatically fix violations by adjusting the number of spaces based on the value of property `indent` and the previous indentation:

```php
// Before fix
$rootNode
    ->children()
		        ->booleanNode('auto_connect')
        ->end();

// After fix
$rootNode
    ->children()
        ->booleanNode('auto_connect')
    ->end();
```
Tests are included to confirm the correctness.