### PR TITLE
Generic/SpaceAfterNot: make the sniff configurable

### DIFF
--- a/src/Standards/Generic/Docs/Formatting/SpaceAfterNotStandard.xml
+++ b/src/Standards/Generic/Docs/Formatting/SpaceAfterNotStandard.xml
@@ -1,0 +1,25 @@
+<documentation title="Space After NOT operator">
+    <standard>
+    <![CDATA[
+    Exactly one space is allowed after the NOT operator.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: A NOT operator followed by one space.">
+        <![CDATA[
+if (!<em> </em>$someVar || !<em> </em>$x instanceOf stdClass) {};
+        ]]>
+        </code>
+        <code title="Invalid: A NOT operator not followed by whitespace.">
+        <![CDATA[
+if (!<em></em>$someVar || !<em></em>$x instanceOf stdClass) {};
+        ]]>
+        </code>
+        <code title="Invalid: A NOT operator followed by a new line or more than one space.">
+        <![CDATA[
+if (!<em>     </em>$someVar || !<em>
+    </em>$x instanceOf stdClass) {};
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class SpaceAfterNotSniff implements Sniff
 {
@@ -24,6 +25,20 @@ class SpaceAfterNotSniff implements Sniff
         'PHP',
         'JS',
     ];
+
+    /**
+     * The number of spaces desired after the NOT operator.
+     *
+     * @var integer
+     */
+    public $spacing = 1;
+
+    /**
+     * Allow newlines instead of spaces.
+     *
+     * @var boolean
+     */
+    public $ignoreNewlines = false;
 
 
     /**
@@ -49,25 +64,78 @@ class SpaceAfterNotSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
+        $tokens        = $phpcsFile->getTokens();
+        $this->spacing = (int) $this->spacing;
 
-        $spacing = 0;
-        if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-            $spacing = $tokens[($stackPtr + 1)]['length'];
-        }
-
-        if ($spacing === 1) {
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
             return;
         }
 
-        $message = 'There must be a single space after a NOT operator; %s found';
-        $fix     = $phpcsFile->addFixableError($message, $stackPtr, 'Incorrect', [$spacing]);
+        if ($this->ignoreNewlines === true
+            && $tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']
+        ) {
+            return;
+        }
+
+        if ($this->spacing === 0 && $nextNonEmpty === ($stackPtr + 1)) {
+            return;
+        }
+
+        $maybePlural = '';
+        if ($this->spacing !== 1) {
+            $maybePlural = 's';
+        }
+
+        $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty !== $nextNonWhitespace) {
+            $error = 'Expected %s space%s after NOT operator; comment found';
+            $data  = [
+                $this->spacing,
+                $maybePlural,
+            ];
+            $phpcsFile->addError($error, $stackPtr, 'CommentFound', $data);
+
+            return;
+        }
+
+        $found = 0;
+        if ($tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']) {
+            $found = 'newline';
+        } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+            $found = $tokens[($stackPtr + 1)]['length'];
+        }
+
+        if ($found === $this->spacing) {
+            return;
+        }
+
+        $error = 'Expected %s space%s after NOT operator; %s found';
+        $data  = [
+            $this->spacing,
+            $maybePlural,
+            $found,
+        ];
+        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Incorrect', $data);
 
         if ($fix === true) {
-            if ($spacing === 0) {
-                $phpcsFile->fixer->addContent($stackPtr, ' ');
+            $padding = str_repeat(' ', $this->spacing);
+            if ($found === 0) {
+                $phpcsFile->fixer->addContent($stackPtr, $padding);
             } else {
-                $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                $phpcsFile->fixer->beginChangeset();
+                $start = ($stackPtr + 1);
+
+                if ($this->spacing > 0) {
+                    $phpcsFile->fixer->replaceToken($start, $padding);
+                    ++$start;
+                }
+
+                for ($i = $start; $i < $nextNonWhitespace; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
             }
         }
 

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.inc
@@ -1,5 +1,86 @@
 <?php
-if (!$someVar || !$x instanceOf stdClass) {}
 if (! $someVar || ! $x instanceOf stdClass) {}
+if (!$someVar || !$x instanceOf stdClass) {}
+if (!     $someVar || !   $x instanceOf stdClass) {}
 if (!foo() && (!$x || true)) {}
 $var = !($x || $y);
+$var = !           ($x || $y);
+$var = ! /*comment*/ ($x || $y);
+
+$baz = function () {
+    return !  $bar;
+};
+
+if ( !
+    ($x || $y)
+) {
+    return !$bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines true
+if ( !
+    ($x || $y)
+) {
+    return !$bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines false
+
+// phpcs:set Generic.Formatting.SpaceAfterNot spacing 2
+if (!  $someVar || !  $x instanceOf stdClass) {}
+if (!$someVar || !$x instanceOf stdClass) {}
+if (! $someVar || !       $x instanceOf stdClass) {}
+if (!foo() && (!  $x || true)) {}
+$var = ! ($x || $y);
+$var = !           ($x || $y);
+
+$baz = function () {
+    return !  $bar;
+};
+
+if ( !
+    ($x || $y)
+) {
+    return !$bar;
+}
+
+// phpcs:set Generic.Formatting.SpaceAfterNot spacing 0
+if (!$someVar || !$x instanceOf stdClass) {}
+if (! $someVar || !    $x instanceOf stdClass) {}
+if (!   foo() && (!$x || true)) {}
+$var = ! ($x || $y);
+$var = ! /*comment*/ ($x || $y);
+
+$baz = function () {
+    return !  $bar;
+};
+
+if ( !
+    ($x || $y)
+) {
+    return ! $bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines true
+if ( !
+    ($x || $y)
+) {
+    return !    $bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines false
+// phpcs:set Generic.Formatting.SpaceAfterNot spacing 1

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.inc.fixed
@@ -1,5 +1,83 @@
 <?php
 if (! $someVar || ! $x instanceOf stdClass) {}
 if (! $someVar || ! $x instanceOf stdClass) {}
+if (! $someVar || ! $x instanceOf stdClass) {}
 if (! foo() && (! $x || true)) {}
 $var = ! ($x || $y);
+$var = ! ($x || $y);
+$var = ! /*comment*/ ($x || $y);
+
+$baz = function () {
+    return ! $bar;
+};
+
+if ( ! ($x || $y)
+) {
+    return ! $bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines true
+if ( !
+    ($x || $y)
+) {
+    return ! $bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines false
+
+// phpcs:set Generic.Formatting.SpaceAfterNot spacing 2
+if (!  $someVar || !  $x instanceOf stdClass) {}
+if (!  $someVar || !  $x instanceOf stdClass) {}
+if (!  $someVar || !  $x instanceOf stdClass) {}
+if (!  foo() && (!  $x || true)) {}
+$var = !  ($x || $y);
+$var = !  ($x || $y);
+
+$baz = function () {
+    return !  $bar;
+};
+
+if ( !  ($x || $y)
+) {
+    return !  $bar;
+}
+
+// phpcs:set Generic.Formatting.SpaceAfterNot spacing 0
+if (!$someVar || !$x instanceOf stdClass) {}
+if (!$someVar || !$x instanceOf stdClass) {}
+if (!foo() && (!$x || true)) {}
+$var = !($x || $y);
+$var = ! /*comment*/ ($x || $y);
+
+$baz = function () {
+    return !$bar;
+};
+
+if ( !($x || $y)
+) {
+    return !$bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines true
+if ( !
+    ($x || $y)
+) {
+    return !$bar;
+}
+
+if ( ! // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    ($x || $y)
+) {}
+// phpcs:set Generic.Formatting.SpaceAfterNot ignoreNewlines false
+// phpcs:set Generic.Formatting.SpaceAfterNot spacing 1

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterNotUnitTest.php
@@ -21,15 +21,54 @@ class SpaceAfterNotUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getErrorList()
+    public function getErrorList($testFile='')
     {
-        return [
-            2 => 2,
-            4 => 2,
-            5 => 1,
-        ];
+        switch ($testFile) {
+        case 'SpaceAfterNotUnitTest.inc':
+            return [
+                3  => 2,
+                4  => 2,
+                5  => 2,
+                6  => 1,
+                7  => 1,
+                8  => 1,
+                11 => 1,
+                14 => 1,
+                17 => 1,
+                20 => 1,
+                28 => 1,
+                38 => 2,
+                39 => 2,
+                40 => 1,
+                41 => 1,
+                42 => 1,
+                48 => 1,
+                51 => 1,
+                56 => 2,
+                57 => 1,
+                58 => 1,
+                59 => 1,
+                62 => 1,
+                65 => 1,
+                68 => 1,
+                71 => 1,
+                79 => 1,
+            ];
+
+        case 'SpaceAfterNotUnitTest.js':
+            return [
+                2 => 2,
+                4 => 2,
+                5 => 1,
+            ];
+
+        default:
+            return [];
+        }//end switch
 
     }//end getErrorList()
 


### PR DESCRIPTION
This PR makes the `Generic.Formatting.SpaceAfterNot` sniff configurable as discussed in PR https://github.com/squizlabs/PHP_CodeSniffer/pull/2057#issuecomment-396093803.

Notes:
* Adds a public `spacing` property. Defaults to `1` to maintain BC.
* Adds a public `ignoreNewLines` property. Defaults to `false` to maintain BC.
* Adds a new non-fixable `CommentFound` error for when non-whitespace tokens are found between the NOT operator and the next non-empty token.
* Adjusts the error message for the `Incorrect` error to allow for the flexibility now needed, what with the configurable `spacing` property.
    Note: the error **code** has not been changed to prevent a BC-break.
* Makes the fixer more efficient compared to before.
    Previously, if a whitespace + new line + whitespace would be found with `spacing` set to `1`, the fixer would need three loops to apply all the fixes, now this is fixed in one go.

Includes extensive additional unit tests.
Unit tests have been added to the PHP file, but the changes should work just as well for JS.

Includes basic xml documentation for the sniff.