### PR TITLE
Generic/SpaceAfterCast: make the sniff configurable & deprecates NoSpaceAfterCast

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/NoSpaceAfterCastSniff.php
@@ -5,6 +5,9 @@
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ *
+ * @deprecated 3.4.0 Use the Generic.Formatting.SpaceAfterCast sniff with
+ *                   the $spacing property set to 0 instead.
  */
 
 namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting;

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.inc
@@ -10,7 +10,7 @@ $var = (integer)  $var2;
 
 $var = (string) $var2;
 $var = (string)$var2;
-$var = (string)  $var2;
+$var = (string)    $var2;
 
 $var = (float) $var2;
 $var = (float)$var2;
@@ -42,10 +42,54 @@ $var = (object)  $var2;
 
 $var = (unset) $var2;
 $var = (unset)$var2;
-$var = (unset)  $var2;
+$var = (unset)          $var2;
 
 $var = b"binary $foo";
 $var = b"binary string";
 $var = b'binary string';
 $var = (binary) $string;
 $var = (binary)$string;
+
+$var = (boolean) /* comment */ $var2;
+
+$var = (int)
+	$var2;
+
+if ( (string) // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    $x === 'test'
+) {}
+
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines true
+$var = (int)
+	$var1 + (bool)  $var2;
+
+if ( (string) // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    $x === 'test'
+) {}
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines false
+
+// phpcs:set Generic.Formatting.SpaceAfterCast spacing 2
+$var = (int) $var2;
+$var = (string)$var2;
+$var = (array)  $var2;
+$var = (unset)        $var2;
+$var = (boolean) /* comment */ $var2;
+
+$var = (integer)
+	$var2;
+
+// phpcs:set Generic.Formatting.SpaceAfterCast spacing 0
+$var = (int) $var2;
+$var = (string)$var2;
+$var = (array)  $var2;
+$var = (unset)        $var2;
+$var = (boolean) /* comment */ $var2;
+
+$var = (integer)
+	$var2;
+
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines true
+$var = (int)
+	$var1 + (bool)  $var2;
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines false
+// phpcs:set Generic.Formatting.SpaceAfterCast spacing 1

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.inc.fixed
@@ -49,3 +49,44 @@ $var = b"binary string";
 $var = b'binary string';
 $var = (binary) $string;
 $var = (binary) $string;
+
+$var = (boolean) /* comment */ $var2;
+
+$var = (int) $var2;
+
+if ( (string) // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    $x === 'test'
+) {}
+
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines true
+$var = (int)
+	$var1 + (bool) $var2;
+
+if ( (string) // phpcs:ignore Standard.Cat.SniffName -- for reasons.
+    $x === 'test'
+) {}
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines false
+
+// phpcs:set Generic.Formatting.SpaceAfterCast spacing 2
+$var = (int)  $var2;
+$var = (string)  $var2;
+$var = (array)  $var2;
+$var = (unset)  $var2;
+$var = (boolean) /* comment */ $var2;
+
+$var = (integer)  $var2;
+
+// phpcs:set Generic.Formatting.SpaceAfterCast spacing 0
+$var = (int)$var2;
+$var = (string)$var2;
+$var = (array)$var2;
+$var = (unset)$var2;
+$var = (boolean) /* comment */ $var2;
+
+$var = (integer)$var2;
+
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines true
+$var = (int)
+	$var1 + (bool)$var2;
+// phpcs:set Generic.Formatting.SpaceAfterCast ignoreNewlines false
+// phpcs:set Generic.Formatting.SpaceAfterCast spacing 1

--- a/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/SpaceAfterCastUnitTest.php
@@ -49,6 +49,21 @@ class SpaceAfterCastUnitTest extends AbstractSniffUnitTest
             44 => 1,
             45 => 1,
             51 => 1,
+            53 => 1,
+            55 => 1,
+            58 => 1,
+            64 => 1,
+            72 => 1,
+            73 => 1,
+            75 => 1,
+            76 => 1,
+            78 => 1,
+            82 => 1,
+            84 => 1,
+            85 => 1,
+            86 => 1,
+            88 => 1,
+            93 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This PR makes the `Generic.Formatting.SpaceAfterCast` sniff configurable as discussed in PR https://github.com/squizlabs/PHP_CodeSniffer/pull/2057#issuecomment-396103995 and deprecates the `Generic.Formatting.NoSpaceAfterCast` sniff.

Notes:
* Adds a public `spacing` property. Defaults to `1` to maintain BC.
* Adds a public `ignoreNewLines` property. Defaults to `false` to maintain BC.
* Adds a new non-fixable `CommentFound` error for when non-whitespace tokens are found between the type cast and the next non-empty token.
* Adds a new fixable `TooLittleSpace` error code for when `$spacing` is set to more than `1` and there is whitespace, but not enough.
* Adjusts the error message for the `NoSpace` and `TooMuchSpace` errors to allow for the flexibility now needed, what with the configurable `spacing` property.
    Note: the error **codes** have not been changed to prevent a BC-break.
* Makes the fixer more efficient compared to before.
    Previously, if a whitespace + new line + whitespace would be found with `spacing` set to `1`, the fixer would need three loops to apply all the fixes, now this is fixed in one go.

Includes additional unit tests.