### PR TITLE
Squiz/ObjectOperatorSpacing: fix whitespace in one loop

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -104,7 +104,16 @@ class ObjectOperatorSpacingSniff implements Sniff
             $error = 'Space found before object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Before');
             if ($fix === true) {
-                $phpcsFile->fixer->replaceToken(($stackPtr - 1), '');
+                $tokens = $phpcsFile->getTokens();
+                $curPos = ($stackPtr - 1);
+
+                $phpcsFile->fixer->beginChangeset();
+                while ($tokens[$curPos]['code'] === T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken($curPos, '');
+                    --$curPos;
+                }
+
+                $phpcsFile->fixer->endChangeset();
             }
 
             return false;
@@ -134,7 +143,16 @@ class ObjectOperatorSpacingSniff implements Sniff
             $error = 'Space found after object operator';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'After');
             if ($fix === true) {
-                $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+                $tokens = $phpcsFile->getTokens();
+                $curPos = ($stackPtr + 1);
+
+                $phpcsFile->fixer->beginChangeset();
+                while ($tokens[$curPos]['code'] === T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken($curPos, '');
+                    ++$curPos;
+                }
+
+                $phpcsFile->fixer->endChangeset();
             }
 
             return false;

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
@@ -2,7 +2,7 @@
 $this->testThis();
 $this-> testThis();
 $this    ->  testThis();
-$this->/* comment here */testThis();
+$this-> /* comment here */testThis();
 $this/* comment here */ -> testThis();
 $this
     ->testThis();

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -28,6 +28,7 @@ class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest
         return [
             3  => 1,
             4  => 2,
+            5  => 1,
             6  => 2,
             8  => 1,
             9  => 1,


### PR DESCRIPTION
Efficiency fix. Prevents the fixer having to be triggered multiple times when, for instance, whitespace + newline + whitespace or several new lines are found between the object operator and the token before/after.

Existing unit tests already cover this change.

The effect of the change can be seen by running `phpcbf -v --standard=Squiz ./src/Standards/Squiz.Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc --sniffs=Squiz.WhiteSpaceObjectOperatorSpacing` first on `master` (3 passes needed), then on this branch (2 passes needed).

Includes minor improvement to an existing unit test checking the handling of whitespace in combination with comments.