### PR TITLE
Squiz/SelfMemberReference: various bug fixes

### DIFF
--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -108,9 +108,10 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
 
                     $phpcsFile->fixer->replaceToken($stackPtr, 'self::');
                     $phpcsFile->fixer->endChangeset();
-                }
 
-                return;
+                    // Fix potential whitespace issues in the next loop.
+                    return;
+                }
             }//end if
         }//end if
 

--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -16,6 +16,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes;
 
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class SelfMemberReferenceSniff extends AbstractScopeSniff
 {
@@ -57,7 +58,12 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
             return;
         }
 
-        $calledClassName = ($stackPtr - 1);
+        $calledClassName = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($calledClassName === false) {
+            // Parse error.
+            return;
+        }
+
         if ($tokens[$calledClassName]['code'] === T_SELF) {
             if ($tokens[$calledClassName]['content'] !== 'self') {
                 $error = 'Must use "self::" for local static member reference; found "%s::"';

--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -208,7 +208,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
         $namespaceDeclaration = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr);
 
         if ($namespaceDeclaration !== false) {
-            $endOfNamespaceDeclaration = $phpcsFile->findNext(T_SEMICOLON, $namespaceDeclaration);
+            $endOfNamespaceDeclaration = $phpcsFile->findNext([T_SEMICOLON, T_OPEN_CURLY_BRACKET], $namespaceDeclaration);
             $namespace = $this->getDeclarationNameWithNamespace(
                 $phpcsFile->getTokens(),
                 ($endOfNamespaceDeclaration - 1)

--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -81,7 +81,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($calledClassName - 1), null, true);
             if ($prevNonEmpty !== false && $tokens[$prevNonEmpty]['code'] === T_NS_SEPARATOR) {
                 $declarationName        = $this->getDeclarationNameWithNamespace($tokens, $calledClassName);
-                $declarationName        = substr($declarationName, 1);
+                $declarationName        = ltrim($declarationName, '\\');
                 $fullQualifiedClassName = $this->getNamespaceOfScope($phpcsFile, $currScope);
                 if ($fullQualifiedClassName === '\\') {
                     $fullQualifiedClassName = '';

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc
@@ -66,7 +66,7 @@ class MyClass {
 
     public static function walk() {
         $callback = function($value, $key) {
-                        // This is valid because you cant use self:: in a closure
+                        // This is valid because you can't use self:: in a closure.
                         MyClass::test($value);
                     };
 
@@ -131,4 +131,44 @@ class Baz {
         \Foo\Bar\Whatever::something();
         \Foo\Bar\Baz::something();
     }
+}
+
+class Nested_Anon_Class {
+    public function getAnonymousClass() {
+		// Spacing/comments should not cause false negatives for the NotUsed error.
+        Nested_Anon_Class      ::       $prop;
+		Nested_Anon_Class
+		/* some comment */
+
+		::
+
+		// phpcs:ignore Standard.Category.SniffName -- for reasons.
+		Bar();
+
+		// Anonymous class is a different scope.
+        return new class() {
+            public function nested_function() {
+                Nested_Anon_Class::$prop;
+                Nested_Anon_Class::BAR;
+            }
+        };
+    }
+}
+
+// Test dealing with scoped namespaces.
+namespace Foo\Baz {
+	class BarFoo {
+		public function foo() {
+			echo Foo\Baz\BarFoo::$prop;
+		}
+	}
+}
+
+// Prevent false negative when namespace has whitespace/comments.
+namespace Foo /*comment*/ \ Bah {
+	class BarFoo {
+		public function foo() {
+			echo Foo \ /*comment*/ Bah\BarFoo::$prop;
+		}
+	}
 }

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.inc.fixed
@@ -56,7 +56,7 @@ class MyClass {
 
     public static function walk() {
         $callback = function($value, $key) {
-                        // This is valid because you cant use self:: in a closure
+                        // This is valid because you can't use self:: in a closure.
                         MyClass::test($value);
                     };
 
@@ -121,4 +121,42 @@ class Baz {
         \Foo\Bar\Whatever::something();
         self::something();
     }
+}
+
+class Nested_Anon_Class {
+    public function getAnonymousClass() {
+		// Spacing/comments should not cause false negatives for the NotUsed error.
+              self::$prop;
+		
+		/* some comment */
+
+		self::// phpcs:ignore Standard.Category.SniffName -- for reasons.
+		Bar();
+
+		// Anonymous class is a different scope.
+        return new class() {
+            public function nested_function() {
+                Nested_Anon_Class::$prop;
+                Nested_Anon_Class::BAR;
+            }
+        };
+    }
+}
+
+// Test dealing with scoped namespaces.
+namespace Foo\Baz {
+	class BarFoo {
+		public function foo() {
+			echo self::$prop;
+		}
+	}
+}
+
+// Prevent false negative when namespace has whitespace/comments.
+namespace Foo /*comment*/ \ Bah {
+	class BarFoo {
+		public function foo() {
+			echo   /*comment*/ self::$prop;
+		}
+	}
 }

--- a/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/SelfMemberReferenceUnitTest.php
@@ -36,6 +36,11 @@ class SelfMemberReferenceUnitTest extends AbstractSniffUnitTest
             92  => 1,
             121 => 1,
             132 => 1,
+            139 => 3,
+            140 => 1,
+            143 => 2,
+            162 => 1,
+            171 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This PR takes care of the issues identified in https://github.com/squizlabs/PHP_CodeSniffer/pull/2185#issuecomment-430027868 as well as some other bugs.

**Note**: As the sniff is now more directly targeted at the use of `self` in the right places, I would strongly recommend for the whitespace related errors - `SpaceBefore` and `SpaceAfter` - to be removed from this sniff.
The `Squiz.WhiteSpace.ObjectOperatorSpacing` sniff already handles this anyway and handles this better.

## Relevant Commit Summary

### Squiz/SelfMemberReference: prevent false positives icw anonymous classes

Fixes #2232

### Squiz/SelfMemberReference: prevent false negatives for NotUsed error

... when the double colon is preceded by whitespace/comments.

### Squiz/SelfMemberReference: don't hide one error behind another

Prevent the sniff from not throwing the whitespace errors when the `NotUsed` error is also found.

### Squiz/SelfMemberReference: allow for scoped namespace declarations

### Squiz/SelfMemberReference: allow for namespace declarations interspersed with whitespace/comments

Loosely related to #2150

### Squiz/SelfMemberReference: only strip leading namespace separator 

... to prevent the name comparison breaking.


The PR includes unit tests for all fixes.