### PR TITLE
[WIP] Squiz.WhiteSpace.FunctionSpacing and nested functions

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -166,7 +166,21 @@ class FunctionSpacingSniff implements Sniff
             } else {
                 $foundLines += ($tokens[$nextContent]['line'] - $tokens[$nextLineToken]['line']);
             }
-        }
+
+            $sliced = array_slice($tokens, ($closer + 1), $phpcsFile->findEndOfStatement($closer + 1), true);
+            foreach ($sliced as $number => $token) {
+                if (in_array($token['code'], [T_COMMENT, T_WHITESPACE]) === true) {
+                    continue;
+                }
+
+                if ($token['type'] === 'T_CLOSE_CURLY_BRACKET' && $tokens[$token['scope_condition']]['code'] === T_FUNCTION) {
+                    // Is a nested function.
+                    $requiredSpacing = 0;
+                }
+
+                break;
+            }
+        }//end if
 
         if ($foundLines !== $requiredSpacing) {
             $error = 'Expected %s blank line';

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc
@@ -411,3 +411,31 @@ class MyClass
      */
     function func2() {}
 }//end class
+
+function func1() {
+    function func2() {}
+
+    function func3() {
+        function func4() {}
+
+
+    }
+
+}
+
+class MyClass
+{
+
+    function func1() {
+        function func2() {}
+
+        function func3() {
+            function func4() {}
+
+
+        }
+
+
+    }
+
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.inc.fixed
@@ -454,3 +454,24 @@ class MyClass
     function func2() {}
 
 }//end class
+
+function func1() {
+    function func2() {}
+
+    function func3() {
+        function func4() {}
+    }
+}
+
+class MyClass
+{
+
+    function func1() {
+        function func2() {}
+
+        function func3() {
+            function func4() {}
+        }
+    }
+
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/FunctionSpacingUnitTest.php
@@ -64,6 +64,10 @@ class FunctionSpacingUnitTest extends AbstractSniffUnitTest
             393 => 1,
             405 => 2,
             412 => 2,
+            419 => 1,
+            422 => 1,
+            433 => 1,
+            436 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Currently nested functions still have extra lines appended after. Since this applies to the last one in the list, I wouldn't expect it (refs https://github.com/libero/php-coding-standard/pull/30#discussion_r230062042). I've left this as WIP, however, because I'm not sure that this would apply globally (maybe should be a new config option?).