### PR TITLE
Generic.CodeAnalysis.EmptyStatement Add option to allow only comments in statements

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -30,6 +30,13 @@ use PHP_CodeSniffer\Util\Tokens;
 class EmptyStatementSniff implements Sniff
 {
 
+    /**
+     * Whether to allow statements that contain only comments.
+     *
+     * @var boolean
+     */
+    public $allowComments = false;
+
 
     /**
      * Registers the tokens that this sniff wants to listen for.
@@ -74,10 +81,16 @@ class EmptyStatementSniff implements Sniff
             return;
         }
 
+        if ($this->allowComments === true) {
+            $emptyTokens = ([T_WHITESPACE => T_WHITESPACE] + Tokens::$phpcsCommentTokens);
+        } else {
+            $emptyTokens = Tokens::$emptyTokens;
+        }
+
         $next = $phpcsFile->findNext(
-            Tokens::$emptyTokens,
+            $emptyTokens,
             ($token['scope_opener'] + 1),
-            ($token['scope_closer'] - 1),
+            $token['scope_closer'],
             true
         );
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.inc
@@ -70,3 +70,17 @@ try {
 }
 
 if (true) {} elseif (false) {}
+
+// phpcs:set Generic.CodeAnalysis.EmptyStatement allowComments true
+
+if ($foo) {
+    // Just a comment
+} elseif ($bar) {
+    /*
+     * Yet another comment
+     */
+} elseif ($baz) {
+    // phpcs:set Generic.CodeAnalysis.EmptyStatement somethingMadeUp true
+} else {
+
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -39,6 +39,8 @@ class EmptyStatementUnitTest extends AbstractSniffUnitTest
             64 => 1,
             68 => 1,
             72 => 2,
+            82 => 1,
+            84 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
There are cases where it's valid to only have a comment in a statement, this adds an option to allow it (refs https://github.com/libero/php-coding-standard/pull/34#discussion_r233818322).