### PR TITLE
Squiz/LowercaseFunctionKeywords: various improvements

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1534,6 +1534,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="GlobalFunctionUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="GlobalFunctionUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseFunctionKeywordsUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowercaseFunctionKeywordsUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseFunctionKeywordsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MultiLineFunctionDeclarationUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MultiLineFunctionDeclarationUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class LowercaseFunctionKeywordsSniff implements Sniff
 {
@@ -23,13 +24,11 @@ class LowercaseFunctionKeywordsSniff implements Sniff
      */
     public function register()
     {
-        return [
-            T_FUNCTION,
-            T_PUBLIC,
-            T_PRIVATE,
-            T_PROTECTED,
-            T_STATIC,
-        ];
+        $tokens   = Tokens::$methodPrefixes;
+        $tokens[] = T_FUNCTION;
+        $tokens[] = T_CLOSURE;
+
+        return $tokens;
 
     }//end register()
 
@@ -47,15 +46,20 @@ class LowercaseFunctionKeywordsSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $content = $tokens[$stackPtr]['content'];
-        if ($content !== strtolower($content)) {
+        $content   = $tokens[$stackPtr]['content'];
+        $contentLc = strtolower($content);
+        if ($content !== $contentLc) {
             $error = '%s keyword must be lowercase; expected "%s" but found "%s"';
             $data  = [
                 strtoupper($content),
-                strtolower($content),
+                $contentLc,
                 $content,
             ];
-            $phpcsFile->addError($error, $stackPtr, 'FoundUppercase', $data);
+
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, 'FoundUppercase', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($stackPtr, $contentLc);
+            }
         }
 
     }//end process()

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.inc.fixed
@@ -13,14 +13,14 @@ abstract class Foo {
 }
 
 // Incorrect.
-Function Bar() {}
-$a = FUNCTION() {};
+function Bar() {}
+$a = function() {};
 
 abstract class Bar {
-	Public function PublicFunction() {}
-	Private function PrivateFunction() {}
-	Protected function ProtectedFunction() {}
-	Static function StaticFunction() {}
-	ABSTRACT proTECted FUNCTION AbstractProtectedFunction();
-	Final STATIC PUBLIC Function FinalStaticPublicFunction() {}
+	public function PublicFunction() {}
+	private function PrivateFunction() {}
+	protected function ProtectedFunction() {}
+	static function StaticFunction() {}
+	abstract protected function AbstractProtectedFunction();
+	final static public function FinalStaticPublicFunction() {}
 }

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
@@ -26,11 +26,14 @@ class LowercaseFunctionKeywordsUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            2 => 1,
-            3 => 1,
-            4 => 1,
-            5 => 1,
-            6 => 1,
+            16 => 1,
+            17 => 1,
+            20 => 1,
+            21 => 1,
+            22 => 1,
+            23 => 1,
+            24 => 3,
+            25 => 4,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
* Also check closures and the `abstract` and `final` method prefixes.
* Make the error fixable.
* Minor code duplication removal.

Includes improved unit tests + added a `fixed` file.