### PR TITLE
[Minor] Move isSpecialMethod

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -37,10 +37,9 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
      */
     protected function processReturn(File $phpcsFile, $stackPtr, $commentStart)
     {
-        $tokens     = $phpcsFile->getTokens();
-        $methodName = $phpcsFile->getDeclarationName($stackPtr);
-
+        $tokens = $phpcsFile->getTokens();
         $return = null;
+
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
             if ($tokens[$tag]['content'] === '@return') {
                 if ($return !== null) {
@@ -54,6 +53,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         }
 
         // Skip constructor and destructor.
+        $methodName      = $phpcsFile->getDeclarationName($stackPtr);
         $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
         if ($isSpecialMethod === true) {
             return;

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -37,9 +37,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
      */
     protected function processReturn(File $phpcsFile, $stackPtr, $commentStart)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        // Skip constructor and destructor.
+        $tokens     = $phpcsFile->getTokens();
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
 
         $return = null;
@@ -55,6 +53,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
             }
         }
 
+        // Skip constructor and destructor.
         $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
         if ($isSpecialMethod === true) {
             return;

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -41,7 +41,6 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 
         // Skip constructor and destructor.
         $methodName      = $phpcsFile->getDeclarationName($stackPtr);
-        $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
 
         $return = null;
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
@@ -56,6 +55,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
             }
         }
 
+        $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
         if ($isSpecialMethod === true) {
             return;
         }

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -40,7 +40,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         $tokens = $phpcsFile->getTokens();
 
         // Skip constructor and destructor.
-        $methodName      = $phpcsFile->getDeclarationName($stackPtr);
+        $methodName = $phpcsFile->getDeclarationName($stackPtr);
 
         $return = null;
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {


### PR DESCRIPTION
Minor improvement by moving $isSpecialMethod to the next lines. This way in case you return to the if statement before you save a not needed comparison.