### PR TITLE
Squiz.CSS.SemicolonSpacing: add fixed file and various improvements

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1504,6 +1504,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="OpacityUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="OpacityUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SemicolonSpacingUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SemicolonSpacingUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SemicolonSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ShorthandSizeUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ShorthandSizeUnitTest.php" role="test" />

--- a/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css.fixed
@@ -4,7 +4,7 @@
 }
 
 #MetadataAdminScreen-addField-add {
-    float: left ;
+    float: left;
 }
 
 .TableWidgetType .recover:hover {
@@ -40,15 +40,12 @@
 }
 
 #multi-line-style-whitespace {
-	padding: 0 /* phpcs:ignore Standard.Cat.Sniff -- for reasons */      ;
+	padding: 0; /* phpcs:ignore Standard.Cat.Sniff -- for reasons */
 	border:
-	    20    ;
+	    20;
 	margin:
 		10px /* top */
-		0px  /* right + left */
-
-
-	;
+		0px;  /* right + left */
 }
 
 /* Live coding. Has to be the last test in the file. */

--- a/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.php
@@ -26,8 +26,15 @@ class SemicolonSpacingUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            2 => 1,
-            7 => 1,
+            2  => 1,
+            7  => 1,
+            30 => 1,
+            34 => 1,
+            36 => 1,
+            39 => 1,
+            43 => 1,
+            45 => 1,
+            48 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contains fixers, but didn't have a `fixed` file.

While I was at it, I've reviewed the sniff and applied any improvements I could think of:
* The sniff will now bow out during live coding.
* The sniff did not take multiple CSS declarations on a single line into account.
* The sniff did not take multi-line CSS declarations into account.
    The error messages will now be thrown on the last line of the CSS declaration, not on the line containing the `T_STYLE` token.
* The sniff did not take multi-line whitespace between the end of a declaration and the semi-colon into account.
    - The error message has been adjusted to provide better information in that case.
    - The fixer has been adjusted to now fix this in one go.
* The sniff did not take comments or PHPCS annotations into account.
    - The sniff has been adjusted to not get confused over this anymore.
    - The fixer has been adjusted to handle comments correctly.

Includes additional unit tests for all fixes.

N.B.: Working on this left me wondering why the `NotAtEnd` (missing semi-colon) error is not auto-fixable. I couldn't find anything in the file history related to this and with the code as it is in this PR, adding a fixer for the missing semi-colon would actually be really easy, so let me know if that would be desired.