### PR TITLE
Squiz.CSS.ClassDefinitionClosingBrace: add fixed file and various improvements

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1470,6 +1470,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        </dir>
        <dir name="CSS">
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionClosingBraceSpaceUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionClosingBraceSpaceUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionClosingBraceSpaceUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionNameSpacingUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionNameSpacingUnitTest.php" role="test" />

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php
@@ -48,33 +48,57 @@ class ClassDefinitionClosingBraceSpaceSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+        $next   = $stackPtr;
+        while (true) {
+            $next = $phpcsFile->findNext(T_WHITESPACE, ($next + 1), null, true);
+            if ($next === false) {
+                return;
+            }
 
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
-        if ($next === false) {
-            return;
+            if (isset(Tokens::$emptyTokens[$tokens[$next]['code']]) === true
+                && $tokens[$next]['line'] === $tokens[$stackPtr]['line']
+            ) {
+                // Trailing comment.
+                continue;
+            }
+
+            break;
         }
 
         if ($tokens[$next]['code'] !== T_CLOSE_TAG) {
             $found = (($tokens[$next]['line'] - $tokens[$stackPtr]['line']) - 1);
             if ($found !== 1) {
                 $error = 'Expected one blank line after closing brace of class definition; %s found';
-                $data  = [$found];
+                $data  = [max(0, $found)];
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterClose', $data);
 
                 if ($fix === true) {
-                    if ($found === 0) {
-                        $phpcsFile->fixer->addNewline($stackPtr);
+                    $firstOnLine = $next;
+                    while ($tokens[$firstOnLine]['column'] !== 1) {
+                        --$firstOnLine;
+                    }
+
+                    if ($found < 0) {
+                        // Next statement on same line as the closing brace.
+                        $phpcsFile->fixer->addContentBefore($next, $phpcsFile->eolChar.$phpcsFile->eolChar);
+                    } else if ($found === 0) {
+                        // Next statement on next line, no blank line.
+                        $phpcsFile->fixer->addContentBefore($firstOnLine, $phpcsFile->eolChar);
                     } else {
-                        $nextContent = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+                        // Too many blank lines.
                         $phpcsFile->fixer->beginChangeset();
-                        for ($i = ($stackPtr + 1); $i < ($nextContent - 1); $i++) {
+                        for ($i = ($firstOnLine - 1); $i > $stackPtr; $i--) {
+                            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                                break;
+                            }
+
                             $phpcsFile->fixer->replaceToken($i, '');
                         }
 
-                        $phpcsFile->fixer->addNewline($i);
+                        $phpcsFile->fixer->addContentBefore($firstOnLine, $phpcsFile->eolChar.$phpcsFile->eolChar);
                         $phpcsFile->fixer->endChangeset();
                     }
-                }
+                }//end if
             }//end if
         }//end if
 

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.css.fixed
@@ -1,7 +1,6 @@
 .my-style {
 }
 
-
 .my-style {
 }
 
@@ -9,7 +8,6 @@
 
 .my-style {
 }
-
 
 /* Comment */
 
@@ -42,33 +40,36 @@
     header #logo img {
         max-width: 100%;
     }
+
 }
 
-.GUITextBox.container:after {}
+.GUITextBox.container:after {
+}
 
 @media screen and (max-device-width: 769px) {
     .no-blank-line-after {
     }
+
     .no-blank-line-after-second-def {
-    } .my-style {
+    } 
+
+.my-style {
     }
 
     .no-blank-line-and-trailing-comment {
     } /* end long class */
+
     .too-many-blank-lines-and-trailing-comment-extra-whitespace-after-brace {
     } /* end long class */
-
-
 
     .has-blank-line-and-trailing-comment {
     } /* end long class */
 
     .no-blank-line-and-annotation {
     } /* phpcs:ignore Standard.Cat.SniffName -- for reasons */
+
     .too-many-blank-lines-annotation {
     } /* phpcs:ignore Standard.Cat.SniffName -- for reasons */
-
-
 
     .has-blank-line-and-annotation {
     } /* phpcs:ignore Standard.Cat.SniffName -- for reasons */
@@ -78,4 +79,7 @@
 @media screen and (max-device-width: 769px) {
 
     header #logo img {
-        max-width: 100%;}}
+        max-width: 100%;
+}
+
+}

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionClosingBraceSpaceUnitTest.php
@@ -30,6 +30,13 @@ class ClassDefinitionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
             11 => 1,
             44 => 1,
             47 => 1,
+            51 => 1,
+            53 => 1,
+            57 => 1,
+            59 => 1,
+            67 => 1,
+            69 => 1,
+            81 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
[Fixer conflict series PR] + [Missing fixed files series PR]

The sniff contains fixers, but didn't have a `fixed` file.

While I was at it, I've reviewed the sniff and applied any improvements I could think of:
* The sniff did not handle multiple statements on the same line correctly.
* The fixer would inadvertently remove line indentation. Indentation is not the concern of this sniff, so should be left alone.
* The sniff did not take trailing comments or PHPCS annotations into account, which would cause a fixer conflict with itself.
    - The fixer has been adjusted to handle trailing comments correctly.

Includes additional unit tests for all fixes.