### PR TITLE
Squiz.CSS.ColourDefinition: add fixed file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1479,6 +1479,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ColonSpacingUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColonSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColourDefinitionUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ColourDefinitionUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColourDefinitionUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStyleDefinitionsUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStyleDefinitionsUnitTest.php" role="test" />

--- a/src/Standards/Squiz/Tests/CSS/ColourDefinitionUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/ColourDefinitionUnitTest.css.fixed
@@ -1,9 +1,9 @@
 #title-bar-bottom-right {
-    background-color: #333333;
+    background-color: #333;
     padding: 10px;
     border-bottom: 1px dotted #F0F0F0;
-    border-top: 1px dotted #FF00FF;
-    background: #08f7db url(diag_lines_bg.gif) top left;
+    border-top: 1px dotted #F0F;
+    background: #08F7DB url(diag_lines_bg.gif) top left;
 
     /* The sniff only deals with HEX colours. */
     color: DarkSlateGray;


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contains fixers, but didn't have a `fixed` file.

Includes adding some additional unit tests documenting and making sure only HEX colours are examined.