### PR TITLE
Squiz.CSS.DisallowMultipleStyleDefinitions: add fixed file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1481,6 +1481,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ColourDefinitionUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColourDefinitionUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStyleDefinitionsUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStyleDefinitionsUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStyleDefinitionsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassDefinitionUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassDefinitionUnitTest.php" role="test" />

--- a/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.css
@@ -10,3 +10,8 @@ li {
     background:url(<?php print $staticserver; ?>/images/<?php print $staticdir; ?>/bullet.gif) left <?php print $left; ?>px no-repeat; margin:0px; padding-left:10px; margin-bottom:<?php echo $marginBottom; ?>px; line-height:13px;
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#2e62a8, endColorstr=#123363);
 }
+
+/* Document handling of comments and annotations. */
+div#annotations {-webkit-tap-highlight-color:transparent;/* phpcs:disable Standard.Cat.SniffName */-webkit-touch-callout:none;/*phpcs:enable*/-webkit-user-select:none;}
+
+div#comments {height:100%;/*comment*/width:100%;}

--- a/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.css.fixed
@@ -1,0 +1,27 @@
+.SettingsTabPaneWidgetType-tab-mid {
+   background: transparent url(tab_inact_mid.png) repeat-x;
+   height: 100%;
+float: left;
+   line-height: -25px;
+   cursor: pointer; 
+margin: 10px; 
+float: right;
+}
+
+/* testing embedded PHP */
+li {
+    background:url(<?php print $staticserver; ?>/images/<?php print $staticdir; ?>/bullet.gif) left <?php print $left; ?>px no-repeat; 
+margin:0px; 
+padding-left:10px; 
+margin-bottom:<?php echo $marginBottom; ?>px; 
+line-height:13px;
+    filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#2e62a8, endColorstr=#123363);
+}
+
+/* Document handling of comments and annotations. */
+div#annotations {-webkit-tap-highlight-color:transparent;/* phpcs:disable Standard.Cat.SniffName */
+-webkit-touch-callout:none;/*phpcs:enable*/
+-webkit-user-select:none;}
+
+div#comments {height:100%;/*comment*/
+width:100%;}

--- a/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DisallowMultipleStyleDefinitionsUnitTest.php
@@ -29,6 +29,8 @@ class DisallowMultipleStyleDefinitionsUnitTest extends AbstractSniffUnitTest
             3  => 1,
             5  => 2,
             10 => 4,
+            15 => 2,
+            17 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contains fixers, but didn't have a `fixed` file.

Includes tests documenting how the sniff handles inline comments and annotations.