### PR TITLE
Squiz.Objects.ObjectMemberComma: add fixed file and minor fix

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1559,6 +1559,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ObjectInstantiationUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ObjectInstantiationUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ObjectMemberCommaUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ObjectMemberCommaUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ObjectMemberCommaUnitTest.php" role="test" />
        </dir>
        <dir name="Operators">

--- a/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php
@@ -52,7 +52,7 @@ class ObjectMemberCommaSniff implements Sniff
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($tokens[$prev]['code'] === T_COMMA) {
             $error = 'Last member of object must not be followed by a comma';
-            $fix   = $phpcsFile->addFixableError($error, $prev, 'Missing');
+            $fix   = $phpcsFile->addFixableError($error, $prev, 'Found');
             if ($fix === true) {
                 $phpcsFile->fixer->replaceToken($prev, '');
             }

--- a/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.js.fixed
@@ -1,4 +1,4 @@
-this.request({ action: 'getTypeFormatContents', });
+this.request({ action: 'getTypeFormatContents' });
 
 addTypeFormatButton.addClickEvent(function() {
    self.addNewTypeFormat();
@@ -19,7 +19,7 @@ var z = {
    VarTwo  : ['Alonzo played you', 'for a fool', 'esse'],
    VarThree: function(arg) {
        console.info(1);
-   },
+   }
 };
 
 var x = function() {
@@ -35,13 +35,13 @@ AssetListingEditWidgetType.prototype = {
 AssetListingEditWidgetType.prototype = {
    init: function(data, assetid, editables)
    {
-   },
+   }
 };
 
 AssetListingEditWidgetType.prototype = {
    // phpcs: disable Standard.Cat.SniffName -- testing annotation between closing brace and comma
    init: function(data, assetid, editables)
    {
-   },
+   }
    // phpcs:enable
 };

--- a/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectMemberCommaUnitTest.php
@@ -21,20 +21,15 @@ class ObjectMemberCommaUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
-     * @param string $testFile The name of the file being tested.
-     *
      * @return array<int, int>
      */
-    public function getErrorList($testFile='ObjectMemberCommaUnitTest.js')
+    public function getErrorList()
     {
-        if ($testFile !== 'ObjectMemberCommaUnitTest.js') {
-            return [];
-        }
-
         return [
             1  => 1,
             22 => 1,
             38 => 1,
+            45 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contains fixers, but didn't have a `fixed` file.

Notes:
* While this constitutes a BC-break, the error code used by this sniff was incorrect as the error is thrown when a comma is _found_, not when it's _missing_.
* Added an additional unit test documenting that the sniff correctly skips over PHPCS annotations and comments.
* Removed some redundant code from the unit test file.