### PR TITLE
Squiz/LogicalOperatorSpacing: add fixed file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1648,7 +1648,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="LanguageConstructSpacingUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LanguageConstructSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LogicalOperatorSpacingUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LogicalOperatorSpacingUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LogicalOperatorSpacingUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LogicalOperatorSpacingUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LogicalOperatorSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MemberVarSpacingUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MemberVarSpacingUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.inc.fixed
@@ -1,9 +1,9 @@
 <?php
 
 if ($foo || $bar) {}
-if ($foo||$bar && $baz) {}
-if ($foo|| $bar&&$baz) {}
-if ($foo  ||   $bar   && $baz) {}
+if ($foo || $bar && $baz) {}
+if ($foo || $bar && $baz) {}
+if ($foo || $bar && $baz) {}
 
 // Spacing after || below is ignored as it is EOL whitespace.
 if ($foo ||    
@@ -12,8 +12,8 @@ if ($foo ||
 ) {
 }
 
-if ($foo||
+if ($foo ||
     $bar
-    &&$baz
+    && $baz
 ) {
 }

--- a/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/LogicalOperatorSpacingUnitTest.js.fixed
@@ -1,0 +1,19 @@
+
+
+if (foo || bar) {}
+if (foo || bar && baz) {}
+if (foo || bar && baz) {}
+if (foo || bar && baz) {}
+
+// Spacing after || below is ignored as it is EOL whitespace.
+if (foo ||    
+    bar
+    && baz
+) {
+}
+
+if (foo ||
+    bar
+    && baz
+) {
+}


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contains fixers, but didn't have `fixed` files.