### PR TITLE
Squiz/LowercaseDeclaration: add fixed file and minor efficiency fix

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1463,6 +1463,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineIfDeclarationUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineIfDeclarationUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseDeclarationUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowercaseDeclarationUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseDeclarationUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SwitchDeclarationUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SwitchDeclarationUnitTest.js" role="test" />

--- a/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
@@ -52,18 +52,19 @@ class LowercaseDeclarationSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $content = $tokens[$stackPtr]['content'];
-        if ($content !== strtolower($content)) {
+        $content   = $tokens[$stackPtr]['content'];
+        $contentLc = strtolower($content);
+        if ($content !== $contentLc) {
             $error = '%s keyword must be lowercase; expected "%s" but found "%s"';
             $data  = [
                 strtoupper($content),
-                strtolower($content),
+                $contentLc,
                 $content,
             ];
 
             $fix = $phpcsFile->addFixableError($error, $stackPtr, 'FoundUppercase', $data);
             if ($fix === true) {
-                $phpcsFile->fixer->replaceToken($stackPtr, strtolower($content));
+                $phpcsFile->fixer->replaceToken($stackPtr, $contentLc);
             }
         }
 

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc
@@ -20,4 +20,3 @@ If ($condition) {
 TRY {
 } Catch (Exception $e) {
 }
-?>

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc.fixed
@@ -1,0 +1,22 @@
+<?php
+
+foreach ($condition as $cond) {}
+
+for ($i = 1; $i < 10; $i++) {}
+
+while ($i < 10) {}
+
+do {
+} while ($1 < 10)
+
+switch ($condition) {}
+
+if ($condition) {
+} else if ($condition) {
+} elseif ($condition) {
+} else {
+}
+
+try {
+} catch (Exception $e) {
+}


### PR DESCRIPTION
[Missing fixed files series PR]

The `Squiz.ControlStructures.LowercaseDeclaration` sniff contains fixers, but didn't have a `fixed` file.

Includes minor efficiency fix (code duplication).