### PR TITLE
PSR2/ClosingTag: add missing fixed file + additional test

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1145,6 +1145,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.4.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.4.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.5.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.5.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.6.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.6.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="EndFileNewlineUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="EndFileNewlineUnitTest.2.inc" role="test" />

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.5.inc.fixed
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.5.inc.fixed
@@ -1,0 +1,1 @@
+<?php $foo = true; if ($foo) { echo 'hi'; } //hello 

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.6.inc
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.6.inc
@@ -1,0 +1,5 @@
+<?php
+// This tests the behaviour of the sniff when there is no trailing whitespace or new line at the end of the file.
+echo 'hi';
+
+?>

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.6.inc.fixed
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.6.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+// This tests the behaviour of the sniff when there is no trailing whitespace or new line at the end of the file.
+echo 'hi';
+
+

--- a/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
+++ b/src/Standards/PSR2/Tests/Files/ClosingTagUnitTest.php
@@ -35,6 +35,9 @@ class ClosingTagUnitTest extends AbstractSniffUnitTest
         case 'ClosingTagUnitTest.5.inc':
             return [1 => 1];
 
+        case 'ClosingTagUnitTest.6.inc':
+            return [5 => 1];
+
         default:
             return [];
         }


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contains fixers, but the `ClosingTagUnitTest.5.inc` file - which does contain fixable errors - didn't have a `fixed` file.

Includes adding one new unit test to cover "closing tag as last token/no new line at end of file".