### PR TITLE
Squiz/LowercaseClassKeywords: add fixed file and minor improvements

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1394,6 +1394,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicatePropertyUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicatePropertyUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseClassKeywordsUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LowercaseClassKeywordsUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercaseClassKeywordsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SelfMemberReferenceUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SelfMemberReferenceUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 class LowercaseClassKeywordsSniff implements Sniff
 {
@@ -23,17 +24,15 @@ class LowercaseClassKeywordsSniff implements Sniff
      */
     public function register()
     {
-        return [
-            T_CLASS,
-            T_INTERFACE,
-            T_TRAIT,
-            T_EXTENDS,
-            T_IMPLEMENTS,
-            T_ABSTRACT,
-            T_FINAL,
-            T_VAR,
-            T_CONST,
-        ];
+        $targets   = Tokens::$ooScopeTokens;
+        $targets[] = T_EXTENDS;
+        $targets[] = T_IMPLEMENTS;
+        $targets[] = T_ABSTRACT;
+        $targets[] = T_FINAL;
+        $targets[] = T_VAR;
+        $targets[] = T_CONST;
+
+        return $targets;
 
     }//end register()
 
@@ -51,18 +50,19 @@ class LowercaseClassKeywordsSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $content = $tokens[$stackPtr]['content'];
-        if ($content !== strtolower($content)) {
+        $content   = $tokens[$stackPtr]['content'];
+        $contentLc = strtolower($content);
+        if ($content !== $contentLc) {
             $error = '%s keyword must be lowercase; expected "%s" but found "%s"';
             $data  = [
                 strtoupper($content),
-                strtolower($content),
+                $contentLc,
                 $content,
             ];
 
             $fix = $phpcsFile->addFixableError($error, $stackPtr, 'FoundUppercase', $data);
             if ($fix === true) {
-                $phpcsFile->fixer->replaceToken($stackPtr, strtolower($content));
+                $phpcsFile->fixer->replaceToken($stackPtr, $contentLc);
             }
         }
 

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
@@ -9,4 +9,5 @@ class MyClass
     Var $myVar = null;
     Const myConst = true;
 }
-?>
+
+$a = new CLASS() {};

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
@@ -1,0 +1,13 @@
+<?php
+abstract class MyClass extends MyClass {}
+final class MyClass implements MyInterface {}
+interface MyInterface {}
+trait MyTrait {}
+
+class MyClass
+{
+    var $myVar = null;
+    const myConst = true;
+}
+
+$a = new class() {};

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -32,6 +32,7 @@ class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
             5  => 1,
             9  => 1,
             10 => 1,
+            13 => 1,
         ];
 
         return $errors;


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contain a fixer, but didn't have a `fixed` file.

While I was at it, I've reviewed the sniff and applied any improvements I could think of:
* The sniff will now also examine the `class` keyword for anonymous classes.
* Minor code de-duplication fix.

Includes additional unit tests for all fixes.