### PR TITLE
Generic/LineEndings: add fixed files + minor bug fix

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -567,9 +567,11 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineHTMLUnitTest.7.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineHTMLUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineEndingsUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LineEndingsUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineEndingsUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineEndingsUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineEndingsUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LineEndingsUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineEndingsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.2.inc" role="test" />

--- a/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
@@ -120,11 +120,16 @@ class LineEndingsSniff implements Sniff
                         $tokenContent = $tokens[$i]['content'];
                     }
 
+                    if ($tokenContent === '') {
+                        // Special case for JS/CSS close tag.
+                        continue;
+                    }
+
                     $newContent  = rtrim($tokenContent, "\r\n");
                     $newContent .= $eolChar;
                     $phpcsFile->fixer->replaceToken($i, $newContent);
                 }
-            }
+            }//end for
         }//end if
 
         // Ignore the rest of the file.

--- a/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.css.fixed
+++ b/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.css.fixed
@@ -1,0 +1,3 @@
+#login-container {
+    margin-left: -225px;
+}

--- a/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.js.fixed
+++ b/src/Standards/Generic/Tests/Files/LineEndingsUnitTest.js.fixed
@@ -1,0 +1,2 @@
+alert('hi');
+alert('hi');


### PR DESCRIPTION
[Missing fixed files series PR]

The sniff contain a fixer, but didn't have a `fixed` file for the CSS and JS test case files.

While creating the `fixed` files, I noticed that the `T_CLOSE_TAG`, which for CSS and JS files is empty, would also be replaced with a new line, resulting in an extra, superfluous new line at the end of a file.
This has now been fixed.