### PR TITLE
Squiz.CSS.ClassDefinitionNameSpacing: fix "Undefined index: bracket_closer" error

### DIFF
--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
@@ -49,6 +49,11 @@ class ClassDefinitionNameSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
+            // Syntax error or live coding, bow out.
+            return;
+        }
+
         // Do not check nested style definitions as, for example, in @media style rules.
         $nested = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1), $tokens[$stackPtr]['bracket_closer']);
         if ($nested !== false) {

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionNameSpacingUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionNameSpacingUnitTest.css
@@ -60,3 +60,7 @@ td.TableWidgetType-header.TableWidgetType-header-userName {
 {
     border: none;
 }
+
+/* Live coding. Has to be the last test in the file. */
+.intentional-parse-error {
+	float: left


### PR DESCRIPTION
[Fixer conflicts series PR]

Improves the resilience of the sniff against syntax/parse errors and during live coding.

Includes unit test.