### PR TITLE
Squiz.CSS.DuplicateStyleDefinition: fix "Undefined index: bracket_closer" error

### DIFF
--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php
@@ -48,6 +48,11 @@ class DuplicateStyleDefinitionSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
+            // Syntax error or live coding, bow out.
+            return;
+        }
+
         // Find the content of each style definition name.
         $styleNames = [];
 

--- a/src/Standards/Squiz/Tests/CSS/DuplicateStyleDefinitionUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/DuplicateStyleDefinitionUnitTest.css
@@ -21,3 +21,7 @@
     header nav.meta a { display: none; }
     header nav.meta a.search { display: block; }
 }
+
+/* Live coding. Has to be the last test in the file. */
+.intentional-parse-error {
+	float: left


### PR DESCRIPTION
[Fixer conflicts series PR]

Improves the resilience of the sniff against syntax/parse errors and during live coding.

Includes unit test.