### PR TITLE
Squiz.CSS.MissingColon: fix "Undefined index: bracket_closer" error

### DIFF
--- a/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php
@@ -46,7 +46,13 @@ class MissingColonSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens   = $phpcsFile->getTokens();
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
+            // Syntax error or live coding, bow out.
+            return;
+        }
+
         $lastLine = $tokens[$stackPtr]['line'];
         $end      = $tokens[$stackPtr]['bracket_closer'];
 

--- a/src/Standards/Squiz/Tests/CSS/MissingColonUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/MissingColonUnitTest.css
@@ -15,3 +15,7 @@
 
 #foo { background-color: #FF0000;
 }
+
+/* Live coding. Has to be the last test in the file. */
+.intentional-parse-error {
+	float


### PR DESCRIPTION
[Fixer conflicts series PR]

Improves the resilience of the sniff against syntax/parse errors and during live coding.

Includes unit test.