### PR TITLE
Progress reporting: Report files with tokenizer errors as skipped

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -321,6 +321,11 @@ class File
 
         $this->parse();
 
+        // Check if tokenizer errors cause this file to be ignored.
+        if ($this->ignored === true) {
+            return;
+        }
+
         $this->fixer->startFile($this);
 
         if (PHP_CODESNIFFER_VERBOSITY > 2) {
@@ -564,6 +569,7 @@ class File
             $this->tokenizer = new $tokenizerClass($this->content, $this->config, $this->eolChar);
             $this->tokens    = $this->tokenizer->getTokens();
         } catch (TokenizerException $e) {
+            $this->ignored = true;
             $this->addWarning($e->getMessage(), null, 'Internal.Tokenizer.Exception');
             if (PHP_CODESNIFFER_VERBOSITY > 0) {
                 echo "[$this->tokenizerType => tokenizer error]... ";


### PR DESCRIPTION
Minified files are not processed by the tokenizer and when such files are encountered PHPCS throws an `Internal.Tokenizer.Exception` warning.

In the progress report these files show up with a `W` because of this warning.

However, as the file isn't really processed at all, indicating these files as "skipped" with an `S` in the progress report seems more appropriate.

Also, when there is a tokenizer error, the rest of the processing in the `File::process()` method can be skipped.

This commit makes that change.

The existing warning is left in place, but the progress report will now report these files with an `S`.

To test this change:
* Grab any project with minified CSS and/or JS files.
* While on `master`, run `phpcs -p . --standard=PSR2 --report=summary,source` on the project and take note of the `summary` report showing minified files with 1 warning and the `source` report showing `[ ] Internal ... Tokenizer #`.
* Now switch to this branch and run the same command again.
    The source and summary reports will be the same, but for the progress line, the files which have the tokenizer warning should now show as `S` instead of `W`.