### PR TITLE
Squiz.CSS.ClassDefinitionOpeningBrace: add fixed file and various bug fixes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1474,6 +1474,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionNameSpacingUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionNameSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionOpeningBraceSpaceUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionOpeningBraceSpaceUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDefinitionOpeningBraceSpaceUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColonSpacingUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ColonSpacingUnitTest.css.fixed" role="test" />

--- a/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php
@@ -47,79 +47,124 @@ class ClassDefinitionOpeningBraceSpaceSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
+        $tokens            = $phpcsFile->getTokens();
+        $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
 
-        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
-            $error = 'Expected 1 space before opening brace of class definition; 0 found';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoneBefore');
-            if ($fix === true) {
-                $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
-            }
-        } else {
-            $content = $tokens[($stackPtr - 1)]['content'];
-            if ($content !== ' ') {
-                if ($tokens[($stackPtr - 1)]['line'] < $tokens[$stackPtr]['line']) {
-                    $length = 'newline';
+        if ($prevNonWhitespace !== false) {
+            $length = 0;
+            if ($tokens[$stackPtr]['line'] !== $tokens[$prevNonWhitespace]['line']) {
+                $length = 'newline';
+            } else if ($tokens[($stackPtr - 1)]['code'] === T_WHITESPACE) {
+                if (strpos($tokens[($stackPtr - 1)]['content'], "\t") !== false) {
+                    $length = 'tab';
                 } else {
-                    $length = strlen($content);
-                    if ($length === 1) {
-                        $length = 'tab';
-                    }
+                    $length = $tokens[($stackPtr - 1)]['length'];
                 }
+            }
 
+            if ($length === 0) {
+                $error = 'Expected 1 space before opening brace of class definition; 0 found';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoneBefore');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
+                }
+            } else if ($length !== 1) {
                 $error = 'Expected 1 space before opening brace of class definition; %s found';
                 $data  = [$length];
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Before', $data);
                 if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken(($stackPtr - 1), ' ');
+                    $phpcsFile->fixer->beginChangeset();
+
+                    for ($i = ($stackPtr - 1); $i > $prevNonWhitespace; $i--) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->addContentBefore($stackPtr, ' ');
+                    $phpcsFile->fixer->endChangeset();
                 }
-            }
+            }//end if
         }//end if
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($next === false) {
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
             return;
         }
 
-        // Check for nested class definitions.
-        $nested = false;
-        $found  = $phpcsFile->findNext(
-            T_OPEN_CURLY_BRACKET,
-            ($stackPtr + 1),
-            $tokens[$stackPtr]['bracket_closer']
-        );
-
-        if ($found !== false) {
-            $nested = true;
-        }
-
-        if ($tokens[$next]['line'] === $tokens[$stackPtr]['line']) {
+        if ($tokens[$nextNonEmpty]['line'] === $tokens[$stackPtr]['line']) {
             $error = 'Opening brace should be the last content on the line';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'ContentBefore');
             if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
                 $phpcsFile->fixer->addNewline($stackPtr);
+
+                // Remove potentially left over trailing whitespace.
+                if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
             }
         } else {
-            $foundLines = ($tokens[$next]['line'] - $tokens[$stackPtr]['line'] - 1);
-            if ($nested === true) {
-                if ($foundLines !== 1) {
-                    $error = 'Expected 1 blank line after opening brace of nesting class definition; %s found';
-                    $data  = [$foundLines];
-                    $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'AfterNesting', $data);
+            if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
+                // Syntax error or live coding, bow out.
+                return;
+            }
 
-                    if ($fix === true) {
-                        if ($foundLines === 0) {
-                            $phpcsFile->fixer->addNewline($stackPtr);
-                        } else {
-                            $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
-                            $phpcsFile->fixer->beginChangeset();
-                            for ($i = ($stackPtr + 1); $i < ($next + 1); $i++) {
-                                $phpcsFile->fixer->replaceToken($i, '');
+            // Check for nested class definitions.
+            $found = $phpcsFile->findNext(
+                T_OPEN_CURLY_BRACKET,
+                ($stackPtr + 1),
+                $tokens[$stackPtr]['bracket_closer']
+            );
+
+            if ($found === false) {
+                // Not nested.
+                return;
+            }
+
+            $lastOnLine = $stackPtr;
+            for ($lastOnLine; $lastOnLine < $tokens[$stackPtr]['bracket_closer']; $lastOnLine++) {
+                if ($tokens[$lastOnLine]['line'] !== $tokens[($lastOnLine + 1)]['line']) {
+                    break;
+                }
+            }
+
+            $nextNonWhiteSpace = $phpcsFile->findNext(T_WHITESPACE, ($lastOnLine + 1), null, true);
+            if ($nextNonWhiteSpace === false) {
+                return;
+            }
+
+            $foundLines = ($tokens[$nextNonWhiteSpace]['line'] - $tokens[$stackPtr]['line'] - 1);
+            if ($foundLines !== 1) {
+                $error = 'Expected 1 blank line after opening brace of nesting class definition; %s found';
+                $data  = [max(0, $foundLines)];
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'AfterNesting', $data);
+
+                if ($fix === true) {
+                    $firstOnNextLine = $nextNonWhiteSpace;
+                    while ($tokens[$firstOnNextLine]['column'] !== 1) {
+                        --$firstOnNextLine;
+                    }
+
+                    if ($found < 0) {
+                        // First statement on same line as the opening brace.
+                        $phpcsFile->fixer->addContentBefore($nextNonWhiteSpace, $phpcsFile->eolChar.$phpcsFile->eolChar);
+                    } else if ($found === 0) {
+                        // Next statement on next line, no blank line.
+                        $phpcsFile->fixer->addNewlineBefore($firstOnNextLine);
+                    } else {
+                        // Too many blank lines.
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($i = ($firstOnNextLine - 1); $i > $stackPtr; $i--) {
+                            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                                break;
                             }
 
-                            $phpcsFile->fixer->addNewline($stackPtr);
-                            $phpcsFile->fixer->endChangeset();
+                            $phpcsFile->fixer->replaceToken($i, '');
                         }
+
+                        $phpcsFile->fixer->addContentBefore($firstOnNextLine, $phpcsFile->eolChar.$phpcsFile->eolChar);
+                        $phpcsFile->fixer->endChangeset();
                     }
                 }//end if
             }//end if

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.css.fixed
@@ -1,13 +1,13 @@
 .HelpWidgetType-new-bug-title {
     float: left;
 }
-.HelpWidgetType-new-bug-title   {
+.HelpWidgetType-new-bug-title {
     float: left;
 }
-.HelpWidgetType-new-bug-title	{
+.HelpWidgetType-new-bug-title {
     float: left;
 }
-.HelpWidgetType-new-bug-title{
+.HelpWidgetType-new-bug-title {
     float: left;
 }
 .HelpWidgetType-new-bug-title {
@@ -24,6 +24,7 @@
 }
 
 @media screen and (max-device-width: 769px) {
+
     header #logo img {
         max-width: 100%;
     }
@@ -32,34 +33,32 @@
 
 @media screen and (max-device-width: 769px) {
 
-    
-
     header #logo img {
         max-width: 100%;
     }
 
 }
 
-.GUITextBox.container:after {}
+.GUITextBox.container:after {
+}
 
-.single-line {float: left;}
+.single-line {
+float: left;}
 
-#opening-brace-on-different-line
-
-
-{
+#opening-brace-on-different-line {
     color: #FFFFFF;
 }
 
-#opening-brace-on-different-line-and-inline-style
+#opening-brace-on-different-line-and-inline-style {
+color: #FFFFFF;}
 
+@media screen and (max-device-width: 769px) {
 
-{color: #FFFFFF;}
-
-@media screen and (max-device-width: 769px) { .everything-on-one-line { float: left; } }
+.everything-on-one-line {
+float: left; } }
 
 /* Document handling of comments in various places */
-.no-space-before-opening-with-comment /* comment*/{
+.no-space-before-opening-with-comment /* comment*/ {
     float: left;
 }
 
@@ -69,12 +68,12 @@
 }
 
 #opening-brace-on-different-line-with-comment-between
-/*comment*/
-{
+/*comment*/ {
     padding: 0;
 }
 
-.single-line-with-comment { /* comment*/ float: left; }
+.single-line-with-comment {
+/* comment*/ float: left; }
 
 .multi-line-with-trailing-comment { /* comment*/
     float: left;
@@ -82,6 +81,7 @@
 
 
 @media screen and (max-device-width: 769px) {
+
     /*comment*/
     .comment-line-after-nesting-class-opening {
     }
@@ -95,8 +95,6 @@
 }
 
 @media screen and (max-device-width: 769px) {
-
-
 
     /* phpcs:ignore Standard.Category.Sniffname -- for reasons */
     .blank-line-and-annotation-after-nesting-class-opening {

--- a/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ClassDefinitionOpeningBraceSpaceUnitTest.php
@@ -32,6 +32,15 @@ class ClassDefinitionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
             26 => 1,
             33 => 1,
             43 => 1,
+            45 => 1,
+            50 => 1,
+            57 => 2,
+            59 => 2,
+            62 => 1,
+            73 => 1,
+            77 => 1,
+            84 => 1,
+            97 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The sniff contains fixers, but didn't have a `fixed` file.

While I was add it, I've reviewed the sniff and applied any improvements I could think of:
* For the `Before` error code, the sniff would report on a `tab` being found if the whitespace length was 1, but not a space. This meant that for a "3 space" whitespace token, it would also report as `tab`.
    I've now changed the `$length` determination to be more accurate.
* The  fixer for the `Before` error will now fix the whitespace between in one go if there is more than one whitespace token.
    Previously, it would replace the first preceding whitespace token with a space, which in effect left any additional new lines in place as the fixer would not be triggered again.
* While the `ContentBefore` error states "Opening brace should be the last content on the line", the way the code was, allowed for trailing comments on the line of the opening brace.
     I've elected not to change this behaviour, but have documented it with a unit test.
* The fixer for the `AfterNesting` error would remove the first non-whitespace token after the opening brace if too many lines after the opener were found. This changes the meaning of the style declaration and/or could remove comments.
    The existing unit test on line 33 demonstrates this, as well as the new unit tests on line 88 and 95.
* The fixer for `AfterNesting` would also inadvertently remove line indentation. Indentation is not the concern of this sniff, so should be left alone.
* The `AfterNesting` check would also **not** report an error if the line between the original opening brace and the nested style declaration, contained a comment.
* Lastly, the handling of trailing comments was inconsistent with the handling of these in the `ContentBefore` part, i.e. for `ContentBefore` they would be allowed, but if the `AfterNesting` error was triggered, the fixer would move them.
* Improved the resilience of the sniff against syntax/parse errors and during live coding. This prevents an `Undefined index: bracket_closer` error.
* Minor other defensive coding improvements.

In effect, this constitutes a complete rewrite of this sniff.

Includes additional unit tests covering all fixes.