### PR TITLE
Generic/ScopeIndent: lower memory usage

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -238,8 +238,9 @@ class ScopeIndentSniff implements Sniff
                     if (isset($tokens[$parenCloser]['nested_parenthesis']) === true
                         && empty($tokens[$parenCloser]['nested_parenthesis']) === false
                     ) {
-                        end($tokens[$parenCloser]['nested_parenthesis']);
-                        $parens = key($tokens[$parenCloser]['nested_parenthesis']);
+                        $parens = $tokens[$parenCloser]['nested_parenthesis'];
+                        end($parens);
+                        $parens = key($parens);
                         if ($this->debug === true) {
                             $line = $tokens[$parens]['line'];
                             echo "\t* token has nested parenthesis $parens on line $line *".PHP_EOL;
@@ -250,8 +251,9 @@ class ScopeIndentSniff implements Sniff
                     if (isset($tokens[$parenCloser]['conditions']) === true
                         && empty($tokens[$parenCloser]['conditions']) === false
                     ) {
-                        end($tokens[$parenCloser]['conditions']);
-                        $condition = key($tokens[$parenCloser]['conditions']);
+                        $condition = $tokens[$parenCloser]['conditions'];
+                        end($condition);
+                        $condition = key($condition);
                         if ($this->debug === true) {
                             $line = $tokens[$condition]['line'];
                             $type = $tokens[$condition]['type'];
@@ -511,8 +513,9 @@ class ScopeIndentSniff implements Sniff
                 && $tokens[$checkToken]['scope_opener'] === $checkToken))
             ) {
                 if (empty($tokens[$checkToken]['conditions']) === false) {
-                    end($tokens[$checkToken]['conditions']);
-                    $condition = key($tokens[$checkToken]['conditions']);
+                    $condition = $tokens[$checkToken]['conditions'];
+                    end($condition);
+                    $condition = key($condition);
                 } else {
                     $condition = $tokens[$checkToken]['scope_condition'];
                 }
@@ -653,8 +656,9 @@ class ScopeIndentSniff implements Sniff
                 if (isset($tokens[$scopeCloser]['nested_parenthesis']) === true
                     && empty($tokens[$scopeCloser]['nested_parenthesis']) === false
                 ) {
-                    end($tokens[$scopeCloser]['nested_parenthesis']);
-                    $parens = key($tokens[$scopeCloser]['nested_parenthesis']);
+                    $parens = $tokens[$scopeCloser]['nested_parenthesis'];
+                    end($parens);
+                    $parens = key($parens);
                     if ($this->debug === true) {
                         $line = $tokens[$parens]['line'];
                         echo "\t* token has nested parenthesis $parens on line $line *".PHP_EOL;
@@ -665,8 +669,9 @@ class ScopeIndentSniff implements Sniff
                 if (isset($tokens[$scopeCloser]['conditions']) === true
                     && empty($tokens[$scopeCloser]['conditions']) === false
                 ) {
-                    end($tokens[$scopeCloser]['conditions']);
-                    $condition = key($tokens[$scopeCloser]['conditions']);
+                    $condition = $tokens[$scopeCloser]['conditions'];
+                    end($condition);
+                    $condition = key($condition);
                     if ($this->debug === true) {
                         $line = $tokens[$condition]['line'];
                         $type = $tokens[$condition]['type'];
@@ -1181,8 +1186,9 @@ class ScopeIndentSniff implements Sniff
                 if (isset($tokens[$i]['nested_parenthesis']) === true
                     && empty($tokens[$i]['nested_parenthesis']) === false
                 ) {
-                    end($tokens[$i]['nested_parenthesis']);
-                    $parens = key($tokens[$i]['nested_parenthesis']);
+                    $parens = $tokens[$i]['nested_parenthesis'];
+                    end($parens);
+                    $parens = key($parens);
                     if ($this->debug === true) {
                         $line = $tokens[$parens]['line'];
                         echo "\t* token has nested parenthesis $parens on line $line *".PHP_EOL;
@@ -1193,8 +1199,9 @@ class ScopeIndentSniff implements Sniff
                 if (isset($tokens[$i]['conditions']) === true
                     && empty($tokens[$i]['conditions']) === false
                 ) {
-                    end($tokens[$i]['conditions']);
-                    $condition = key($tokens[$i]['conditions']);
+                    $condition = $tokens[$i]['conditions'];
+                    end($condition);
+                    $condition = key($condition);
                     if ($this->debug === true) {
                         $line = $tokens[$condition]['line'];
                         $type = $tokens[$condition]['type'];


### PR DESCRIPTION
Based on an analysis of some runs with [BlackFire](https://blackfire.io/), this small tweak will lower the memory usage of any run which includes the `Generic.WhiteSpace.ScopeIndent` - and by extension, the `PEAR.WhiteSpace.ScopeIndent` - sniff significantly.

A comparison between a run on `master` and a run on this branch can be found here: https://blackfire.io/profiles/compare/7adc96c7-09a4-4ec8-8821-bbf9d5906b2f/graph
**Note**: this comparison is only available for 24 hours.

The benchmark was created by running PHPCS over itself with the native ruleset and this command:
`phpcs -p --report-source --no-cache`.

For when the comparison isn't available anymore, this is the significant part:
![phpcs-generic-scopeindent-tweak](https://user-images.githubusercontent.com/663378/49219212-e70ef900-f3d2-11e8-8a77-38ec825e06e1.png)
