### PR TITLE
Generic/DisallowMultipleStatements: add fixed file + minor bug fix

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -589,6 +589,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        </dir>
        <dir name="Formatting">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStatementsUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStatementsUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowMultipleStatementsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MultipleStatementAlignmentUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="MultipleStatementAlignmentUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.inc.fixed
@@ -1,11 +1,16 @@
 <?php
-$y = 2;;
+$y = 2;
+;
 echo $y;
 for ($i = 1; $i < $length; $i++) {}
 for (; $i < $length; $i++) {}
-echo 'x'; echo $y;
-$x = 10; echo $y;
-$this->wizardid = 10; $this->paint(); echo 'x';
+echo 'x';
+echo $y;
+$x = 10;
+echo $y;
+$this->wizardid = 10;
+$this->paint();
+echo 'x';
 ?>
 <div class="<?php echo $class; ?>" id="<?php echo $id; ?>"></div>
 <div class="<?php echo $class ?>" id="<?php echo $id ?>"></div>

--- a/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/DisallowMultipleStatementsUnitTest.php
@@ -26,10 +26,11 @@ class DisallowMultipleStatementsUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            2 => 1,
-            6 => 1,
-            7 => 1,
-            8 => 2,
+            2  => 1,
+            6  => 1,
+            7  => 1,
+            8  => 2,
+            16 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The sniff contain a fixer, but didn't have a `fixed` file.

The fixer did not yet take the new PHPCS annotations into account. The only one which is problematic if it's moved, is the `T_PHPCS_IGNORE` token, so if that token would be encountered, the error will still be thrown, but will no longer be fixable.

Includes additional unit test covering this.