### PR TITLE
Squiz.Operators.ComparisonOperatorUsage false positive when inline IF contained in parentheses

### DIFF
--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -125,7 +125,7 @@ class ComparisonOperatorUsageSniff implements Sniff
                         ) {
                             break;
                         }
-                    }
+                    }//end if
                 }//end for
 
                 $start = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -116,6 +116,15 @@ class ComparisonOperatorUsageSniff implements Sniff
                         if (isset($tokens[$i]['scope_closer']) === true) {
                             break;
                         }
+                    } else if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS) {
+                        // Stop if this is the start of a pair of
+                        // parentheses that surrounds the inline
+                        // IF statement.
+                        if (isset($tokens[$i]['parenthesis_opener']) === true
+                            && $tokens[$i]['parenthesis_closer'] >= $stackPtr
+                        ) {
+                            break;
+                        }
                     }
                 }//end for
 

--- a/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
@@ -120,7 +120,7 @@ class ComparisonOperatorUsageSniff implements Sniff
                         // Stop if this is the start of a pair of
                         // parentheses that surrounds the inline
                         // IF statement.
-                        if (isset($tokens[$i]['parenthesis_opener']) === true
+                        if (isset($tokens[$i]['parenthesis_closer']) === true
                             && $tokens[$i]['parenthesis_closer'] >= $stackPtr
                         ) {
                             break;

--- a/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Operators/ComparisonOperatorUsageUnitTest.inc
@@ -134,3 +134,5 @@ function foo(string $bar, array $baz, ?MyClass $object) : MyClass {}
 
 if (empty($argTags > 0)) {
 }
+
+myFunction($var1 === true ? "" : "foobar");


### PR DESCRIPTION
This bug caused false positives from Sniff.Operators.ComparisonOperatorUsage for inline if statements that were completely surrounded by a pair of parentheses, e.g. from a function call.