### PR TITLE
Squiz/SuperfluousWhitespace: fix fixer conflict with nested anonymous functions

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -228,6 +228,13 @@ class SuperfluousWhitespaceSniff implements Sniff
                 && $tokens[($stackPtr - 1)]['line'] < $tokens[$stackPtr]['line']
                 && $tokens[($stackPtr - 2)]['line'] === $tokens[($stackPtr - 1)]['line']
             ) {
+                // Spacing around properties and functions in nested classes has their own rules.
+                $conditions   = $tokens[$stackPtr]['conditions'];
+                $deepestScope = end($conditions);
+                if ($deepestScope === T_ANON_CLASS) {
+                    return;
+                }
+
                 // This is an empty line and the line before this one is not
                 // empty, so this could be the start of a multiple empty
                 // line block.

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.inc
@@ -52,5 +52,23 @@ function myFunction2()
 
 // Уберём из системных свойств все кроме информации об услугах
 
+class Nested_Function {
+    public function getAnonymousClass() {
+        return new class() {
+
+
+            static private final function _nested_function() {
+                echo 'code here';
+
+
+                echo 'code here';
+         
+            }
+
+
+        };
+    }
+}
+
 ?>
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.inc.fixed
@@ -48,4 +48,21 @@ function myFunction2()
 
 // Уберём из системных свойств все кроме информации об услугах
 
+class Nested_Function {
+    public function getAnonymousClass() {
+        return new class() {
+
+
+            static private final function _nested_function() {
+                echo 'code here';
+
+                echo 'code here';
+
+            }
+
+
+        };
+    }
+}
+
 ?>

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -40,7 +40,9 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                 28 => 1,
                 33 => 1,
                 49 => 1,
-                55 => 1,
+                62 => 1,
+                65 => 1,
+                73 => 1,
             ];
             break;
         case 'SuperfluousWhitespaceUnitTest.2.inc':


### PR DESCRIPTION
[Fixer conflicts series PR]

Similar to the issues which were fixed in #2182 and #2192, the `Squiz.WhiteSpace.SuperfluousWhitespace` sniff also did not yet take nested anonymous classes into account.

Spacing around properties and functions within nested anonymous classes have their own rules and the "multiple empty lines in a row" error should not be triggered for these.

This fixes a fixer conflict between the `FunctionSpacing` sniff and this one.

Includes unit test.