### PR TITLE
PSR2/PSR12 rulesets: prevent duplicate messages

### DIFF
--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -220,6 +220,12 @@
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterOpen">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingBeforeClose">
+        <severity>0</severity>
+    </rule>
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
     <rule ref="PSR2.ControlStructures.ControlStructureSpacing"/>
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>

--- a/src/Standards/PSR2/ruleset.xml
+++ b/src/Standards/PSR2/ruleset.xml
@@ -167,6 +167,12 @@
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterOpen">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingBeforeClose">
+        <severity>0</severity>
+    </rule>
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
     <!-- checked in ControlStructures/ControlStructureSpacingSniff -->
 


### PR DESCRIPTION
The `PSR2.ControlStructures.ControlStructureSpacing` sniff already checks, throws errors and fixes spacing after the opening parenthesis and closing parenthesis of a `for()` statement.

As the `Squiz.ControlStructures.ForLoopDeclaration` sniff does so as well, this leads to two errors for the same issue being thrown with slightly different messages.

This tweak prevents this message duplication and gives preference to the PSR2 native sniff.