### PR TITLE
PSR1/PSR2 rulesets: improve inline documentation

### DIFF
--- a/src/Standards/PSR1/ruleset.xml
+++ b/src/Standards/PSR1/ruleset.xml
@@ -20,13 +20,13 @@
     <!-- 2.3. Side Effects -->
 
     <!-- A file SHOULD declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it SHOULD execute logic with side effects, but SHOULD NOT do both. -->
-    <!-- checked in Files/SideEffectsSniff -->
+    <!-- checked by PSR1.Files.SideEffects -->
 
     <!-- 3. Namespace and Class Names -->
 
     <!-- Namespaces and classes MUST follow PSR-0.
          This means each class is in a file by itself, and is in a namespace of at least one level: a top-level vendor name. -->
-    <!-- checked in Classes/ClassDeclarationSniff -->
+    <!-- checked by PSR1.Classes.ClassDeclaration -->
 
     <!-- Class names MUST be declared in StudlyCaps. -->
     <rule ref="Squiz.Classes.ValidClassName"/>
@@ -41,6 +41,6 @@
     <!-- 4.3. Methods -->
 
     <!-- Method names MUST be declared in camelCase(). -->
-    <!-- checked in Methods/CamelCapsMethodNameSniff -->
+    <!-- checked by PSR1.Methods.CamelCapsMethodName -->
 
 </ruleset>

--- a/src/Standards/PSR2/ruleset.xml
+++ b/src/Standards/PSR2/ruleset.xml
@@ -20,10 +20,10 @@
     </rule>
 
     <!-- All PHP files MUST end with a single blank line. -->
-    <!-- checked in Files/EndFileNewlineSniff -->
+    <!-- checked by PSR2.Files.EndFileNewline -->
 
     <!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
-    <!-- checked in Files/ClosingTagSniff -->
+    <!-- checked by PSR2.Files.ClosingTagSniff -->
 
     <!-- 2.3 Lines -->
 
@@ -78,12 +78,12 @@
     <!-- 3. Namespace and Use Declarations -->
 
     <!-- When present, there MUST be one blank line after the namespace declaration. -->
-    <!-- checked in Namespaces/NamespaceDeclarationSniff -->
+    <!-- checked by PSR2.Namespaces.NamespaceDeclaration -->
 
     <!-- When present, all use declarations MUST go after the namespace declaration.
          There MUST be one use keyword per declaration.
          There MUST be one blank line after the use block. -->
-    <!-- checked in Namespaces/UseDeclarationSniff -->
+    <!-- checked by PSR2.Namespaces.UseDeclaration -->
 
     <!-- 4. Classes, Properties, and Methods -->
 
@@ -92,7 +92,7 @@
     <!-- The extends and implements keywords MUST be declared on the same line as the class name.
          The opening brace for the class go MUST go on its own line; the closing brace for the class MUST go on the next line after the body.
          Lists of implements MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one interface per line. -->
-    <!-- checked in Classes/ClassDeclarationSniff -->
+    <!-- checked by PSR2.Classes.ClassDeclaration -->
 
     <!-- 4.2. Properties -->
 
@@ -100,7 +100,7 @@
          The var keyword MUST NOT be used to declare a property.
          There MUST NOT be more than one property declared per statement.
          Property names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility. -->
-    <!-- checked in Classes/PropertyDeclarationSniff -->
+    <!-- checked by PSR2.Classes.PropertyDeclaration -->
 
     <!-- 4.3 Methods -->
 
@@ -109,10 +109,10 @@
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
 
     <!-- Method names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility. -->
-    <!-- checked in Methods/MethodDeclarationSniff -->
+    <!-- checked by PSR2.Methods.MethodDeclaration -->
 
     <!-- Method names MUST NOT be declared with a space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. -->
-    <!-- checked in Methods/FunctionClosingBraceSniff -->
+    <!-- checked by PSR2.Methods.FunctionClosingBrace -->
     <rule ref="Squiz.Functions.FunctionDeclaration"/>
     <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
 
@@ -138,7 +138,7 @@
 
     <!-- When present, the abstract and final declarations MUST precede the visibility declaration.
          When present, the static declaration MUST come after the visibility declaration. -->
-    <!-- checked in Methods/MethodDeclarationSniff -->
+    <!-- checked by PSR2.Methods.MethodDeclaration -->
 
     <!-- 4.6 Method and Function Calls -->
 
@@ -168,7 +168,7 @@
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
-    <!-- checked in ControlStructures/ControlStructureSpacingSniff -->
+    <!-- checked by PSR2.ControlStructures.ControlStructureSpacing -->
 
     <!-- exclude this message as it is already checked Generic.PHP.LowerCaseKeyword -->
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.AsNotLower">
@@ -181,12 +181,12 @@
     <!-- 5.1. if, elseif, else -->
 
     <!-- The keyword elseif SHOULD be used instead of else if so that all control keywords look like single words. -->
-    <!-- checked in ControlStructures/ElseIfDeclarationSniff -->
+    <!-- checked by PSR2.ControlStructures.ElseIfDeclaration -->
 
     <!-- 5.2. switch, case -->
 
     <!-- The case statement MUST be indented once from switch, and the break keyword (or other terminating keyword) MUST be indented at the same level as the case body. There MUST be a comment such as // no break when fall-through is intentional in a non-empty case body. -->
-    <!-- checked in ControlStructures/SwitchDeclarationSniff -->
+    <!-- checked by PSR2.ControlStructures.SwitchDeclaration -->
 
     <!-- 6. Closures -->
 


### PR DESCRIPTION
Use complete sniff name instead of partial file name reference to avoid confusion what with there being sniffs with the same name in different standards.