### PR TITLE
Squiz/ForLoopDeclaration: add fixed file + fix fixer conflict + fix other bugs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1457,7 +1457,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ForEachLoopDeclarationUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForEachLoopDeclarationUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopDeclarationUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ForLoopDeclarationUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopDeclarationUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ForLoopDeclarationUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForLoopDeclarationUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineIfDeclarationUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineIfDeclarationUnitTest.inc.fixed" role="test" />

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -80,7 +80,16 @@ class ForLoopDeclarationSniff implements Sniff
             $error = 'Whitespace found after opening bracket of FOR loop';
             $fix   = $phpcsFile->addFixableError($error, $openingBracket, 'SpacingAfterOpen');
             if ($fix === true) {
-                $phpcsFile->fixer->replaceToken(($openingBracket + 1), '');
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($openingBracket + 1); $i < $closingBracket; $i++) {
+                    if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
             }
         } else if ($this->requiredSpacesAfterOpen > 0) {
             $nextNonWhiteSpace = $phpcsFile->findNext(T_WHITESPACE, ($openingBracket + 1), $closingBracket, true);
@@ -103,17 +112,32 @@ class ForLoopDeclarationSniff implements Sniff
                     if ($spaceAfterOpen === 0) {
                         $phpcsFile->fixer->addContent($openingBracket, $padding);
                     } else {
+                        $phpcsFile->fixer->beginChangeset();
                         $phpcsFile->fixer->replaceToken(($openingBracket + 1), $padding);
+                        for ($i = ($openingBracket + 2); $i < $nextNonWhiteSpace; $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
                     }
                 }
-            }
+            }//end if
         }//end if
 
         if ($this->requiredSpacesBeforeClose === 0 && $tokens[($closingBracket - 1)]['code'] === T_WHITESPACE) {
             $error = 'Whitespace found before closing bracket of FOR loop';
             $fix   = $phpcsFile->addFixableError($error, $closingBracket, 'SpacingBeforeClose');
             if ($fix === true) {
-                $phpcsFile->fixer->replaceToken(($closingBracket - 1), '');
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($closingBracket - 1); $i > $openingBracket; $i--) {
+                    if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
             }
         } else if ($this->requiredSpacesBeforeClose > 0) {
             $prevNonWhiteSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($closingBracket - 1), $openingBracket, true);
@@ -136,10 +160,16 @@ class ForLoopDeclarationSniff implements Sniff
                     if ($spaceBeforeClose === 0) {
                         $phpcsFile->fixer->addContentBefore($closingBracket, $padding);
                     } else {
+                        $phpcsFile->fixer->beginChangeset();
                         $phpcsFile->fixer->replaceToken(($closingBracket - 1), $padding);
+                        for ($i = ($closingBracket - 2); $i > $prevNonWhiteSpace; $i--) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
                     }
                 }
-            }
+            }//end if
         }//end if
 
         $firstSemicolon = $phpcsFile->findNext(T_SEMICOLON, $openingBracket, $closingBracket);

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -176,13 +176,24 @@ class ForLoopDeclarationSniff implements Sniff
          * Check whitespace around each of the semicolon tokens.
          */
 
-        $semicolonCount = 0;
-        $semicolon      = $openingBracket;
+        $semicolonCount     = 0;
+        $semicolon          = $openingBracket;
+        $targetNestinglevel = 0;
+        if (isset($tokens[$openingBracket]['conditions']) === true) {
+            $targetNestinglevel += count($tokens[$openingBracket]['conditions']);
+        }
 
         do {
             $semicolon = $phpcsFile->findNext(T_SEMICOLON, ($semicolon + 1), $closingBracket);
             if ($semicolon === false) {
                 break;
+            }
+
+            if (isset($tokens[$semicolon]['conditions']) === true
+                && count($tokens[$semicolon]['conditions']) > $targetNestinglevel
+            ) {
+                // Semicolon doesn't belong to the for().
+                continue;
             }
 
             ++$semicolonCount;

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -77,15 +77,18 @@ class ForLoopDeclarationSniff implements Sniff
         $closingBracket = $tokens[$openingBracket]['parenthesis_closer'];
 
         if ($this->requiredSpacesAfterOpen === 0 && $tokens[($openingBracket + 1)]['code'] === T_WHITESPACE) {
-            $error = 'Space found after opening bracket of FOR loop';
+            $error = 'Whitespace found after opening bracket of FOR loop';
             $fix   = $phpcsFile->addFixableError($error, $openingBracket, 'SpacingAfterOpen');
             if ($fix === true) {
                 $phpcsFile->fixer->replaceToken(($openingBracket + 1), '');
             }
         } else if ($this->requiredSpacesAfterOpen > 0) {
-            $spaceAfterOpen = 0;
-            if ($tokens[($openingBracket + 1)]['code'] === T_WHITESPACE) {
-                $spaceAfterOpen = strlen($tokens[($openingBracket + 1)]['content']);
+            $nextNonWhiteSpace = $phpcsFile->findNext(T_WHITESPACE, ($openingBracket + 1), $closingBracket, true);
+            $spaceAfterOpen    = 0;
+            if ($tokens[$openingBracket]['line'] !== $tokens[$nextNonWhiteSpace]['line']) {
+                $spaceAfterOpen = 'newline';
+            } else if ($tokens[($openingBracket + 1)]['code'] === T_WHITESPACE) {
+                $spaceAfterOpen = $tokens[($openingBracket + 1)]['length'];
             }
 
             if ($spaceAfterOpen !== $this->requiredSpacesAfterOpen) {
@@ -107,15 +110,18 @@ class ForLoopDeclarationSniff implements Sniff
         }//end if
 
         if ($this->requiredSpacesBeforeClose === 0 && $tokens[($closingBracket - 1)]['code'] === T_WHITESPACE) {
-            $error = 'Space found before closing bracket of FOR loop';
+            $error = 'Whitespace found before closing bracket of FOR loop';
             $fix   = $phpcsFile->addFixableError($error, $closingBracket, 'SpacingBeforeClose');
             if ($fix === true) {
                 $phpcsFile->fixer->replaceToken(($closingBracket - 1), '');
             }
         } else if ($this->requiredSpacesBeforeClose > 0) {
-            $spaceBeforeClose = 0;
-            if ($tokens[($closingBracket - 1)]['code'] === T_WHITESPACE) {
-                $spaceBeforeClose = strlen($tokens[($closingBracket - 1)]['content']);
+            $prevNonWhiteSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($closingBracket - 1), $openingBracket, true);
+            $spaceBeforeClose  = 0;
+            if ($tokens[$closingBracket]['line'] !== $tokens[$prevNonWhiteSpace]['line']) {
+                $spaceBeforeClose = 'newline';
+            } else if ($tokens[($closingBracket - 1)]['code'] === T_WHITESPACE) {
+                $spaceBeforeClose = $tokens[($closingBracket - 1)]['length'];
             }
 
             if ($this->requiredSpacesBeforeClose !== $spaceBeforeClose) {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -78,7 +78,7 @@ class ForLoopDeclarationSniff implements Sniff
 
         if ($this->requiredSpacesAfterOpen === 0 && $tokens[($openingBracket + 1)]['code'] === T_WHITESPACE) {
             $error = 'Space found after opening bracket of FOR loop';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterOpen');
+            $fix   = $phpcsFile->addFixableError($error, $openingBracket, 'SpacingAfterOpen');
             if ($fix === true) {
                 $phpcsFile->fixer->replaceToken(($openingBracket + 1), '');
             }
@@ -94,7 +94,7 @@ class ForLoopDeclarationSniff implements Sniff
                     $this->requiredSpacesAfterOpen,
                     $spaceAfterOpen,
                 ];
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterOpen', $data);
+                $fix   = $phpcsFile->addFixableError($error, $openingBracket, 'SpacingAfterOpen', $data);
                 if ($fix === true) {
                     $padding = str_repeat(' ', $this->requiredSpacesAfterOpen);
                     if ($spaceAfterOpen === 0) {
@@ -108,7 +108,7 @@ class ForLoopDeclarationSniff implements Sniff
 
         if ($this->requiredSpacesBeforeClose === 0 && $tokens[($closingBracket - 1)]['code'] === T_WHITESPACE) {
             $error = 'Space found before closing bracket of FOR loop';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeClose');
+            $fix   = $phpcsFile->addFixableError($error, $closingBracket, 'SpacingBeforeClose');
             if ($fix === true) {
                 $phpcsFile->fixer->replaceToken(($closingBracket - 1), '');
             }
@@ -124,7 +124,7 @@ class ForLoopDeclarationSniff implements Sniff
                     $this->requiredSpacesBeforeClose,
                     $spaceBeforeClose,
                 ];
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeClose', $data);
+                $fix   = $phpcsFile->addFixableError($error, $closingBracket, 'SpacingBeforeClose', $data);
                 if ($fix === true) {
                     $padding = str_repeat(' ', $this->requiredSpacesBeforeClose);
                     if ($spaceBeforeClose === 0) {
@@ -142,7 +142,7 @@ class ForLoopDeclarationSniff implements Sniff
         if ($firstSemicolon !== false) {
             if ($tokens[($firstSemicolon - 1)]['code'] === T_WHITESPACE) {
                 $error = 'Space found before first semicolon of FOR loop';
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeFirst');
+                $fix   = $phpcsFile->addFixableError($error, $firstSemicolon, 'SpacingBeforeFirst');
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken(($firstSemicolon - 1), '');
                 }
@@ -152,7 +152,7 @@ class ForLoopDeclarationSniff implements Sniff
                 && $tokens[($firstSemicolon + 1)]['code'] !== T_SEMICOLON
             ) {
                 $error = 'Expected 1 space after first semicolon of FOR loop; 0 found';
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterFirst');
+                $fix   = $phpcsFile->addFixableError($error, $firstSemicolon, 'NoSpaceAfterFirst');
                 if ($fix === true) {
                     $phpcsFile->fixer->addContent($firstSemicolon, ' ');
                 }
@@ -161,7 +161,7 @@ class ForLoopDeclarationSniff implements Sniff
                     $spaces = strlen($tokens[($firstSemicolon + 1)]['content']);
                     $error  = 'Expected 1 space after first semicolon of FOR loop; %s found';
                     $data   = [$spaces];
-                    $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterFirst', $data);
+                    $fix    = $phpcsFile->addFixableError($error, $firstSemicolon, 'SpacingAfterFirst', $data);
                     if ($fix === true) {
                         $phpcsFile->fixer->replaceToken(($firstSemicolon + 1), ' ');
                     }
@@ -175,7 +175,7 @@ class ForLoopDeclarationSniff implements Sniff
                     && $tokens[($firstSemicolon + 1)]['code'] !== T_SEMICOLON
                 ) {
                     $error = 'Space found before second semicolon of FOR loop';
-                    $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeSecond');
+                    $fix   = $phpcsFile->addFixableError($error, $secondSemicolon, 'SpacingBeforeSecond');
                     if ($fix === true) {
                         $phpcsFile->fixer->replaceToken(($secondSemicolon - 1), '');
                     }
@@ -185,7 +185,7 @@ class ForLoopDeclarationSniff implements Sniff
                     && $tokens[($secondSemicolon + 1)]['code'] !== T_WHITESPACE
                 ) {
                     $error = 'Expected 1 space after second semicolon of FOR loop; 0 found';
-                    $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpaceAfterSecond');
+                    $fix   = $phpcsFile->addFixableError($error, $secondSemicolon, 'NoSpaceAfterSecond');
                     if ($fix === true) {
                         $phpcsFile->fixer->addContent($secondSemicolon, ' ');
                     }
@@ -195,13 +195,13 @@ class ForLoopDeclarationSniff implements Sniff
                         $data   = [$spaces];
                         if (($secondSemicolon + 2) === $closingBracket) {
                             $error = 'Expected no space after second semicolon of FOR loop; %s found';
-                            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterSecondNoThird', $data);
+                            $fix   = $phpcsFile->addFixableError($error, $secondSemicolon, 'SpacingAfterSecondNoThird', $data);
                             if ($fix === true) {
                                 $phpcsFile->fixer->replaceToken(($secondSemicolon + 1), '');
                             }
                         } else {
                             $error = 'Expected 1 space after second semicolon of FOR loop; %s found';
-                            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterSecond', $data);
+                            $fix   = $phpcsFile->addFixableError($error, $secondSemicolon, 'SpacingAfterSecond', $data);
                             if ($fix === true) {
                                 $phpcsFile->fixer->replaceToken(($secondSemicolon + 1), ' ');
                             }

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -200,7 +200,7 @@ class ForLoopDeclarationSniff implements Sniff
             $prevNonWhiteSpace = $phpcsFile->findPrevious(T_WHITESPACE, ($semicolon - 1), $openingBracket, true);
             if ($semicolonCount !== 1 || $prevNonWhiteSpace !== $openingBracket) {
                 if ($tokens[($semicolon - 1)]['code'] === T_WHITESPACE) {
-                    $error     = 'Space found before %s semicolon of FOR loop';
+                    $error     = 'Whitespace found before %s semicolon of FOR loop';
                     $errorCode = 'SpacingBefore'.$humanReadableCode;
                     $fix       = $phpcsFile->addFixableError($error, $semicolon, $errorCode, $data);
                     if ($fix === true) {
@@ -225,7 +225,11 @@ class ForLoopDeclarationSniff implements Sniff
                 } else if ($tokens[($semicolon + 1)]['code'] === T_WHITESPACE
                     && $tokens[$nextNonWhiteSpace]['code'] !== T_SEMICOLON
                 ) {
-                    $spaces = strlen($tokens[($semicolon + 1)]['content']);
+                    $spaces = $tokens[($semicolon + 1)]['length'];
+                    if ($tokens[$semicolon]['line'] !== $tokens[$nextNonWhiteSpace]['line']) {
+                        $spaces = 'newline';
+                    }
+
                     if ($spaces !== 1) {
                         $error     = 'Expected 1 space after %s semicolon of FOR loop; %s found';
                         $errorCode = 'SpacingAfter'.$humanReadableCode;

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForLoopDeclarationSniff.php
@@ -204,7 +204,12 @@ class ForLoopDeclarationSniff implements Sniff
                     $errorCode = 'SpacingBefore'.$humanReadableCode;
                     $fix       = $phpcsFile->addFixableError($error, $semicolon, $errorCode, $data);
                     if ($fix === true) {
-                        $phpcsFile->fixer->replaceToken(($semicolon - 1), '');
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($i = ($semicolon - 1); $i > $prevNonWhiteSpace; $i--) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
                     }
                 }
             }
@@ -236,7 +241,13 @@ class ForLoopDeclarationSniff implements Sniff
                         $data[]    = $spaces;
                         $fix       = $phpcsFile->addFixableError($error, $semicolon, $errorCode, $data);
                         if ($fix === true) {
+                            $phpcsFile->fixer->beginChangeset();
                             $phpcsFile->fixer->replaceToken(($semicolon + 1), ' ');
+                            for ($i = ($semicolon + 2); $i < $nextNonWhiteSpace; $i++) {
+                                $phpcsFile->fixer->replaceToken($i, '');
+                            }
+
+                            $phpcsFile->fixer->endChangeset();
                         }
                     }
                 }//end if

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc
@@ -39,3 +39,81 @@ for ( $i = 0; $i < 10; $i++ ) {}
 for (  $i = 0; $i < 10; $i++  ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+for (         ; $i < 10; $i++) {}
+for (; $i < 10; $i++) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( ; $i < 10; $i++ ) {}
+for (         ; $i < 10; $i++ ) {}
+for (; $i < 10; $i++ ) {}
+
+for ( $i = 0; $i < 10; ) {}
+for ( $i = 0; $i < 10;) {}
+for ( $i = 0; $i < 10;     ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test handling of comments and inline annotations.
+for ( /*phpcs:enable*/ $i = 0 /*start*/ ;    /*end*/$i < 10/*comment*/; $i++ /*comment*/   ) {}
+
+// Test multi-line FOR control structure.
+for (
+    $i = 0;
+    $i < 10;
+    $i++
+) {}
+
+// Test multi-line FOR control structure with comments and annotations.
+for (
+    $i = 0; /* Start */
+    $i < 10; /* phpcs:ignore Standard.Category.SniffName -- for reasons. */
+    $i++ // comment
+
+) {}
+
+// Test fixing each error in one go. Note: lines 78 + 82 contain trailing whitespace on purpose.
+for (
+      
+
+      $i = 0
+
+      ; 
+
+      $i < 10
+
+      ;
+
+      $i++
+
+
+) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for (
+
+
+
+      $i = 0
+
+      ;
+
+      $i < 10
+
+      ;
+
+      $i++
+
+
+) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test with semi-colon not belonging to for.
+for ($i = function() { return $this->i  ;    }; $i < function() { return $this->max; }; $i++) {}
+for ($i = function() { return $this->i; }; $i < function() { return $this->max; }  ;   $i++) {}
+
+// This test has to be the last one in the file! Intentional parse error check.
+for

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc.fixed
@@ -39,3 +39,47 @@ for ( $i = 0; $i < 10; $i++ ) {}
 for ( $i = 0; $i < 10; $i++ ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+for (; $i < 10; $i++) {}
+for (; $i < 10; $i++) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( ; $i < 10; $i++ ) {}
+for ( ; $i < 10; $i++ ) {}
+for ( ; $i < 10; $i++ ) {}
+
+for ( $i = 0; $i < 10; ) {}
+for ( $i = 0; $i < 10; ) {}
+for ( $i = 0; $i < 10; ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test handling of comments and inline annotations.
+for (/*phpcs:enable*/ $i = 0 /*start*/; /*end*/$i < 10/*comment*/; $i++ /*comment*/) {}
+
+// Test multi-line FOR control structure.
+for ($i = 0; $i < 10; $i++) {}
+
+// Test multi-line FOR control structure with comments and annotations.
+for ($i = 0; /* Start */
+    $i < 10; /* phpcs:ignore Standard.Category.SniffName -- for reasons. */
+    $i++ // comment
+
+) {}
+
+// Test fixing each error in one go. Note: lines 78 + 82 contain trailing whitespace on purpose.
+for ($i = 0; $i < 10; $i++) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( $i = 0; $i < 10; $i++ ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test with semi-colon not belonging to for.
+for ($i = function() { return $this->i  ;    }; $i < function() { return $this->max; }; $i++) {}
+for ($i = function() { return $this->i; }; $i < function() { return $this->max; }; $i++) {}
+
+// This test has to be the last one in the file! Intentional parse error check.
+for

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc.fixed
@@ -1,0 +1,41 @@
+<?php
+
+// Valid.
+for ($i = 0; $i < 10; $i++) {
+}
+
+// Invalid.
+for ($i = 0; $i < 10; $i++) {
+}
+
+for ($i = 0; $i < 10; $i++) {
+}
+
+for ($i = 0; $i < 10; $i++) {
+}
+
+for ($i = 0; $i < 10; $i++) {
+}
+
+// The works.
+for ($i = 0; $i < 10; $i++) {
+}
+
+for ($i = 0; $i < 10;) {
+}
+
+for ($i = 0; $i < 10;) {
+}
+
+for ($i = 0;; $i++) {
+}
+for ($i = 0;; $i++) {
+}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( $i = 0; $i < 10; $i++ ) {}
+for ( $i = 0; $i < 10; $i++ ) {}
+for ( $i = 0; $i < 10; $i++ ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js
@@ -45,3 +45,81 @@ for ( var i = 0; i < 10; i++ ) {}
 for (  var i = 0; i < 10; i++  ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+for (      ; i < 10; i++) {}
+for (; i < 10; i++) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( ; i < 10; i++ ) {}
+for (         ; i < 10; i++ ) {}
+for (; i < 10; i++ ) {}
+
+for ( i = 0; i < 10; ) {}
+for ( i = 0; i < 10;) {}
+for ( i = 0; i < 10;     ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test handling of comments and inline annotations.
+for ( /*phpcs:enable*/ i = 0 /*start*/ ;    /*end*/i < 10/*comment*/; i++ /*comment*/   ) {}
+
+// Test multi-line FOR control structure.
+for (
+    i = 0;
+    i < 10;
+    i++
+) {}
+
+// Test multi-line FOR control structure with comments and annotations.
+for (
+    i = 0; /* Start */
+    i < 10; /* phpcs:ignore Standard.Category.SniffName -- for reasons. */
+    i++ // comment
+
+) {}
+
+// Test fixing each error in one go. Note: lines 84 + 88 contain trailing whitespace on purpose.
+for (
+     
+
+      i = 0
+
+      ; 
+
+      i < 10
+
+      ;
+
+      i++
+
+
+) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for (
+
+
+
+      i = 0
+
+      ;
+
+      i < 10
+
+      ;
+
+      i++
+
+
+) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test with semi-colon not belonging to for.
+for (i = function() {self.widgetLoaded(widget.id)  ;  }; i < function() {self.widgetLoaded(widget.id);}; i++) {}
+for (i = function() {self.widgetLoaded(widget.id);}; i < function() {self.widgetLoaded(widget.id);}  ;   i++) {}
+
+// This test has to be the last one in the file! Intentional parse error check.
+for

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js.fixed
@@ -1,0 +1,47 @@
+// Valid.
+for (var i = 0; i < 10; i++) {
+}
+
+// Invalid.
+for (i = 0; i < 10; i++) {
+}
+
+for (i = 0; i < 10; i++) {
+}
+
+for (var i = 0; i < 10; i++) {
+}
+
+for (i = 0; i < 10; i++) {
+}
+
+// The works.
+for (var i = 0; i < 10; i++) {
+}
+
+this.formats = {};
+dfx.inherits('ContentFormat', 'Widget');
+
+for (var widgetid in this.loadedContents) {
+    if (dfx.isset(widget) === true) {
+        widget.loadAutoSaveCWidgetStore.setData('activeScreen', null);widget.getContents(this.loadedContents[widgetid], function() {self.widgetLoaded(widget.id);});
+    }
+}
+
+for (var i = 0; i < 10;) {
+}
+for (var i = 0; i < 10;) {
+}
+
+for (var i = 0;; i++) {
+}
+for (var i = 0;; i++) {
+}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( var i = 0; i < 10; i++ ) {}
+for ( var i = 0; i < 10; i++ ) {}
+for ( var i = 0; i < 10; i++ ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.js.fixed
@@ -45,3 +45,47 @@ for ( var i = 0; i < 10; i++ ) {}
 for ( var i = 0; i < 10; i++ ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+for (; i < 10; i++) {}
+for (; i < 10; i++) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( ; i < 10; i++ ) {}
+for ( ; i < 10; i++ ) {}
+for ( ; i < 10; i++ ) {}
+
+for ( i = 0; i < 10; ) {}
+for ( i = 0; i < 10; ) {}
+for ( i = 0; i < 10; ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test handling of comments and inline annotations.
+for (/*phpcs:enable*/ i = 0 /*start*/; /*end*/i < 10/*comment*/; i++ /*comment*/) {}
+
+// Test multi-line FOR control structure.
+for (i = 0; i < 10; i++) {}
+
+// Test multi-line FOR control structure with comments and annotations.
+for (i = 0; /* Start */
+    i < 10; /* phpcs:ignore Standard.Category.SniffName -- for reasons. */
+    i++ // comment
+
+) {}
+
+// Test fixing each error in one go. Note: lines 84 + 88 contain trailing whitespace on purpose.
+for (i = 0; i < 10; i++) {}
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 1
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 1
+for ( i = 0; i < 10; i++ ) {}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// Test with semi-colon not belonging to for.
+for (i = function() {self.widgetLoaded(widget.id)  ;  }; i < function() {self.widgetLoaded(widget.id);}; i++) {}
+for (i = function() {self.widgetLoaded(widget.id);}; i < function() {self.widgetLoaded(widget.id);}; i++) {}
+
+// This test has to be the last one in the file! Intentional parse error check.
+for

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -30,33 +30,74 @@ class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'ForLoopDeclarationUnitTest.inc':
             return [
-                8  => 2,
-                11 => 2,
-                14 => 2,
-                17 => 2,
-                21 => 6,
-                27 => 1,
-                30 => 1,
-                37 => 2,
-                39 => 2,
+                8   => 2,
+                11  => 2,
+                14  => 2,
+                17  => 2,
+                21  => 6,
+                27  => 1,
+                30  => 1,
+                37  => 2,
+                39  => 2,
+                43  => 1,
+                49  => 1,
+                50  => 1,
+                53  => 1,
+                54  => 1,
+                59  => 4,
+                62  => 1,
+                63  => 1,
+                64  => 1,
+                66  => 1,
+                69  => 1,
+                74  => 1,
+                77  => 1,
+                82  => 2,
+                86  => 2,
+                91  => 1,
+                95  => 1,
+                101 => 2,
+                105 => 2,
+                110 => 1,
+                116 => 2,
             ];
-             break;
+
         case 'ForLoopDeclarationUnitTest.js':
             return [
-                6  => 2,
-                9  => 2,
-                12 => 2,
-                15 => 2,
-                19 => 6,
-                33 => 1,
-                36 => 1,
-                43 => 2,
-                45 => 2,
+                6   => 2,
+                9   => 2,
+                12  => 2,
+                15  => 2,
+                19  => 6,
+                33  => 1,
+                36  => 1,
+                43  => 2,
+                45  => 2,
+                49  => 1,
+                55  => 1,
+                56  => 1,
+                59  => 1,
+                60  => 1,
+                65  => 4,
+                68  => 1,
+                69  => 1,
+                70  => 1,
+                72  => 1,
+                75  => 1,
+                80  => 1,
+                83  => 1,
+                88  => 2,
+                92  => 2,
+                97  => 1,
+                101 => 1,
+                107 => 2,
+                111 => 2,
+                116 => 1,
+                122 => 2,
             ];
-             break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()
@@ -68,11 +109,22 @@ class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getWarningList()
+    public function getWarningList($testFile='ForLoopDeclarationUnitTest.inc')
     {
-        return [];
+        switch ($testFile) {
+        case 'ForLoopDeclarationUnitTest.inc':
+            return [119 => 1];
+
+        case 'ForLoopDeclarationUnitTest.js':
+            return [125 => 1];
+
+        default:
+            return [];
+        }//end switch
 
     }//end getWarningList()
 


### PR DESCRIPTION
[Fixer conflict series PR] + [Missing fixed files series PR]

**Note**: This PR will be easiest to review by looking at the individual commits.

## Commit Summary

### Squiz/ForLoopDeclaration: add missing fixed files

The sniff contains fixers, but didn't have `fixed` files.

### Squiz/ForLoopDeclaration: add a lot more unit tests

Tests covering:
* Missing first expression.
* First/Last expression missing in combination with non-zero `requiredSpacesAfterOpen`/`requiredSpacesBeforeClose`.
* Expressions interlaces with comments.
* Multi-line expressions.
* Multi-line whitespace which needs to be removed.
* Expressions including code which itself contains a semi-colon.
* The parse error warning.

### Squiz/ForLoopDeclaration: report errors on the line they occur

Report errors for multi-line `for` control structures on the line they refer to, i.e. opening brace, close brace, semicolon line, instead of the line the `for` keyword is on.

This improves the usability of the error messages for multi-line `for` declarations.

### Squiz/ForLoopDeclaration: improve the accuracy of the SpaceAfterOpen/SpaceBeforeClose error messages

The error messages for `SpaceAfterOpen`/`SpaceBeforeClose` did not handle situations where the spacing found was a new line.

The determination of `$spaceAfterOpen` and `$spaceBeforeClose` has now been brought in line with other sniffs and will report `newline` when a new line was found.

Includes using the predetermined `length` of the token instead of doing length calculations.

For the "spaces found, no spaces allowed" situations, only a minor tweak has been made to the error message to acknowledge that more than just a space may have been found.

### Squiz/ForLoopDeclaration: fix SpaceAfterOpen/SpaceBeforeClose in one loop

Fix the `SpaceAfterOpen`/`SpaceBeforeClose` errors in one go instead of one whitespace token per loop.

### Squiz/ForLoopDeclaration: refactor semi-colon related code

The first and second semi-colon examinations were basically the same, i.e. duplicate code.

This refactors the semicolon examination to use a `do-while` loop on the semicolons within a `for`, removing the code duplication (and opening the way for further improvements in the next few commits).

This commit does not change the behaviour of the sniff.

### Squiz/ForLoopDeclaration: fix fixer conflict

Fix a fixer conflict within the sniff.

If `$requiredSpacingAfterOpen/BeforeClose` would be set to anything but `0` and the first or the last clause of the `for()` would be empty, the sniff had a fixer conflict with itself, as the `SpacingAfterOpen/BeforeClose` error would demand whitespace, while the `SpacingBeforeFirst/AfterSecondNoThird` would try to remove it.

Fixed by skipping the semicolon spacing checks when an empty first/last expression is detected and leaving the handling of those situations up to the `SpaceAfterOpen/BeforeClose` logic.

This fix effectively removes the `SpacingAfterSecondNoThird` error code.

### Squiz/ForLoopDeclaration: improve the semicolon spacing determination

The `SpacingBeforeFirst/Second`/`SpacingAfterFirst/Second` checks did not handle situations where the spacing found was a new line.

The determination of `$spaces` has now been brought in line with other sniffs and will report `newline` when a new line was found.

Includes using the predetermined `length` of the token instead of doing length calculations.

For the "spaces before" situation, only a minor tweak has been made to the error message to acknowledge that more than just a space may have been found.

**Note**: This _does_ change the behaviour of the sniff for multi-line `for` declarations.
Previously a new line character would be regarded as "one space" and left alone.
Now, the new line (and other extraneous whitespace) will be removed.

Note: spacing _within_ expressions is not affected by this change.

### Squiz/ForLoopDeclaration: fix semicolon spacing issues in one loop

Fix the `SpaceBeforeFirst/Second` and `SpaceAfterFirst/Second` errors in one go instead of one whitespace token per loop.

### Squiz/ForLoopDeclaration: bugfix with closures being used in expressions

When a closure would be used within an expression, the code within the closure would also contain semicolons.

The existing code did not take that into account and would throw false positives for spacing around semicolons in the closures (not the concern of this sniff) and would incorrectly neglect to throw errors for spacing around semicolons after the closure.

This is now fixed.

### Squiz/ForLoopDeclaration: prevent creating parse error with `SpacingBeforeClose` fixer

When a `//`-style comment would be at the end of a multi-line `for` declaration, the `SpacingBeforeClose` fixers could inadvertently create a parse error, by moving the `for` close parenthesis into the comment.

Fixed by checking whether the previous non-whitespace token is on another line and a comment and making the errors non-fixable in that case.