### PR TITLE
Few more minor memory management tweaks

### DIFF
--- a/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
+++ b/src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php
@@ -141,8 +141,9 @@ class CreateWidgetTypeCallbackSniff implements Sniff
 
                 // Note that we use this endBracket down further when checking
                 // for a RETURN statement.
-                $endBracket = end($tokens[$i]['nested_parenthesis']);
-                $bracket    = key($tokens[$i]['nested_parenthesis']);
+                $nestedParens = $tokens[$i]['nested_parenthesis'];
+                $endBracket   = end($nestedParens);
+                $bracket      = key($nestedParens);
 
                 $prev = $phpcsFile->findPrevious(
                     Tokens::$emptyTokens,

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -62,7 +62,8 @@ class SemicolonSpacingSniff implements Sniff
         // Detect whether this is a semi-colons for a conditions in a `for()` control structure.
         $forCondition = false;
         if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-            $closeParenthesis = end($tokens[$stackPtr]['nested_parenthesis']);
+            $nestedParens     = $tokens[$stackPtr]['nested_parenthesis'];
+            $closeParenthesis = end($nestedParens);
 
             if (isset($tokens[$closeParenthesis]['parenthesis_owner']) === true) {
                 $owner = $tokens[$closeParenthesis]['parenthesis_owner'];

--- a/src/Tokenizers/JS.php
+++ b/src/Tokenizers/JS.php
@@ -1111,8 +1111,8 @@ class JS extends Tokenizer
                 && isset($this->tokens[$i]['scope_condition']) === false
                 && isset($this->tokens[$i]['bracket_closer']) === true
             ) {
-                $condition = end($this->tokens[$i]['conditions']);
-                reset($this->tokens[$i]['conditions']);
+                $condition = $this->tokens[$i]['conditions'];
+                $condition = end($condition);
                 if ($condition === T_CLASS) {
                     // Possibly an ES6 method. To be classified as one, the previous
                     // non-empty tokens need to be a set of parenthesis, and then a string


### PR DESCRIPTION
Related to #2273 - I've done a quick search of rest of the code base and adjusted any usage of the `end()` / `key()` functions in combination with the `$tokens` array.

All relevant instances of this in the existing code base have now been fixed for the memory leakage.