### PR TITLE
Unit Tests: report on number of sniff test case files tested

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -127,6 +127,7 @@ abstract class AbstractSniffUnitTest extends TestCase
 
         // Get a list of all test files to check.
         $testFiles = $this->getTestFiles($testFileBase);
+        $GLOBALS['PHP_CODESNIFFER_SNIFF_CASE_FILES'][] = $testFiles;
 
         if (isset($GLOBALS['PHP_CODESNIFFER_CONFIG']) === true) {
             $config = $GLOBALS['PHP_CODESNIFFER_CONFIG'];

--- a/tests/Standards/AllSniffs.php
+++ b/tests/Standards/AllSniffs.php
@@ -40,8 +40,9 @@ class AllSniffs
      */
     public static function suite()
     {
-        $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']   = [];
-        $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'] = [];
+        $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']      = [];
+        $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES']    = [];
+        $GLOBALS['PHP_CODESNIFFER_SNIFF_CASE_FILES'] = [];
 
         $suite = new TestSuite('PHP CodeSniffer Standards');
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,4 +62,9 @@ function printPHPCodeSnifferTestOutput()
         echo "; $fixes were fixable ($percent%)";
     }
 
+    $files     = call_user_func_array('array_merge', $GLOBALS['PHP_CODESNIFFER_SNIFF_CASE_FILES']);
+    $files     = array_unique($files);
+    $fileCount = count($files);
+    echo PHP_EOL, PHP_EOL, "Examined $fileCount sniff test case files";
+
 }//end printPHPCodeSnifferTestOutput()


### PR DESCRIPTION
This commit adds an additional line below a unit test run, listing how many sniff test case files were examined. This information can be used as input to check and debug unit test runs.