### PR TITLE
Remove unnecessary strlen() function calls

### DIFF
--- a/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
@@ -101,7 +101,7 @@ class OpeningBraceSameLineSniff implements Sniff
         } else if ($tokens[($openingBrace - 1)]['content'] === "\t") {
             $length = '\t';
         } else {
-            $length = strlen($tokens[($openingBrace - 1)]['content']);
+            $length = $tokens[($openingBrace - 1)]['length'];
         }
 
         if ($length !== 1) {

--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -140,7 +140,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
                     // each argument on a newline, which is valid, so ignore it.
                     $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextSeparator + 1), null, true);
                     if ($tokens[$next]['line'] === $tokens[$nextSeparator]['line']) {
-                        $space = strlen($tokens[($nextSeparator + 1)]['content']);
+                        $space = $tokens[($nextSeparator + 1)]['length'];
                         if ($space > 1) {
                             $error = 'Expected 1 space after comma in function call; %s found';
                             $data  = [$space];

--- a/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/src/Standards/PEAR/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -73,7 +73,7 @@ class MultiLineConditionSniff implements Sniff
             if (strpos($tokens[($openBracket + 1)]['content'], $phpcsFile->eolChar) !== false) {
                 $spaceAfterOpen = 'newline';
             } else {
-                $spaceAfterOpen = strlen($tokens[($openBracket + 1)]['content']);
+                $spaceAfterOpen = $tokens[($openBracket + 1)]['length'];
             }
         }
 
@@ -100,7 +100,7 @@ class MultiLineConditionSniff implements Sniff
         }
 
         if ($i >= 0 && $tokens[$i]['code'] === T_WHITESPACE) {
-            $statementIndent = strlen($tokens[$i]['content']);
+            $statementIndent = $tokens[$i]['length'];
         }
 
         // Each line between the parenthesis should be indented 4 spaces
@@ -157,7 +157,7 @@ class MultiLineConditionSniff implements Sniff
                 if ($tokens[$i]['code'] !== T_WHITESPACE) {
                     $foundIndent = 0;
                 } else {
-                    $foundIndent = strlen($tokens[$i]['content']);
+                    $foundIndent = $tokens[$i]['length'];
                 }
 
                 if ($expectedIndent !== $foundIndent) {
@@ -247,7 +247,7 @@ class MultiLineConditionSniff implements Sniff
         } else if ($openBrace === ($closeBracket + 2)
             && $tokens[($closeBracket + 1)]['code'] === T_WHITESPACE
         ) {
-            $length = strlen($tokens[($closeBracket + 1)]['content']);
+            $length = $tokens[($closeBracket + 1)]['length'];
         } else {
             // Confused, so don't check.
             $length = 1;

--- a/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -83,14 +83,14 @@ class MultiLineAssignmentSniff implements Sniff
         }
 
         if ($tokens[$i]['code'] === T_WHITESPACE) {
-            $assignmentIndent = strlen($tokens[$i]['content']);
+            $assignmentIndent = $tokens[$i]['length'];
         }
 
         // Find the actual indent.
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1));
 
         $expectedIndent = ($assignmentIndent + $this->indent);
-        $foundIndent    = strlen($tokens[$prev]['content']);
+        $foundIndent    = $tokens[$prev]['length'];
         if ($foundIndent !== $expectedIndent) {
             $error = 'Multi-line assignment not indented correctly; expected %s spaces but found %s';
             $data  = [

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -230,7 +230,7 @@ class FunctionCallSignatureSniff implements Sniff
         } else if ($requiredSpacesAfterOpen > 0) {
             $spaceAfterOpen = 0;
             if ($tokens[($openBracket + 1)]['code'] === T_WHITESPACE) {
-                $spaceAfterOpen = strlen($tokens[($openBracket + 1)]['content']);
+                $spaceAfterOpen = $tokens[($openBracket + 1)]['length'];
             }
 
             if ($spaceAfterOpen !== $requiredSpacesAfterOpen) {
@@ -262,7 +262,7 @@ class FunctionCallSignatureSniff implements Sniff
         if ($tokens[$prev]['line'] !== $tokens[$closer]['line']) {
             $spaceBeforeClose = 'newline';
         } else if ($tokens[($closer - 1)]['code'] === T_WHITESPACE) {
-            $spaceBeforeClose = strlen($tokens[($closer - 1)]['content']);
+            $spaceBeforeClose = $tokens[($closer - 1)]['length'];
         }
 
         if ($spaceBeforeClose !== $requiredSpacesBeforeClose) {
@@ -505,7 +505,7 @@ class FunctionCallSignatureSniff implements Sniff
                             $foundIndent = 0;
                         }
                     } else {
-                        $foundIndent = strlen($tokens[$i]['content']);
+                        $foundIndent = $tokens[$i]['length'];
                     }
 
                     if ($foundIndent < $expectedIndent

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -80,7 +80,7 @@ class FunctionDeclarationSniff implements Sniff
             if ($tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar) {
                 $spaces = 'newline';
             } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-                $spaces = strlen($tokens[($stackPtr + 1)]['content']);
+                $spaces = $tokens[($stackPtr + 1)]['length'];
             } else {
                 $spaces = 0;
             }
@@ -110,7 +110,7 @@ class FunctionDeclarationSniff implements Sniff
             if ($tokens[($openBracket - 1)]['content'] === $phpcsFile->eolChar) {
                 $spaces = 'newline';
             } else if ($tokens[($openBracket - 1)]['code'] === T_WHITESPACE) {
-                $spaces = strlen($tokens[($openBracket - 1)]['content']);
+                $spaces = $tokens[($openBracket - 1)]['length'];
             } else {
                 $spaces = 0;
             }
@@ -130,7 +130,7 @@ class FunctionDeclarationSniff implements Sniff
                 if ($tokens[($end - 1)]['content'] === $phpcsFile->eolChar) {
                     $spaces = 'newline';
                 } else if ($tokens[($end - 1)]['code'] === T_WHITESPACE) {
-                    $spaces = strlen($tokens[($end - 1)]['content']);
+                    $spaces = $tokens[($end - 1)]['length'];
                 } else {
                     $spaces = 0;
                 }
@@ -155,7 +155,7 @@ class FunctionDeclarationSniff implements Sniff
                 } else if ($tokens[($use + 1)]['content'] === "\t") {
                     $length = '\t';
                 } else {
-                    $length = strlen($tokens[($use + 1)]['content']);
+                    $length = $tokens[($use + 1)]['length'];
                 }
 
                 if ($length !== 1) {
@@ -176,7 +176,7 @@ class FunctionDeclarationSniff implements Sniff
                 } else if ($tokens[($use - 1)]['content'] === "\t") {
                     $length = '\t';
                 } else {
-                    $length = strlen($tokens[($use - 1)]['content']);
+                    $length = $tokens[($use - 1)]['length'];
                 }
 
                 if ($length !== 1) {
@@ -296,7 +296,7 @@ class FunctionDeclarationSniff implements Sniff
         $i++;
 
         if ($tokens[$i]['code'] === T_WHITESPACE) {
-            $functionIndent = strlen($tokens[$i]['content']);
+            $functionIndent = $tokens[$i]['length'];
         }
 
         // The closing parenthesis must be on a new line, even
@@ -377,7 +377,7 @@ class FunctionDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
                 } else {
-                    $foundIndent = strlen($tokens[$i]['content']);
+                    $foundIndent = $tokens[$i]['length'];
                 }
 
                 if ($expectedIndent !== $foundIndent) {

--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -73,7 +73,7 @@ class ObjectOperatorIndentSniff implements Sniff
 
         $requiredIndent = 0;
         if ($i >= 0 && $tokens[$i]['code'] === T_WHITESPACE) {
-            $requiredIndent = strlen($tokens[$i]['content']);
+            $requiredIndent = $tokens[$i]['length'];
         }
 
         $requiredIndent += $this->indent;

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -113,7 +113,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
 
             // We changed lines.
             if ($tokens[($i + 1)]['code'] === T_WHITESPACE) {
-                $classIndent = strlen($tokens[($i + 1)]['content']);
+                $classIndent = $tokens[($i + 1)]['length'];
             }
 
             break;
@@ -181,7 +181,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                     // Check the whitespace before. Whitespace after is checked
                     // later by looking at the whitespace before the first class name
                     // in the list.
-                    $gap = strlen($tokens[($keyword - 1)]['content']);
+                    $gap = $tokens[($keyword - 1)]['length'];
                     if ($gap !== 1) {
                         $error = 'Expected 1 space before '.$keywordType.' keyword; %s found';
                         $data  = [$gap];
@@ -302,7 +302,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                     if ($tokens[$prev]['line'] !== $tokens[$className]['line']) {
                         $found = 0;
                     } else {
-                        $found = strlen($tokens[$prev]['content']);
+                        $found = $tokens[$prev]['length'];
                     }
 
                     $expected = ($classIndent + $this->indent);
@@ -344,7 +344,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                         $prev = ($className - 1);
                     }
 
-                    $spaceBefore = strlen($tokens[$prev]['content']);
+                    $spaceBefore = $tokens[$prev]['length'];
                     if ($spaceBefore !== 1) {
                         $error = 'Expected 1 space before "%s"; %s found';
                         $data  = [
@@ -371,7 +371,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                         $error = 'Expected 0 spaces between "%s" and comma; %s found';
                         $data  = [
                             $tokens[$className]['content'],
-                            strlen($tokens[($className + 1)]['content']),
+                            $tokens[($className + 1)]['length'],
                         ];
 
                         $fix = $phpcsFile->addFixableError($error, $className, 'SpaceBeforeComma', $data);

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -82,7 +82,7 @@ class ControlStructureSpacingSniff implements Sniff
             if (strpos($tokens[($parenOpener + 1)]['content'], $phpcsFile->eolChar) !== false) {
                 $spaceAfterOpen = 'newline';
             } else {
-                $spaceAfterOpen = strlen($tokens[($parenOpener + 1)]['content']);
+                $spaceAfterOpen = $tokens[($parenOpener + 1)]['length'];
             }
         }
 

--- a/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/SelfMemberReferenceSniff.php
@@ -127,7 +127,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
         }//end if
 
         if ($tokens[($stackPtr - 1)]['code'] === T_WHITESPACE) {
-            $found = strlen($tokens[($stackPtr - 1)]['content']);
+            $found = $tokens[($stackPtr - 1)]['length'];
             $error = 'Expected 0 spaces before double colon; %s found';
             $data  = [$found];
             $fix   = $phpcsFile->addFixableError($error, ($stackPtr - 1), 'SpaceBefore', $data);
@@ -144,7 +144,7 @@ class SelfMemberReferenceSniff extends AbstractScopeSniff
         }
 
         if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-            $found = strlen($tokens[($stackPtr + 1)]['content']);
+            $found = $tokens[($stackPtr + 1)]['length'];
             $error = 'Expected 0 spaces after double colon; %s found';
             $data  = [$found];
             $fix   = $phpcsFile->addFixableError($error, ($stackPtr - 1), 'SpaceAfter', $data);

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -144,7 +144,7 @@ class DocCommentAlignmentSniff implements Sniff
                 && $tokens[($i + 1)]['content'] !== ' '
             ) {
                 $error = 'Expected 1 space after asterisk; %s found';
-                $data  = [strlen($tokens[($i + 1)]['content'])];
+                $data  = [$tokens[($i + 1)]['length']];
                 $fix   = $phpcsFile->addFixableError($error, $i, 'SpaceAfterStar', $data);
                 if ($fix === true) {
                     $phpcsFile->fixer->replaceToken(($i + 1), ' ');

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -319,7 +319,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                             if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
                                 $indent = 0;
                                 if ($tokens[($i - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
-                                    $indent = strlen($tokens[($i - 1)]['content']);
+                                    $indent = $tokens[($i - 1)]['length'];
                                 }
 
                                 $comment       .= ' '.$tokens[$i]['content'];

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -98,7 +98,7 @@ class ControlSignatureSniff implements Sniff
             if (strpos($tokens[($stackPtr + 1)]['content'], $phpcsFile->eolChar) !== false) {
                 $found = 'newline';
             } else {
-                $found = strlen($tokens[($stackPtr + 1)]['content']);
+                $found = $tokens[($stackPtr + 1)]['length'];
             }
         }
 
@@ -236,7 +236,7 @@ class ControlSignatureSniff implements Sniff
                 if (strpos($tokens[($closer + 1)]['content'], $phpcsFile->eolChar) !== false) {
                     $found = 'newline';
                 } else {
-                    $found = strlen($tokens[($closer + 1)]['content']);
+                    $found = $tokens[($closer + 1)]['length'];
                 }
             }
 
@@ -291,7 +291,7 @@ class ControlSignatureSniff implements Sniff
         } else if ($tokens[$closer]['line'] !== $tokens[$stackPtr]['line']) {
             $found = 'newline';
         } else if ($tokens[($closer + 1)]['content'] !== ' ') {
-            $found = strlen($tokens[($closer + 1)]['content']);
+            $found = $tokens[($closer + 1)]['length'];
         }
 
         if ($found !== 1) {

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ForEachLoopDeclarationSniff.php
@@ -82,7 +82,7 @@ class ForEachLoopDeclarationSniff implements Sniff
         } else if ($this->requiredSpacesAfterOpen > 0) {
             $spaceAfterOpen = 0;
             if ($tokens[($openingBracket + 1)]['code'] === T_WHITESPACE) {
-                $spaceAfterOpen = strlen($tokens[($openingBracket + 1)]['content']);
+                $spaceAfterOpen = $tokens[($openingBracket + 1)]['length'];
             }
 
             if ($spaceAfterOpen !== $this->requiredSpacesAfterOpen) {
@@ -112,7 +112,7 @@ class ForEachLoopDeclarationSniff implements Sniff
         } else if ($this->requiredSpacesBeforeClose > 0) {
             $spaceBeforeClose = 0;
             if ($tokens[($closingBracket - 1)]['code'] === T_WHITESPACE) {
-                $spaceBeforeClose = strlen($tokens[($closingBracket - 1)]['content']);
+                $spaceBeforeClose = $tokens[($closingBracket - 1)]['length'];
             }
 
             if ($spaceBeforeClose !== $this->requiredSpacesBeforeClose) {
@@ -165,8 +165,8 @@ class ForEachLoopDeclarationSniff implements Sniff
                     $phpcsFile->fixer->addContentBefore($doubleArrow, ' ');
                 }
             } else {
-                if (strlen($tokens[($doubleArrow - 1)]['content']) !== 1) {
-                    $spaces = strlen($tokens[($doubleArrow - 1)]['content']);
+                if ($tokens[($doubleArrow - 1)]['length'] !== 1) {
+                    $spaces = $tokens[($doubleArrow - 1)]['length'];
                     $error  = 'Expected 1 space before "=>"; %s found';
                     $data   = [$spaces];
                     $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeArrow', $data);
@@ -183,8 +183,8 @@ class ForEachLoopDeclarationSniff implements Sniff
                     $phpcsFile->fixer->addContent($doubleArrow, ' ');
                 }
             } else {
-                if (strlen($tokens[($doubleArrow + 1)]['content']) !== 1) {
-                    $spaces = strlen($tokens[($doubleArrow + 1)]['content']);
+                if ($tokens[($doubleArrow + 1)]['length'] !== 1) {
+                    $spaces = $tokens[($doubleArrow + 1)]['length'];
                     $error  = 'Expected 1 space after "=>"; %s found';
                     $data   = [$spaces];
                     $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterArrow', $data);
@@ -202,8 +202,8 @@ class ForEachLoopDeclarationSniff implements Sniff
                 $phpcsFile->fixer->addContentBefore($asToken, ' ');
             }
         } else {
-            if (strlen($tokens[($asToken - 1)]['content']) !== 1) {
-                $spaces = strlen($tokens[($asToken - 1)]['content']);
+            if ($tokens[($asToken - 1)]['length'] !== 1) {
+                $spaces = $tokens[($asToken - 1)]['length'];
                 $error  = 'Expected 1 space before "as"; %s found';
                 $data   = [$spaces];
                 $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingBeforeAs', $data);
@@ -220,8 +220,8 @@ class ForEachLoopDeclarationSniff implements Sniff
                 $phpcsFile->fixer->addContent($asToken, ' ');
             }
         } else {
-            if (strlen($tokens[($asToken + 1)]['content']) !== 1) {
-                $spaces = strlen($tokens[($asToken + 1)]['content']);
+            if ($tokens[($asToken + 1)]['length'] !== 1) {
+                $spaces = $tokens[($asToken + 1)]['length'];
                 $error  = 'Expected 1 space after "as"; %s found';
                 $data   = [$spaces];
                 $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfterAs', $data);

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -121,7 +121,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                 // Check parameter default spacing.
                 $spacesBefore = 0;
                 if (($nextToken - $nextParam) > 1) {
-                    $spacesBefore = strlen($tokens[($nextParam + 1)]['content']);
+                    $spacesBefore = $tokens[($nextParam + 1)]['length'];
                 }
 
                 if ($spacesBefore !== $this->equalsSpacing) {
@@ -144,7 +144,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                 $spacesAfter = 0;
                 if ($tokens[($nextToken + 1)]['code'] === T_WHITESPACE) {
-                    $spacesAfter = strlen($tokens[($nextToken + 1)]['content']);
+                    $spacesAfter = $tokens[($nextToken + 1)]['length'];
                 }
 
                 if ($spacesAfter !== $this->equalsSpacing) {
@@ -174,7 +174,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                     $error = 'Expected 0 spaces between argument "%s" and comma; %s found';
                     $data  = [
                         $tokens[$nextParam]['content'],
-                        strlen($tokens[($nextComma - 1)]['content']),
+                        $tokens[($nextComma - 1)]['length'],
                     ];
 
                     $fix = $phpcsFile->addFixableError($error, $nextToken, 'SpaceBeforeComma', $data);
@@ -211,7 +211,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
                 $gap = 0;
                 if ($tokens[$whitespace]['code'] === T_WHITESPACE) {
-                    $gap = strlen($tokens[$whitespace]['content']);
+                    $gap = $tokens[$whitespace]['length'];
                 }
 
                 if ($nextToken !== $nextParam) {
@@ -244,7 +244,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                                 $phpcsFile->fixer->addContent($comma, ' ');
                             }
                         } else {
-                            $gap = strlen($tokens[($comma + 1)]['content']);
+                            $gap = $tokens[($comma + 1)]['length'];
                             if ($gap !== 1) {
                                 $error = 'Expected 1 space between comma and type hint "%s"; %s found';
                                 $data  = [
@@ -286,7 +286,7 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
             } else {
                 $gap = 0;
                 if ($tokens[$whitespace]['code'] === T_WHITESPACE) {
-                    $gap = strlen($tokens[$whitespace]['content']);
+                    $gap = $tokens[$whitespace]['length'];
                 }
 
                 $arg = $tokens[$nextParam]['content'];

--- a/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php
@@ -328,7 +328,7 @@ class EmbeddedPhpSniff implements Sniff
         // The open tag token always contains a single space after it.
         $leadingSpace = 1;
         if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
-            $leadingSpace = (strlen($tokens[($stackPtr + 1)]['content']) + 1);
+            $leadingSpace = ($tokens[($stackPtr + 1)]['length'] + 1);
         }
 
         if ($leadingSpace !== 1) {
@@ -371,7 +371,7 @@ class EmbeddedPhpSniff implements Sniff
 
         $trailingSpace = 0;
         if ($tokens[($closeTag - 1)]['code'] === T_WHITESPACE) {
-            $trailingSpace = strlen($tokens[($closeTag - 1)]['content']);
+            $trailingSpace = $tokens[($closeTag - 1)]['length'];
         } else if (($tokens[($closeTag - 1)]['code'] === T_COMMENT
             || isset(Tokens::$phpcsCommentTokens[$tokens[($closeTag - 1)]['code']]) === true)
             && substr($tokens[($closeTag - 1)]['content'], -1) === ' '

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php
@@ -62,9 +62,9 @@ class LogicalOperatorSpacingSniff implements Sniff
         } else {
             $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
             if ($tokens[$stackPtr]['line'] === $tokens[$prev]['line']
-                && strlen($tokens[($stackPtr - 1)]['content']) !== 1
+                && $tokens[($stackPtr - 1)]['length'] !== 1
             ) {
-                $found = strlen($tokens[($stackPtr - 1)]['content']);
+                $found = $tokens[($stackPtr - 1)]['length'];
                 $error = 'Expected 1 space before logical operator; %s found';
                 $data  = [$found];
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'TooMuchSpaceBefore', $data);
@@ -84,9 +84,9 @@ class LogicalOperatorSpacingSniff implements Sniff
         } else {
             $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
             if ($tokens[$stackPtr]['line'] === $tokens[$next]['line']
-                && strlen($tokens[($stackPtr + 1)]['content']) !== 1
+                && $tokens[($stackPtr + 1)]['length'] !== 1
             ) {
-                $found = strlen($tokens[($stackPtr + 1)]['content']);
+                $found = $tokens[($stackPtr + 1)]['length'];
                 $error = 'Expected 1 space after logical operator; %s found';
                 $data  = [$found];
                 $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'TooMuchSpaceAfter', $data);


### PR DESCRIPTION
The `$tokens` array already contains the `length` of each and every token, so there is no need to (re-)calculate this in individual sniffs, unless we're examining `T_COMMENT` or `T_INLINE_HTML` tokens.

Using the `length` from the tokenizer array should also be more accurate when tabs have been replaced with spaces or when dealing with Unicode texts.

Fixes #2285