### PR TITLE
Squiz/ControlSignature: fix fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -71,7 +71,8 @@ class ControlSignatureSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[($stackPtr + 1)]) === false) {
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
             return;
         }
 

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
@@ -289,3 +289,7 @@ if ($this) {
     if ($that)
         foo(${$a[$b]});
 }
+
+// Intentional parse error. This should be the last test in the file.
+foreach
+   // Some unrelated comment.

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
@@ -292,3 +292,7 @@ if ($this) {
     if ($that)
         foo(${$a[$b]});
 }
+
+// Intentional parse error. This should be the last test in the file.
+foreach
+   // Some unrelated comment.


### PR DESCRIPTION
[Fixer conflict series PR]

The check to prevent the sniff from kicking in during live coding/at the end of a file wasn't stable enough and allowed the sniff to kick in anyway if there was a new line or comment after the control structure keyword.
This, in turn, would cause a fixer conflict with `EndFileNewLine` sniffs and - depending on the control structure - other sniffs.

The fixer conflict can be reproduced using this code sample:
```php
<?php
foreach

```
and this command:
`phpcbf ./testfile.php --standard=Squiz`

And while PSR2 does not generate a fixer conflict for this code sample, incorrect fixes would still be made resulting in (more) parse errors.
Using this code sample:
```php
<?php
for

```

Using the following command:
`phpcbf ./testfile.php --standard=PSR2`

This would be fixed to:
```php
for {
    ;
}
```

While rare to come across this in practice, the sniff should be stable and prevent this situation from ever occurring.
By changing the 'live coding' check to look at more than just the next token, this issue is prevented.

Includes unit test demonstrating the issue.