### PR TITLE
Core tests: set up abstract class and remove code duplication

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -206,6 +206,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        <file baseinstalldir="" name="AcceptTest.php" role="test" />
       </dir>
      </dir>
+     <file baseinstalldir="" name="AbstractMethodUnitTest.php" role="test" />
      <file baseinstalldir="" name="AllTests.php" role="test" />
      <file baseinstalldir="" name="ErrorSuppressionTest.php" role="test" />
      <file baseinstalldir="" name="IsCamelCapsTest.php" role="test" />
@@ -1959,6 +1960,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="TestSuite.php" name="tests/TestSuite.php" />
    <install as="TestSuite7.php" name="tests/TestSuite7.php" />
    <install as="tests/bootstrap.php" name="tests/bootstrap.php" />
+   <install as="CodeSniffer/Core/AbstractMethodUnitTest.php" name="tests/Core/AbstractMethodUnitTest.php" />
    <install as="CodeSniffer/Core/AllTests.php" name="tests/Core/AllTests.php" />
    <install as="CodeSniffer/Core/IsCamelCapsTest.php" name="tests/Core/IsCamelCapsTest.php" />
    <install as="CodeSniffer/Core/ErrorSuppressionTest.php" name="tests/Core/ErrorSuppressionTest.php" />
@@ -1994,6 +1996,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="tests/bootstrap.php" name="tests/bootstrap.php" />
    <install as="tests/TestSuite.php" name="tests/TestSuite.php" />
    <install as="tests/TestSuite7.php" name="tests/TestSuite7.php" />
+   <install as="CodeSniffer/Core/AbstractMethodUnitTest.php" name="tests/Core/AbstractMethodUnitTest.php" />
    <install as="CodeSniffer/Core/AllTests.php" name="tests/Core/AllTests.php" />
    <install as="CodeSniffer/Core/IsCamelCapsTest.php" name="tests/Core/IsCamelCapsTest.php" />
    <install as="CodeSniffer/Core/ErrorSuppressionTest.php" name="tests/Core/ErrorSuppressionTest.php" />

--- a/package.xml
+++ b/package.xml
@@ -217,6 +217,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     </dir>
     <file baseinstalldir="" name="AllTests.php" role="test" />
     <file baseinstalldir="" name="bootstrap.php" role="test" />
+    <file baseinstalldir="" name="FileList.php" role="test" />
     <file baseinstalldir="" name="TestSuite.php" role="test" />
     <file baseinstalldir="" name="TestSuite7.php" role="test" />
    </dir>
@@ -1957,6 +1958,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="LICENCE" name="licence.txt" />
    <install as="phpunit.xml" name="phpunit.xml.dist" />
    <install as="AllTests.php" name="tests/AllTests.php" />
+   <install as="FileList.php" name="tests/FileList.php" />
    <install as="TestSuite.php" name="tests/TestSuite.php" />
    <install as="TestSuite7.php" name="tests/TestSuite7.php" />
    <install as="tests/bootstrap.php" name="tests/bootstrap.php" />
@@ -1994,6 +1996,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="phpunit.xml" name="phpunit.xml.dist" />
    <install as="tests/AllTests.php" name="tests/AllTests.php" />
    <install as="tests/bootstrap.php" name="tests/bootstrap.php" />
+   <install as="tests/FileList.php" name="tests/FileList.php" />
    <install as="tests/TestSuite.php" name="tests/TestSuite.php" />
    <install as="tests/TestSuite7.php" name="tests/TestSuite7.php" />
    <install as="CodeSniffer/Core/AbstractMethodUnitTest.php" name="tests/Core/AbstractMethodUnitTest.php" />

--- a/scripts/ValidatePEAR/ValidatePEARPackageXML.php
+++ b/scripts/ValidatePEAR/ValidatePEARPackageXML.php
@@ -11,6 +11,8 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
+use PHP_CodeSniffer\Tests\FileList;
+
 /**
  * Validate the PHP_CodeSniffer PEAR package.xml file.
  */

--- a/scripts/validate-pear-package.php
+++ b/scripts/validate-pear-package.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-require_once __DIR__.'/ValidatePEAR/FileList.php';
+require_once dirname(__DIR__).'/tests/FileList.php';
 require_once __DIR__.'/ValidatePEAR/ValidatePEARPackageXML.php';
 
 $validate = new ValidatePEARPackageXML();

--- a/tests/Core/AbstractMethodUnitTest.php
+++ b/tests/Core/AbstractMethodUnitTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Base class to use when testing utility methods.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2018-2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Files\DummyFile;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractMethodUnitTest extends TestCase
+{
+
+    /**
+     * The file extension of the test case file (without leading dot).
+     *
+     * This allows child classes to overrule the default `inc` with, for instance,
+     * `js` or `css` when applicable.
+     *
+     * @var string
+     */
+    protected static $fileExtension = 'inc';
+
+    /**
+     * The \PHP_CodeSniffer\Files\File object containing the parsed contents of the test case file.
+     *
+     * @var \PHP_CodeSniffer\Files\File
+     */
+    protected static $phpcsFile;
+
+
+    /**
+     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
+     *
+     * The test case file for a unit test class has to be in the same directory
+     * directory and use the same file name as the test class, using the .inc extension.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        $config            = new Config();
+        $config->standards = ['PSR1'];
+
+        $ruleset = new Ruleset($config);
+
+        // Default to a file with the same name as the test class. Extension is property based.
+        $relativeCN     = str_replace(__NAMESPACE__, '', get_called_class());
+        $relativePath   = str_replace('\\', DIRECTORY_SEPARATOR, $relativeCN);
+        $pathToTestFile = realpath(__DIR__).$relativePath.'.'.static::$fileExtension;
+
+        // Make sure the file gets parsed correctly based on the file type.
+        $contents  = 'phpcs_input_file: '.$pathToTestFile.PHP_EOL;
+        $contents .= file_get_contents($pathToTestFile);
+
+        self::$phpcsFile = new DummyFile($contents, $ruleset, $config);
+        self::$phpcsFile->process();
+
+    }//end setUpBeforeClass()
+
+
+    /**
+     * Clean up after finished test.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass()
+    {
+        self::$phpcsFile = null;
+
+    }//end tearDownAfterClass()
+
+
+}//end class

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -3,25 +3,16 @@
  * A test class for testing the core.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHP_CodeSniffer\Tests\Core;
 
+use PHP_CodeSniffer\Tests\FileList;
 use PHPUnit\TextUI\TestRunner;
 use PHPUnit\Framework\TestSuite;
-
-require_once 'IsCamelCapsTest.php';
-require_once 'ErrorSuppressionTest.php';
-require_once 'File/FindEndOfStatementTest.php';
-require_once 'File/FindExtendedClassNameTest.php';
-require_once 'File/FindImplementedInterfaceNamesTest.php';
-require_once 'File/GetMemberPropertiesTest.php';
-require_once 'File/GetMethodParametersTest.php';
-require_once 'File/GetMethodPropertiesTest.php';
-require_once 'File/IsReferenceTest.php';
-require_once 'Filters/Filter/AcceptTest.php';
 
 class AllTests
 {
@@ -47,16 +38,23 @@ class AllTests
     public static function suite()
     {
         $suite = new TestSuite('PHP CodeSniffer Core');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\IsCamelCapsTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\ErrorSuppressionTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindEndOfStatementTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindExtendedClassNameTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\FindImplementedInterfaceNamesTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMemberPropertiesTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodParametersTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodPropertiesTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\IsReferenceTest');
-        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\Filters\Filter\AcceptTest');
+
+        $testFileIterator = new FileList(__DIR__, '', '`Test\.php$`Di');
+        foreach ($testFileIterator->fileIterator as $file) {
+            if (strpos($file, 'AbstractMethodUnitTest.php') !== false) {
+                continue;
+            }
+
+            include_once $file;
+
+            $class = str_replace(__DIR__, '', $file);
+            $class = str_replace('.php', '', $class);
+            $class = str_replace('/', '\\', $class);
+            $class = 'PHP_CodeSniffer\Tests\Core'.$class;
+
+            $suite->addTestSuite($class);
+        }
+
         return $suite;
 
     }//end suite()

--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -9,54 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class FindEndOfStatementTest extends TestCase
+class FindEndOfStatementTest extends AbstractMethodUnitTest
 {
-
-    /**
-     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
-     *
-     * @var \PHP_CodeSniffer\Files\File
-     */
-    private $phpcsFile;
-
-
-    /**
-     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
-     *
-     * Methods used for these tests can be found in a test case file in the same
-     * directory and with the same name, using the .inc extension.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-
-        $ruleset = new Ruleset($config);
-
-        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
-        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
-        $this->phpcsFile->process();
-
-    }//end setUp()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->phpcsFile);
-
-    }//end tearDown()
 
 
     /**
@@ -66,10 +22,10 @@ class FindEndOfStatementTest extends TestCase
      */
     public function testSimpleAssignment()
     {
-        $start = ($this->phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSimpleAssignment */') + 2);
-        $found = $this->phpcsFile->findEndOfStatement($start);
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSimpleAssignment */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 5)], $tokens[$found]);
 
     }//end testSimpleAssignment()
@@ -82,10 +38,10 @@ class FindEndOfStatementTest extends TestCase
      */
     public function testControlStructure()
     {
-        $start = ($this->phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testControlStructure */') + 2);
-        $found = $this->phpcsFile->findEndOfStatement($start);
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testControlStructure */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 6)], $tokens[$found]);
 
     }//end testControlStructure()
@@ -98,10 +54,10 @@ class FindEndOfStatementTest extends TestCase
      */
     public function testClosureAssignment()
     {
-        $start = ($this->phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testClosureAssignment */') + 2);
-        $found = $this->phpcsFile->findEndOfStatement($start);
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testClosureAssignment */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 13)], $tokens[$found]);
 
     }//end testClosureAssignment()
@@ -115,24 +71,24 @@ class FindEndOfStatementTest extends TestCase
     public function testHeredocFunctionArg()
     {
         // Find the end of the function.
-        $start = ($this->phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testHeredocFunctionArg */') + 2);
-        $found = $this->phpcsFile->findEndOfStatement($start);
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testHeredocFunctionArg */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 10)], $tokens[$found]);
 
         // Find the end of the heredoc.
         $start += 2;
-        $found  = $this->phpcsFile->findEndOfStatement($start);
+        $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 4)], $tokens[$found]);
 
         // Find the end of the last arg.
         $start = ($found + 2);
-        $found = $this->phpcsFile->findEndOfStatement($start);
+        $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[$start], $tokens[$found]);
 
     }//end testHeredocFunctionArg()
@@ -146,24 +102,24 @@ class FindEndOfStatementTest extends TestCase
     public function testSwitch()
     {
         // Find the end of the switch.
-        $start = ($this->phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSwitch */') + 2);
-        $found = $this->phpcsFile->findEndOfStatement($start);
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSwitch */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 28)], $tokens[$found]);
 
         // Find the end of the case.
         $start += 9;
-        $found  = $this->phpcsFile->findEndOfStatement($start);
+        $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 8)], $tokens[$found]);
 
         // Find the end of default case.
         $start += 11;
-        $found  = $this->phpcsFile->findEndOfStatement($start);
+        $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 6)], $tokens[$found]);
 
     }//end testSwitch()
@@ -177,24 +133,24 @@ class FindEndOfStatementTest extends TestCase
     public function testStatementAsArrayValue()
     {
         // Test short array syntax.
-        $start = ($this->phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStatementAsArrayValue */') + 7);
-        $found = $this->phpcsFile->findEndOfStatement($start);
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStatementAsArrayValue */') + 7);
+        $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 2)], $tokens[$found]);
 
         // Test long array syntax.
         $start += 12;
-        $found  = $this->phpcsFile->findEndOfStatement($start);
+        $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 2)], $tokens[$found]);
 
         // Test same statement outside of array.
         $start += 10;
-        $found  = $this->phpcsFile->findEndOfStatement($start);
+        $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = $this->phpcsFile->getTokens();
+        $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 3)], $tokens[$found]);
 
     }//end testStatementAsArrayValue()

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -9,54 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class FindExtendedClassNameTest extends TestCase
+class FindExtendedClassNameTest extends AbstractMethodUnitTest
 {
-
-    /**
-     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
-     *
-     * @var \PHP_CodeSniffer\Files\File
-     */
-    private $phpcsFile;
-
-
-    /**
-     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
-     *
-     * Methods used for these tests can be found in a test case file in the same
-     * directory and with the same name, using the .inc extension.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-
-        $ruleset = new Ruleset($config);
-
-        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
-        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
-        $this->phpcsFile->process();
-
-    }//end setUp()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->phpcsFile);
-
-    }//end tearDown()
 
 
     /**
@@ -72,17 +28,17 @@ class FindExtendedClassNameTest extends TestCase
      */
     public function testFindExtendedClassName($identifier, $expected)
     {
-        $start   = ($this->phpcsFile->numTokens - 1);
-        $delim   = $this->phpcsFile->findPrevious(
+        $start   = (self::$phpcsFile->numTokens - 1);
+        $delim   = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
             false,
             $identifier
         );
-        $OOToken = $this->phpcsFile->findNext([T_CLASS, T_ANON_CLASS, T_INTERFACE], ($delim + 1));
+        $OOToken = self::$phpcsFile->findNext([T_CLASS, T_ANON_CLASS, T_INTERFACE], ($delim + 1));
 
-        $result = $this->phpcsFile->findExtendedClassName($OOToken);
+        $result = self::$phpcsFile->findExtendedClassName($OOToken);
         $this->assertSame($expected, $result);
 
     }//end testFindExtendedClassName()

--- a/tests/Core/File/FindExtendedClassNameTest.php
+++ b/tests/Core/File/FindExtendedClassNameTest.php
@@ -28,17 +28,8 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
      */
     public function testFindExtendedClassName($identifier, $expected)
     {
-        $start   = (self::$phpcsFile->numTokens - 1);
-        $delim   = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            $identifier
-        );
-        $OOToken = self::$phpcsFile->findNext([T_CLASS, T_ANON_CLASS, T_INTERFACE], ($delim + 1));
-
-        $result = self::$phpcsFile->findExtendedClassName($OOToken);
+        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
+        $result  = self::$phpcsFile->findExtendedClassName($OOToken);
         $this->assertSame($expected, $result);
 
     }//end testFindExtendedClassName()

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -9,54 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class FindImplementedInterfaceNamesTest extends TestCase
+class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
 {
-
-    /**
-     * The \PHP_CodeSniffer\Files\File object containing parsed contents of the test case file.
-     *
-     * @var \PHP_CodeSniffer\Files\File
-     */
-    private $phpcsFile;
-
-
-    /**
-     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
-     *
-     * Methods used for these tests can be found in a test case file in the same
-     * directory and with the same name, using the .inc extension.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-
-        $ruleset = new Ruleset($config);
-
-        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
-        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
-        $this->phpcsFile->process();
-
-    }//end setUp()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->phpcsFile);
-
-    }//end tearDown()
 
 
     /**
@@ -71,17 +27,17 @@ class FindImplementedInterfaceNamesTest extends TestCase
      */
     public function testFindImplementedInterfaceNames($identifier, $expected)
     {
-        $start   = ($this->phpcsFile->numTokens - 1);
-        $delim   = $this->phpcsFile->findPrevious(
+        $start   = (self::$phpcsFile->numTokens - 1);
+        $delim   = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
             false,
             $identifier
         );
-        $OOToken = $this->phpcsFile->findNext([T_CLASS, T_ANON_CLASS, T_INTERFACE], ($delim + 1));
+        $OOToken = self::$phpcsFile->findNext([T_CLASS, T_ANON_CLASS, T_INTERFACE], ($delim + 1));
 
-        $result = $this->phpcsFile->findImplementedInterfaceNames($OOToken);
+        $result = self::$phpcsFile->findImplementedInterfaceNames($OOToken);
         $this->assertSame($expected, $result);
 
     }//end testFindImplementedInterfaceNames()

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -27,17 +27,8 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
      */
     public function testFindImplementedInterfaceNames($identifier, $expected)
     {
-        $start   = (self::$phpcsFile->numTokens - 1);
-        $delim   = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            $identifier
-        );
-        $OOToken = self::$phpcsFile->findNext([T_CLASS, T_ANON_CLASS, T_INTERFACE], ($delim + 1));
-
-        $result = self::$phpcsFile->findImplementedInterfaceNames($OOToken);
+        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
+        $result  = self::$phpcsFile->findImplementedInterfaceNames($OOToken);
         $this->assertSame($expected, $result);
 
     }//end testFindImplementedInterfaceNames()

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -9,54 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class GetMemberPropertiesTest extends TestCase
+class GetMemberPropertiesTest extends AbstractMethodUnitTest
 {
-
-    /**
-     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
-     *
-     * @var \PHP_CodeSniffer\Files\File
-     */
-    private $phpcsFile;
-
-
-    /**
-     * Initialize & tokenize PHP_CodeSniffer_File with code from the test case file.
-     *
-     * Methods used for these tests can be found in a test case file in the same
-     * directory and with the same name, using the .inc extension.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-
-        $ruleset = new Ruleset($config);
-
-        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
-        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
-        $this->phpcsFile->process();
-
-    }//end setUp()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->phpcsFile);
-
-    }//end tearDown()
 
 
     /**
@@ -71,17 +27,17 @@ class GetMemberPropertiesTest extends TestCase
      */
     public function testGetMemberProperties($identifier, $expected)
     {
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $delim    = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $delim    = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
             false,
             $identifier
         );
-        $variable = $this->phpcsFile->findNext(T_VARIABLE, ($delim + 1));
+        $variable = self::$phpcsFile->findNext(T_VARIABLE, ($delim + 1));
 
-        $result = $this->phpcsFile->getMemberProperties($variable);
+        $result = self::$phpcsFile->getMemberProperties($variable);
         unset($result['type_token']);
         unset($result['type_end_token']);
         $this->assertSame($expected, $result);
@@ -532,17 +488,17 @@ class GetMemberPropertiesTest extends TestCase
      */
     public function testNotClassPropertyException($identifier)
     {
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $delim    = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $delim    = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
             false,
             $identifier
         );
-        $variable = $this->phpcsFile->findNext(T_VARIABLE, ($delim + 1));
+        $variable = self::$phpcsFile->findNext(T_VARIABLE, ($delim + 1));
 
-        $result = $this->phpcsFile->getMemberProperties($variable);
+        $result = self::$phpcsFile->getMemberProperties($variable);
 
     }//end testNotClassPropertyException()
 
@@ -578,17 +534,17 @@ class GetMemberPropertiesTest extends TestCase
      */
     public function testNotAVariableException()
     {
-        $start = ($this->phpcsFile->numTokens - 1);
-        $delim = $this->phpcsFile->findPrevious(
+        $start = (self::$phpcsFile->numTokens - 1);
+        $delim = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
             false,
             '/* testNotAVariable */'
         );
-        $next  = $this->phpcsFile->findNext(T_WHITESPACE, ($delim + 1), null, true);
+        $next  = self::$phpcsFile->findNext(T_WHITESPACE, ($delim + 1), null, true);
 
-        $result = $this->phpcsFile->getMemberProperties($next);
+        $result = self::$phpcsFile->getMemberProperties($next);
 
     }//end testNotAVariableException()
 

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -29,9 +29,8 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
     {
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
         $result   = self::$phpcsFile->getMemberProperties($variable);
-        unset($result['type_token']);
-        unset($result['type_end_token']);
-        $this->assertSame($expected, $result);
+
+        $this->assertArraySubset($expected, $result, true);
 
     }//end testGetMemberProperties()
 

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -27,17 +27,8 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
      */
     public function testGetMemberProperties($identifier, $expected)
     {
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $delim    = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            $identifier
-        );
-        $variable = self::$phpcsFile->findNext(T_VARIABLE, ($delim + 1));
-
-        $result = self::$phpcsFile->getMemberProperties($variable);
+        $variable = $this->getTargetToken($identifier, T_VARIABLE);
+        $result   = self::$phpcsFile->getMemberProperties($variable);
         unset($result['type_token']);
         unset($result['type_end_token']);
         $this->assertSame($expected, $result);
@@ -488,17 +479,8 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNotClassPropertyException($identifier)
     {
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $delim    = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            $identifier
-        );
-        $variable = self::$phpcsFile->findNext(T_VARIABLE, ($delim + 1));
-
-        $result = self::$phpcsFile->getMemberProperties($variable);
+        $variable = $this->getTargetToken($identifier, T_VARIABLE);
+        $result   = self::$phpcsFile->getMemberProperties($variable);
 
     }//end testNotClassPropertyException()
 
@@ -534,16 +516,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
      */
     public function testNotAVariableException()
     {
-        $start = (self::$phpcsFile->numTokens - 1);
-        $delim = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testNotAVariable */'
-        );
-        $next  = self::$phpcsFile->findNext(T_WHITESPACE, ($delim + 1), null, true);
-
+        $next   = $this->getTargetToken('/* testNotAVariable */', T_RETURN);
         $result = self::$phpcsFile->getMemberProperties($next);
 
     }//end testNotAVariableException()

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -19,7 +19,8 @@ function defaultValues($var1=1, $var2='value') {}
 function typeHint(foo $var1, bar $var2) {}
 
 class MyClass {
-/* testSelfTypeHint */ function typeSelfHint(self $var) {}
+    /* testSelfTypeHint */
+    function typeSelfHint(self $var) {}
 }
 
 /* testNullableTypeHint */

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -32,23 +32,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testPassByReference */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[0]['variadic_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testPassByReference()
 
@@ -70,23 +54,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testArrayHint */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[0]['variadic_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testArrayHint()
 
@@ -117,29 +85,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testTypeHint */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[1]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[1]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[1]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[1]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[1]['reference_token']);
-        unset($found[0]['variadic_token']);
-        unset($found[1]['variadic_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testTypeHint()
 
@@ -161,23 +107,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testSelfTypeHint */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[0]['variadic_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testSelfTypeHint()
 
@@ -208,29 +138,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testNullableTypeHint */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[1]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[1]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[1]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[1]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[1]['reference_token']);
-        unset($found[0]['variadic_token']);
-        unset($found[1]['variadic_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testNullableTypeHint()
 
@@ -252,23 +160,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testVariable */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[0]['variadic_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testVariable()
 
@@ -291,25 +183,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testSingleDefaultValue */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[0]['variadic_token']);
-        unset($found[0]['default_token']);
-        unset($found[0]['default_equal_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testSingleDefaultValue()
 
@@ -341,33 +215,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testDefaultValues */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[1]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[1]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[1]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[1]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[1]['reference_token']);
-        unset($found[0]['variadic_token']);
-        unset($found[1]['variadic_token']);
-        unset($found[0]['default_token']);
-        unset($found[1]['default_token']);
-        unset($found[0]['default_equal_token']);
-        unset($found[1]['default_equal_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testDefaultValues()
 
@@ -390,27 +238,27 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'nullable_type'     => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testBitwiseAndConstantExpressionDefaultValue */'
-        );
-
-        $found = self::$phpcsFile->getMethodParameters(($function + 2));
-        unset($found[0]['token']);
-        unset($found[0]['type_hint_token']);
-        unset($found[0]['type_hint_end_token']);
-        unset($found[0]['comma_token']);
-        unset($found[0]['reference_token']);
-        unset($found[0]['variadic_token']);
-        unset($found[0]['default_token']);
-        unset($found[0]['default_equal_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testBitwiseAndConstantExpressionDefaultValue()
+
+
+    /**
+     * Test helper.
+     *
+     * @param string $commentString The comment which preceeds the test.
+     * @param array  $expected      The expected function output.
+     *
+     * @return void
+     */
+    private function getMethodParametersTestHelper($commentString, $expected)
+    {
+        $function = $this->getTargetToken($commentString, [T_FUNCTION]);
+        $found    = self::$phpcsFile->getMethodParameters($function);
+
+        $this->assertArraySubset($expected, $found, true);
+
+    }//end getMethodParametersTestHelper()
 
 
 }//end class

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -9,54 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class GetMethodParametersTest extends TestCase
+class GetMethodParametersTest extends AbstractMethodUnitTest
 {
-
-    /**
-     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
-     *
-     * @var \PHP_CodeSniffer\Files\File
-     */
-    private $phpcsFile;
-
-
-    /**
-     * Initialize & tokenize PHP_CodeSniffer_File with code from the test case file.
-     *
-     * Methods used for these tests can be found in a test case file in the same
-     * directory and with the same name, using the .inc extension.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-
-        $ruleset = new Ruleset($config);
-
-        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
-        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
-        $this->phpcsFile->process();
-
-    }//end setUp()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->phpcsFile);
-
-    }//end tearDown()
 
 
     /**
@@ -76,8 +32,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -85,7 +41,7 @@ class GetMethodParametersTest extends TestCase
             '/* testPassByReference */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[0]['type_hint_token']);
         unset($found[0]['type_hint_end_token']);
@@ -114,8 +70,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -123,7 +79,7 @@ class GetMethodParametersTest extends TestCase
             '/* testArrayHint */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[0]['type_hint_token']);
         unset($found[0]['type_hint_end_token']);
@@ -161,8 +117,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -170,7 +126,7 @@ class GetMethodParametersTest extends TestCase
             '/* testTypeHint */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[1]['token']);
         unset($found[0]['type_hint_token']);
@@ -205,8 +161,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -214,7 +170,7 @@ class GetMethodParametersTest extends TestCase
             '/* testSelfTypeHint */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[0]['type_hint_token']);
         unset($found[0]['type_hint_end_token']);
@@ -252,8 +208,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -261,7 +217,7 @@ class GetMethodParametersTest extends TestCase
             '/* testNullableTypeHint */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[1]['token']);
         unset($found[0]['type_hint_token']);
@@ -296,8 +252,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -305,7 +261,7 @@ class GetMethodParametersTest extends TestCase
             '/* testVariable */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[0]['type_hint_token']);
         unset($found[0]['type_hint_end_token']);
@@ -335,8 +291,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -344,7 +300,7 @@ class GetMethodParametersTest extends TestCase
             '/* testSingleDefaultValue */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[0]['type_hint_token']);
         unset($found[0]['type_hint_end_token']);
@@ -385,8 +341,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -394,7 +350,7 @@ class GetMethodParametersTest extends TestCase
             '/* testDefaultValues */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[1]['token']);
         unset($found[0]['type_hint_token']);
@@ -434,8 +390,8 @@ class GetMethodParametersTest extends TestCase
             'nullable_type'     => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -443,7 +399,7 @@ class GetMethodParametersTest extends TestCase
             '/* testBitwiseAndConstantExpressionDefaultValue */'
         );
 
-        $found = $this->phpcsFile->getMethodParameters(($function + 2));
+        $found = self::$phpcsFile->getMethodParameters(($function + 2));
         unset($found[0]['token']);
         unset($found[0]['type_hint_token']);
         unset($found[0]['type_hint_end_token']);

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -6,7 +6,8 @@ function myFunction() {}
 /* testReturnFunction */
 function myFunction(array ...$arrays): array
 {
-    return array_map(/* testNestedClosure */function(array $array): int {
+    /* testNestedClosure */
+    return array_map(function(array $array): int {
         return array_sum($array);
     }, $arrays);
 }

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -9,54 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class GetMethodPropertiesTest extends TestCase
+class GetMethodPropertiesTest extends AbstractMethodUnitTest
 {
-
-    /**
-     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
-     *
-     * @var \PHP_CodeSniffer\Files\File
-     */
-    private $phpcsFile;
-
-
-    /**
-     * Initialize & tokenize PHP_CodeSniffer_File with code from the test case file.
-     *
-     * Methods used for these tests can be found in a test case file in the same
-     * directory and with the same name, using the .inc extension.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-
-        $ruleset = new Ruleset($config);
-
-        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
-        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
-        $this->phpcsFile->process();
-
-    }//end setUp()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->phpcsFile);
-
-    }//end tearDown()
 
 
     /**
@@ -77,8 +33,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -86,7 +42,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testBasicFunction */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 2));
+        $found = self::$phpcsFile->getMethodProperties(($function + 2));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -111,8 +67,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -120,7 +76,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testReturnFunction */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 2));
+        $found = self::$phpcsFile->getMethodProperties(($function + 2));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -145,8 +101,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -154,7 +110,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testNestedClosure */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 1));
+        $found = self::$phpcsFile->getMethodProperties(($function + 1));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -179,8 +135,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -188,7 +144,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testBasicMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 3));
+        $found = self::$phpcsFile->getMethodProperties(($function + 3));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -213,8 +169,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -222,7 +178,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testPrivateStaticMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 7));
+        $found = self::$phpcsFile->getMethodProperties(($function + 7));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -247,8 +203,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -256,7 +212,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testFinalMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 7));
+        $found = self::$phpcsFile->getMethodProperties(($function + 7));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -281,8 +237,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -290,7 +246,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testProtectedReturnMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 5));
+        $found = self::$phpcsFile->getMethodProperties(($function + 5));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -315,8 +271,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -324,7 +280,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testPublicReturnMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 5));
+        $found = self::$phpcsFile->getMethodProperties(($function + 5));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -349,8 +305,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -358,7 +314,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testNullableReturnMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 5));
+        $found = self::$phpcsFile->getMethodProperties(($function + 5));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -383,8 +339,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -392,7 +348,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testMessyNullableReturnMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 5));
+        $found = self::$phpcsFile->getMethodProperties(($function + 5));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -417,8 +373,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -426,7 +382,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testReturnNamespace */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 3));
+        $found = self::$phpcsFile->getMethodProperties(($function + 3));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -451,8 +407,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => true,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -460,7 +416,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testReturnMultilineNamespace */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 3));
+        $found = self::$phpcsFile->getMethodProperties(($function + 3));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -485,8 +441,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -494,7 +450,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testAbstractMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 5));
+        $found = self::$phpcsFile->getMethodProperties(($function + 5));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -519,8 +475,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -528,7 +484,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testAbstractReturnMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 7));
+        $found = self::$phpcsFile->getMethodProperties(($function + 7));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 
@@ -553,8 +509,8 @@ class GetMethodPropertiesTest extends TestCase
             'has_body'             => false,
         ];
 
-        $start    = ($this->phpcsFile->numTokens - 1);
-        $function = $this->phpcsFile->findPrevious(
+        $start    = (self::$phpcsFile->numTokens - 1);
+        $function = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
@@ -562,7 +518,7 @@ class GetMethodPropertiesTest extends TestCase
             '/* testInterfaceMethod */'
         );
 
-        $found = $this->phpcsFile->getMethodProperties(($function + 3));
+        $found = self::$phpcsFile->getMethodProperties(($function + 3));
         unset($found['return_type_token']);
         $this->assertSame($expected, $found);
 

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -33,18 +33,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testBasicFunction */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 2));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testBasicFunction()
 
@@ -67,18 +56,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testReturnFunction */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 2));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testReturnFunction()
 
@@ -101,18 +79,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testNestedClosure */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 1));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testNestedClosure()
 
@@ -135,18 +102,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testBasicMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 3));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testBasicMethod()
 
@@ -169,18 +125,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testPrivateStaticMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 7));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testPrivateStaticMethod()
 
@@ -203,18 +148,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testFinalMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 7));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testFinalMethod()
 
@@ -237,18 +171,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testProtectedReturnMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 5));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testProtectedReturnMethod()
 
@@ -271,18 +194,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testPublicReturnMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 5));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testPublicReturnMethod()
 
@@ -305,18 +217,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testNullableReturnMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 5));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testNullableReturnMethod()
 
@@ -339,18 +240,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testMessyNullableReturnMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 5));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testMessyNullableReturnMethod()
 
@@ -373,18 +263,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testReturnNamespace */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 3));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testReturnNamespace()
 
@@ -407,18 +286,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => true,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testReturnMultilineNamespace */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 3));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testReturnMultilineNamespace()
 
@@ -441,18 +309,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testAbstractMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 5));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testAbstractMethod()
 
@@ -475,18 +332,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testAbstractReturnMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 7));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testAbstractReturnMethod()
 
@@ -509,20 +355,27 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
             'has_body'             => false,
         ];
 
-        $start    = (self::$phpcsFile->numTokens - 1);
-        $function = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            '/* testInterfaceMethod */'
-        );
-
-        $found = self::$phpcsFile->getMethodProperties(($function + 3));
-        unset($found['return_type_token']);
-        $this->assertSame($expected, $found);
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testInterfaceMethod()
+
+
+    /**
+     * Test helper.
+     *
+     * @param string $commentString The comment which preceeds the test.
+     * @param array  $expected      The expected function output.
+     *
+     * @return void
+     */
+    private function getMethodPropertiesTestHelper($commentString, $expected)
+    {
+        $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE]);
+        $found    = self::$phpcsFile->getMethodProperties($function);
+
+        $this->assertArraySubset($expected, $found, true);
+
+    }//end getMethodPropertiesTestHelper()
 
 
 }//end class

--- a/tests/Core/File/IsReferenceTest.inc
+++ b/tests/Core/File/IsReferenceTest.inc
@@ -2,137 +2,137 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-/* bitwiseAndA */
+/* testBitwiseAndA */
 error_reporting( E_NOTICE & E_STRICT );
 
-/* bitwiseAndB */
+/* testBitwiseAndB */
 $a = [ $something & $somethingElse ];
 
-/* bitwiseAndC */
+/* testBitwiseAndC */
 $a = [ $first, $something & self::$somethingElse ];
 
-/* bitwiseAndD */
+/* testBitwiseAndD */
 $a = array $first, $something & $somethingElse );
 
-/* bitwiseAndE */
+/* testBitwiseAndE */
 $a = [ 'a' => $first, 'b' => $something & $somethingElse ];
 
-/* bitwiseAndF */
+/* testBitwiseAndF */
 $a = array( 'a' => $first, 'b' => $something & \MyClass::$somethingElse );
 
-/* bitwiseAndG */
+/* testBitwiseAndG */
 $a = $something & $somethingElse;
 
-/* bitwiseAndH */
+/* testBitwiseAndH */
 function myFunction($a = 10 & 20) {}
 
-/* bitwiseAndI */
+/* testBitwiseAndI */
 $closure = function ($a = MY_CONSTANT & parent::OTHER_CONSTANT) {};
 
-/* functionReturnByReference */
+/* testFunctionReturnByReference */
 function &myFunction() {}
 
-/* functionPassByReferenceA */
+/* testFunctionPassByReferenceA */
 function myFunction( &$a ) {}
 
-/* functionPassByReferenceB */
+/* testFunctionPassByReferenceB */
 function myFunction( $a, &$b ) {}
 
-/* functionPassByReferenceC */
+/* testFunctionPassByReferenceC */
 $closure = function ( &$a ) {};
 
-/* functionPassByReferenceD */
+/* testFunctionPassByReferenceD */
 $closure = function ( $a, &$b ) {};
 
-/* functionPassByReferenceE */
+/* testFunctionPassByReferenceE */
 function myFunction(array &$one) {}
 
-/* functionPassByReferenceF */
+/* testFunctionPassByReferenceF */
 $closure = function (\MyClass &$one) {};
 
-/* functionPassByReferenceG */
+/* testFunctionPassByReferenceG */
 $closure = function myFunc($param, &...$moreParams) {};
 
-/* foreachValueByReference */
+/* testForeachValueByReference */
 foreach( $array as $key => &$value ) {}
 
-/* foreachKeyByReference */
+/* testForeachKeyByReference */
 foreach( $array as &$key => $value ) {}
 
-/* arrayValueByReferenceA */
+/* testArrayValueByReferenceA */
 $a = [ 'a' => &$something ];
 
-/* arrayValueByReferenceB */
+/* testArrayValueByReferenceB */
 $a = [ 'a' => $something, 'b' => &$somethingElse ];
 
-/* arrayValueByReferenceC */
+/* testArrayValueByReferenceC */
 $a = [ &$something ];
 
-/* arrayValueByReferenceD */
+/* testArrayValueByReferenceD */
 $a = [ $something, &$somethingElse ];
 
-/* arrayValueByReferenceE */
+/* testArrayValueByReferenceE */
 $a = array( 'a' => &$something );
 
-/* arrayValueByReferenceF */
+/* testArrayValueByReferenceF */
 $a = array( 'a' => $something, 'b' => &$somethingElse );
 
-/* arrayValueByReferenceG */
+/* testArrayValueByReferenceG */
 $a = array( &$something );
 
-/* arrayValueByReferenceH */
+/* testArrayValueByReferenceH */
 $a = array( $something, &$somethingElse );
 
-/* assignByReferenceA */
+/* testAssignByReferenceA */
 $b = &$something;
 
-/* assignByReferenceB */
+/* testAssignByReferenceB */
 $b =& $something;
 
-/* assignByReferenceC */
+/* testAssignByReferenceC */
 $b .= &$something;
 
-/* assignByReferenceD */
+/* testAssignByReferenceD */
 $myValue = &$obj->getValue();
 
-/* assignByReferenceE */
+/* testAssignByReferenceE */
 $collection = &collector();
 
-/* passByReferenceA */
+/* testPassByReferenceA */
 functionCall(&$something, $somethingElse);
 
-/* passByReferenceB */
+/* testPassByReferenceB */
 functionCall($something, &$somethingElse);
 
-/* passByReferenceC */
+/* testPassByReferenceC */
 functionCall($something, &$this->somethingElse);
 
-/* passByReferenceD */
+/* testPassByReferenceD */
 functionCall($something, &self::$somethingElse);
 
-/* passByReferenceE */
+/* testPassByReferenceE */
 functionCall($something, &parent::$somethingElse);
 
-/* passByReferenceF */
+/* testPassByReferenceF */
 functionCall($something, &static::$somethingElse);
 
-/* passByReferenceG */
+/* testPassByReferenceG */
 functionCall($something, &SomeClass::$somethingElse);
 
-/* passByReferenceH */
+/* testPassByReferenceH */
 functionCall(&\SomeClass::$somethingElse);
 
-/* passByReferenceI */
+/* testPassByReferenceI */
 functionCall($something, &\SomeNS\SomeClass::$somethingElse);
 
-/* passByReferenceJ */
+/* testPassByReferenceJ */
 functionCall($something, &namespace\SomeClass::$somethingElse);
 
-/* newByReferenceA */
+/* testNewByReferenceA */
 $foobar2 = &new Foobar();
 
-/* newByReferenceB */
+/* testNewByReferenceB */
 functionCall( $something , &new Foobar() );
 
-/* useByReference */
+/* testUseByReference */
 $closure = function() use (&$var){};

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -9,54 +9,10 @@
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 
-use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Files\DummyFile;
-use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
 
-class IsReferenceTest extends TestCase
+class IsReferenceTest extends AbstractMethodUnitTest
 {
-
-    /**
-     * The PHP_CodeSniffer_File object containing parsed contents of the test case file.
-     *
-     * @var \PHP_CodeSniffer\Files\File
-     */
-    private $phpcsFile;
-
-
-    /**
-     * Initialize & tokenize \PHP_CodeSniffer\Files\File with code from the test case file.
-     *
-     * Methods used for these tests can be found in a test case file in the same
-     * directory and with the same name, using the .inc extension.
-     *
-     * @return void
-     */
-    public function setUp()
-    {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-
-        $ruleset = new Ruleset($config);
-
-        $pathToTestFile  = dirname(__FILE__).'/'.basename(__FILE__, '.php').'.inc';
-        $this->phpcsFile = new DummyFile(file_get_contents($pathToTestFile), $ruleset, $config);
-        $this->phpcsFile->process();
-
-    }//end setUp()
-
-
-    /**
-     * Clean up after finished test.
-     *
-     * @return void
-     */
-    public function tearDown()
-    {
-        unset($this->phpcsFile);
-
-    }//end tearDown()
 
 
     /**
@@ -71,17 +27,17 @@ class IsReferenceTest extends TestCase
      */
     public function testIsReference($identifier, $expected)
     {
-        $start      = ($this->phpcsFile->numTokens - 1);
-        $delim      = $this->phpcsFile->findPrevious(
+        $start      = (self::$phpcsFile->numTokens - 1);
+        $delim      = self::$phpcsFile->findPrevious(
             T_COMMENT,
             $start,
             null,
             false,
             $identifier
         );
-        $bitwiseAnd = $this->phpcsFile->findNext(T_BITWISE_AND, ($delim + 1));
+        $bitwiseAnd = self::$phpcsFile->findNext(T_BITWISE_AND, ($delim + 1));
 
-        $result = $this->phpcsFile->isReference($bitwiseAnd);
+        $result = self::$phpcsFile->isReference($bitwiseAnd);
         $this->assertSame($expected, $result);
 
     }//end testIsReference()

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -27,17 +27,8 @@ class IsReferenceTest extends AbstractMethodUnitTest
      */
     public function testIsReference($identifier, $expected)
     {
-        $start      = (self::$phpcsFile->numTokens - 1);
-        $delim      = self::$phpcsFile->findPrevious(
-            T_COMMENT,
-            $start,
-            null,
-            false,
-            $identifier
-        );
-        $bitwiseAnd = self::$phpcsFile->findNext(T_BITWISE_AND, ($delim + 1));
-
-        $result = self::$phpcsFile->isReference($bitwiseAnd);
+        $bitwiseAnd = $this->getTargetToken($identifier, T_BITWISE_AND);
+        $result     = self::$phpcsFile->isReference($bitwiseAnd);
         $this->assertSame($expected, $result);
 
     }//end testIsReference()
@@ -54,183 +45,183 @@ class IsReferenceTest extends AbstractMethodUnitTest
     {
         return [
             [
-                '/* bitwiseAndA */',
+                '/* testBitwiseAndA */',
                 false,
             ],
             [
-                '/* bitwiseAndB */',
+                '/* testBitwiseAndB */',
                 false,
             ],
             [
-                '/* bitwiseAndC */',
+                '/* testBitwiseAndC */',
                 false,
             ],
             [
-                '/* bitwiseAndD */',
+                '/* testBitwiseAndD */',
                 false,
             ],
             [
-                '/* bitwiseAndE */',
+                '/* testBitwiseAndE */',
                 false,
             ],
             [
-                '/* bitwiseAndF */',
+                '/* testBitwiseAndF */',
                 false,
             ],
             [
-                '/* bitwiseAndG */',
+                '/* testBitwiseAndG */',
                 false,
             ],
             [
-                '/* bitwiseAndH */',
+                '/* testBitwiseAndH */',
                 false,
             ],
             [
-                '/* bitwiseAndI */',
+                '/* testBitwiseAndI */',
                 false,
             ],
             [
-                '/* functionReturnByReference */',
+                '/* testFunctionReturnByReference */',
                 true,
             ],
             [
-                '/* functionPassByReferenceA */',
+                '/* testFunctionPassByReferenceA */',
                 true,
             ],
             [
-                '/* functionPassByReferenceB */',
+                '/* testFunctionPassByReferenceB */',
                 true,
             ],
             [
-                '/* functionPassByReferenceC */',
+                '/* testFunctionPassByReferenceC */',
                 true,
             ],
             [
-                '/* functionPassByReferenceD */',
+                '/* testFunctionPassByReferenceD */',
                 true,
             ],
             [
-                '/* functionPassByReferenceE */',
+                '/* testFunctionPassByReferenceE */',
                 true,
             ],
             [
-                '/* functionPassByReferenceF */',
+                '/* testFunctionPassByReferenceF */',
                 true,
             ],
             [
-                '/* functionPassByReferenceG */',
+                '/* testFunctionPassByReferenceG */',
                 true,
             ],
             [
-                '/* foreachValueByReference */',
+                '/* testForeachValueByReference */',
                 true,
             ],
             [
-                '/* foreachKeyByReference */',
+                '/* testForeachKeyByReference */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceA */',
+                '/* testArrayValueByReferenceA */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceB */',
+                '/* testArrayValueByReferenceB */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceC */',
+                '/* testArrayValueByReferenceC */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceD */',
+                '/* testArrayValueByReferenceD */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceE */',
+                '/* testArrayValueByReferenceE */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceF */',
+                '/* testArrayValueByReferenceF */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceG */',
+                '/* testArrayValueByReferenceG */',
                 true,
             ],
             [
-                '/* arrayValueByReferenceH */',
+                '/* testArrayValueByReferenceH */',
                 true,
             ],
             [
-                '/* assignByReferenceA */',
+                '/* testAssignByReferenceA */',
                 true,
             ],
             [
-                '/* assignByReferenceB */',
+                '/* testAssignByReferenceB */',
                 true,
             ],
             [
-                '/* assignByReferenceC */',
+                '/* testAssignByReferenceC */',
                 true,
             ],
             [
-                '/* assignByReferenceD */',
+                '/* testAssignByReferenceD */',
                 true,
             ],
             [
-                '/* assignByReferenceE */',
+                '/* testAssignByReferenceE */',
                 true,
             ],
             [
-                '/* passByReferenceA */',
+                '/* testPassByReferenceA */',
                 true,
             ],
             [
-                '/* passByReferenceB */',
+                '/* testPassByReferenceB */',
                 true,
             ],
             [
-                '/* passByReferenceC */',
+                '/* testPassByReferenceC */',
                 true,
             ],
             [
-                '/* passByReferenceD */',
+                '/* testPassByReferenceD */',
                 true,
             ],
             [
-                '/* passByReferenceE */',
+                '/* testPassByReferenceE */',
                 true,
             ],
             [
-                '/* passByReferenceF */',
+                '/* testPassByReferenceF */',
                 true,
             ],
             [
-                '/* passByReferenceG */',
+                '/* testPassByReferenceG */',
                 true,
             ],
             [
-                '/* passByReferenceH */',
+                '/* testPassByReferenceH */',
                 true,
             ],
             [
-                '/* passByReferenceI */',
+                '/* testPassByReferenceI */',
                 true,
             ],
             [
-                '/* passByReferenceJ */',
+                '/* testPassByReferenceJ */',
                 true,
             ],
             [
-                '/* newByReferenceA */',
+                '/* testNewByReferenceA */',
                 true,
             ],
             [
-                '/* newByReferenceB */',
+                '/* testNewByReferenceB */',
                 true,
             ],
             [
-                '/* useByReference */',
+                '/* testUseByReference */',
                 true,
             ],
         ];

--- a/tests/FileList.php
+++ b/tests/FileList.php
@@ -1,19 +1,14 @@
 <?php
 /**
- * Retrieve a filtered file list.
+ * Class to retrieve a filtered file list.
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
  * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
  * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-/**
- * Class to create a file list with filtering.
- */
+namespace PHP_CodeSniffer\Tests;
+
 class FileList
 {
 

--- a/tests/FileList.php
+++ b/tests/FileList.php
@@ -24,7 +24,7 @@ class FileList
      *
      * @var \DirectoryIterator
      */
-    protected $fileIterator;
+    public $fileIterator;
 
     /**
      * Base regex to use if no filter regex is provided.


### PR DESCRIPTION
Note: this PR will be easiest to review by looking at the individual commits.

I've created this PR as a precursor to #2189 (move utility methods to static classes) as most of the new utility functions which are mentioned in that issue will be accompanied by unit tests when they are pulled.

Improving the setup of the utility function testing, as done in this PR, will make that so much simpler.

---

## Commit Summary

### New `Tests\Core\AbstractMethodUnitTest` class

Refactor to remove duplicate code.

This new class abstracts out the `setUp()` and `tearDown()` methods which were included in nearly all the utility method test classes.

The methods have been changed to static `setUpBeforeClass()` and `tearDownAfterClass()` with a static property as the initial processed `File` doesn't change between tests, so there is no need to tokenize and process the unit test case file for each test individually.

This makes the utility method unit tests significantly faster as well as lower the memory usage.

Additionally, the _standard_ against which the files are processed has been changed from `Generic` (75 sniffs) to `PSR1` (7 sniffs), which, again, makes the unit test suite for the Core utility functions significantly faster.

The current implementation allows for only one test case file per utility method test file, but as the utility method tests are not sniff specific, adding additional tests files for a method if needed, should not be a problem.

By default test case files are expected to be PHP `inc` files. Child classes can overload the static `$fileExtension` property when the test case file is a JS or CSS file.


### Implement use of the new AbstractMethodUnitTest class

... in the various utility method unit test classes.

### Tests\Core\AbstractMethodUnitTest: add new getTargetToken() method

This adds a new `getTargetToken()` method which can retrieve the target token for testing with higher precision than the (duplicate) code which was so far used in the individual test methods.

The improvements this method offers are:
* Avoid test leaking/contamination.
    If/when the token to start the test from was retrieved by doing a `findNext()` from the delimiter comment, a typo could cause a token from the *next* test to be used for the testing instead of the target token.
    If the expected results would be the same for both tests, this would go completely unnoticed.
    This is now no longer possible.
    The only requirement is that the delimiter comments start with `/* test...`.
* No more token counting when setting up the unit tests, just pass the target token type constant to this method and it will get you the correct token.
    This also allows for not having to jump through hoops when deciding where to place the delimiter comment for the test.
* If the token a test looks for is a `T_STRING` or text based token, the optional `$tokenContent` allows for selecting the correct token, even when there are several of the same type in the test case line.

### Implement use of the new AbstractMethodUnitTest::getTargetToken() method

... in the various utility method unit test classes.

### GetMethodParametersTest: remove even more duplicate code
### GetMethodPropertiesTest: remove even more duplicate code

Implement use of the new `AbstractMethodUnitTest::getTargetToken()` method as well as abstract out the actual testing to a helper method as the logic was the same in all methods.

I've chosen not to implement this with a data provider as the separate test methods creating the `$expected` arrays make the tests more readable and easier to understand.

### Tests\Core\AllTests: simplify creation of the test suite

As the refactor will add a lot of new unit test files, let's automate the creation of the test suite some more by automatically adding all Test files within the `Test\Core` directory.