### PR TITLE
Require one space before name - class declaration

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -344,19 +344,32 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                         $prev = ($className - 1);
                     }
 
-                    $spaceBefore = strlen($tokens[$prev]['content']);
-                    if ($spaceBefore !== 1) {
+                    $last    = $phpcsFile->findPrevious(T_WHITESPACE, $prev, null, true);
+                    $content = $phpcsFile->getTokensAsString(($last + 1), ($prev - $last));
+                    if ($content !== ' ') {
+                        $found = strlen($content);
+
                         $error = 'Expected 1 space before "%s"; %s found';
                         $data  = [
                             $tokens[$className]['content'],
-                            $spaceBefore,
+                            $found,
                         ];
 
                         $fix = $phpcsFile->addFixableError($error, $className, 'SpaceBeforeName', $data);
                         if ($fix === true) {
-                            $phpcsFile->fixer->replaceToken($prev, ' ');
+                            if ($tokens[$prev]['code'] === T_WHITESPACE) {
+                                $phpcsFile->fixer->beginChangeset();
+                                if ($tokens[($prev - 1)]['code'] === T_WHITESPACE) {
+                                    $phpcsFile->fixer->replaceToken(($prev - 1), ' ');
+                                }
+
+                                $phpcsFile->fixer->replaceToken($prev, ' ');
+                                $phpcsFile->fixer->endChangeset();
+                            } else {
+                                $phpcsFile->fixer->addContent($prev, ' ');
+                            }
                         }
-                    }
+                    }//end if
                 }//end if
             }//end if
 

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -163,3 +163,8 @@ class C2
 {
 
 } // phpcs:ignore Standard.Category.Sniff
+
+class C3 extends
+ C2
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -161,3 +161,7 @@ class C2
 {
 
 } // phpcs:ignore Standard.Category.Sniff
+
+class C3 extends C2
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -50,6 +50,7 @@ class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             130 => 2,
             131 => 1,
             158 => 1,
+            168 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
We require just one space before parent class name (after extends keyword).

Fixes #2298