### PR TITLE
Squiz/FunctionCommentThrowTag: two bug fixes

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -69,6 +69,7 @@ class FunctionCommentThrowTagSniff implements Sniff
         $thrownExceptions = [];
         $currPos          = $stackPtr;
         $foundThrows      = false;
+        $unknownCount     = 0;
         do {
             $currPos = $phpcsFile->findNext([T_THROW, T_ANON_CLASS, T_CLOSURE], ($currPos + 1), $stackPtrEnd);
             if ($currPos === false) {
@@ -156,6 +157,8 @@ class FunctionCommentThrowTagSniff implements Sniff
                         }
                     }
                 }
+            } else {
+                ++$unknownCount;
             }//end if
         } while ($currPos < $stackPtrEnd && $currPos !== false);
 
@@ -196,7 +199,7 @@ class FunctionCommentThrowTagSniff implements Sniff
         }
 
         // Make sure @throws tag count matches thrown count.
-        $thrownCount = count($thrownExceptions);
+        $thrownCount = (count($thrownExceptions) + $unknownCount);
         $tagCount    = count($throwTags);
         if ($thrownCount !== $tagCount) {
             $error = 'Expected %s @throws tag(s) in function comment; %s found';

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentThrowTagSniff.php
@@ -212,11 +212,19 @@ class FunctionCommentThrowTagSniff implements Sniff
         }
 
         foreach ($thrownExceptions as $throw) {
-            if (isset($throwTags[$throw]) === false) {
-                $error = 'Missing @throws tag for "%s" exception';
-                $data  = [$throw];
-                $phpcsFile->addError($error, $commentEnd, 'Missing', $data);
+            if (isset($throwTags[$throw]) === true) {
+                continue;
             }
+
+            foreach ($throwTags as $tag => $ignore) {
+                if (strrpos($tag, $throw) === (strlen($tag) - strlen($throw))) {
+                    continue 2;
+                }
+            }
+
+            $error = 'Missing @throws tag for "%s" exception';
+            $data  = [$throw];
+            $phpcsFile->addError($error, $commentEnd, 'Missing', $data);
         }
 
     }//end process()

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
@@ -410,3 +410,27 @@ abstract class SomeClass {
      */
     abstract public function getGroups();
 }
+
+class SomeClass {
+	/**
+	 * Validates something.
+	 *
+	 * @param string $method The set method parameter.
+	 *
+	 * @return string The validated method.
+	 *
+	 * @throws Prefix_Invalid_Argument_Exception The invalid argument exception.
+	 * @throws InvalidArgumentException          The invalid argument exception.
+	 */
+	protected function validate_something( $something ) {
+		if ( ! Prefix_Validator::is_string( $something ) ) {
+			throw Prefix_Invalid_Argument_Exception::invalid_string_parameter( $something, 'something' );
+		}
+
+		if ( ! in_array( $something, $this->valid_http_something, true ) ) {
+			throw new InvalidArgumentException( sprintf( '%s is not a valid HTTP something', $something ) );
+		}
+
+		return $something;
+	}
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentThrowTagUnitTest.inc
@@ -434,3 +434,53 @@ class SomeClass {
 		return $something;
 	}
 }
+
+namespace Test\Admin {
+	class NameSpacedClass {
+		/**
+		 * @throws \ExceptionFromGlobalNamespace
+		 */
+		public function ExceptionInGlobalNamespace() {
+			throw new \ExceptionFromGlobalNamespace();
+		}
+
+		/**
+		 * @throws ExceptionFromSameNamespace
+		 */
+		public function ExceptionInSameNamespace() {
+			throw new ExceptionFromSameNamespace();
+		}
+
+		/**
+		 * @throws \Test\Admin\ExceptionFromSameNamespace
+		 */
+		public function ExceptionInSameNamespaceToo() {
+			throw new ExceptionFromSameNamespace();
+		}
+
+		/**
+		 * @throws \Different\NameSpaceName\ExceptionFromDifferentNamespace
+		 */
+		public function ExceptionInSameNamespaceToo() {
+			throw new \Different\NameSpaceName\ExceptionFromDifferentNamespace();
+		}
+	}
+}
+
+namespace {
+	class GlobalNameSpaceClass {
+		/**
+		 * @throws SomeGlobalException
+		 */
+		public function ThrowGlobalException() {
+			throw new SomeGlobalException();
+		}
+
+		/**
+		 * @throws \SomeGlobalException
+		 */
+		public function ThrowGlobalExceptionToo() {
+			throw new SomeGlobalException();
+		}
+	}
+}


### PR DESCRIPTION
### Squiz/FunctionCommentThrowTag: fix incorrect `WrongNumber` error

When it isn't clear what type of Exception a `throw` will generate, but there are more than one `throw`s in a function, the "unknown" exceptions wouldn't be taken into account when determining whether the correct number of exceptions were being thrown.

Includes unit test.

(In case anyone is wondering: the `Prefix_Invalid_Argument_Exception::invalid_string_parameter()` method returns an instance of `self` in the code where I encountered this issue.)

### Squiz/FunctionCommentThrowTag: fix incorrect `Missing` errors with FQN Exception names

The code did not take into account that Fully Qualified names could be used in the `@throws` tag while a relative Exception name may be used in the `throw` statement.

Includes unit tests (probably a few too many, but I wanted to be sure that I understood how the sniff was dealing with this).