### PR TITLE
PSR12/ShortFormTypeKeywords: bug fix / false positive

### DIFF
--- a/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.inc
@@ -6,3 +6,9 @@ $bar = (BOOLEAN) $foo;
 $bar = (int) $foo;
 $bar = (integer) $foo;
 $bar = (INT) $foo;
+
+// Test recognition with whitespace within the cast.
+$bar = (  bool  ) $foo;
+$bar = ( int ) $foo;
+$bar = (     boolean   	    ) $foo;
+$bar = (  integer) $foo;

--- a/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.inc.fixed
@@ -6,3 +6,9 @@ $bar = (bool) $foo;
 $bar = (int) $foo;
 $bar = (int) $foo;
 $bar = (INT) $foo;
+
+// Test recognition with whitespace within the cast.
+$bar = (  bool  ) $foo;
+$bar = ( int ) $foo;
+$bar = (     bool   	    ) $foo;
+$bar = (  int) $foo;

--- a/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
+++ b/src/Standards/PSR12/Tests/Keywords/ShortFormTypeKeywordsUnitTest.php
@@ -26,9 +26,11 @@ class ShortFormTypeKeywordsUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            3 => 1,
-            5 => 1,
-            7 => 1,
+            3  => 1,
+            5  => 1,
+            7  => 1,
+            13 => 1,
+            14 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The PSR 12 standard (currently) says nothing about whether or not spaces within type casts are allowed.

As it was, the `PSR12.Keywords.ShortFormTypeKeywords` sniff would throw a false positive for a short form type cast like `( bool )` and "fix" it by removing the spaces, which is not the concern of this sniff.

If at some point the PSR12 standard would take a stand about spaces within type casts, the `Squiz.WhiteSpace.CastSpacing` sniff could be added to check & fix these issues.

In the mean time, the `ShortFormTypeKeywords` sniff should be space-agnostic.

This PR takes care of that.

It also makes the error message slightly more descriptive by being explicit about the type cast found in the error message.

Includes unit tests.