### PR TITLE
Efficiency fixes

### DIFF
--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -260,10 +260,9 @@ abstract class AbstractPatternSniff implements Sniff
         $errors      = [];
         $found       = '';
 
-        $ignoreTokens = [T_WHITESPACE];
+        $ignoreTokens = [T_WHITESPACE => T_WHITESPACE];
         if ($this->ignoreComments === true) {
-            $ignoreTokens
-                = array_merge($ignoreTokens, Tokens::$commentTokens);
+            $ignoreTokens += Tokens::$commentTokens;
         }
 
         $origStackPtr = $stackPtr;

--- a/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/CallTimePassByReferenceSniff.php
@@ -45,10 +45,8 @@ class CallTimePassByReferenceSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $findTokens = array_merge(
-            Tokens::$emptyTokens,
-            [T_BITWISE_AND]
-        );
+        $findTokens   = Tokens::$emptyTokens;
+        $findTokens[] = T_BITWISE_AND;
 
         $prev = $phpcsFile->findPrevious($findTokens, ($stackPtr - 1), null, true);
 

--- a/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
@@ -24,20 +24,16 @@ class OperatorSpacingSniff extends SquizOperatorSpacingSniff
      */
     public function register()
     {
-        return array_unique(
-            array_merge(
-                Tokens::$comparisonTokens,
-                Tokens::$operators,
-                Tokens::$assignmentTokens,
-                Tokens::$booleanOperators,
-                [
-                    T_INLINE_THEN,
-                    T_INLINE_ELSE,
-                    T_STRING_CONCAT,
-                    T_INSTANCEOF,
-                ]
-            )
-        );
+        $targets   = Tokens::$comparisonTokens;
+        $targets  += Tokens::$operators;
+        $targets  += Tokens::$assignmentTokens;
+        $targets  += Tokens::$booleanOperators;
+        $targets[] = T_INLINE_THEN;
+        $targets[] = T_INLINE_ELSE;
+        $targets[] = T_STRING_CONCAT;
+        $targets[] = T_INSTANCEOF;
+
+        return $targets;
 
     }//end register()
 

--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -38,8 +38,12 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         // Detect multiple properties defined at the same time. Throw an error
         // for this, but also only process the first property in the list so we don't
         // repeat errors.
-        $find = Tokens::$scopeModifiers;
-        $find = array_merge($find, [T_VARIABLE, T_VAR, T_SEMICOLON, T_OPEN_CURLY_BRACKET]);
+        $find   = Tokens::$scopeModifiers;
+        $find[] = T_VARIABLE;
+        $find[] = T_VAR;
+        $find[] = T_SEMICOLON;
+        $find[] = T_OPEN_CURLY_BRACKET;
+
         $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1));
         if ($tokens[$prev]['code'] === T_VARIABLE) {
             return;

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -41,17 +41,13 @@ class OperatorSpacingSniff implements Sniff
      */
     public function register()
     {
-        $comparison = Tokens::$comparisonTokens;
-        $operators  = Tokens::$operators;
-        $assignment = Tokens::$assignmentTokens;
-        $inlineIf   = [
-            T_INLINE_THEN,
-            T_INLINE_ELSE,
-        ];
+        $targets   = Tokens::$comparisonTokens;
+        $targets  += Tokens::$operators;
+        $targets  += Tokens::$assignmentTokens;
+        $targets[] = T_INLINE_THEN;
+        $targets[] = T_INLINE_ELSE;
 
-        return array_unique(
-            array_merge($comparison, $operators, $assignment, $inlineIf)
-        );
+        return $targets;
 
     }//end register()
 


### PR DESCRIPTION
Array union `+` is much faster than `array_merge()`, though the behaviour is different.

The differences are:

-- | Array union | Array merge
-- | -- | --
Numeric keys | Will keep the keys which already exist | Will renumber & add keys for all values
String keys | Will keep the keys which already exist | Will keep the keys which already exist
Values | Will *not overwrite* existing value | Will *overwrite* existing value

As the arrays which are defined in the `Tokens` class have the same keys as well as values, using array union on those token arrays will be:
* more efficient than using a function call to `array_merge()`;
* will auto-deduplicate the arrays, so no need for a call to `array_unique()`;
* and the result will be the same.

Similarly, using straight assignments to an array is also more efficient than using `array_merge()` when it's a small number of assignments.