### PR TITLE
Hotfix for PEAR install

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,7 +37,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
   <dir name="/">
    <file baseinstalldir="PHP/CodeSniffer" name="autoload.php" role="php">
     <tasks:replace from="@test_dir@" to="test_dir" type="pear-config" />
-  </file>
+   </file>
    <file baseinstalldir="PHP/CodeSniffer" name="CodeSniffer.conf.dist" role="data" />
    <file baseinstalldir="PHP/CodeSniffer" name="README.md" role="doc" />
    <file baseinstalldir="PHP/CodeSniffer" name="CONTRIBUTING.md" role="doc" />
@@ -125,6 +125,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     <dir name="Reports">
      <file baseinstalldir="PHP/CodeSniffer" name="Cbf.php" role="php" />
      <file baseinstalldir="PHP/CodeSniffer" name="Checkstyle.php" role="php" />
+     <file baseinstalldir="PHP/CodeSniffer" name="Code.php" role="php" />
      <file baseinstalldir="PHP/CodeSniffer" name="Csv.php" role="php" />
      <file baseinstalldir="PHP/CodeSniffer" name="Diff.php" role="php" />
      <file baseinstalldir="PHP/CodeSniffer" name="Emacs.php" role="php" />
@@ -201,6 +202,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="MultipleStatementAlignmentStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="NoSpaceAfterCastStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="SpaceAfterCastStandard.xml" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpaceAfterNotStandard.xml" role="php" />
        </dir>
        <dir name="Functions">
         <file baseinstalldir="PHP/CodeSniffer" name="CallTimePassByReferenceStandard.xml" role="php" />
@@ -301,6 +303,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="NoSpaceAfterCastSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="SpaceAfterCastSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="SpaceAfterNotSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpaceBeforeCastSniff.php" role="php" />
        </dir>
        <dir name="Functions">
         <file baseinstalldir="PHP/CodeSniffer" name="CallTimePassByReferenceSniff.php" role="php" />
@@ -346,6 +349,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="IncrementDecrementSpacingSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LanguageConstructSpacingSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentSniff.php" role="php" />
        </dir>
       </dir>
@@ -492,6 +496,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="SpaceAfterNotUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SpaceAfterNotUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SpaceAfterNotUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpaceBeforeCastUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpaceBeforeCastUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpaceBeforeCastUnitTest.php" role="test" />
        </dir>
        <dir name="Functions">
         <file baseinstalldir="PHP/CodeSniffer" name="CallTimePassByReferenceUnitTest.inc" role="test" />
@@ -608,6 +615,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="IncrementDecrementSpacingUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="IncrementDecrementSpacingUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="IncrementDecrementSpacingUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LanguageConstructSpacingUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LanguageConstructSpacingUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LanguageConstructSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentUnitTest.1.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentUnitTest.1.js" role="test" />
@@ -1626,6 +1636,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.4.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.4.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.5.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.5.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingTagUnitTest.php" role="test" />
        </dir>
        <dir name="NamingConventions">


### PR DESCRIPTION
In the WordPressCS repo we received a bug report from someone using PHPCS 3.4.0 but missing the `Generic.WhiteSpace.LanguageConstructSpacing` sniff.
Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1614

Turned out that that sniff is missing from the `package.xml` file which is why it's not available when someone is using a PEAR install of PHPCS.

I've now done a comprehensive check of all relevant files in the repo versus the files listed in the `<contents>` tag of the `package.xml` file and found some more discrepancies with this commit as a result.

As this basically means that the PEAR install is currently "broken" with regards to the `Code` report (PHPCS 3.0), the `Generic.Formatting.SpaceBeforeCast` sniff (PHPCS 3.4.0) as well as the `Generic.WhiteSpace.LanguageConstructSpacing` sniff (PHPCS 3.3.0), this should be considered a hotfix.