### PR TITLE
Squiz/BlockComment: don't require a blank line between PHP open tag and block comment

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -360,8 +360,9 @@ class BlockCommentSniff implements Sniff
 
         // Check that the lines before and after this comment are blank.
         $contentBefore = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (isset($tokens[$contentBefore]['scope_closer']) === true
-            && $tokens[$contentBefore]['scope_opener'] === $contentBefore
+        if ((isset($tokens[$contentBefore]['scope_closer']) === true
+            && $tokens[$contentBefore]['scope_opener'] === $contentBefore)
+            || $tokens[$contentBefore]['code'] === T_OPEN_TAG
         ) {
             if (($tokens[$stackPtr]['line'] - $tokens[$contentBefore]['line']) !== 1) {
                 $error = 'Empty line not required before block comment';

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -242,3 +242,17 @@ $y = 10 + /* test */ -2;
  * See: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1918}
  * @phpcs:disable Standard.Category.Sniff
  */
+
+?>
+<?php
+/*
+ * No blank line required above the comment if it's the first non-empty token after a PHP open tag.
+ */
+
+?>
+<?php
+
+
+/*
+ * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
+ */

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -244,3 +244,17 @@ $y = 10 + /* test */ -2;
  * See: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1918}
  * @phpcs:disable Standard.Category.Sniff
  */
+
+?>
+<?php
+/*
+ * No blank line required above the comment if it's the first non-empty token after a PHP open tag.
+ */
+
+?>
+<?php
+
+
+/*
+ * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
+ */

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
@@ -41,6 +41,7 @@ class BlockCommentUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         $errors = [
+            3   => 1,
             8   => 1,
             20  => 1,
             24  => 1,
@@ -75,6 +76,7 @@ class BlockCommentUnitTest extends AbstractSniffUnitTest
             227 => 1,
             232 => 1,
             233 => 1,
+            256 => 1,
         ];
 
         return $errors;


### PR DESCRIPTION
Just like with scope openers, if a block comment is the first thing after a PHP open tag, no blank line should be required.

Includes unit tests.