### PR TITLE
Move documentation in repo for consumption by mkodcs, establish sniff documentation pattern.

### DIFF
--- a/docs/Documentation/Advanced-Usage.md
+++ b/docs/Documentation/Advanced-Usage.md
@@ -1,0 +1,398 @@
+## Table of contents
+  * [Specifying Valid File Extensions](#specifying-valid-file-extensions)
+  * [Ignoring Files and Folders](#ignoring-files-and-folders)
+  * [Ignoring Parts of a File](#ignoring-parts-of-a-file)
+  * [Limiting Results to Specific Sniffs](#limiting-results-to-specific-sniffs)
+  * [Filtering Errors and Warnings Based on Severity](#filtering-errors-and-warnings-based-on-severity)
+  * [Replacing Tabs with Spaces](#replacing-tabs-with-spaces)
+  * [Specifying an Encoding](#specifying-an-encoding)
+  * [Using a Bootstrap File](#using-a-bootstrap-file)
+  * [Using a Default Configuration File](#using-a-default-configuration-file)
+  * [Specifying php.ini Settings](#specifying-phpini-settings)
+  * [Setting Configuration Options](#setting-configuration-options)
+  * [Deleting Configuration Options](#deleting-configuration-options)
+  * [Viewing Configuration Options](#viewing-configuration-options)
+  * [Printing Verbose Tokeniser Output](#printing-verbose-tokeniser-output)
+  * [Printing Verbose Token Processing Output](#printing-verbose-token-processing-output)
+  * [Quieting Output](#quieting-output)
+
+***
+
+## Specifying Valid File Extensions
+By default, PHP_CodeSniffer will check any file it finds with a `.inc`, `.php`, `.js` or `.css` extension, although not all standards will actually check all these file types. Sometimes, this means that PHP_CodeSniffer is not checking enough of your files. Sometimes, the opposite is true. PHP_CodeSniffer allows you to specify a list of valid file extensions using the `--extensions` command line argument. Extensions are separated by commas.
+
+To only check .php files:
+
+    $ phpcs --extensions=php /path/to/code
+
+To check .php, .inc and .lib files:
+
+    $ phpcs --extensions=php,inc,lib /path/to/code
+
+## Ignoring Files and Folders
+Sometimes you want PHP_CodeSniffer to run over a very large number of files, but you want some files and folders to be skipped. The `--ignore` command line argument can be used to tell PHP_CodeSniffer to skip files and folders that match one or more patterns.
+
+In the following example, PHP_CodeSniffer will skip all files inside the package's tests and data directories. This is useful if you are checking a PEAR package but don't want your test or data files to conform to your coding standard.
+
+    $ phpcs --ignore=*/tests/*,*/data/* /path/to/code
+
+> The ignore patterns are treated as regular expressions. If you do specify a regular expression, be aware that `*` is converted to `.*` for the convenience in simple patterns, like those used in the example above. So use `*` anywhere you would normally use `.*`. Also ensure you escape any `.` characters that you want treated as a literal dot, such as when checking file extensions. So if you are checking for `.inc` in your ignore pattern, use `\.inc` instead. 
+
+You can also tell PHP_CodeSniffer to ignore a file using a special comment inserted at the top of the file. This will stop the file being checked even if it does not match the ignore pattern.
+
+```php
+<?php
+// phpcs:ignoreFile
+$xmlPackage = new XMLPackage;
+$xmlPackage['error_code'] = get_default_error_code_value();
+$xmlPackage->send();
+```
+
+> Note: Before PHP_CodeSniffer version 3.2.0, use `// @codingStandardsIgnoreFile` instead of `// phpcs:ignoreFile`. The `@codingStandards` syntax is deprecated and will be removed in PHP_CodeSniffer version 4.0.
+
+> Note: The `phpcs:ignoreFile` comment syntax does not allow for a specific set of sniffs to be ignored for a file. Use the `phpcs:disable` comment syntax if you want to disable a specific set of sniffs for the entire file.
+
+If required, you can add a note explaining why the file is being ignored by using the `--` separator.
+
+```php
+<?php
+// phpcs:ignoreFile -- this is not a core file
+$xmlPackage = new XMLPackage;
+$xmlPackage['error_code'] = get_default_error_code_value();
+$xmlPackage->send();
+```
+
+> Note: The comment syntax note feature is only available from PHP_CodeSniffer version 3.2.0 onwards.
+
+## Ignoring Parts of a File
+Some parts of your code may be unable to conform to your coding standard. For example, you might have to break your standard to integrate with an external library or web service. To stop PHP_CodeSniffer generating errors for this code, you can wrap it in special comments. PHP_CodeSniffer will then hide all errors and warnings that are generated for these lines of code.
+
+```php
+$xmlPackage = new XMLPackage;
+// phpcs:disable
+$xmlPackage['error_code'] = get_default_error_code_value();
+$xmlPackage->send();
+// phpcs:enable
+```
+
+> Note: Before PHP_CodeSniffer version 3.2.0, use `// @codingStandardsIgnoreStart` instead of `// phpcs:disable`, and use `// @codingStandardsIgnoreEnd` instead of `// phpcs:enable`. The `@codingStandards` syntax is deprecated and will be removed in PHP_CodeSniffer version 4.0.
+
+If you don't want to disable all coding standard errors, you can selectively disable and re-enable specific error message codes, sniffs, categories of sniffs, or entire coding standards. The following example disables the specific `Generic.Commenting.Todo.Found` message and then re-enables all checks at the end.
+
+```php
+// phpcs:disable Generic.Commenting.Todo.Found
+$xmlPackage = new XMLPackage;
+$xmlPackage['error_code'] = get_default_error_code_value();
+// TODO: Add an error message here.
+$xmlPackage->send();
+// phpcs:enable
+```
+
+You can disable multiple error message codes, sniff, categories, or standards by using a comma separated list. You can also selectively re-enable just the ones you want. The following example disables the entire PEAR coding standard, and all the Squiz array sniffs, before selectively re-enabling a specific sniff. It then re-enables all checking rules at the end.
+
+```php
+// phpcs:disable PEAR,Squiz.Arrays
+$foo = [1,2,3];
+bar($foo,true);
+// phpcs:enable PEAR.Functions.FunctionCallSignature
+bar($foo,false);
+// phpcs:enable
+```
+
+> Note: All `phpcs:disable` and `phpcs:enable` comments only apply to the file they are contained within. After the file has finished processing all sniffs are re-enabled for future files.
+
+> Note: Selective disabling and re-enabling of codes/sniffs/categories/standards is only available from PHP_CodeSniffer version 3.2.0 onwards.
+
+You can also ignore a single line using the `phpcs:ignore` comment. This comment will ignore the line that the comment is on, and the following line. It is typically used like this:
+
+```php
+// phpcs:ignore
+$foo = [1,2,3];
+bar($foo, false);
+```
+
+Or like this:
+
+```php
+$foo = [1,2,3]; // phpcs:ignore
+bar($foo, false);
+```
+
+> Note: Before PHP_CodeSniffer version 3.2.0, use `// @codingStandardsIgnoreLine` instead of `// phpcs:ignore`. The `@codingStandards` syntax is deprecated and will be removed in PHP_CodeSniffer version 4.0.
+
+Again, you can selectively ignore one or more specific error message codes, sniffs, categories of sniffs, or entire standards.
+
+```php
+// phpcs:ignore Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed
+$foo = [1,2,3];
+bar($foo, false);
+```
+
+> Note: Selective ignoring of codes/sniffs/categories/standards is only available from PHP_CodeSniffer version 3.2.0 onwards.
+
+If required, you can add a note explaining why sniffs are being disable and re-enabled by using the `--` separator.
+
+```php
+// phpcs:disable PEAR,Squiz.Arrays -- this isn't our code
+$foo = [1,2,3];
+bar($foo,true);
+// phpcs:enable PEAR.Functions.FunctionCallSignature -- check function calls again
+bar($foo,false);
+// phpcs:enable -- this is out code again, so turn everything back on
+```
+
+> Note: The comment syntax note feature is only available from PHP_CodeSniffer version 3.2.0 onwards.
+
+## Limiting Results to Specific Sniffs
+By default, PHP_CodeSniffer will check your code using all sniffs in the specified standard. Sometimes you may want to find all occurrences of a single error to eliminate it more quickly, or to exclude sniffs to see if they are causing conflicts in your standard. PHP_CodeSniffer allows you to specify a list of sniffs to limit results to using the `--sniffs` command line argument, or a list of sniffs to exclude using the `--exclude` command line argument. Sniff codes are separated by commas.
+
+> Note: All sniffs specified on the command line must be used in the coding standard you are using to check your files.
+
+The following example will only run two sniffs over the code instead of all sniffs in the PEAR standard:
+
+    $ phpcs --standard=PEAR --sniffs=Generic.PHP.LowerCaseConstant,PEAR.WhiteSpace.ScopeIndent /path/to/code
+
+The following example will run all sniffs in the PEAR standard except for the two specified:
+
+    $ phpcs --standard=PEAR --exclude=Generic.PHP.LowerCaseConstant,PEAR.WhiteSpace.ScopeIndent /path/to/code
+
+> Note: If you use both the `--sniffs` and `--exclude` command line arguments together, the `--exclude` list will be ignored.
+
+## Filtering Errors and Warnings Based on Severity
+By default, PHP_CodeSniffer assigns a severity of 5 to all errors and warnings. Standards may change the severity of some messages so they are hidden by default or even so that they are raised to indicate greater importance. PHP_CodeSniffer allows you to decide what the minimum severity level must be to show a message in its report using the `--severity` command line argument.
+
+To hide errors and warnings with a severity less than 3:
+
+    $ phpcs --severity=3 /path/to/code
+
+You can specify different values for errors and warnings using the `--error-severity` and `--warning-severity` command line arguments.
+
+To show all errors, but only warnings with a severity of 8 or more:
+
+    $ phpcs --error-severity=1 --warning-severity=8 /path/to/code
+
+Setting the severity of warnings to `0` is the same as using the `-n` command line argument. If you set the severity of errors to `0` PHP_CodeSniffer will not show any errors, which may be useful if you just want to show warnings.
+
+This feature is particularly useful during manual code reviews. During normal development, or an automated build, you may want to only check code formatting issues. But while during a code review, you may wish to show less severe errors and warnings that may need manual peer review.
+
+## Replacing Tabs with Spaces
+Most of the sniffs written for PHP_CodeSniffer do not support the usage of tabs for indentation and alignment. You can write your own sniffs that check for tabs instead of spaces, but you can also get PHP_CodeSniffer to convert your tabs into spaces before a file is checked. This allows you to use the existing space-based sniffs on your tab-based files.
+
+In the following example, PHP_CodeSniffer will replace all tabs in the files being checked with between 1 and 4 spaces, depending on the column the tab indents to.
+
+    $ phpcs --tab-width=4 /path/to/code
+
+> Note: The [included sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php) that enforces space indentation will still generate errors even if you have replaced tabs with spaces using the `--tab-width` setting. This sniff looks at the unmodified version of the code to check line indentation and so must be disabled in a [[custom ruleset.xml file|Annotated ruleset]] if you want to use tab indentation.
+
+## Specifying an Encoding
+By default, PHP_CodeSniffer will treat all source files as if they use UTF-8 encoding. If you need your source files to be processed using a specific encoding, you can specify the encoding using the `--encoding` command line argument.
+
+    $ phpcs --encoding=windows-1251 /path/to/code
+
+## Using a Bootstrap File
+PHP_CodeSniffer can optionally include one or more custom bootstrap files before beginning the run. Bootstrap files are included after command line arguments and rulesets have been parsed, and right before files begin to process. These custom files may be used to perform such taks as manipulating the internal settings of PHP_CodeSniffer that are not exposed through command line arguments. Multiple bootstrap files are seperated by commas.
+
+    $ phpcs --bootstrap=/path/to/boostrap.1.inc,/path/to/bootstrap.2.inc /path/to/code
+
+## Using a Default Configuration File
+If you run PHP_CodeSniffer without specifying a coding standard, PHP_CodeSniffer will look in the current directory, and all parent directories, for a file called either `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist`, or `phpcs.xml.dist`. If found, configuration information will be read from this file, including the files to check, the coding standard to use, and any command line arguments to apply.
+
+> Note: If multiple default configuration files are found, PHP_CodeSniffer will select one using the following order: `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist`, `phpcs.xml.dist`
+
+The `phpcs.xml` file has exactly the same format as a normal [[ruleset.xml file|Annotated ruleset]], so all the same options are available in it. The `phpcs.xml` file essentially acts as a default coding standard and configuration file for a code base, and is typically used to allow the `phpcs` command to be run on a repository without specifying any arguments.
+
+> An example `phpcs.xml` file can be found in the PHP_CodeSniffer repository: [phpcs.xml.dist](https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xml.dist)
+
+## Specifying php.ini Settings
+PHP_CodeSniffer allows you to set temporary php.ini settings during a run using the `-d` command line argument. The name of the php.ini setting must be specified on the command line, but the value is optional. If no value is set, the php.ini setting will be given a value of TRUE.
+
+    $ phpcs -d memory_limit=32M /path/to/code
+
+You can also specific multiple values:
+
+    $ phpcs -d memory_limit=32M -d include_path=.:/php/includes /path/to/code
+
+## Setting Configuration Options
+PHP_CodeSniffer has some configuration options that can be set. Individual coding standards may also require configuration options to be set before functionality can be used. [[View a full list of configuration options|Configuration Options]].
+
+To set a configuration option, use the `--config-set` command line argument.
+
+    $ phpcs --config-set <option> <value>
+
+Configuration options are written to a global configuration file. If you want to set them for a single run only, use the `--runtime-set` command line argument.
+
+    $ phpcs --runtime-set <option> <value> /path/to/code
+
+> Note: Not all configuration options can be set using the `--runtime-set` command line argument. Configuration options that provide defaults for command line arguments, such as the default standard or report type, can not be used with `--runtime-set`. To set these values for a single run only, use the dedicated CLI arguments that PHP_CodeSniffer provides. The [[Configuration Options|Configuration Options]] list provides an alternative CLI argument for each configuration option not supported by `--runtime-set`.
+
+## Deleting Configuration Options
+PHP_CodeSniffer allows you to delete any configuration option, reverting it to its default value. [[View a full list of configuration options|Configuration Options]].
+
+To delete a configuration option, use the `--config-delete` command line argument.
+
+    $ phpcs --config-delete <option>
+
+   
+## Viewing Configuration Options
+To view the currently set configuration options, use the `--config-show` command line argument.
+
+    $ phpcs --config-show
+    Array
+    (
+        [default_standard] => PEAR
+        [zend_ca_path] => /path/to/ZendCodeAnalyzer
+    )
+
+## Printing Verbose Tokeniser Output
+This feature is provided for debugging purposes only. Using this feature will dramatically increase screen output and script running time.
+
+PHP_CodeSniffer contains multiple verbosity levels. Level 2 (indicated by the command line argument `-vv`) will print all verbosity information for level 1 (file specific token and line counts with running times) as well as verbose tokeniser output.
+
+The output of the PHP_CodeSniffer tokeniser shows the step-by-step creation of the scope map and the level map.
+
+### The Scope Map
+The scope map is best explained with an example. For the following file:
+
+    <?php
+    if ($condition) {
+        echo 'Condition was true';
+    }
+    ?>
+
+The scope map output is:
+
+    *** START SCOPE MAP ***
+    Start scope map at 1: T_IF => if
+    Process token 2 []: T_WHITESPACE =>  
+    Process token 3 []: T_OPEN_PARENTHESIS => (
+    * skipping parenthesis *
+    Process token 6 []: T_WHITESPACE =>  
+    Process token 7 []: T_OPEN_CURLY_BRACKET => {
+    => Found scope opener for 1 (T_IF)
+    Process token 8 [opener:7;]: T_WHITESPACE => \n
+    Process token 9 [opener:7;]: T_WHITESPACE =>     
+    Process token 10 [opener:7;]: T_ECHO => echo
+    Process token 11 [opener:7;]: T_WHITESPACE =>  
+    Process token 12 [opener:7;]: T_CONSTANT_ENCAPSED_STRING => 'Condition was true'
+    Process token 13 [opener:7;]: T_SEMICOLON => ;
+    Process token 14 [opener:7;]: T_WHITESPACE => \n
+    Process token 15 [opener:7;]: T_CLOSE_CURLY_BRACKET => }
+    => Found scope closer for 1 (T_IF)
+    *** END SCOPE MAP ***
+    
+The scope map output above shows the following pieces of information about the file:
+* A scope token `if` was found at token 1 (note that token 0 is the open PHP tag).
+* The opener for the if statement, the open curly brace, was found at token 7.
+* The closer for the if statement, the close curly brace, was found at token 15.
+* Tokens 8 - 15 are all included in the scope set by the scope opener at token 7, the open curly brace. This indicates that these tokens are all within the if statement.
+
+The scope map output is most useful when debugging PHP_CodeSniffer's scope map, which is critically important to the successful checking of a file, but is also useful for checking the type of a particular token. For example, if you are unsure of the token type for an opening curly brace, the scope map output shows you that the type is T_OPEN_CURLY_BRACKET and not, for example, T_OPEN_CURLY_BRACE.
+
+### The Level Map 
+The level map is best explained with an example. For the following file:
+
+    <?php
+    if ($condition) {
+        echo 'Condition was true';
+    }
+    ?>
+
+The level map output is:
+
+    *** START LEVEL MAP ***
+    Process token 0 on line 1 [lvl:0;]: T_OPEN_TAG => <?php\n
+    Process token 1 on line 2 [lvl:0;]: T_IF => if
+    Process token 2 on line 2 [lvl:0;]: T_WHITESPACE =>  
+    Process token 3 on line 2 [lvl:0;]: T_OPEN_PARENTHESIS => (
+    Process token 4 on line 2 [lvl:0;]: T_VARIABLE => $condition
+    Process token 5 on line 2 [lvl:0;]: T_CLOSE_PARENTHESIS => )
+    Process token 6 on line 2 [lvl:0;]: T_WHITESPACE =>  
+    Process token 7 on line 2 [lvl:0;]: T_OPEN_CURLY_BRACKET => {
+    => Found scope opener for 1 (T_IF)
+        * level increased *
+        * token 1 (T_IF) added to conditions array *
+        Process token 8 on line 2 [lvl:1;conds;T_IF;]: T_WHITESPACE => \n
+        Process token 9 on line 3 [lvl:1;conds;T_IF;]: T_WHITESPACE =>     
+        Process token 10 on line 3 [lvl:1;conds;T_IF;]: T_ECHO => echo
+        Process token 11 on line 3 [lvl:1;conds;T_IF;]: T_WHITESPACE =>  
+        Process token 12 on line 3 [lvl:1;conds;T_IF;]: T_CONSTANT_ENCAPSED_STRING => 'Condition was true'
+        Process token 13 on line 3 [lvl:1;conds;T_IF;]: T_SEMICOLON => ;
+        Process token 14 on line 3 [lvl:1;conds;T_IF;]: T_WHITESPACE => \n
+        Process token 15 on line 4 [lvl:1;conds;T_IF;]: T_CLOSE_CURLY_BRACKET => }
+        => Found scope closer for 7 (T_OPEN_CURLY_BRACKET)
+        * token T_IF removed from conditions array *
+        * level decreased *
+    Process token 16 on line 4 [lvl:0;]: T_WHITESPACE => \n
+    Process token 17 on line 5 [lvl:0;]: T_CLOSE_TAG => ?>\n
+    *** END LEVEL MAP ***
+
+    
+The level map output above shows the following pieces of information about the file:
+* A scope opener, an open curly brace, was found at token 7 and opened the scope for an if statement, defined at token 1.
+* Tokens 8 - 15 are all included in the scope set by the scope opener at token 7, the open curly brace. All these tokens are at level 1, indicating that they are enclosed in 1 scope condition, and all these tokens are enclosed in a single condition; an if statement.
+
+The level map is most commonly used to determine indentation rules (e.g., a token 4 levels deep requires 16 spaces of indentation) or to determine if a particular token is within a particular scope (e.g., a function keyword is within a class scope, making it a method).
+
+## Printing Verbose Token Processing Output
+This feature is provided for debugging purposes only. Using this feature will dramatically increase screen output and script running time.
+
+PHP_CodeSniffer contains multiple verbosity levels. Level 3 (indicated by the command line argument `-vvv`) will print all verbosity information for level 1 (file specific token and line counts with running times), level 2 (tokeniser output) as well as token processing output with sniff running times.
+
+The token processing output is best explained with an example. For the following file:
+
+    <?php
+    if ($condition) {
+        echo 'Condition was true';
+    }
+    ?>
+
+The token processing output is:
+
+    *** START TOKEN PROCESSING ***
+    Process token 0: T_OPEN_TAG => <?php\n
+        Processing PEAR_Sniffs_Commenting_FileCommentSniff... DONE in 0 seconds
+        Processing Generic_Sniffs_PHP_DisallowShortOpenTagSniff... DONE in 0 seconds
+        Processing Generic_Sniffs_Files_LineLengthSniff... DONE in 0.0001 seconds
+        Processing Generic_Sniffs_Files_LineEndingsSniff... DONE in 0 seconds
+    Process token 1: T_IF => if
+        Processing PEAR_Sniffs_ControlStructures_ControlSignatureSniff... DONE in 0.0001 seconds
+        Processing PEAR_Sniffs_ControlStructures_MultiLineConditionSniff... DONE in 0 seconds
+        Processing PEAR_Sniffs_WhiteSpace_ScopeClosingBraceSniff... DONE in 0 seconds
+        Processing PEAR_Sniffs_WhiteSpace_ScopeIndentSniff... DONE in 0 seconds
+        Processing Generic_Sniffs_ControlStructures_InlineControlStructureSniff... DONE in 0 seconds
+    Process token 2: T_WHITESPACE =>  
+        Processing Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff... DONE in 0 seconds
+    Process token 3: T_OPEN_PARENTHESIS => (
+    Process token 4: T_VARIABLE => $condition
+        Processing PEAR_Sniffs_NamingConventions_ValidVariableNameSniff... DONE in 0 seconds
+    Process token 5: T_CLOSE_PARENTHESIS => )
+    Process token 6: T_WHITESPACE =>  
+        Processing Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff... DONE in 0 seconds
+    Process token 7: T_OPEN_CURLY_BRACKET => {
+    Process token 8: T_WHITESPACE => \n
+        Processing Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff... DONE in 0 seconds
+    Process token 9: T_WHITESPACE =>     
+        Processing Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff... DONE in 0 seconds
+    Process token 10: T_ECHO => echo
+    Process token 11: T_WHITESPACE =>  
+        Processing Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff... DONE in 0 seconds
+    Process token 12: T_CONSTANT_ENCAPSED_STRING => 'Condition was true'
+    Process token 13: T_SEMICOLON => ;
+    Process token 14: T_WHITESPACE => \n
+        Processing Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff... DONE in 0 seconds
+    Process token 15: T_CLOSE_CURLY_BRACKET => }
+    Process token 16: T_WHITESPACE => \n
+        Processing Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff... DONE in 0 seconds
+    Process token 17: T_CLOSE_TAG => ?>\n
+    *** END TOKEN PROCESSING ***
+
+Every token processed is shown, along with its ID, type and contents. For each token, all sniffs that were executed on the token are displayed, along with the running time.
+
+For example, the output above shows us that token 1, an if keyword, had 5 sniffs executed on it; the ControlSignature sniff, the MultiLineCondition sniff, the ScopeClosingBrace sniff, the ScopeIndent sniff and the InlineControlStructure sniff. Each was executed fairly quickly, but the slowest was the ControlSignature sniff, taking 0.0001 seconds to process that token.
+
+The other interesting piece of information we get from the output above is that some tokens didn't have any sniffs executed on them. This is normal behaviour for PHP_CodeSniffer as most sniffs listen for specific or rarely used tokens and then execute on it and a number of tokens following it.
+
+For example, the ScopeIndentSniff executes on the if statement's token only, but actually checks the indentation of every line within the if statement. The sniff uses the scope map to find all tokens within the if statement.
+
+## Quieting Output
+If a coding standard or configuration file includes settings to print progress or verbose output while running PHP_CodeSniffer, it can make it difficult to use the standard with automated checking tools and build scripts as these typically only expect an error report. If you have this problem, or just want less output, you can quieten the output of PHP_CodeSniffer by using the `-q` command line argument. When using this quiet mode, PHP_CodeSniffer will only print report output, and only if errors or warnings are found. No progress or verbose output will be printed.

--- a/docs/Documentation/Annotated-Ruleset.md
+++ b/docs/Documentation/Annotated-Ruleset.md
@@ -1,0 +1,466 @@
+PHP_CodeSniffer allows developers to design their own coding standards by creating a simple ruleset XML file that both pulls in sniffs from existing standards and customises them for the developer's needs. This XML file can be named anything you like, as long as it has an `xml` extension and complies to the ruleset.xml format. The file can be stored anywhere, making it perfect for placing under version control with a project's source code and unit tests.
+
+Once created, a ruleset file can be used with the `--standard` command line argument. In the following example, PHP_CodeSniffer will use the coding standard defined in a custom ruleset file called custom_ruleset.xml:
+
+    $ phpcs --standard=/path/to/custom_ruleset.xml test.php
+
+## The Annotated Sample File
+
+The following sample file documents the ruleset.xml format and shows you the complete range of features that the format supports. The file is designed for documentation purposes only and is not a working coding standard.
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="Custom Standard" namespace="MyProject\CS\Standard">
+
+ <!--
+    The name attribute of the ruleset tag is displayed
+    when running PHP_CodeSniffer with the -v command line
+    argument.
+
+    If you have custom sniffs, and they use a namespace prefix
+    that is different to the name of the directory containing
+    your ruleset.xml file, you can set the namespace prefix using
+    the namespace attribute of the ruleset tag.
+
+    For example, if your namespace format for sniffs is
+    MyProject\CS\Standard\Sniffs\Category, set the namespace to
+    MyProject\CS\Standard (everything up to \Sniffs\)
+ -->
+
+ <!--
+    The content of the description tag is not displayed anywhere
+    except in this file, so it can contain information for
+    developers who may change this file in the future.
+ -->
+ <description>A custom coding standard</description>
+
+ <!--
+    You can hard-code config values used by sniffs directly
+    into your custom standard. Note that this does not work
+    for config values that override command line arguments,
+    such as show_warnings and report_format.
+    
+    The following tag is equivalent to the command line argument:
+    --runtime-set zend_ca_path /path/to/ZendCodeAnalyzer
+ -->
+ <config name="zend_ca_path" value="/path/to/ZendCodeAnalyzer"/>
+
+<!--
+    If no files or directories are specified on the command line
+    your custom standard can specify what files should be checked
+    instead.
+
+    Note that file and directory paths specified in a ruleset are
+    relative to the ruleset's location, and that specifying any file or
+    directory path on the command line will ignore all file tags.
+ -->
+ <file>./path/to/directory</file>
+ <file>./path/to/file.php</file>
+
+ <!--
+    You can hard-code ignore patterns directly into your
+    custom standard so you don't have to specify the
+    patterns on the command line.
+    
+    The following two tags are equivalent to the command line argument:
+    --ignore=*/tests/*,*/data/*
+ -->
+ <exclude-pattern>*/tests/*</exclude-pattern>
+ <exclude-pattern>*/data/*</exclude-pattern>
+
+<!--
+    Patterns can be specified as relative if you would
+    like the relative path of the file checked instead of the
+    full path. This can sometimes help with portability.
+    
+    The relative path is determined based on the paths you
+    pass into PHP_CodeSniffer on the command line.
+ -->
+ <exclude-pattern type="relative">^/tests/*</exclude-pattern>
+ <exclude-pattern type="relative">^/data/*</exclude-pattern>
+
+ <!--
+    You can hard-code command line values into your custom standard.
+    Note that this does not work for the command line values:
+    -v[v][v], -l, -d, --sniffs and --standard
+    
+    The following tags are equivalent to the command line arguments:
+    --report=summary --colors -sp
+ -->
+ <arg name="report" value="summary"/>
+ <arg name="colors"/>
+ <arg value="sp"/>
+
+ <!--
+    You can hard-code custom php.ini settings into your custom standard.
+    The following tag sets the memory limit to 64M.
+ -->
+ <ini name="memory_limit" value="64M"/>
+
+ <!--
+    If your helper classes need custom autoloading rules that you are
+    not able to include in other ways, you can hard-code files to include
+    before the ruleset is processed and any sniff classes have been loaded.
+
+    This is different to bootstrap files, which are loaded after the ruleset
+    has already been processed.
+ -->
+ <autoload>/path/to/autoload.php</autoload>
+ <autoload>/path/to/other/autoload.php</autoload>
+
+ <!--
+    Include all sniffs in the PEAR standard. Note that the
+    path to the standard does not have to be specified as the
+    PEAR standard exists inside the PHP_CodeSniffer install
+    directory.
+ -->
+ <rule ref="PEAR"/>
+
+ <!--
+    Include all sniffs in an external standard directory. Note
+    that we have to specify the full path to the standard's
+    directory because it does not exist inside the PHP_CodeSniffer
+    install directory.
+ -->
+ <rule ref="/home/username/standards/mystandard"/>
+
+ <!--
+    Include everything in another ruleset.xml file. This is
+    really handy if you want to customise another developer's
+    custom standard. They just need to distribute their single
+    ruleset file to allow this.
+ -->
+ <rule ref="/home/username/standards/custom.xml"/>
+
+ <!--
+    Relative paths can also be used everywhere absolute paths are used.
+    Make sure the reference starts with ./ or ../ so PHP_CodeSniffer
+    knows it is a relative path.
+ -->
+ <rule ref="./standards/mystandard"/>
+ <rule ref="../username/custom.xml"/>
+
+ <!--
+    Include all sniffs in the Squiz standard except one. Note that
+    the name of the sniff being excluded is the code that the sniff
+    is given by PHP_CodeSniffer and is based on the file name and
+    path of the sniff class. You can display these codes using the
+    -s command line argument when checking a file.
+ -->
+ <rule ref="Squiz">
+  <exclude name="Squiz.PHP.CommentedOutCode"/>
+ </rule>
+
+ <!--
+    You can also exclude a single sniff message.
+ -->
+ <rule ref="Squiz">
+  <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
+ </rule>
+
+ <!--
+    Or, you can exclude a whole category of sniffs.
+ -->
+ <rule ref="Squiz">
+  <exclude name="Squiz.PHP"/>
+ </rule>
+
+<!--
+    You can even exclude a whole standard. This example includes
+    all sniffs from the Squiz standard, but excludes any that come
+    from the Generic standard.
+ -->
+ <rule ref="Squiz">
+  <exclude name="Generic"/>
+ </rule>
+
+ <!--
+    Include some specific sniffs from the Generic standard.
+    Note again that the name of the sniff is the code that
+    PHP_CodeSniffer gives it.
+ -->
+ <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+ <rule ref="Generic.Commenting.Todo"/>
+ <rule ref="Generic.ControlStructures.InlineControlStructure"/>
+
+ <!--
+    If you are including sniffs that are not installed, you can
+    reference the sniff class using an absolute or relative path
+    instead of using the sniff code.
+ -->
+ <rule ref="/path/to/standards/Generic/Sniffs/Commenting/TodoSniff.php"/>
+ <rule ref="../Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php"/>
+
+ <!--
+    Here we are including a specific sniff but also changing
+    the error message of a specific message inside the sniff.
+    Note that the specific code for the message, which is
+    CommentFound in this case, is defined by the sniff developer.
+    You can display these codes by using the -s command line
+    argument when checking a file.
+
+    Also note that this message has a variable inside it,
+    which is why it is important that sniffs use a printf style
+    format for their error messages.
+
+    We also drop the severity of this message from the
+    default value (5) so that it is hidden by default. It can be
+    displayed by setting the minimum severity on the PHP_CodeSniffer
+    command line. This is great if you want to use some messages
+    only in code reviews and not have them block code commits.
+ -->
+ <rule ref="Generic.Commenting.Todo.CommentFound">
+  <message>Please review this TODO comment: %s</message>
+  <severity>3</severity>
+ </rule>
+
+ <!--
+    You can also change the type of a message from error to
+    warning and vice versa.
+ -->
+ <rule ref="Generic.Commenting.Todo.CommentFound">
+  <type>error</type>
+ </rule>
+ <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+  <type>warning</type>
+ </rule>
+
+ <!--
+    Here we change two messages from the same sniff. Note how the
+    codes are slightly different because the sniff developer has
+    defined both a MaxExceeded message and a TooLong message. In the
+    case of this sniff, one is used for warnings and one is used
+    for errors.
+ -->
+ <rule ref="Generic.Files.LineLength.MaxExceeded">
+  <message>Line contains %2$s chars, which is more than the limit of %1$s</message>
+ </rule>
+ <rule ref="Generic.Files.LineLength.TooLong">
+  <message>Line longer than %s characters; contains %s characters</message>
+ </rule>
+
+ <!--
+    Some sniffs have public member vars that allow you to
+    customise specific elements of the sniff. In the case of
+    the Generic LineLength sniff, you can customise the limit
+    at which the sniff will throw warnings and the limit at
+    which it will throw errors.
+
+    The rule below includes the LineLength sniff but changes the
+    settings so the sniff will show warnings for any line longer
+    than 90 chars and errors for any line longer than 100 chars.
+ -->
+ <rule ref="Generic.Files.LineLength">
+  <properties>
+   <property name="lineLimit" value="90"/>
+   <property name="absoluteLineLimit" value="100"/>
+  </properties>
+ </rule>
+
+ <!--
+    Another useful example of changing sniff settings is
+    to specify the end of line character that your standard
+    should check for.
+ -->
+ <rule ref="Generic.Files.LineEndings">
+  <properties>
+   <property name="eolChar" value="\r\n"/>
+  </properties>
+ </rule>
+
+ <!--
+    Boolean values should be specified by using the strings
+    "true" and "false" rather than the integers 0 and 1.
+ -->
+ <rule ref="Generic.Formatting.MultipleStatementAlignment">
+  <properties>
+   <property name="maxPadding" value="8"/>
+   <property name="ignoreMultiLine" value="true"/>
+   <property name="error" value="true"/>
+  </properties>
+ </rule>
+ 
+<!--
+    Array values are specified by using "element" tags
+    with "key" and "value" attributes.
+
+    NOTE: This syntax is is only supported in PHP_CodeSniffer
+    versions 3.3.0 and greater.
+ -->
+ <rule ref="Generic.PHP.ForbiddenFunctions">
+  <properties>
+   <property name="forbiddenFunctions" type="array">
+    <element key="delete" value="unset"/>
+    <element key="print" value="echo"/>
+    <element key="create_function" value="null"/>
+   </property>
+  </properties>
+ </rule>
+
+ <!--
+    Before version 3.3.0, array values are specified by using a string
+    representation of the array.
+
+    NOTE: This syntax is deprecated and will be removed in
+    PHP_CodeSniffer version 4.0
+ -->
+ <rule ref="Generic.PHP.ForbiddenFunctions">
+  <properties>
+   <property name="forbiddenFunctions" type="array" value="delete=>unset,print=>echo,create_function=>null" />
+  </properties>
+ </rule>
+
+ <!--
+    If you are including another standard, some array properties may
+    have already been defined. Instead of having to redefine them
+    you can choose to extend the property value instead. Any elements with
+    new keys will be added to the property value, and any elements with
+    existing keys will override the imported value.
+
+    NOTE: This syntax is is only supported in PHP_CodeSniffer
+    versions 3.4.0 and greater.
+ -->
+ <rule ref="Generic.PHP.ForbiddenFunctions">
+  <properties>
+   <property name="forbiddenFunctions" type="array" extend="true">
+    <element key="sizeof" value="count"/>
+   </property>
+  </properties>
+ </rule>
+
+ <!--
+    If you want to completely disable an error message in a sniff
+    but you don't want to exclude the whole sniff, you can
+    change the severity of the message to 0. In this case, we
+    want the Squiz DoubleQuoteUsage sniff to be included in our
+    standard, but we don't want the ContainsVar error message to
+    ever be displayed.
+ -->
+ <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+  <severity>0</severity>
+ </rule>
+
+ <!--
+    There is a special internal error message produced by PHP_CodeSniffer
+    when it is unable to detect code in a file, possible due to
+    the use of short open tags even though php.ini disables them.
+    You can disable this message in the same way as sniff messages.
+
+    Again, the code here will be displayed in the PHP_CodeSniffer
+    output when using the -s command line argument while checking a file.
+ -->
+ <rule ref="Internal.NoCodeFound">
+  <severity>0</severity>
+ </rule>
+
+ <!--
+    You can hard-code ignore patterns for specific sniffs,
+    a feature not available on the command line. Please note that
+    all sniff-specific ignore patterns are checked using absolute paths.
+
+    The code here will hide all messages from the Squiz DoubleQuoteUsage
+    sniff for files that match either of the two exclude patterns.
+ -->
+ <rule ref="Squiz.Strings.DoubleQuoteUsage">
+    <exclude-pattern>*/tests/*</exclude-pattern>
+    <exclude-pattern>*/data/*</exclude-pattern>
+ </rule>
+
+ <!--
+    You can also be more specific and just exclude some messages.
+    Please note that all message-specific ignore patterns are
+    checked using absolute paths.
+
+    The code here will just hide the ContainsVar error generated by the
+    Squiz DoubleQuoteUsage sniff for files that match either of the two
+    exclude patterns.
+ -->
+ <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+    <exclude-pattern>*/tests/*</exclude-pattern>
+    <exclude-pattern>*/data/*</exclude-pattern>
+ </rule>
+
+  <!--
+    You can hard-code include patterns for specific sniffs,
+    allowing you to only include sniffs when checking specific files.
+    Please note that all sniff-specific include patterns are checked using
+    absolute paths.
+
+    The code here will only run the Squiz DoubleQuoteUsage sniff for
+    files that match either of the two include patterns.
+ -->
+ <rule ref="Squiz.Strings.DoubleQuoteUsage">
+    <include-pattern>*/templates/*</include-pattern>
+    <include-pattern>*.tpl</include-pattern>
+ </rule>
+
+ <!--
+    As with exclude rules, you can be more specific and just include
+    some messages. Please note that all message-specific include patterns
+    are checked using absolute paths.
+
+    The code here will just show the ContainsVar error generated by the
+    Squiz DoubleQuoteUsage sniff for files that match either of the two
+    include patterns.
+ -->
+ <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+    <include-pattern>*/templates/*</include-pattern>
+    <include-pattern>*.tpl</include-pattern>
+ </rule>
+
+</ruleset>
+```
+
+## Selectively Applying Rules
+
+All tags in a ruleset file, with the exception of `ruleset` and `description`, can be selectively applied when a specific tool is being run. The two tools that are available are `phpcs` (the coding standards checker) and `phpcbf` (the coding standards fixer). Restrictions are applied by using the `phpcs-only` and `phpcbf-only` tag attributes.
+
+Setting the `phpcs-only` attribute to `true` will only apply the rule when the `phpcs` tool is running. The rule will not be applied while the file is being fixed with the `phpcbf` tool.
+
+Setting the `phpcbf-only` attribute to `true` will only apply the rule when the `phpcbf` tool is fixing a file. The rule will not be applied while the file is being checked with the `phpcs` tool.
+
+The following sample file shows a ruleset.xml file that makes use of selective rules. The file is designed for documentation purposes only and is not a working coding standard.
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="Selective Standard">
+
+ <!--
+    Use an external tool only when checking coding standards
+    and not while fixing a file.
+ -->
+ <config phpcs-only="true" name="zend_ca_path" value="/path/to/ZendCodeAnalyzer"/>
+
+ <!--
+    Exclude some files from being fixed.
+ -->
+ <exclude-pattern phpcbf-only="true">*/3rdparty/*</exclude-pattern>
+
+ <!--
+    Exclude some sniffs when fixing files, but allow them
+    to still report errors while checking files.
+ -->
+ <rule ref="Squiz">
+  <exclude phpcbf-only="true" name="Generic.WhiteSpace.ScopeIndent"/>
+ </rule>
+
+ <!--
+    Exclude some messages when fixing files, but allow them
+    to still report errors while checking files.
+ -->
+ <rule ref="Generic.Commenting.Todo.CommentFound">
+  <severity phpcbf-only="true">0</severity>
+ </rule>
+
+ <!--
+    Set different property values for fixing and checking.
+ -->
+ <rule ref="Generic.Files.LineLength">
+  <properties>
+   <property phpcs-only="true" name="lineLimit" value="80"/>
+   <property phpcbf-only="true" name="lineLimit" value="120"/>
+  </properties>
+ </rule>
+
+</ruleset>
+```

--- a/docs/Documentation/Coding-Standard-Tutorial.md
+++ b/docs/Documentation/Coding-Standard-Tutorial.md
@@ -1,0 +1,177 @@
+In this tutorial, we will create a new coding standard with a single sniff. Our sniff will prohibit the use of Perl style hash comments.
+
+## Creating the Coding Standard Directory
+
+All sniffs in PHP_CodeSniffer must belong to a coding standard. A coding standard is a directory with a specific sub-directory structure and a ruleset.xml file, so we can create one very easily. Let's call our coding standard _MyStandard_. Run the following commands to create the coding standard directory structure:
+
+    $ mkdir MyStandard
+    $ mkdir MyStandard/Sniffs
+
+As this coding standard directory sits outside the main PHP_CodeSniffer directory structure, PHP_CodeSniffer will not show it as an installed standard when using the `-i` command line argument. If you want your standard to be shown as installed, create the MyStandard directory inside the PHP_CodeSniffer install:
+
+    $ cd /path/to/PHP_CodeSniffer/src/Standards
+    $ mkdir MyStandard
+    $ mkdir MyStandard/Sniffs
+
+The `MyStandard` directory represents our coding standard. The `Sniffs` sub-directory is used to store all the sniff files for this coding standard.
+
+Now that our directory structure is created, we need to add our ruleset.xml file. This file will allow PHP_CodeSniffer to ask our coding standard for information about itself, and also identify this directory as one that contains code sniffs.
+
+    $ cd MyStandard
+    $ touch ruleset.xml
+
+The content of the `ruleset.xml` file should be the following:
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="MyStandard">
+  <description>A custom coding standard.</description>
+</ruleset>
+```
+
+> The ruleset.xml can be left quite small, as it is in this example coding standard. For information about the other features that the ruleset.xml provides, see the [[Annotated ruleset]].
+
+## Creating the Sniff
+
+A sniff requires a single PHP file that must be placed into a sub-directory to categorise the type of check it performs. It's name should clearly describe the standard that we are enforcing and must end with `Sniff.php`. For our sniff, we will name the PHP file `DisallowHashCommentsSniff.php` and place it into a `Commenting` sub-directory to categorise this sniff as relating to commenting. Run the following commands to create the category and the sniff:
+
+    $ cd Sniffs
+    $ mkdir Commenting
+    $ touch Commenting/DisallowHashCommentsSniff.php
+
+> It does not matter what sub-directories you use for categorising your sniffs. Just make them descriptive enough so you can find your sniffs again later when you want to modify them.
+
+Each sniff must implement the `PHP_CodeSniffer\Sniffs\Sniff` interface so that PHP_CodeSniffer knows that it should instantiate the sniff once it's invoked. The interface defines two methods that must be implemented; `register` and `process`.
+
+## The `register` and `process` Methods
+
+The `register` method allows a sniff to subscribe to one or more token types that it wants to process. Once PHP_CodeSniffer encounters one of those tokens, it calls the `process` method with the `PHP_CodeSniffer\Files\File` object (a representation of the current file being checked) and the position in the stack where the token was found.
+
+For our sniff, we are interested in single line comments. The `token_get_all` method that PHP_CodeSniffer uses to acquire the tokens within a file distinguishes doc comments and normal comments as two separate token types. Therefore, we don't have to worry about doc comments interfering with our test. The `register` method only needs to return one token type, `T_COMMENT`.
+
+## The Token Stack
+
+A sniff can gather more information about a token by acquiring the token stack with a call to the `getTokens` method on the `PHP_CodeSniffer\Files\File` object. This method returns an array and is indexed by the position where the token occurs in the token stack. Each element in the array represents a token. All tokens have a `code`, `type` and a `content` index in their array. The `code` value is a unique integer for the type of token. The `type` value is a string representation of the token (e.g., 'T_COMMENT' for comment tokens). The `type` has a corresponding globally defined integer with the same name. Finally, the `content` value contains the content of the token as it appears in the code.
+
+## Reporting Errors
+
+Once an error is detected, a sniff should indicate that an error has occurred by calling the `addError` method on the `PHP_CodeSniffer\Files\File` object, passing in an appropriate error message as the first argument, the position in the stack where the error was detected as the second, a code to uniquely identify the error within this sniff and an array of data used inside the error message. Alternatively, if the violation is considered not as critical as an error, the `addWarning` method can be used.
+
+## DisallowHashCommentsSniff.php
+
+We now have to write the content of our sniff. The content of the `DisallowHashCommentsSniff.php` file should be the following:
+
+```php
+<?php
+/**
+ * This sniff prohibits the use of Perl style hash comments.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Your Name <you@domain.net>
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace PHP_CodeSniffer\Standards\MyStandard\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DisallowHashCommentsSniff implements Sniff
+{
+
+
+    /**
+     * Returns the token types that this sniff is interested in.
+     *
+     * @return array(int)
+     */
+    public function register()
+    {
+        return array(T_COMMENT);
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being checked.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['content']{0} === '#') {
+            $error = 'Hash comments are prohibited; found %s';
+            $data  = array(trim($tokens[$stackPtr]['content']));
+            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+        }
+
+    }//end process()
+
+
+}//end class
+
+?>
+```
+
+By default, PHP_CodeSniffer assumes all sniffs are designed to check PHP code only. You can specify a list of tokenizers that your sniff supports, allowing it to be used wth PHP, JavaScript or XML files, or any combination of the three. You do this by setting the `$supportedTokenizers` member variable in your sniff. Adding the following code to your sniff will tell PHP_CodeSniffer that it can be used to check both PHP and JavaScript code:
+
+```php
+/**
+ * A list of tokenizers this sniff supports.
+ *
+ * @var array
+ */
+public $supportedTokenizers = array(
+                               'PHP',
+                               'JS',
+                              );
+```
+
+
+## Results
+
+Now that we have defined a coding standard, let's validate a file that contains hash comments. The test file we are using has the following contents:
+
+```php
+<?php
+
+# Check for valid contents.
+if ($obj->contentsAreValid($array)) {
+    $value = $obj->getValue();
+
+    # Value needs to be an array.
+    if (is_array($value) === false) {
+        # Error.
+        $obj->throwError();
+        exit();
+    }
+}
+
+?>
+```
+
+When PHP_CodeSniffer is run on the file using our new coding standard, 3 errors will be reported:
+
+    $ phpcs --standard=/path/to/MyStandard test.php
+
+    FILE: test.php
+    --------------------------------------------------------------------------------
+    FOUND 3 ERROR(S) AFFECTING 3 LINE(S)
+    --------------------------------------------------------------------------------
+     3 | ERROR | Hash comments are prohibited; found # Check for valid contents.
+     7 | ERROR | Hash comments are prohibited; found # Value needs to be an array.
+     9 | ERROR | Hash comments are prohibited; found # Error.
+    --------------------------------------------------------------------------------
+
+Note that we pass the absolute path to our coding standard directory on the command line because our standard is not installed inside the main PHP_CodeSniffer directory structure. If you have created your standard inside PHP_CodeSniffer, you can simply pass the name of the standard:
+
+    $ phpcs --standard=MyStandard Test.php

--- a/docs/Documentation/Configuration-Options.md
+++ b/docs/Documentation/Configuration-Options.md
@@ -1,0 +1,186 @@
+## Table of contents
+* [Setting the default coding standard](#setting-the-default-coding-standard)
+* [Setting the default report format](#setting-the-default-report-format)
+* [Hiding warnings by default](#hiding-warnings-by-default)
+* [Showing progress by default](#showing-progress-by-default)
+* [Using colors in output by default](#using-colors-in-output-by-default)
+* [Changing the default severity levels](#changing-the-default-severity-levels)
+* [Setting the default report width](#setting-the-default-report-width)
+* [Setting the default encoding](#setting-the-default-encoding)
+* [Setting the default tab width](#setting-the-default-tab-width)
+* [Setting the installed standard paths](#setting-the-installed-standard-paths)
+* [Setting the PHP version](#setting-the-php-version)
+* [Ignoring errors when generating the exit code](#ignoring-errors-when-generating-the-exit-code)
+* [Ignoring warnings when generating the exit code](#ignoring-warnings-when-generating-the-exit-code)
+* Setting tool paths
+    * [CSSLint](#setting-the-path-to-csslint)
+    * [Google Closure Linter](#setting-the-path-to-the-google-closure-linter)
+    * [PHP](#setting-the-path-to-php)
+    * [JSHint](#setting-the-path-to-jshint)
+    * [JSLint](#setting-the-path-to-jslint)
+    * [JavaScript Lint](#setting-the-path-to-javascript-lint)
+    * [Zend Code Analyzer](#setting-the-path-to-the-zend-code-analyzer)
+
+***
+
+## Setting the default coding standard
+By default, PHP_CodeSniffer will use the PEAR coding standard if no standard is supplied on the command line. You can change the default standard by setting the default_standard configuration option.
+
+    $ phpcs --config-set default_standard Squiz
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To set the coding standard for a single run only, use the `--standard` command line argument.
+
+## Setting the default report format
+By default, PHP_CodeSniffer will use the full report format if no format is supplied on the command line. You can change the default report format by setting the report_format configuration option.
+
+    $ phpcs --config-set report_format summary
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To set the report format for a single run only, use the `--report` command line argument.
+
+## Hiding warnings by default
+By default, PHP_CodeSniffer will show both errors and warnings for your code. You can hide warnings for a single script run by using the `-n` command line argument, but you can also enable this by default if you prefer. To hide warnings by default, set the `show_warnings` configuration option to `0`.
+
+    $ phpcs --config-set show_warnings 0
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To hide warnings for a single run only, use the `-n` command line argument.
+
+> Note: When warnings are hidden by default, you can use the `-w` command line argument to show them for a single script run.
+
+## Showing progress by default
+By default, PHP_CodeSniffer will run quietly and only print the report of errors and warnings at the end. If you want to know what is happening you can turn on progress output, but you can also enable this by default if you prefer. To show progress by default, set the `show_progress` configuration option to `1`.
+
+    $ phpcs --config-set show_progress 1
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To show progress for a single run only, use the `-p` command line argument.
+
+## Using colors in output by default
+By default, PHP_CodeSniffer will not use colors in progress or report screen output. To use colors in output by default, set the `colors` configuration option to `1`.
+
+    $ phpcs --config-set colors 1
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To show colors for a single run only, use the `--colors` command line argument.
+
+> Note: When colors are being used by default, you can use the `--no-colors` command line argument to disable them for a single script run.
+
+## Changing the default severity levels
+By default, PHP_CodeSniffer will show all errors and warnings with a severity level of 5 or greater. You can change these settings for a single script run by using the `--severity`, `--error-severity` and `--warning-severity` command line arguments, but you can also change the default settings if you prefer.
+
+To change the default severity level to show all errors and warnings:
+
+    $ phpcs --config-set severity 1
+
+To change the default severity levels to show all errors but only some warnings
+
+    $ phpcs --config-set error_severity 1
+    $ phpcs --config-set warning_severity 8
+
+> Note: Setting the severity of warnings to 0 is the same as using the `-n` command line argument. If you set the severity of errors to `0` PHP_CodeSniffer will not show any errors, which may be useful if you just want to show warnings.
+
+> Note: These configuration options cannot be set using the `--runtime-set` command line argument. To change severity levels for a single run only, use the `--severity`, `--error-severity`, and `--warning-severity` command line arguments.
+
+## Setting the default report width
+By default, PHP_CodeSniffer will print all screen-based reports 80 characters wide. File paths will be truncated if they don't fit within this limit and error messages will be wrapped across multiple lines. You can increase the report width to show longer file paths and limit the wrapping of error messages using the `--report-width` command line argument, but you can also change the default report width by setting the `report_width` configuration option.
+
+    $ phpcs --config-set report_width 120
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To set the report width for a single run only, use the `--report-width` command line argument.
+
+> Note: If you want reports to fill the entire terminal width (in supported terminals), set the `report_width` config configuration option to `auto`.
+>
+>    `$phpcs --config-set report_width auto`
+
+## Setting the default encoding
+By default, PHP_CodeSniffer will treat all source files as if they use UTF-8 encoding. If you need your source files to be processed using a specific encoding, you can specify the encoding using the `--encoding` command line argument, but you can also change the default encoding by setting the `encoding` configuration option.
+
+    $ phpcs --config-set encoding windows-1251
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To set the encoding for a single run only, use the `--encoding` command line argument.
+
+## Setting the default tab width
+By default, PHP_CodeSniffer will not convert tabs to spaces in checked files. Specifying a tab width will make PHP_CodeSniffer replace tabs with spaces. You can force PHP_CodeSniffer to replace tabs with spaces by default by setting the `tab_width` configuration option.
+
+    $ phpcs --config-set tab_width 4
+
+> Note: This configuration option cannot be set using the `--runtime-set` command line argument. To set the tab width for a single run only, use the `--tab-width` command line argument.
+    
+When the tab width is set by default, the replacement of tabs with spaces can be disabled for a single script run by setting the tab width to zero.
+
+    $ phpcs --tab-width=0 /path/to/code
+
+## Setting the installed standard paths
+By default, PHP_CodeSniffer will look inside its own `src/Standards` directory to find installed coding standards. An installed standard appears when you use the `-i` command line argument and can be referenced using a name instead of a path when using the `--standard` command line argument. You can add install paths by setting the `installed_paths` configuration option.
+
+    $ phpcs --config-set installed_paths /path/to/one,/path/to/two
+
+> Note: If you want to use relative paths, ensure they begin with `./` (e.g., `./path/to/one`) or PHP_CodeSniffer will assume the path is absolute. Relative paths should always be defined relative to the top-level PHP_CodeSniffer install directory (i.e., the directory that contains the `src` sub-directory).
+
+## Setting the PHP version
+Some sniffs change their behaviour based on the version of PHP being used to run PHPCS. For example, a sniff that checks for namespaces may choose to ignore this check if the version of PHP does not include namespace support. Sometimes a code base that supports older PHP versions is checked using a newer PHP version. In this case, sniffs see the new PHP version and report errors that may not be correct. To let the sniffs know what version of PHP you are targeting, the `php_version` configuration option can be used.
+
+    $ phpcs --config-set php_version 50403
+
+> Note: The format of the `php_version` value is the same as the PHP_VERSION_ID constant. e.g., 50403 for version 5.4.3.
+
+## Ignoring errors when generating the exit code
+By default, PHP_CodeSniffer will exit with a non-zero code if any errors or warnings are found. If you want to display errors to the user, but still return with a zero exit code if no warnings are found, you can set the `ignore_errors_on_exit` configuration option. This option is typically used by automated build tools so that a list of errors can be generated without failing the build.
+
+    $ phpcs --config-set ignore_errors_on_exit 1
+
+> If you want to generate a zero exit code in all cases, additionally set the `ignore_warnings_on_exit` config configuration option.
+
+    $ phpcs --config-set ignore_errors_on_exit 1
+    $ phpcs --config-set ignore_warnings_on_exit 1
+
+## Ignoring warnings when generating the exit code
+By default, PHP_CodeSniffer will exit with a non-zero code if any errors or warnings are found. If you want to display warnings to the user, but still return with a zero exit code if no errors are found, you can set the `ignore_warnings_on_exit` configuration option. This option is typically used by automated build tools so that a list of warnings can be generated without failing the build.
+
+    $ phpcs --config-set ignore_warnings_on_exit 1
+
+## Generic Coding Standard Configuration Options
+
+### Setting the path to CSSLint
+The Generic coding standard [includes a sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php) that will check each CSS file using [CSS Lint](http://csslint.net/). Use the `csslint_path` configuration option to tell the CSSLint sniff where to find the tool.
+
+    $ phpcs --config-set csslint_path /path/to/csslint
+
+### Setting the path to the Google Closure Linter
+The Generic coding standard [includes a sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php) that will check each file using the [Google Closure Linter](https://github.com/google/closure-linter), an open source JavaScript style checker from Google. Use the `gjslint_path` configuration option to tell the Google Closure Linter sniff where to find the tool.
+
+    $ phpcs --config-set gjslint_path /path/to/gjslint
+
+### Setting the path to PHP
+The Generic coding standard [includes a sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php) that will check the syntax of each PHP file using [the built-in PHP linter](http://php.net/manual/en/features.commandline.options.php). Use the `php_path` configuration option to tell the Syntax sniff where to find the PHP binary.
+
+    $ phpcs --config-set php_path /path/to/php
+
+### Setting the path to JSHint
+
+The Generic coding standard [includes a sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php) that will check each JavaScript file using [JSHint](http://www.jshint.com/), a tool to detect errors and potential problems in JavaScript code. Use the `jshint_path` configuration option to tell the JSHint sniff where to find the tool.
+
+    $ phpcs --config-set jshint_path /path/to/jshint.js
+
+As JSHint is just JavaScript code, you also need to install [Rhino](http://www.mozilla.org/rhino/) to be able to execute it. Use the `rhino_path` configuration option to tell the JSHint sniff where to find the tool.
+
+    $ phpcs --config-set rhino_path /path/to/rhino
+ 
+## Squiz Coding Standard Configuration Options
+
+### Setting the path to JSLint
+The Squiz coding standard [includes a sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php) that will check each JavaScript file using [JSLint](http://www.jslint.com/), a JavaScript program that looks for problems in JavaScript programs. Use the `jslint_path` configuration option to tell the JSLint sniff where to find the tool.
+
+    $ phpcs --config-set jslint_path /path/to/jslint.js
+
+As JSLint is just JavaScript code, you also need to install [Rhino](https://developer.mozilla.org/en-US/docs/Rhino) to be able to execute it. Use the `rhino_path` configuration option to tell the JSLint sniff where to find the tool.
+
+    $ phpcs --config-set rhino_path /path/to/rhino
+
+### Setting the path to JavaScript Lint
+The Squiz coding standard [includes a sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php) that will check each JavaScript file using [JavaScript Lint](http://www.javascriptlint.com/), a tool that checks all your JavaScript source code for common mistakes without actually running the script or opening the web page. Use the `jsl_path` configuration option to tell the JavaScript Lint sniff where to find the tool.
+
+    $ phpcs --config-set jsl_path /path/to/jsl
+
+## Zend Coding Standard Configuration Options
+### Setting the path to the Zend Code Analyzer
+The Zend coding standard [includes a sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php) that will check each file using the Zend Code Analyzer, a tool that comes with Zend Studio. Use the `zend_ca_path` configuration option to tell the Zend Code Analyzer sniff where to find the tool.
+
+    $ phpcs --config-set zend_ca_path /path/to/ZendCodeAnalyzer

--- a/docs/Documentation/Customisable-Sniff-Properties.md
+++ b/docs/Documentation/Customisable-Sniff-Properties.md
@@ -1,0 +1,1379 @@
+The behaviour of some sniffs can be changed by setting certain sniff properties in your ruleset.xml file. This page lists the sniff properties that are available for customisation. For properties that were added after ruleset support was introduced in version 1.3.0, the first stable version that made the property available is listed.
+
+For more information about changing sniff behaviour by customising your ruleset, see the [[Annotated ruleset]].
+
+## Table of contents
+* Generic Sniffs
+    * [Generic.Arrays.ArrayIndent](#genericarraysarrayindent)
+    * [Generic.ControlStructures.InlineControlStructure](#genericcontrolstructuresinlinecontrolstructure)
+    * [Generic.Debug.ClosureLinter](#genericdebugclosurelinter)
+    * [Generic.Debug.ESLint](#genericdebugeslint)
+    * [Generic.Files.LineEndings](#genericfileslineendings)
+    * [Generic.Files.LineLength](#genericfileslinelength)
+    * [Generic.Formatting.MultipleStatementAlignment](#genericformattingmultiplestatementalignment)
+    * [Generic.Formatting.SpaceAfterCast](#genericformattingspaceaftercast)
+    * [Generic.Formatting.SpaceAfterNot](#genericformattingspaceafternot)
+    * [Generic.Functions.OpeningFunctionBraceBsdAllman](#genericfunctionsopeningfunctionbracebsdallman)
+    * [Generic.Functions.OpeningFunctionBraceKernighanRitchie](#genericfunctionsopeningfunctionbracekernighanritchie)
+    * [Generic.Metrics.CyclomaticComplexity](#genericmetricscyclomaticcomplexity)
+    * [Generic.Metrics.NestingLevel](#genericmetricsnestinglevel)
+    * [Generic.NamingConventions.CamelCapsFunctionName](#genericnamingconventionscamelcapsfunctionname)
+    * [Generic.PHP.ForbiddenFunctions](#genericphpforbiddenfunctions)
+    * [Generic.PHP.NoSilencedErrors](#genericphpnosilencederrors)
+    * [Generic.Strings.UnnecessaryStringConcat](#genericstringsunnecessarystringconcat)
+    * [Generic.WhiteSpace.ArbitraryParenthesesSpacing](#genericwhitespacearbitraryparenthesesspacing)
+    * [Generic.WhiteSpace.ScopeIndent](#genericwhitespacescopeindent)
+* PEAR Sniffs
+    * [PEAR.ControlStructures.ControlSignature](#pearcontrolstructurescontrolsignature)
+    * [PEAR.ControlStructures.MultiLineCondition](#pearcontrolstructuresmultilinecondition)
+    * [PEAR.Formatting.MultiLineAssignment](#pearformattingmultilineassignment)
+    * [PEAR.Functions.FunctionCallSignature](#pearfunctionsfunctioncallsignature)
+    * [PEAR.Functions.FunctionDeclaration](#pearfunctionsfunctiondeclaration)
+    * [PEAR.WhiteSpace.ObjectOperatorIndent](#pearwhitespaceobjectoperatorindent)
+    * [PEAR.WhiteSpace.ScopeClosingBrace](#pearwhitespacescopeclosingbrace)
+    * [PEAR.WhiteSpace.ScopeIndent](#pearwhitespacescopeindent)
+* PSR2 Sniffs
+    * [PSR2.Classes.ClassDeclaration](#psr2classesclassdeclaration)
+    * [PSR2.ControlStructures.ControlStructureSpacing](#psr2controlstructurescontrolstructurespacing)
+    * [PSR2.ControlStructures.SwitchDeclaration](#psr2controlstructuresswitchdeclaration)
+    * [PSR2.Methods.FunctionCallSignature](#psr2methodsfunctioncallsignature)
+* PSR12 Sniffs
+    * [PSR12.Namespaces.CompoundNamespaceDepth](#psr12namespacescompoundnamespacedepth)
+* Squiz Sniffs
+    * [Squiz.Classes.ClassDeclaration](#squizclassesclassdeclaration)
+    * [Squiz.Commenting.LongConditionClosingComment](#squizcommentinglongconditionclosingcomment)
+    * [Squiz.ControlStructures.ControlSignature](#squizcontrolstructurescontrolsignature)
+    * [Squiz.ControlStructures.ForEachLoopDeclaration](#squizcontrolstructuresforeachloopdeclaration)
+    * [Squiz.ControlStructures.ForLoopDeclaration](#squizcontrolstructuresforloopdeclaration)
+    * [Squiz.ControlStructures.SwitchDeclaration](#squizcontrolstructuresswitchdeclaration)
+    * [Squiz.CSS.ForbiddenStyles](#squizcssforbiddenstyles)
+    * [Squiz.CSS.Indentation](#squizcssindentation)
+    * [Squiz.Functions.FunctionDeclaration](#squizfunctionsfunctiondeclaration)
+    * [Squiz.Functions.FunctionDeclarationArgumentSpacing](#squizfunctionsfunctiondeclarationargumentspacing)
+    * [Squiz.PHP.CommentedOutCode](#squizphpcommentedoutcode)
+    * [Squiz.PHP.DiscouragedFunctions](#squizphpdiscouragedfunctions)
+    * [Squiz.PHP.ForbiddenFunctions](#squizphpforbiddenfunctions)
+    * [Squiz.Strings.ConcatenationSpacing](#squizstringsconcatenationspacing)
+    * [Squiz.WhiteSpace.FunctionSpacing](#squizwhitespacefunctionspacing)
+    * [Squiz.WhiteSpace.MemberVarSpacing](#squizwhitespacemembervarspacing)
+    * [Squiz.WhiteSpace.ObjectOperatorSpacing](#squizwhitespaceobjectoperatorspacing)
+    * [Squiz.WhiteSpace.OperatorSpacing](#squizwhitespaceoperatorspacing)
+    * [Squiz.WhiteSpace.SuperfluousWhitespace](#squizwhitespacesuperfluouswhitespace)
+
+***
+
+## Generic Sniffs
+
+### Generic.Arrays.ArrayIndent
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 3.2.0
+
+One of the rules that this sniff enforces is the indent of keys in a multi-line array declaration. By default, this sniff ensures that each key is indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="Generic.Arrays.ArrayIndent">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### Generic.ControlStructures.InlineControlStructure
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+error         | bool | true    | -
+
+If the `error` property is set to `false`, a warning will be thrown for violations instead of an error.
+
+```xml
+<rule ref="Generic.ControlStructures.InlineControlStructure">
+    <properties>
+        <property name="error" value="false" />
+    </properties>
+</rule>
+```
+
+### Generic.Debug.ClosureLinter
+
+Property Name | Type  | Default | Available Since
+------------- | ----- | ------- | ---------------
+errorCodes    | array | -       | -
+ignoreCodes   | array | -       | -
+
+The `Generic.Debug.ClosureLinter` sniff runs the [Google Closure Linter](https://github.com/google/closure-linter) tool over JavaScript files and reports errors that the tool finds. All found errors are reported as PHP_CodeSniffer warnings by default.
+
+There are two configurable options:
+* `errorCodes` : a list of error codes that should show as errors instead of warnings
+* `ignoreCodes` : a list of error codes that should be ignored
+
+> Note: The error codes accepted by this sniff are the 4-digit codes generated by the `gjslint` tool and displayed in the warning messages produced by this sniff.
+
+```xml
+<rule ref="Generic.Debug.ClosureLinter">
+    <properties>
+        <property name="errorCodes" type="array" value="0210"/>
+        <property name="ignoreCodes" type="array" value="0001,0110,0240"/>
+    </properties>
+</rule>
+```
+
+### Generic.Debug.ESLint
+
+Property Name | Type   | Default | Available Since
+------------- | ------ | ------- | ---------------
+configFile    | string | -       | 2.9.0
+
+The `Generic.Debug.ESLint` sniff runs the [ESLint](https://eslint.org/) tool over JavaScript files and reports errors that the tool finds. All found violations are reported as either PHP_CodeSniffer errors or warnings based on the severity level that the ESLint tool provides.
+
+The sniff will attempt to auto-discover an ESLint config file in the current directory, but a config file path can also be specified by setting the `configFile` property.
+
+```xml
+<rule ref="Generic.Debug.ESLint">
+    <properties>
+        <property name="configFile" value="/path/to/.eslintrc.json"/>
+    </properties>
+</rule>
+```
+
+### Generic.Files.LineEndings
+
+Property Name | Type   | Default | Available Since
+------------- | ------ | ------- | ---------------
+eolChar       | string | \n      | -
+
+This sniff ensures that files use a specific line ending, which can be customised by setting the `eolChar` property.
+
+```xml
+<rule ref="Generic.Files.LineEndings">
+    <properties>
+        <property name="eolChar" value="\r\n" />
+    </properties>
+</rule>
+```
+
+### Generic.Files.LineLength
+
+Property Name     | Type  | Default | Available Since
+----------------- | ----  | ------- | ---------------
+lineLimit         | int   | 80      | -
+absoluteLineLimit | int   | 100     | -
+ignoreComments    | bool  | false   | 3.1.0
+
+This sniff checks all lines in a file and generates warnings if they are over `lineLimit` characters in length and errors if they are over `absoluteLineLimit` in length. These properties can be used to set the threshold at which errors are reported.
+
+> Note: The value of the `lineLimit` property should be less than or equal to the value of the `absoluteLineLimit` property.
+
+```xml
+<!--
+ Warn about lines longer than 100 chars,
+ and error for lines longer than 135 chars.
+-->
+<rule ref="Generic.Files.LineLength">
+    <properties>
+        <property name="lineLimit" value="100" />
+        <property name="absoluteLineLimit" value="135" />
+    </properties>
+</rule>
+```
+
+If errors are not required, the value of `absoluteLineLimit` can be set to zero.
+
+```xml
+<!-- Warn about lines longer than 135 chars, and never error. -->
+<rule ref="Generic.Files.LineLength">
+    <properties>
+        <property name="lineLimit" value="135" />
+        <property name="absoluteLineLimit" value="0" />
+    </properties>
+</rule>
+```
+
+If the `ignoreComments` property is set to `true`, no error or warning will be thrown for a line that only contains a comment, no matter how long the line is.
+
+```xml
+<rule ref="Generic.Files.LineLength">
+    <properties>
+        <property name="ignoreComments" value="true" />
+    </properties>
+</rule>
+```
+
+### Generic.Formatting.MultipleStatementAlignment
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+maxPadding    | int  | 1000    | -
+error         | bool | false   | -
+
+This sniff checks the alignment of assignment operators. If there are multiple adjacent assignments, it checks that the equals signs of each assignment are aligned.
+
+The difference in alignment between two adjacent assignments is occasionally quite large, so aligning equals signs would create extremely long lines. By setting the `maxPadding` property, you can configure the maximum amount of padding required to align the assignment with the surrounding assignments before the alignment is ignored and no warnings will be generated.
+
+```xml
+<rule ref="Generic.Formatting.MultipleStatementAlignment">
+    <properties>
+        <property name="maxPadding" value="50" />
+    </properties>
+</rule>
+```
+
+If the `error` property is set to `true`, an error will be thrown for violations instead of a warning.
+
+```xml
+<rule ref="Generic.Formatting.MultipleStatementAlignment">
+    <properties>
+        <property name="error" value="true" />
+    </properties>
+</rule>
+```
+
+### Generic.Formatting.SpaceAfterCast
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+spacing        | int  | 1       | 3.4.0
+ignoreNewlines | bool | false   | 3.4.0
+
+This sniff checks the spacing after a type cast. By default, the sniff ensures there is one space after the cast, as shown in the following code snippet:
+
+```php
+$var = (int) $foo;
+```
+
+Another common way of type casting is to follow the cast with no space, as shown in the following code snippet:
+
+```php
+$var = (int)$foo;
+```
+
+If you prefer to write your code like this, you can set the `spacing` property to `0`, or whatever padding you prefer.
+
+```xml
+<rule ref="Generic.Formatting.SpaceAfterCast">
+    <properties>
+        <property name="spacing" value="0" />
+    </properties>
+</rule>
+```
+
+Sometimes complex statements are broken over multiple lines for readability. By default, this sniff will generate an error if the type cast is followed by a newline. Setting the `ignoreNewlines` property to `true` will allow newline characters after a type cast.
+
+```xml
+<rule ref="Generic.Formatting.SpaceAfterCast">
+    <properties>
+        <property name="ignoreNewlines" value="true" />
+    </properties>
+</rule>
+```
+
+### Generic.Formatting.SpaceAfterNot
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+spacing        | int  | 1       | 3.4.0
+ignoreNewlines | bool | false   | 3.4.0
+
+This sniff checks the spacing after a `!` operator. By default, the sniff ensures there is one space after the operator, as shown in the following code snippet:
+
+```php
+if (! $foo) {
+}
+```
+
+Another common way of using the `!` operator is to follow it with no space, as shown in the following code snippet:
+
+```php
+if (!$foo) {
+}
+```
+
+If you prefer to write your code like this, you can set the `spacing` property to `0`, or whatever padding you prefer.
+
+```xml
+<rule ref="Generic.Formatting.SpaceAfterNot">
+    <properties>
+        <property name="spacing" value="0" />
+    </properties>
+</rule>
+```
+
+Sometimes complex statements are broken over multiple lines for readability, as shown in the following code snippet:
+```php
+if (!
+    ($foo || $bar)
+) {
+}
+```
+
+By default, this sniff will generate an error if the `!` operator is followed by a newline. Setting the `ignoreNewlines` property to `true` will allow newline characters after a `!` operator.
+
+```xml
+<rule ref="Generic.Formatting.SpaceAfterNot">
+    <properties>
+        <property name="ignoreNewlines" value="true" />
+    </properties>
+</rule>
+```
+
+### Generic.Functions.OpeningFunctionBraceBsdAllman
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+checkFunctions | bool | true    | 2.3.0
+checkClosures  | bool | false   | 2.3.0
+
+The sniff checks the position of the opening brace of a function and/or closure (anonymous function). The sniff only checks functions by default, but the `checkFunctions` and `checkClosures` properties can be used to have the sniff check one or both of these code blocks.
+
+```xml
+<!-- Don't check function braces, but check closure braces. -->
+<rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman">
+    <properties>
+        <property name="checkFunctions" value="false" />
+        <property name="checkClosures" value="true" />
+    </properties>
+</rule>
+```
+
+### Generic.Functions.OpeningFunctionBraceKernighanRitchie
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+checkFunctions | bool | true    | 2.3.0
+checkClosures  | bool | false   | 2.3.0
+
+The sniff checks the position of the opening brace of a function and/or closure (anonymous function). The sniff only checks functions by default, but the `checkFunctions` and `checkClosures` properties can be used to have the sniff check one or both of these code blocks.
+
+```xml
+<!-- Don't check function braces, but check closure braces. -->
+<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
+    <properties>
+        <property name="checkFunctions" value="false" />
+        <property name="checkClosures" value="true" />
+    </properties>
+</rule>
+```
+
+### Generic.Metrics.CyclomaticComplexity
+
+Property Name      | Type | Default | Available Since
+------------------ | ---- | ------- | ---------------
+complexity         | int  | 10      | -
+absoluteComplexity | int  | 20      | -
+
+This sniff checks the cyclomatic complexity for functions by counting the different paths the function includes.
+
+There are two configurable options:
+* `complexity` : the cyclomatic complexity above which this sniff will generate warnings
+* `absoluteComplexity` : the cyclomatic complexity above which this sniff will generate errors
+
+> Note: The value of the `complexity` property should be less than or equal to the value of the `absoluteComplexity` property.
+
+```xml
+<rule ref="Generic.Metrics.CyclomaticComplexity">
+    <properties>
+        <property name="complexity" value="15" />
+        <property name="absoluteComplexity" value="30" />
+    </properties>
+</rule>
+```
+
+### Generic.Metrics.NestingLevel
+
+Property Name        | Type | Default | Available Since
+-------------------- | ---- | ------- | ---------------
+nestingLevel         | int  | 5       | -
+absoluteNestingLevel | int  | 10      | -
+
+This sniff checks how many level deep that code is nested within a function.
+
+There are two configurable options:
+* `nestingLevel` : the nesting level above which this sniff will generate warnings
+* `absoluteNestingLevel` : the nesting level above which this sniff will generate errors
+
+```xml
+<rule ref="Generic.Metrics.NestingLevel">
+    <properties>
+        <property name="nestingLevel" value="8" />
+        <property name="absoluteNestingLevel" value="12" />
+    </properties>
+</rule>
+```
+
+### Generic.NamingConventions.CamelCapsFunctionName
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+strict        | bool | true    | 1.3.5
+
+This sniff ensures function and method names are in CamelCaps.
+
+Strictly speaking, a name cannot have two capital letters next to each other in CamelCaps format. By setting the `strict` property to `false`, the sniff applies the rule more leniently and allows for two capital letters next to each other in function and method names.
+
+```xml
+<rule ref="Generic.NamingConventions.CamelCapsFunctionName">
+    <properties>
+        <property name="strict" value="false" />
+    </properties>
+</rule>
+```
+
+### Generic.PHP.ForbiddenFunctions
+
+Property Name      | Type  | Default                     | Available Since
+-------------------| ----- | --------------------------- | ---------------
+forbiddenFunctions | array | sizeof=>count,delete=>unset | 2.0.0
+error              | bool  | true                        | -
+
+This sniff discourages the use of alias functions that are kept in PHP for compatibility with older versions. The sniff can be used to forbid the use of any function by setting the `forbiddenFunctions` property. The property is defined as an array, with the keys being the names of the functions to forbid and the values being the names of suggested alternative functions to use instead. If no alternative function exists (i.e., the function should never be used) specify `null` as the value.
+
+```xml
+<rule ref="Generic.PHP.ForbiddenFunctions">
+    <properties>
+        <property name="forbiddenFunctions" type="array"
+            value="print=>echo,create_function=>null" />
+     </properties>
+</rule>
+```
+
+If the `error` property is set to `false`, a warning will be thrown for violations instead of an error.
+
+```xml
+<rule ref="Generic.PHP.ForbiddenFunctions">
+    <properties>
+        <property name="error" value="false" />
+    </properties>
+</rule>
+```
+
+### Generic.PHP.NoSilencedErrors
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+error         | bool | true    | -
+
+If the `error` property is set to `false`, a warning will be thrown for violations instead of an error.
+
+```xml
+<rule ref="Generic.PHP.NoSilencedErrors">
+    <properties>
+        <property name="error" value="false" />
+    </properties>
+</rule>
+```
+
+### Generic.Strings.UnnecessaryStringConcat
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+allowMultiline | bool | false   | 2.3.4
+error          | bool | true    | -
+
+This sniff checks that two strings using the same quoting style are not concatenated. Sometimes long strings are broken over multiple lines to work within a maximum line length, but this sniff will generate an error for these cases by default. Setting the `allowMultiline` property to `true` will get the sniff to allow string concatenation if the string covers multiple lines.
+
+```xml
+<rule ref="Generic.Strings.UnnecessaryStringConcat">
+    <properties>
+        <property name="allowMultiline" value="true" />
+    </properties>
+</rule>
+```
+
+If the `error` property is set to `false`, a warning will be thrown for violations instead of an error.
+
+```xml
+<rule ref="Generic.Strings.UnnecessaryStringConcat">
+    <properties>
+        <property name="error" value="false" />
+    </properties>
+</rule>
+```
+
+### Generic.WhiteSpace.ArbitraryParenthesesSpacing
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+spacing        | int  | 0       | 3.3.0
+ignoreNewlines | bool | false   | 3.3.0
+
+This sniff checks the padding inside parenthesis that are not being used by function declarations, function calls, or control structures. By default, the sniff ensures there are zero spaces inside the parenthesis, as shown in the following code snippet:
+
+```php
+$foo = ($bar !== 'bar');
+```
+
+Another common way of padding parenthesis is to use a single space, as shown in the following code snippet:
+
+```php
+$foo = ( $bar !== 'bar' );
+```
+
+If you prefer to write your code like this, you can set the `spacing` property to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing">
+    <properties>
+        <property name="spacing" value="1" />
+    </properties>
+</rule>
+```
+
+Sometimes long statements are broken over multiple lines to work within a maximum line length, but this sniff will generate an error for these cases by default. Setting the `ignoreNewlines` property to `true` will allow newline characters inside parenthesis, and any required padding for alignment.
+
+```xml
+<rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing">
+    <properties>
+        <property name="ignoreNewlines" value="true" />
+    </properties>
+</rule>
+```
+
+### Generic.WhiteSpace.ScopeIndent
+
+Property Name           | Type  | Default | Available Since
+----------------------- | ----- | ------- | ---------------
+indent                  | int   | 4       | -
+exact                   | bool  | false   | -
+tabIndent               | bool  | false   | 2.0.0
+ignoreIndentationTokens | array | -       | 1.4.8
+
+This sniff checks that code blocks are indented correctly. By default, this sniff ensures that code blocks are indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+The `exact` property is used to determine whether an indent is treated as an exact number or as a minimum amount. By default, code blocks must be indented at least `indent` spaces from the last code block. If `exact` is set to `true`, code blocks must be indented exactly `indent` spaces from the last code block.
+
+> Note: Enforcing exact indent checking is generally not advised because it doesn't allow for any flexibility when indenting and aligning code. It is almost always better to use the default value and then allow other sniffs to enforce specific indenting rules.
+
+```xml
+<rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+        <property name="exact" value="true" />
+    </properties>
+</rule>
+```
+
+By default, this sniff enforces the use of spaces for indentation and also uses spaces when fixing the indentation of code blocks. If you prefer using tabs, you can set the `tabIndent` property to `true`. 
+
+> Note: The size of each tab is important, so it should be specified using the `--tab-width` CLI argument or by adding `<arg name="tab-width" value="4"/>` to your ruleset. This sniff will use this value when checking and fixing indents.
+
+```xml
+<!-- Tabs should represent 4 spaces. -->
+<arg name="tab-width" value="4"/>
+...
+<!-- Indent using tabs. -->
+<rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+        <property name="tabIndent" value="true" />
+    </properties>
+</rule>
+```
+
+Setting the `ignoreIndentationTokens` property provides the sniff with a list of tokens that do not need to be checked for indentation. This is commonly used to ignore indentation for code structures such as comments and here/nowdocs.
+
+```xml
+<rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+        <property name="ignoreIndentationTokens" type="array"
+            value="T_COMMENT,T_DOC_COMMENT_OPEN_TAG"/>
+    </properties>
+</rule>
+```
+
+
+
+
+## PEAR Sniffs
+
+### PEAR.ControlStructures.ControlSignature
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | --------------
+ignoreComments | bool | true    | 1.4.0
+
+> Note: The `ignoreComments` property is inherited from the AbstractPattern sniff.
+
+This sniff verifies that control structures match a specific pattern of whitespace and bracket placement. By default, comments placed within the declaration will generate an error, but the sniff can be told to ignore comments by setting the `ignoreComments` property to `true`.
+
+```xml
+<rule ref="PEAR.ControlStructures.ControlSignature">
+    <properties>
+        <property name="ignoreComments" value="false" />
+    </properties>
+</rule>
+```
+
+### PEAR.ControlStructures.MultiLineCondition
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.4.7
+
+One of the rules that this sniff enforces is the indent of a condition that has been split over multiple lines. By default, this sniff ensures that each line of the condition is indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PEAR.ControlStructures.MultiLineCondition">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PEAR.Formatting.MultiLineAssignment
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.4.7
+
+One of the rules that this sniff enforces is the indent of an assignment that has been split over multiple lines. By default, this sniff ensures that the line with the assignment operator is indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PEAR.Formatting.MultiLineAssignment">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PEAR.Functions.FunctionCallSignature
+
+Property Name             | Type | Default | Available Since
+------------------------- | ---- | ------- | ---------------
+indent                    | int  | 4       | 1.3.4
+allowMultipleArguments    | bool | true    | 1.3.6
+requiredSpacesAfterOpen   | int  | 0       | 1.5.2
+requiredSpacesBeforeClose | int  | 0       | 1.5.2
+
+One of the rules this sniff enforces is that function calls have the correct padding inside their bracketed argument lists. By default, the sniff ensures there are zero spaces following the opening bracket, and zero spaces preceding the closing bracket, as shown in the following code snippet:
+
+```php
+$foo = getValue($a, $b, $c);
+```
+
+Another common way of padding function calls is to use a single space, as shown in the following code snippet:
+
+```php
+$foo = getValue( $a, $b, $c );
+```
+
+If you prefer to write your code like this, you can set the `requiredSpacesAfterOpen` and `requiredSpacesBeforeClose` properties to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="PEAR.Functions.FunctionCallSignature">
+    <properties>
+        <property name="requiredSpacesAfterOpen" value="1" />
+        <property name="requiredSpacesBeforeClose" value="1" />
+    </properties>
+</rule>
+```
+
+This sniff also enforces the formatting of multi-line function calls. By default, multiple arguments can appear on each line, as shown in the following code snippet:
+
+```php
+$returnValue = foo(
+    $a, $b, $c,
+    $d, $e
+);
+```
+
+Another common way of defining multi-line function calls is to have one argument per line, as shown in the following code snippet:
+
+```php
+$returnValue = foo(
+    $a,
+    $b,
+    $c,
+    $d,
+    $e
+);
+```
+
+If you prefer to write your code like this, you can set the `allowMultipleArguments` property to `false`.
+
+```xml
+<rule ref="PEAR.Functions.FunctionCallSignature">
+    <properties>
+        <property name="allowMultipleArguments" value="false" />
+    </properties>
+</rule>
+```
+
+By default, this sniff ensures that each line in a multi-line function call is indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PEAR.Functions.FunctionCallSignature">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PEAR.Functions.FunctionDeclaration
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.4.7
+
+One of the rules that this sniff enforces is the indent of each function argument in a multi-line function declaration. By default, this sniff ensures that each line is indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PEAR.Functions.FunctionDeclaration">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PEAR.WhiteSpace.ObjectOperatorIndent
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.4.6
+
+One of the rules that this sniff enforces is the indent of each line in a multi-line object chain. By default, this sniff ensures that each line is indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PEAR.WhiteSpace.ObjectOperatorIndent">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PEAR.WhiteSpace.ScopeClosingBrace
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.3.4
+
+One of the rules that this sniff enforces is the indent of the case terminating statement. By default, this sniff ensures that the statement is indented 4 spaces from the `case` or `default` keyword, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PEAR.WhiteSpace.ScopeClosingBrace">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PEAR.WhiteSpace.ScopeIndent
+
+Property Name           | Type  | Default | Available Since
+----------------------- | ----- | ------- | ---------------
+indent                  | int   | 4       | -
+exact                   | bool  | false   | -
+tabIndent               | bool  | false   | 2.0.0
+ignoreIndentationTokens | array | -       | 1.4.8
+
+> Note: All properties are inherited from the [Generic.WhiteSpace.ScopeIndent](#genericwhitespacescopeindent) sniff.
+
+See the [Generic.WhiteSpace.ScopeIndent](#genericwhitespacescopeindent) sniff for an explanation of all properties.
+
+```xml
+<!-- Tabs should represent 4 spaces. -->
+<arg name="tab-width" value="4"/>
+...
+<rule ref="PEAR.WhiteSpace.ScopeIndent">
+    <properties>
+        <property name="exact" value="true" />
+        <property name="tabIndent" value="true" />
+        <property name="ignoreIndentationTokens" type="array"
+            value="T_COMMENT,T_DOC_COMMENT_OPEN_TAG"/>
+    </properties>
+</rule>
+```
+
+
+
+
+## PSR2 Sniffs
+
+### PSR2.Classes.ClassDeclaration
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+indent        | int  | 4       | 1.3.5
+
+One of the rules that this sniff enforces is the indent of a list of implemented or extended class names that have been split over multiple lines. By default, this sniff ensures that the class names are indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PSR2.Classes.ClassDeclaration">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PSR2.ControlStructures.ControlStructureSpacing
+
+Property Name             | Type | Default | Available Since
+------------------------- | ---- | ------- | ---------------
+requiredSpacesAfterOpen   | int  | 0       | 1.5.2
+requiredSpacesBeforeClose | int  | 0       | 1.5.2
+
+This sniff checks that control structures have the correct padding inside their bracketed statement. By default, the sniff ensures there are zero spaces following the opening bracket, and zero spaces preceding the closing bracket, as shown in the following code snippet:
+
+```php
+if ($condition === true) {
+    // Body.
+}
+```
+
+Another common way of padding control structures is to use a single space, as shown in the following code snippet:
+
+```php
+if ( $condition === true ) {
+    // Body.
+}
+```
+
+If you prefer to write your code like this, you can set the `requiredSpacesAfterOpen` and `requiredSpacesBeforeClose` properties to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="PSR2.ControlStructures.ControlStructureSpacing">
+    <properties>
+        <property name="requiredSpacesAfterOpen" value="1" />
+        <property name="requiredSpacesBeforeClose" value="1" />
+    </properties>
+</rule>
+```
+
+### PSR2.ControlStructures.SwitchDeclaration
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.4.5
+
+One of the rules that this sniff enforces is the indent of the case terminating statement. By default, this sniff ensures that the statement is indented 4 spaces from the `case` or `default` keyword, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="PSR2.ControlStructures.SwitchDeclaration">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### PSR2.Methods.FunctionCallSignature
+
+Property Name             | Type | Default | Available Since
+------------------------- | ---- | ------- | ---------------
+indent                    | int  | 4       | 1.3.4
+allowMultipleArguments    | bool | false   | 1.4.7
+requiredSpacesAfterOpen   | int  | 0       | 1.5.2
+requiredSpacesBeforeClose | int  | 0       | 1.5.2
+
+> Note: All properties are inherited from the [PEAR.Functions.FunctionCallSignature](#pearfunctionsfunctioncallsignature) sniff, although the default value of `allowMultipleArguments` is changed.
+
+See the [PEAR.Functions.FunctionCallSignature](#pearfunctionsfunctioncallsignature) sniff for an explanation of all properties.
+
+
+
+
+## PSR12 Sniffs
+
+### PSR12.Namespaces.CompoundNamespaceDepth
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+maxDepth      | int  | 2       | 3.3.0
+
+This sniff checks the depth of imported namespaces inside compound use statements. By default, this sniff ensures that the namespaces are no more than two levels deep, but you can change the depth limit by setting the `maxDepth` property.
+
+```xml
+<rule ref="PSR12.Namespaces.CompoundNamespaceDepth">
+    <properties>
+        <property name="maxDepth" value="4" />
+    </properties>
+</rule>
+```
+
+
+
+
+## Squiz Sniffs
+
+### Squiz.Classes.ClassDeclaration
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.3.5
+
+> Note: The `indent` property is inherited from the [PSR2.Classes.ClassDeclaration](#psr2classesclassdeclaration) sniff.
+
+One of the rules that this sniff enforces is the indent of a list of implemented or extended class names that have been split over multiple lines. By default, this sniff ensures that the class names are indented 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="Squiz.Classes.ClassDeclaration">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### Squiz.Commenting.LongConditionClosingComment
+
+Property Name | Type   | Default  | Available Since
+------------- | ------ | -------- | ---------------
+lineLimit     | int    | 20       | 2.7.0
+commentFormat | string | //end %s | 2.7.0
+
+This sniff checks that long blocks of code have a closing comment. The `lineLimit` property allows you to configure the numbers of lines that the code block must span before requiring a comment. By default, the code block must be at least 20 lines long, including the opening and closing lines, but you can change the required length by setting the `lineLimit` property.
+
+```xml
+<rule ref="Squiz.Commenting.LongConditionClosingComment">
+    <properties>
+        <property name="lineLimit" value="40" />
+    </properties>
+</rule>
+```
+
+When a closing comment is required, the format defaults to `//end %s`, where the %s placeholder is replaced with the type of the code block. For example, `//end if`, `//end foreach`, or `//end switch`. You can change the format of the end comment by setting the `commentFormat` property.
+
+```xml
+<!-- Have code block comments look like // end foreach() etc. -->
+<rule ref="Squiz.Commenting.LongConditionClosingComment">
+    <properties>
+        <property name="commentFormat" value="// end %s()" />
+    </properties>
+</rule>
+```
+
+### Squiz.ControlStructures.ControlSignature
+
+Property Name             | Type | Default | Available Since
+------------------------- | ---- | ------- | ---------------
+requiredSpacesBeforeColon | int  | 1       | 3.2.0
+
+One of the rules this sniff enforces is the number of spaces before the opening brace of control structures. By default, the sniff ensures there is one space before the opening brace for control structures using standard syntax, and one space before the colon for control structures using alternative syntax, as shown in the following code snippet:
+
+```php
+if ($foo) :
+    // IF body.
+else :
+    // ELSE body.
+endif;
+```
+
+A common way of defining control structures using alternative syntax is to put no padding before the colon, as shown in the following code snippet:
+
+```php
+if ($foo):
+    // IF body.
+else:
+    // ELSE body.
+endif;
+```
+
+If you prefer to write your code like this, you can set the `requiredSpacesBeforeColon` property to `0`.
+
+```xml
+<rule ref="Squiz.ControlStructures.ControlSignature">
+    <properties>
+        <property name="requiredSpacesBeforeColon" value="0" />
+    </properties>
+</rule>
+```
+
+### Squiz.ControlStructures.ForEachLoopDeclaration
+
+Property Name             | Type | Default | Available Since
+------------------------- | ---- | ------- | ---------------
+requiredSpacesAfterOpen   | int  | 0       | 1.5.2
+requiredSpacesBeforeClose | int  | 0       | 1.5.2
+
+This sniff checks that `foreach` structures have the correct padding inside their bracketed statement. By default, the sniff ensures there are zero spaces following the opening bracket, and zero spaces preceding the closing bracket, as shown in the following code snippet:
+
+```php
+foreach ($foo as $bar) {
+    // Body.
+}
+```
+
+Another common way of padding control structures is to use a single space, as shown in the following code snippet:
+
+```php
+foreach ( $foo as $bar ) {
+    // Body.
+}
+```
+
+If you prefer to write your code like this, you can set the `requiredSpacesAfterOpen` and `requiredSpacesBeforeClose` properties to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="Squiz.ControlStructures.ForEachLoopDeclaration">
+    <properties>
+        <property name="requiredSpacesAfterOpen" value="1" />
+        <property name="requiredSpacesBeforeClose" value="1" />
+    </properties>
+</rule>
+```
+
+### Squiz.ControlStructures.ForLoopDeclaration
+
+Property Name             | Type | Default | Available Since
+------------------------- | ---- | ------- | ---------------
+requiredSpacesAfterOpen   | int  | 0       | 1.5.2
+requiredSpacesBeforeClose | int  | 0       | 1.5.2
+
+This sniff checks that `for` structures have the correct padding inside their bracketed statement. By default, the sniff ensures there are zero spaces following the opening bracket, and zero spaces preceding the closing bracket, as shown in the following code snippet:
+
+```php
+for ($i = 0; $i < 10; $i++) {
+    // Body.
+}
+```
+
+Another common way of padding control structures is to use a single space, as shown in the following code snippet:
+
+```php
+for ( $i = 0; $i < 10; $i++ ) {
+    // Body.
+}
+```
+
+If you prefer to write your code like this, you can set the `requiredSpacesAfterOpen` and `requiredSpacesBeforeClose` properties to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="Squiz.ControlStructures.ForLoopDeclaration">
+    <properties>
+        <property name="requiredSpacesAfterOpen" value="1" />
+        <property name="requiredSpacesBeforeClose" value="1" />
+    </properties>
+</rule>
+```
+
+### Squiz.ControlStructures.SwitchDeclaration
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.4.7
+
+Two of the rules that this sniff enforces are the indent of `case` and `default` keywords, and the indent of the case terminating statement. By default, this sniff ensures that the keywords are indented 4 spaces from the `switch` keyword and that the terminating statement is indented 4 spaces from the `case` or `default` keyword, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="Squiz.ControlStructures.SwitchDeclaration">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### Squiz.CSS.ForbiddenStyles
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+error         | bool | true    | 1.4.6
+
+If the `error` property is set to `false`, a warning will be thrown for violations instead of an error.
+
+```xml
+<rule ref="Squiz.CSS.ForbiddenStyles">
+    <properties>
+        <property name="error" value="false" />
+    </properties>
+</rule>
+```
+
+### Squiz.CSS.Indentation
+
+Property Name | Type | Default | Available Since
+------------  | ---- | ------- | ---------------
+indent        | int  | 4       | 1.4.7
+
+This sniff checks the indentation of CSS class definitions. By default, this sniff ensures that style statements are indented using 4 spaces, but you can change the size of the indent by setting the `indent` property.
+
+```xml
+<rule ref="Squiz.CSS.Indentation">
+    <properties>
+        <property name="indent" value="2" />
+    </properties>
+</rule>
+```
+
+### Squiz.Functions.FunctionDeclaration
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | --------------
+ignoreComments | bool | false   | 1.4.0
+
+> Note: The `ignoreComments` property is inherited from the AbstractPattern sniff.
+
+This sniff verifies that functions declarations match a specific pattern of whitespace and bracket placement. By default, comments placed within the function declaration will generate an error, but the sniff can be told to ignore comments by setting the `ignoreComments` property to `true`.
+
+```xml
+<rule ref="Squiz.Functions.FunctionDeclaration">
+    <properties>
+        <property name="ignoreComments" value="false" />
+    </properties>
+</rule>
+```
+
+### Squiz.Functions.FunctionDeclarationArgumentSpacing
+
+Property Name             | Type | Default | Available Since
+------------------------- | ---- | ------- | ---------------
+equalsSpacing             | int  | 0       | 1.3.5
+requiredSpacesAfterOpen   | int  | 0       | 1.5.2
+requiredSpacesBeforeClose | int  | 0       | 1.5.2
+
+One of the rules this sniff enforces is the padding around equal signs in the function argument list. By default, the sniff ensures there are zero spaces before and after the equals sign, as shown in the following code snippet:
+
+```php
+function foo($a='a', $b='b') {
+    // Body.
+}
+```
+
+Another common way of defining default values is to use a single space, as shown in the following code snippet:
+
+```php
+function foo($a = 'a', $b = 'b') {
+    // Body.
+}
+```
+
+If you prefer to write your code like this, you can set the `equalsSpacing` property to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+    <properties>
+        <property name="equalsSpacing" value="1" />
+    </properties>
+</rule>
+```
+
+Another of the rules this sniff enforces is that functions have the correct padding inside their bracketed list of arguments. By default, the sniff ensures there are zero spaces following the opening bracket, and zero spaces preceding the closing bracket, as shown in the following code snippet:
+
+```php
+function foo($a, $b) {
+    // Body.
+}
+```
+
+Another common way of padding argument lists is to use a single space, as shown in the following code snippet:
+
+```php
+function foo( $a, $b ) {
+    // Body.
+}
+```
+
+If you prefer to write your code like this, you can set the `requiredSpacesAfterOpen` and `requiredSpacesBeforeClose` properties to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+    <properties>
+        <property name="requiredSpacesAfterOpen" value="1" />
+        <property name="requiredSpacesBeforeClose" value="1" />
+    </properties>
+</rule>
+```
+
+### Squiz.PHP.CommentedOutCode
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+maxPercentage | int  | 35      | 1.3.3
+
+This sniff generates warnings for commented out code. By default, a warning is generated if a comment appears to be more than 35% valid code. If you find that the sniff is generating a lot of false positive, you may want to raise the valid code threshold by increasing the `maxPercentage` property. Similarly, if you find that the sniff is generating a lot of false negatives, you may want to make it more sensitive by dropping the threshold by decreasing the `maxPercentage` property.
+
+```xml
+<!-- Make this sniff more sensitive to commented out code blocks. -->
+<rule ref="Squiz.PHP.CommentedOutCode">
+    <properties>
+        <property name="maxPercentage" value="20" />
+    </properties>
+</rule>
+```
+
+### Squiz.PHP.DiscouragedFunctions
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+error         | bool | false   | -
+
+> Note: This sniff also has a `forbiddenFunctions` property inherited from the [Generic.PHP.ForbiddenFunctions](#genericphpforbiddenfunctions) sniff, but it should not be used. If you want to customise the list of discouraged functions, use the Generic.PHP.ForbiddenFunctions sniff directly.
+
+If the `error` property is set to `true`, an error will be thrown for violations instead of a warning.
+
+```xml
+<rule ref="Squiz.PHP.DiscouragedFunctions">
+    <properties>
+        <property name="error" value="true" />
+    </properties>
+</rule>
+```
+
+### Squiz.PHP.ForbiddenFunctions
+
+Property Name | Type | Default | Available Since
+------------- | ---- | ------- | ---------------
+error         | bool | false   | -
+
+> Note: This sniff also has a `forbiddenFunctions` property inherited from the [Generic.PHP.ForbiddenFunctions](#genericphpforbiddenfunctions) sniff, but it should not be used. If you want to customise the list of forbidden functions, use the Generic.PHP.ForbiddenFunctions sniff directly.
+
+If the `error` property is set to `true`, an error will be thrown for violations instead of a warning.
+
+```xml
+<rule ref="Squiz.PHP.ForbiddenFunctions">
+    <properties>
+        <property name="error" value="true" />
+    </properties>
+</rule>
+```
+
+### Squiz.Strings.ConcatenationSpacing
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+spacing        | int  | 0       | 2.0.0
+ignoreNewlines | bool | false   | 2.3.1
+
+One of the rules this sniff enforces is the padding around concatenation operators. By default, the sniff ensures there are zero spaces before and after the concatenation operator, as shown in the following code snippet:
+
+```php
+$foo = $number.'-'.$letter;
+```
+
+Another common way of padding concatenation operators is to use a single space, as shown in the following code snippet:
+
+```php
+$foo = $number . '-' . $letter;
+```
+
+If you prefer to write your code like this, you can set the `spacing` property to `1`, or whatever padding you prefer.
+
+```xml
+<rule ref="Squiz.Strings.ConcatenationSpacing">
+    <properties>
+        <property name="spacing" value="1" />
+    </properties>
+</rule>
+```
+
+Sometimes long concatenation statements are broken over multiple lines to work within a maximum line length, but this sniff will generate an error for these cases by default. Setting the `ignoreNewlines` property to `true` will allow newline characters before or after a concatenation operator, and any required padding for alignment.
+
+```xml
+<rule ref="Squiz.Strings.ConcatenationSpacing">
+    <properties>
+        <property name="ignoreNewlines" value="true" />
+    </properties>
+</rule>
+```
+
+### Squiz.WhiteSpace.FunctionSpacing
+
+Property Name      | Type | Default | Available Since
+------------------ | ---- | ------- | ---------------
+spacing            | int  | 2       | 1.4.5
+spacingBeforeFirst | int  | 2       | 3.3.0
+spacingAfterLast   | int  | 2       | 3.3.0
+
+This sniff checks that there are two blank lines before and after functions declarations, but you can change the required padding using the `spacing`, `spacingBeforeFirst`, and `spacingAfterLast` properties.
+
+The `spacingBeforeFirst` property is used to determine how many blank lines are required before a function when it is the first block of code inside a class, interface, or trait. This property is ignored when the function is outside one of these scopes, or if the function is preceded by member vars. If this property has not been set, the sniff will use whatever value has been set for the `spacing` property.
+
+The `spacingAfterLast` property is used to determine how many blank lines are required after a function when it is the last block of code inside a class, interface, or trait. This property is ignored when the function is outside one of these scopes, or if any member vars are placed after the function. If this property has not been set, the sniff will use whatever value has been set for the `spacing` property.
+
+The `spacing` property applies in all other cases.
+
+```xml
+<!-- Ensure 1 blank line before and after functions, except at the top and bottom. -->
+<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+    <properties>
+        <property name="spacing" value="1" />
+        <property name="spacingBeforeFirst" value="0" />
+        <property name="spacingAfterLast" value="0" />
+    </properties>
+</rule>
+```
+
+As the `spacingBeforeFirst` and `spacingAfterLast` properties use the value of the `spacing` property when not set, a shortcut for setting all three properties to the same value is to specify a value for the `spacing` property only.
+
+```xml
+<!-- Ensure 1 blank line before and after functions in all cases. -->
+<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+    <properties>
+        <property name="spacing" value="1" />
+    </properties>
+</rule>
+```
+
+### Squiz.WhiteSpace.MemberVarSpacing
+
+Property Name       | Type | Default | Available Since
+------------------- | ---- | ------- | ---------------
+spacing             | int  | 1       | 3.1.0
+spacingBeforeFirst  | int  | 1       | 3.1.0
+
+This sniff checks that there is one blank line before between member vars and before the fist member var, but you can change the required padding using the `spacing` and `spacingBeforeFirst` properties.
+
+```xml
+<!--
+ Ensure 2 blank lines between member vars,
+ but don't require blank lines before the first.
+-->
+<rule ref="Squiz.WhiteSpace.MemberVarSpacing">
+    <properties>
+        <property name="spacing" value="2" />
+        <property name="spacingBeforeFirst" value="0" />
+    </properties>
+</rule>
+```
+
+### Squiz.WhiteSpace.ObjectOperatorSpacing
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+ignoreNewlines | bool | false   | 2.7.0
+
+This sniff ensures there are no spaces surrounding an object operator. Sometimes long object chains are broken over multiple lines to work within a maximum line length, but this sniff will generate an error for these cases by default. Setting the `ignoreNewlines` property to `true` will allow newline characters before or after an object operator, and any required padding for alignment.
+
+```xml
+<rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
+    <properties>
+        <property name="ignoreNewlines" value="true" />
+    </properties>
+</rule>
+```
+
+### Squiz.WhiteSpace.OperatorSpacing
+
+Property Name  | Type | Default | Available Since
+-------------- | ---- | ------- | ---------------
+ignoreNewlines | bool | false   | 2.2.0
+
+This sniff ensures there is one space before and after an operators. Sometimes long statements are broken over multiple lines to work within a maximum line length, but this sniff will generate an error for these cases by default. Setting the `ignoreNewlines` property to `true` will allow newline characters before or after an operator, and any required padding for alignment.
+
+```xml
+<rule ref="Squiz.WhiteSpace.OperatorSpacing">
+    <properties>
+        <property name="ignoreNewlines" value="true" />
+    </properties>
+</rule>
+```
+
+### Squiz.WhiteSpace.SuperfluousWhitespace
+
+Property Name    | Type | Default | Available Since
+---------------- | ---- | ------- | ---------------
+ignoreBlankLines | bool | false   | 1.4.2
+
+Some of the rules this sniff enforces are that there should not be whitespace at the end of a line, and that functions should not contain multiple blank lines in a row. If the `ignoreBlankLines` property is set to `true`, blank lines (lines that contain only whitespace) may have spaces and tabs as their content, and multiple blank lines will be allows inside functions.
+
+```xml
+<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+    <properties>
+        <property name="ignoreBlankLines" value="true" />
+    </properties>
+</rule>
+```

--- a/docs/Documentation/FAQ.md
+++ b/docs/Documentation/FAQ.md
@@ -1,0 +1,28 @@
+## Does PHP_CodeSniffer perform any code coverage or unit testing?
+No. PHP_CodeSniffer is not a tool for testing that your PHP application works correctly. All PHP_CodeSniffer will do is ensure your PHP code meets the standards that you are following.
+
+## My code is fine! Why do I need PHP_CodeSniffer?
+Maybe you don't, but if you want to ensure you adhere to a set of coding standards, PHP_CodeSniffer is a quick and easy way to do that. PHP_CodeSniffer is a replacement for the more manual task of checking coding standards in code reviews. With PHP_CodeSniffer, you can reserve code reviews for the checking of code correctness.
+
+Coding standards are a good thing. They will make your code easier to read and maintain, especially when multiple developers are working on the same application. Consider using coding standards if you don't already.
+
+## Does PHP_CodeSniffer parse my code to ensure it will execute?
+No. PHP_CodeSniffer does not actually parse your code, and so cannot accurately tell if your code contains parse errors. PHP_CodeSniffer does know about some parse errors and will warn you if it finds code that it is unable to sniff correctly due to a suspected parse error. However, as there is no actual parsing taking place, PHP_CodeSniffer may return an incorrect number of errors when checking code that does contain parse errors.
+
+You can easily check for parse errors in a file using the PHP command line interface and the `-l` (lowercase L) option.
+
+    $ php -l /path/to/code/myfile.inc
+    No syntax errors detected in /path/to/code/myfile.inc
+    
+## I don't agree with your coding standards! Can I make PHP_CodeSniffer enforce my own?
+Yes. At its core, PHP_CodeSniffer is just a framework for enforcing coding standards. PHP_CodeSniffer is released with some sample coding standards to help developers get started on projects where there is no standard defined. If you want to write your own standard, read the tutorial on creating coding standards.
+
+## How come PHP_CodeSniffer reported errors, I fixed them, now I get even more?
+Sometimes, errors mask the existence of other errors, or new errors are created as you fix others. For example, PHP_CodeSniffer might tell you that an inline IF statement needs to be defined with braces. Once you make this change, PHP_CodeSniffer may report that the braces you added are not correctly aligned.
+
+Always run PHP_CodeSniffer until you get a passing result. Once you've made the changes PHP_CodeSniffer recommends, run PHP_CodeSniffer again to ensure no new errors have been added.
+
+## What does PHP_CodeSniffer use to tokenize my code?
+For PHP files, PHP_CodeSniffer uses [PHP's inbuilt tokenizer functions](http://www.php.net/tokenizer) to parse your code. It then modifies that output to include much more data about the file, such as matching function braces to function keywords.
+
+For all other file types, PHP_CodeSniffer includes a custom tokenizer that either makes use of PHP's inbuilt tokenizer or emulates it. In both cases, the token array must be checked and changed manually before all the standard PHP_CodeSniffer matching rules are applied, making tokenizing a bit slower for these file types.

--- a/docs/Documentation/Fixing-Errors-Automatically.md
+++ b/docs/Documentation/Fixing-Errors-Automatically.md
@@ -1,0 +1,138 @@
+PHP_CodeSniffer is able to fix many errors and warnings automatically. The `diff` report can be used to generate a diff that can be applied using the `patch` command. Alternatively, the PHP Code Beautifier and Fixer (`phpcbf`) can be used in place of `phpcs` to automatically generate and apply the diff for you.
+
+Screen-based reports, such as the [full](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-full-and-summary-reports), [summary](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-full-and-summary-reports) and [source](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-a-source-report) reports, provide information about how many errors and warnings are found. If any of the issues can be fixed automatically by `phpcbf`, additional information will be printed:
+
+    $ phpcs /path/to/code/myfile.php
+
+    FILE: /path/to/code/myfile.php
+    --------------------------------------------------------------------------------
+    FOUND 5 ERRORS AFFECTING 4 LINES
+    --------------------------------------------------------------------------------
+     2 | ERROR | [ ] Missing file doc comment
+     3 | ERROR | [x] TRUE, FALSE and NULL must be lowercase; expected "false" but
+       |       |     found "FALSE"
+     5 | ERROR | [x] Line indented incorrectly; expected at least 4 spaces, found 1
+     8 | ERROR | [ ] Missing function doc comment
+     8 | ERROR | [ ] Opening brace should be on a new line
+    --------------------------------------------------------------------------------
+    PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
+    --------------------------------------------------------------------------------
+
+## Printing a Diff Report
+PHP_CodeSniffer can output a diff file that can be applied using the `patch` command. The suggested changes will fix some of the sniff violations that are present in the source code. To print a diff report, use the `--report=diff` command line argument. The output will look like this:
+
+    $ phpcs --report=diff /path/to/code
+    
+    --- /path/to/code/file.php
+    +++ PHP_CodeSniffer
+    @@ -1,8 +1,8 @@
+     <?php
+     
+    -if ($foo === FALSE) {
+    +if ($foo === false) {
+    +    echo 'hi';
+         echo 'hi';
+    - echo 'hi';
+     }
+     
+     function foo() {
+
+Diff reports are more easily used when output to a file. They can then be applied using the `patch` command:
+
+    $ phpcs --report-diff=/path/to/changes.diff /path/to/code
+    $ patch -p0 -ui /path/to/changes.diff
+    patching file /path/to/code/file.php
+
+## Using the PHP Code Beautifier and Fixer
+To automatically fix as many sniff violations as possible, use the `phpcbf` command in place of the `phpcs` command. While most of the PHPCS command line arguments can be used by PHPCBF, some are specific to reporting and will be ignored. Running PHPCBF with the `-h` or `--help` command line arguments will print a list of commands that PHPCBF will respond to. The output of `phpcbf -h` is shown below.
+```
+Usage: phpcbf [-nwli] [-d key[=value]] [--ignore-annotations] [--stdin-path=<stdinPath>]
+  [--standard=<standard>] [--sniffs=<sniffs>] [--exclude=<sniffs>] [--suffix=<suffix>]
+  [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]
+  [--tab-width=<tabWidth>] [--encoding=<encoding>] [--parallel=<processes>]
+  [--basepath=<basepath>] [--extensions=<extensions>] [--ignore=<patterns>] <file> - ...
+
+ -     Fix STDIN instead of local files and directories
+ -n    Do not fix warnings (shortcut for --warning-severity=0)
+ -w    Fix both warnings and errors (on by default)
+ -l    Local directory only, no recursion
+ -p    Show progress of the run
+ -q    Quiet mode; disables progress and verbose output
+ -v    Print processed files
+ -vv   Print ruleset and token output
+ -vvv  Print sniff processing information
+ -i    Show a list of installed coding standards
+ -d    Set the [key] php.ini value to [value] or [true] if value is omitted
+
+ --help                Print this help message
+ --version             Print version information
+ --ignore-annotations  Ignore all @codingStandard annotations in code comments
+
+ <basepath>    A path to strip from the front of file paths inside reports
+ <file>        One or more files and/or directories to fix
+ <encoding>    The encoding of the files being fixed (default is utf-8)
+ <extensions>  A comma separated list of file extensions to fix
+               (extension filtering only valid when checking a directory)
+               The type of the file can be specified using: ext/type
+               e.g., module/php,es/js
+ <patterns>    A comma separated list of patterns to ignore files and directories
+ <processes>   How many files should be fixed simultaneously (default is 1)
+ <severity>    The minimum severity required to fix an error or warning
+ <sniffs>      A comma separated list of sniff codes to include or exclude from fixing
+               (all sniffs must be part of the specified standard)
+ <standard>    The name or path of the coding standard to use
+ <stdinPath>   If processing STDIN, the file path that STDIN will be processed as
+ <suffix>      Write modified files to a filename using this suffix
+               ("diff" and "patch" are not used in this mode)
+ <tabWidth>    The number of spaces each tab represents
+```
+When using the PHPCBF command, you do not need to specify a report type. PHPCBF will automatically make changes to your source files:
+
+    $ phpcbf /path/to/code
+    Processing init.php [PHP => 7875 tokens in 960 lines]... DONE in 274ms (12 fixable violations)
+        => Fixing file: 0/12 violations remaining [made 3 passes]... DONE in 412ms
+    Processing config.php [PHP => 8009 tokens in 957 lines]... DONE in 421ms (155 fixable violations)
+        => Fixing file: 0/155 violations remaining [made 7 passes]... DONE in 937ms
+    Patched 2 files
+    Time: 2.55 secs, Memory: 25.00Mb
+
+If you do not want to overwrite existing files, you can specify the `--suffix` command line argument and provide a filename suffix to use for new files. A fixed copy of each file will be created and stored in the same directory as the original file. If a file already exists with the new name, it will be overwritten.
+
+    $ phpcbf /path/to/code --suffix=.fixed
+    Processing init.php [PHP => 7875 tokens in 960 lines]... DONE in 274ms (12 fixable violations)
+        => Fixing file: 0/12 violations remaining [made 3 passes]... DONE in 412ms
+        => Fixed file written to init.php.fixed
+    Processing config.php [PHP => 8009 tokens in 957 lines]... DONE in 421ms (155 fixable violations)
+        => Fixing file: 0/155 violations remaining [made 7 passes]... DONE in 937ms
+        => Fixed file written to config.php.fixed
+    Fixed 2 files
+    Time: 2.55 secs, Memory: 25.00Mb
+
+## Viewing Debug Information
+
+To see the fixes that are being made to a file, specify the `-vv` command line argument when generating a diff report. There is quite a lot of debug output concerning the standard being used and the tokenizing of the file, but the end of the output will look like this:
+
+    $ phpcs /path/to/file --report=diff -vv
+    ..snip..
+    *** START FILE FIXING ***
+    E: [Line 3] Expected 1 space after "="; 0 found (Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter)
+    Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff (line 259) replaced token 4 (T_EQUAL) "=" => "=·"
+    * fixed 1 violations, starting loop 2 *
+    *** END FILE FIXING ***
+
+Sometimes the file may need to be processed multiple times in order to fix all the violations. This can happen when multiple sniffs need to modify the same part of a file, or if a fix causes a new sniff violation somewhere else in the standard. When this happens, the output will look like this:
+
+    $ phpcs /path/to/file --report=diff -vv
+    ..snip..
+    *** START FILE FIXING ***
+    E: [Line 3] Expected 1 space before "="; 0 found (Squiz.WhiteSpace.OperatorSpacing.NoSpaceBefore)
+    Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff (line 228) replaced token 3 (T_EQUAL) "=" => "·="
+    E: [Line 3] Expected 1 space after "="; 0 found (Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter)
+    * token 3 has already been modified, skipping *
+    E: [Line 3] Equals sign not aligned correctly; expected 1 space but found 0 spaces (Generic.Formatting.MultipleStatementAlignment.Incorrect)
+    * token 3 has already been modified, skipping *
+    * fixed 1 violations, starting loop 2 *
+    E: [Line 3] Expected 1 space after "="; 0 found (Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter)
+    Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff (line 259) replaced token 4 (T_EQUAL) "=" => "=·"
+    * fixed 1 violations, starting loop 3 *
+    *** END FILE FIXING ***

--- a/docs/Documentation/Reporting.md
+++ b/docs/Documentation/Reporting.md
@@ -1,0 +1,490 @@
+## Table of contents
+* [Printing Full and Summary Reports](#printing-full-and-summary-reports)
+* Other Report Types
+    * [Checkstyle](#printing-a-checkstyle-report)
+    * [Code](#printing-a-code-report)
+    * [CSV](#printing-a-csv-report)
+    * Diff
+    * [Emacs](#printing-an-emacs-report)
+    * [Git Blame](#printing-a-git-blame-report)
+    * HG Blame
+    * [Information](#printing-an-information-report)
+    * [JSON](#printing-a-json-report)
+    * [JUnit](#printing-a-junit-report)
+    * Notify-Send
+    * [Source](#printing-a-source-report)
+    * [SVN Blame](#printing-an-svn-blame-report)
+    * [XML](#printing-an-xml-report)
+* [Printing Multiple Reports](#printing-multiple-reports)
+* [Running Interactively](#running-interactively)
+* [Specifying a Report Width](#specifying-a-report-width)
+* [Writing a Report to a File](#writing-a-report-to-a-file)
+
+***
+
+## Printing Full and Summary Reports
+Both the full and summary reports can additionally show information about the source of errors and warnings. Source codes can be used with the `--sniffs` command line argument to only show messages from a specified list of sources. To include source codes in the report, use the `-s` command line argument.
+
+    $ phpcs -s /path/to/code/myfile.php
+    
+    FILE: /path/to/code/classA.php
+    --------------------------------------------------------------------------------
+    FOUND 4 ERRORS AND 1 WARNING AFFECTING 5 LINES
+    --------------------------------------------------------------------------------
+      2 | ERROR   | [ ] Missing file doc comment
+        |         |     (PEAR.Commenting.FileComment.Missing)
+      4 | ERROR   | [x] TRUE, FALSE and NULL must be lowercase; expected "false" but
+        |         |     found "FALSE" (Generic.PHP.LowerCaseConstant.Found)
+      6 | ERROR   | [x] Line indented incorrectly; expected at least 4 spaces, found
+        |         |     1 (PEAR.WhiteSpace.ScopeIndent.Incorrect)
+      9 | ERROR   | [ ] Missing function doc comment
+        |         |     (PEAR.Commenting.FunctionComment.Missing)
+     11 | WARNING | [x] Inline control structures are discouraged
+        |         |     (Generic.ControlStructures.InlineControlStructure.Discouraged)
+    --------------------------------------------------------------------------------
+    PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
+    --------------------------------------------------------------------------------
+
+    $ phpcs -s --report=summary /path/to/code
+    
+    PHP CODE SNIFFER REPORT SUMMARY
+    --------------------------------------------------------------------------------
+    FILE                                                            ERRORS  WARNINGS
+    --------------------------------------------------------------------------------
+    /path/to/code/classA.inc                                        5       0
+    /path/to/code/classB.inc                                        1       1
+    /path/to/code/classC.inc                                        0       2
+    --------------------------------------------------------------------------------
+    A TOTAL OF 6 ERROR(S) AND 3 WARNING(S) WERE FOUND IN 3 FILE(S)
+    --------------------------------------------------------------------------------
+
+## Printing a Source Report
+PHP_CodeSniffer can output a summary report showing you the most common errors detected in your files so you can target specific parts of your coding standard for improvement. To print a source report, use the `--report=source` command line argument. The output will look like this:
+
+    $ phpcs --report=source /path/to/code
+    
+    PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
+    -----------------------------------------------------------------------------
+        STANDARD  CATEGORY            SNIFF                                 COUNT
+    -----------------------------------------------------------------------------
+    [x] PEAR      White space         Scope indent incorrect                1
+    [x] Generic   PHP                 Lower case constant found             1
+    [x] Generic   Control structures  Inline control structure discouraged  1
+    [ ] PEAR      Commenting          Function comment missing              1
+    [ ] PEAR      Commenting          File comment missing                  1
+    -----------------------------------------------------------------------------
+    A TOTAL OF 5 SNIFF VIOLATIONS WERE FOUND IN 5 SOURCES
+    -----------------------------------------------------------------------------
+    PHPCBF CAN FIX THE 3 MARKED SOURCES AUTOMATICALLY (3 VIOLATIONS IN TOTAL)
+    -----------------------------------------------------------------------------
+
+To show source codes instead of friendly names, use the `-s` command line argument.
+
+    $ phpcs -s --report=source /path/to/code
+    
+    PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
+    -----------------------------------------------------------------------
+        SOURCE                                                        COUNT
+    -----------------------------------------------------------------------
+    [x] Generic.ControlStructures.InlineControlStructure.Discouraged  1
+    [x] PEAR.WhiteSpace.ScopeIndent.Incorrect                         1
+    [x] Generic.PHP.LowerCaseConstant.Found                           1
+    [ ] PEAR.Commenting.FunctionComment.Missing                       1
+    [ ] PEAR.Commenting.FileComment.Missing                           1
+    -----------------------------------------------------------------------
+    A TOTAL OF 5 SNIFF VIOLATIONS WERE FOUND IN 5 SOURCES
+    -----------------------------------------------------------------------
+    PHPCBF CAN FIX THE 3 MARKED SOURCES AUTOMATICALLY (3 VIOLATIONS IN TOTAL)
+    -----------------------------------------------------------------------
+
+## Printing an Information Report
+PHP_CodeSniffer can output an information report to show you how your code is written rather than checking that it conforms to a standard. This report will use one or more standards you pass to it and then use the sniffs within those standards to inspect your code. Sniffs must be written to support recording metrics for this feature, so not all sniffs will report back information. To print an information report, use the `--report=info` command line argument. The output will look like this:
+
+    $ phpcs --report=info /path/to/code
+    
+    PHP CODE SNIFFER INFORMATION REPORT
+    --------------------------------------------------------------------------------
+    Class has doc comment: yes [10/10, 100%]
+
+    Class opening brace placement: new line [10/10, 100%]
+
+    Constant name case: upper [81/81, 100%]
+
+    Control structure defined inline: no [863/863, 100%]
+
+    EOL char: \n [10/10, 100%]
+
+    File has doc comment: yes [10/10, 100%]
+
+    Function has doc comment: yes [130/130, 100%]
+
+    Function opening brace placement: new line [111/111, 100%]
+
+    Inline comment style: // ... [585/594, 98.48%]
+        /* ... */ => 9 (1.52%)
+
+    Line indent: spaces [5099/5099, 100%]
+
+    Line length: 80 or less [6723/7134, 94.24%]
+        81-120 => 397 (5.56%)
+        121-150 => 10 (0.14%)
+        151 or more => 4 (0.06%)
+
+    PHP constant case: lower [684/684, 100%]
+
+    PHP short open tag used: no [10/10, 100%]
+
+    Private method prefixed with underscore: yes [11/11, 100%]
+
+    --------------------------------------------------------------------------------
+
+When more than one variation is found for a particular coding convention, the most common variation is printed on the first line and the other variations that were found are indented on subsequent lines. Each convention is followed by a number and each variation followed by a percentage, indicating the number of times the convention was checked and the percentage of code using each variation.
+
+In the example above, the `Inline comment style` convention was checked 594 times, indicating that 594 inline comments were found and checked. 585 of them (98.48%) used the `// ...` style variation and 9 of them (1.52%) used the `/* ... */` style variation.
+
+> **Tip:** To check your code against a wide range of conventions, specify all included standards. This will take longer, but give you more information about your code: `phpcs --standard=Generic,PEAR,Squiz,PSR2,Zend --report=info /path/to/code`
+
+## Printing a Code Report
+
+PHP_CodeSniffer can output a report that shows a code snippet for each error and warning, showing the context in which the violation has occurred. The output will look like this:
+
+    $ phpcs --report=code /path/to/code
+    
+    FILE: /path/to/code/classA.php
+    ------------------------------------------------------------------------------------------------
+    FOUND 4 ERRORS AND 1 WARNING AFFECTING 5 LINES
+    ------------------------------------------------------------------------------------------------
+    LINE  2: ERROR   [ ] Missing file doc comment
+    ------------------------------------------------------------------------------------------------
+        1:  <?php
+    >>  2:
+        3:  if·($foo·===·null)·{
+        4:  ····$foo·=·FALSE;
+    ------------------------------------------------------------------------------------------------
+    LINE  4: ERROR   [x] TRUE, FALSE and NULL must be lowercase; expected "false" but found "FALSE"
+    ------------------------------------------------------------------------------------------------
+        2:
+        3:  if·($foo·===·null)·{
+    >>  4:  ····$foo·=·FALSE;
+        5:  }·else·{
+        6:  ·$foo·=·getFoo();
+    ------------------------------------------------------------------------------------------------
+    LINE  6: ERROR   [x] Line indented incorrectly; expected at least 4 spaces, found 1
+    ------------------------------------------------------------------------------------------------
+        4:  ····$foo·=·FALSE;
+        5:  }·else·{
+    >>  6:  ·$foo·=·getFoo();
+        7:  }
+        8:
+    ------------------------------------------------------------------------------------------------
+    LINE  9: ERROR   [ ] Missing function doc comment
+    ------------------------------------------------------------------------------------------------
+        7:  }
+        8:
+    >>  9:  function·getFoo()
+       10:  {
+       11:  ····if·($foo)·return·'foo';
+    ------------------------------------------------------------------------------------------------
+    LINE 11: WARNING [x] Inline control structures are discouraged
+    ------------------------------------------------------------------------------------------------
+        9:  function·getFoo()
+       10:  {
+    >> 11:  ····if·($foo)·return·'foo';
+       12:  ····return·'bar';
+       13:  }
+    ------------------------------------------------------------------------------------------------
+    PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
+    ------------------------------------------------------------------------------------------------
+
+**Note:** The code report shows up to 5 lines of source code for each violation, so it is best used when checking single files and short code snippets to ensure the report doesn't become unreadble due to its length.
+
+## Printing a Checkstyle Report
+PHP_CodeSniffer can output an XML report similar to the one produced by Checkstyle, allowing you to use the output in scripts and applications that already support Checkstyle. To print a Checkstyle report, use the `--report=checkstyle` command line argument. The output will look like this:
+
+    $ phpcs --report=checkstyle /path/to/code
+    
+    <?xml version="1.0" encoding="UTF-8"?>
+    <checkstyle version="x.x.x">
+    <file name="/path/to/code/classA.php">
+     <error line="2" column="1" severity="error" message="Missing file doc comment" source="PEAR.Commenting.FileComment.Missing"/>
+     <error line="4" column="12" severity="error" message="TRUE, FALSE and NULL must be lowercase; expected &quot;false&quot; but found &quot;FALSE&quot;" source="Generic.PHP.LowerCaseConstant.Found"/>
+     <error line="6" column="2" severity="error" message="Line indented incorrectly; expected at least 4 spaces, found 1" source="PEAR.WhiteSpace.ScopeIndent.Incorrect"/>
+     <error line="9" column="1" severity="error" message="Missing function doc comment" source="PEAR.Commenting.FunctionComment.Missing"/>
+     <error line="11" column="5" severity="warning" message="Inline control structures are discouraged" source="Generic.ControlStructures.InlineControlStructure.Discouraged"/>
+    </file>
+    </checkstyle>
+
+## Printing a CSV Report
+PHP_CodeSniffer can output a CSV report to allow you to parse the output easily and use the results in your own scripts. To print a CSV report, use the `--report=csv` command line argument. The output will look like this:
+
+    $ phpcs --report=csv /path/to/code
+    
+    File,Line,Column,Type,Message,Source,Severity,Fixable
+    "/path/to/code/classA.php",2,1,error,"Missing file doc comment",PEAR.Commenting.FileComment.Missing,5,0
+    "/path/to/code/classA.php",4,12,error,"TRUE, FALSE and NULL must be lowercase; expected \"false\" but found \"FALSE\"",Generic.PHP.LowerCaseConstant.Found,5,1
+    "/path/to/code/classA.php",6,2,error,"Line indented incorrectly; expected at least 4 spaces, found 1",PEAR.WhiteSpace.ScopeIndent.Incorrect,5,1
+    "/path/to/code/classA.php",9,1,error,"Missing function doc comment",PEAR.Commenting.FunctionComment.Missing,5,0
+    "/path/to/code/classA.php",11,5,warning,"Inline control structures are discouraged",Generic.ControlStructures.InlineControlStructure.Discouraged,5,1
+
+**Note:** The first row of the CSV output defines the order of information. When using the CSV output, please parse this header row to determine the order correctly as the format may change over time or new information may be added.
+
+## Printing an Emacs Report
+PHP_CodeSniffer can output a report in a format the compiler built into the GNU Emacs text editor can understand. This lets you use the built-in complier to run PHP_CodeSniffer on a file you are editing and navigate between errors and warnings within the file. To print an Emacs report, use the `--report=emacs` command line argument. The output will look like this:
+
+    $ phpcs --report=emacs /path/to/code
+    
+    /path/to/code/classA.php:2:1: error - Missing file doc comment
+    /path/to/code/classA.php:4:12: error - TRUE, FALSE and NULL must be lowercase; expected "false" but found "FALSE"
+    /path/to/code/classA.php:6:2: error - Line indented incorrectly; expected at least 4 spaces, found 1
+    /path/to/code/classA.php:9:1: error - Missing function doc comment
+    /path/to/code/classA.php:11:5: warning - Inline control structures are discouraged
+
+To use PHP_CodeSniffer with Emacs, make sure you have installed PHP mode for Emacs. Then put the following into your .emacs file, changing PHP_CodeSniffer options as required.
+
+    (require 'compile)
+    (defun my-php-hook-function ()
+     (set (make-local-variable 'compile-command) (format "phpcs --report=emacs --standard=PEAR %s" (buffer-file-name))))
+    (add-hook 'php-mode-hook 'my-php-hook-function)
+
+Now you can use the compile command and associated shortcuts to move between error messages within your file.
+
+## Printing a Git Blame Report
+PHP_CodeSniffer can make use of the `git blame` command to try and determine who committed each error and warning to a Git respository. To print a Git Blame report, use the `--report=gitblame` command line argument. The output will look like this:
+
+    $ phpcs --report=gitblame /path/to/code
+    
+    PHP CODE SNIFFER GIT BLAME SUMMARY
+    --------------------------------------------------------------------------------
+    AUTHOR                                                              COUNT (%)
+    --------------------------------------------------------------------------------
+    jsmith                                                              51 (40.8)
+    jblogs                                                              44 (30)
+    pdeveloper                                                          43 (10.33)
+    jscript                                                             27 (19.84)
+    --------------------------------------------------------------------------------
+    A TOTAL OF 165 SNIFF VIOLATION(S) WERE COMMITTED BY 4 AUTHOR(S)
+    --------------------------------------------------------------------------------
+
+Each author is listed with the number of violations they committed and the percentage of error lines to clean lines. The example report above shows that the developer `pdeveloper` has 43 violations but they only make up 10% of all code they have committed, while `jblogs` has 44 violations but they make up 30% of all their committed code. So these developers have about the same number of total violations, but `pdeveloper` seems to be doing a better job of conforming to the coding standard.
+
+To show a breakdown of the types of violations each author is committing, use the `-s` command line argument.
+
+    $ phpcs -s --report=gitblame /path/to/code
+    
+    PHP CODE SNIFFER GIT BLAME SUMMARY
+    --------------------------------------------------------------------------------
+    AUTHOR   SOURCE                                                     COUNT (%)
+    --------------------------------------------------------------------------------
+    jsmith                                                              51 (40.8)
+             Squiz.Files.LineLength                                     47
+             PEAR.Functions.FunctionCallSignature                       4
+    jblogs                                                              44 (30)
+             Squiz.Files.LineLength                                     40
+             Generic.CodeAnalysis.UnusedFunctionParameter               2
+             Squiz.CodeAnalysis.EmptyStatement                          1
+             Squiz.Formatting.MultipleStatementAlignment                1
+    --------------------------------------------------------------------------------
+    A TOTAL OF 95 SNIFF VIOLATION(S) WERE COMMITTED BY 2 AUTHOR(S)
+    --------------------------------------------------------------------------------
+
+To include authors with no violations, use the `-v` command line argument.
+
+    $ phpcs -v --report=gitblame /path/to/code
+    
+    PHP CODE SNIFFER GIT BLAME SUMMARY
+    --------------------------------------------------------------------------------
+    AUTHOR                                                              COUNT (%)
+    --------------------------------------------------------------------------------
+    jsmith                                                              51 (40.8)
+    jblogs                                                              44 (30)
+    pdeveloper                                                          43 (10.33)
+    jscript                                                             27 (19.84)
+    toogood                                                             0 (0)
+    --------------------------------------------------------------------------------
+    A TOTAL OF 165 SNIFF VIOLATION(S) WERE COMMITTED BY 5 AUTHOR(S)
+    --------------------------------------------------------------------------------
+
+**Note:** You need to make sure the location of the `git` command is in your path. If the command is not in your path, the report will fail to generate.
+
+## Printing a JSON Report
+PHP_CodeSniffer can output an JOSN report to allow you to parse the output easily and use the results in your own scripts. To print a JSON report, use the `--report=json` command line argument. The output will look like this:
+
+    $ phpcs --report=json /path/to/code
+    
+    {
+      "totals": {
+        "errors": 4,
+        "warnings": 1,
+        "fixable": 3
+      },
+      "files": {
+        "\/path\/to\/code\/classA.php": {
+          "errors": 4,
+          "warnings": 1,
+          "messages": [
+            {
+              "message": "Missing file doc comment",
+              "source": "PEAR.Commenting.FileComment.Missing",
+              "severity": 5,
+              "type": "ERROR",
+              "line": 2,
+              "column": 1,
+              "fixable": false
+            },
+            {
+              "message": "TRUE, FALSE and NULL must be lowercase; expected \"false\" but found \"FALSE\"",
+              "source": "Generic.PHP.LowerCaseConstant.Found",
+              "severity": 5,
+              "type": "ERROR",
+              "line": 4,
+              "column": 12,
+              "fixable": true
+            },
+            {
+              "message": "Line indented incorrectly; expected at least 4 spaces, found 1",
+              "source": "PEAR.WhiteSpace.ScopeIndent.Incorrect",
+              "severity": 5,
+              "type": "ERROR",
+              "line": 6,
+              "column": 2,
+              "fixable": true
+            },
+            {
+              "message": "Missing function doc comment",
+              "source": "PEAR.Commenting.FunctionComment.Missing",
+              "severity": 5,
+              "type": "ERROR",
+              "line": 9,
+              "column": 1,
+              "fixable": false
+            },
+            {
+              "message": "Inline control structures are discouraged",
+              "source": "Generic.ControlStructures.InlineControlStructure.Discouraged",
+              "severity": 5,
+              "type": "WARNING",
+              "line": 11,
+              "column": 5,
+              "fixable": true
+            }
+          ]
+        },
+        "\/path\/to\/code\/classB.php": {
+          "errors": 0,
+          "warnings": 0,
+          "messages": [
+            
+          ]
+        }
+      }
+    }
+
+## Printing a JUnit Report
+PHP_CodeSniffer can output an XML report similar to the one produced by JUnit, allowing you to use the output in scripts and applications that already support JUnit. To print a JUnit report, use the `--report=junit` command line argument. The output will look like this:
+
+    $ phpcs --report=junit /path/to/code
+    
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="PHP_CodeSniffer x.x.x" tests="6" failures="5">
+    <testsuite name="/path/to/code/classA.php" tests="5" failures="5">
+     <testcase name="PEAR.Commenting.FileComment.Missing at /path/to/code/classA.php (2:1)">
+      <failure type="error" message="Missing file doc comment"/>
+     </testcase>
+     <testcase name="Generic.PHP.LowerCaseConstant.Found at /path/to/code/classA.php (4:12)">
+      <failure type="error" message="TRUE, FALSE and NULL must be lowercase; expected &quot;false&quot; but found &quot;FALSE&quot;"/>
+     </testcase>
+     <testcase name="PEAR.WhiteSpace.ScopeIndent.Incorrect at /path/to/code/classA.php (6:2)">
+      <failure type="error" message="Line indented incorrectly; expected at least 4 spaces, found 1"/>
+     </testcase>
+     <testcase name="PEAR.Commenting.FunctionComment.Missing at /path/to/code/classA.php (9:1)">
+      <failure type="error" message="Missing function doc comment"/>
+     </testcase>
+     <testcase name="Generic.ControlStructures.InlineControlStructure.Discouraged at /path/to/code/classA.php (11:5)">
+      <failure type="warning" message="Inline control structures are discouraged"/>
+     </testcase>
+    </testsuite>
+    <testsuite name="/path/to/code/classB.php" tests="1" failures="0">
+     <testcase name="/path/to/code/classB.php"/>
+    </testsuite>
+    </testsuites>
+
+
+## Printing an SVN Blame Report
+Like the Git Blame report, PHP_CodeSniffer can make use of the `svn blame` command to try and determine who committed each error and warning to an SVN repository. To print an SVN Blame report, use the `--report=svnblame` command line argument. The output and options are the same as those described in the [Git Blame report](#printing-a-git-blame-report).
+
+**Note:** You need to make sure the location of the `svn` command is in your path and that SVN is storing a username and password (if required by your repository). If the command is not in your path, the report will fail to generate. If SVN does not have a username and password stored, you'll need to enter it for each file being checked by PHP_CodeSniffer that contains violations.
+
+## Printing an XML Report
+PHP_CodeSniffer can output an XML report to allow you to parse the output easily and use the results in your own scripts. To print an XML report, use the `--report=xml` command line argument. The output will look like this:
+
+    $ phpcs --report=xml /path/to/code
+    
+    <?xml version="1.0" encoding="UTF-8"?>
+    <phpcs version="x.x.x">
+    <file name="/path/to/code/classA.php" errors="4" warnings="1" fixable="3">
+     <error line="2" column="1" source="PEAR.Commenting.FileComment.Missing" severity="5" fixable="0">Missing file doc comment</error>
+     <error line="4" column="12" source="Generic.PHP.LowerCaseConstant.Found" severity="5" fixable="1">TRUE, FALSE and NULL must be lowercase; expected &quot;false&quot; but found &quot;FALSE&quot;</error>
+     <error line="6" column="2" source="PEAR.WhiteSpace.ScopeIndent.Incorrect" severity="5" fixable="1">Line indented incorrectly; expected at least 4 spaces, found 1</error>
+     <error line="9" column="1" source="PEAR.Commenting.FunctionComment.Missing" severity="5" fixable="0">Missing function doc comment</error>
+     <warning line="11" column="5" source="Generic.ControlStructures.InlineControlStructure.Discouraged" severity="5" fixable="1">Inline control structures are discouraged</warning>
+    </file>
+    </phpcs>
+
+## Printing Multiple Reports
+PHP_CodeSniffer can print any combination of the above reports to either the screen or to separate files. To print multiple reports, use the `--report-[type]` command line argument instead of the standard `--report=[type]` format. You can then specify multiple reports using multiple arguments. The reports will be printed to the screen in the order you specify them on the command line.
+
+The following command will write both a full and summary report to the screen
+
+    $ phpcs --report-full --report-summary /path/to/code
+
+You can write the reports to separate files by specifying the path to the output file after each report argument.
+
+    $ phpcs --report-full=/path/to/full.txt --report-summary=/path/to/summary.txt /path/to/code
+
+You can print some reports to the screen and other reports to files. The following command will write the full report to a file and a summary report to the screen.
+
+    $ phpcs --report-full=/path/to/full.txt --report-summary /path/to/code
+
+## Running Interactively
+Instead of producing a single report at the end of a run, PHP_CodeSniffer can run interactively and show reports for files one at a time. When using the interactive mode, PHP_CodeSniffer will show a report for the first file it finds an error or warning in. It will then pause and wait for user input. Once you have corrected the errors, you can press `ENTER` to have PHP_CodeSniffer recheck your file and continue if the file is now free of errors. You can also choose to skip the file and move to the next file with errors.
+
+To run PHP_CodeSniffer interactively, use the `-a` command line argument.
+
+    $ phpcs -a /path/to/code
+    
+    FILE: /path/to/code/classA.php
+    --------------------------------------------------------------------------------
+    FOUND 4 ERRORS AND 1 WARNING AFFECTING 5 LINES
+    --------------------------------------------------------------------------------
+      2 | ERROR   | [ ] Missing file doc comment
+      4 | ERROR   | [x] TRUE, FALSE and NULL must be lowercase; expected "false"
+        |         |     but found "FALSE"
+      6 | ERROR   | [x] Line indented incorrectly; expected at least 4 spaces,
+        |         |     found 1
+      9 | ERROR   | [ ] Missing function doc comment
+     11 | WARNING | [x] Inline control structures are discouraged
+    --------------------------------------------------------------------------------
+    PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
+    --------------------------------------------------------------------------------
+    
+    <ENTER> to recheck, [s] to skip or [q] to quit :
+
+**Note:** PHP_CodeSniffer will always print the full error report for a file when running in interactive mode. Any report types you specify on the command line will be ignored.
+
+## Specifying a Report Width
+By default, PHP_CodeSniffer will print all screen-based reports 80 characters wide. File paths will be truncated if they don't fit within this limit and error messages will be wrapped across multiple lines. You can increase the report width to show longer file paths and limit the wrapping of error messages using the `--report-width` command line argument.
+
+    $ phpcs --report-width=120 --report=summary /path/to/code/myfile.php
+
+> Note: If you want reports to fill the entire terminal width (in supported terminals), set the `--report-width` command line argument to `auto`.
+>
+>    `$ phpcs --report-width=auto --report=summary /path/to/code/myfile.php`
+
+## Writing a Report to a File
+PHP_CodeSniffer always prints the specified report to the screen, but it can also be told to write a copy of the report to a file. When writing to a file, all internal parsing errors and verbose output PHP_CodeSniffer produces will not be included in the file. This feature is particularly useful when using report types such as XML and CSV that are often parsed by scripts or used with continuous integration software.
+
+To write a copy of a report to a file, use the `--report-file` command line argument.
+
+    $ phpcs --report=xml --report-file=/path/to/file.xml /path/to/code
+
+**Note:** The report will not be written to the screen when using this option. If you still want to view the report, use the -v command line argument to print verbose output.

--- a/docs/Documentation/Requirements.md
+++ b/docs/Documentation/Requirements.md
@@ -1,0 +1,1 @@
+PHP_CodeSniffer requires PHP version 5.4.0 or greater, although individual sniffs may have additional requirements such as external applications and scripts. See the [[Configuration Options]] manual page for a list of these requirements.

--- a/docs/Documentation/Usage.md
+++ b/docs/Documentation/Usage.md
@@ -1,0 +1,247 @@
+## Table of contents
+  * [Getting Help from the Command Line](#getting-help-from-the-command-line)
+  * [Checking Files and Folders](#checking-files-and-folders)
+  * [Printing a Summary Report](#printing-a-summary-report)
+  * [Printing Progress Information](#printing-progress-information)
+  * [Specifying a Coding Standard](#specifying-a-coding-standard)
+  * [Printing a List of Installed Coding Standards](#printing-a-list-of-installed-coding-standards)
+  * [Listing Sniffs Inside a Coding Standard](#listing-sniffs-inside-a-coding-standard)
+
+***
+
+## Getting Help from the Command Line
+
+Running PHP_CodeSniffer with the `-h` or `--help` command line arguments will print a list of commands that PHP_CodeSniffer will respond to. The output of `phpcs -h` is shown below.
+
+```
+Usage: phpcs [-nwlsaepqvi] [-d key[=value]] [--colors] [--no-colors]
+  [--cache[=<cacheFile>]] [--no-cache] [--tab-width=<tabWidth>]
+  [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>]
+  [--report-width=<reportWidth>] [--basepath=<basepath>] [--bootstrap=<bootstrap>]
+  [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]
+  [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]
+  [--standard=<standard>] [--sniffs=<sniffs>] [--exclude=<sniffs>]
+  [--encoding=<encoding>] [--parallel=<processes>] [--generator=<generator>]
+  [--extensions=<extensions>] [--ignore=<patterns>] [--ignore-annotations]
+  [--stdin-path=<stdinPath>] [--file-list=<fileList>] <file> - ...
+
+ -     Check STDIN instead of local files and directories
+ -n    Do not print warnings (shortcut for --warning-severity=0)
+ -w    Print both warnings and errors (this is the default)
+ -l    Local directory only, no recursion
+ -s    Show sniff codes in all reports
+ -a    Run interactively
+ -e    Explain a standard by showing the sniffs it includes
+ -p    Show progress of the run
+ -q    Quiet mode; disables progress and verbose output
+ -m    Stop error messages from being recorded
+       (saves a lot of memory, but stops many reports from being used)
+ -v    Print processed files
+ -vv   Print ruleset and token output
+ -vvv  Print sniff processing information
+ -i    Show a list of installed coding standards
+ -d    Set the [key] php.ini value to [value] or [true] if value is omitted
+
+ --help                Print this help message
+ --version             Print version information
+ --colors              Use colors in output
+ --no-colors           Do not use colors in output (this is the default)
+ --cache               Cache results between runs
+ --no-cache            Do not cache results between runs (this is the default)
+ --ignore-annotations  Ignore all phpcs: annotations in code comments
+
+ <cacheFile>    Use a specific file for caching (uses a temporary file by default)
+ <basepath>     A path to strip from the front of file paths inside reports
+ <bootstrap>    A comma separated list of files to run before processing begins
+ <file>         One or more files and/or directories to check
+ <fileList>     A file containing a list of files and/or directories to check
+                (one per line)
+ <encoding>     The encoding of the files being checked (default is utf-8)
+ <extensions>   A comma separated list of file extensions to check
+                (extension filtering only valid when checking a directory)
+                The type of the file can be specified using: ext/type
+                e.g., module/php,es/js
+ <generator>    Uses either the "HTML", "Markdown" or "Text" generator
+                (forces documentation generation instead of checking)
+ <patterns>     A comma separated list of patterns to ignore files and directories
+ <processes>    How many files should be checked simultaneously (default is 1)
+ <report>       Print either the "full", "xml", "checkstyle", "csv"
+                "json", "junit", "emacs", "source", "summary", "diff"
+                "svnblame", "gitblame", "hgblame" or "notifysend" report
+                (the "full" report is printed by default)
+ <reportFile>   Write the report to the specified file path
+ <reportWidth>  How many columns wide screen reports should be printed
+                or set to "auto" to use current screen width, where supported
+ <severity>     The minimum severity required to display an error or warning
+ <sniffs>       A comma separated list of sniff codes to include or exclude from checking
+                (all sniffs must be part of the specified standard)
+ <standard>     The name or path of the coding standard to use
+ <stdinPath>    If processing STDIN, the file path that STDIN will be processed as
+ <tabWidth>     The number of spaces each tab represents
+```
+
+> The `--standard` command line argument is optional, even if you have more than one coding standard installed. If no coding standard is specified, PHP_CodeSniffer will default to checking against the _PEAR_ coding standard, or the standard you have set as the default. [View instructions for setting the default coding standard](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-default-coding-standard).
+
+## Checking Files and Folders
+
+The simplest way of using PHP_CodeSniffer is to provide the location of a file or folder for PHP_CodeSniffer to check. If a folder is provided, PHP_CodeSniffer will check all files it finds in that folder and all its sub-folders. If you do not want sub-folders checked, use the `-l` command line argument to force PHP_CodeSniffer to run locally in the folders specified.
+
+In the example below, the first command tells PHP_CodeSniffer to check the `myfile.inc` file for coding standard errors while the second command tells PHP_CodeSniffer to check all PHP files in the `my_dir` directory.
+
+    $ phpcs /path/to/code/myfile.inc
+    $ phpcs /path/to/code/my_dir
+
+You can also specify multiple files and folders to check. The command below tells PHP_CodeSniffer to check the `myfile.inc` file and all files in the `my_dir` directory.
+
+    $ phpcs /path/to/code/myfile.inc /path/to/code/my_dir
+
+After PHP_CodeSniffer has finished processing your files, you will get an error report. The report lists both errors and warnings for all files that violated the coding standard. The output looks like this:
+
+    $ phpcs /path/to/code/myfile.php
+
+    FILE: /path/to/code/myfile.php
+    --------------------------------------------------------------------------------
+    FOUND 5 ERROR(S) AND 1 WARNING(S) AFFECTING 5 LINE(S)
+    --------------------------------------------------------------------------------
+      2 | ERROR   | Missing file doc comment
+     20 | ERROR   | PHP keywords must be lowercase; expected "false" but found
+        |         | "FALSE"
+     47 | ERROR   | Line not indented correctly; expected 4 spaces but found 1
+     47 | WARNING | Equals sign not aligned with surrounding assignments
+     51 | ERROR   | Missing function doc comment
+     88 | ERROR   | Line not indented correctly; expected 9 spaces but found 6
+    --------------------------------------------------------------------------------
+
+If you don't want warnings included in the output, specify the `-n` command line argument.
+
+    $ phpcs -n /path/to/code/myfile.php
+
+    FILE: /path/to/code/myfile.php
+    --------------------------------------------------------------------------------
+    FOUND 5 ERROR(S) AFFECTING 5 LINE(S)
+    --------------------------------------------------------------------------------
+      2 | ERROR | Missing file doc comment
+     20 | ERROR | PHP keywords must be lowercase; expected "false" but found "FALSE"
+     47 | ERROR | Line not indented correctly; expected 4 spaces but found 1
+     51 | ERROR | Missing function doc comment
+     88 | ERROR | Line not indented correctly; expected 9 spaces but found 6
+    --------------------------------------------------------------------------------
+
+## Printing a Summary Report
+
+By default, PHP_CodeSniffer will print a complete list of all errors and warnings it finds. This list can become quite long, especially when checking a large number of files at once. To print a summary report that only shows the number of errors and warnings for each file, use the `--report=summary` command line argument. The output will look like this:
+
+    $ phpcs --report=summary /path/to/code
+
+    PHP CODE SNIFFER REPORT SUMMARY
+    --------------------------------------------------------------------------------
+    FILE                                                            ERRORS  WARNINGS
+    --------------------------------------------------------------------------------
+    /path/to/code/myfile.inc                                        5       0
+    /path/to/code/yourfile.inc                                      1       1
+    /path/to/code/ourfile.inc                                       0       2
+    --------------------------------------------------------------------------------
+    A TOTAL OF 6 ERROR(S) AND 3 WARNING(S) WERE FOUND IN 3 FILE(S)
+    --------------------------------------------------------------------------------
+
+As with the full report, you can suppress the printing of warnings with the `-n` command line argument.
+
+    $ phpcs -n --report=summary /path/to/code
+
+    PHP CODE SNIFFER REPORT SUMMARY
+    --------------------------------------------------------------------------------
+    FILE                                                                      ERRORS
+    --------------------------------------------------------------------------------
+    /path/to/code/myfile.inc                                                  5
+    /path/to/code/yourfile.inc                                                1
+    --------------------------------------------------------------------------------
+    A TOTAL OF 6 ERROR(S) WERE FOUND IN 2 FILE(S)
+    --------------------------------------------------------------------------------
+
+## Printing Progress Information
+
+By default, PHP_CodeSniffer will run quietly, only printing the report of errors and warnings at the end. If you are checking a large number of files, you may have to wait a while to see the report. If you want to know what is happening, you can turn on progress or verbose output.
+
+With progress output enabled, PHP_CodeSniffer will print a single-character status for each file being checked. The possible status characters are:
+
+* `.` : The file contained no errors or warnings
+* `E` : The file contained 1 or more errors
+* `W` : The file contained 1 or more warnings, but no errors
+* `S` : The file contained a [@codingStandardsIgnoreFile](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders) comment and was skipped
+
+Progress output will look like this:
+
+    $ phpcs /path/to/code/CodeSniffer -p
+    ......................S.....................................  60 / 572
+    ..........EEEE.E.E.E.E.E.E.E.E..W..EEE.E.E.E.EE.E.E.E.E.E.E. 120 / 572
+    E.E.E.E.E.WWWW.E.W..EEE.E.................E.E.E.E...E....... 180 / 572
+    E.E.E.E.....................E.E.E.E.E.E.E.E.E.E.W.E.E.E.E.E. 240 / 572
+    E.W......................................................... 300 / 572
+    ..........................................E.E.E.E...E.E.E.E. 360 / 572
+    E.E.E.E.E.E..E.E.E..E..E..E.E.WW.E.E.EE.E.E................. 420 / 572
+    ...................E.E.EE.E.E.E.S.E.EEEE.E...E...EE.E.E..EEE 480 / 572
+    .E.EE.E.E..E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E.E..E..E..E.E.E..E 540 / 572
+    .E.E....E.E.E...E.....E.E.ES....
+
+> You can configure PHP_CodeSniffer to show progress information by default using [the configuration option](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#showing-progress-by-default)</link>.
+
+With verbose output enabled, PHP_CodeSniffer will print the file that it is checking, show you how many tokens and lines the file contains, and let you know how long it took to process. The output will look like this:
+
+    $ phpcs /path/to/code/CodeSniffer -v
+    Registering sniffs in PEAR standard... DONE (24 sniffs registered)
+    Creating file list... DONE (572 files in queue)
+    Processing AbstractDocElement.php [1093 tokens in 303 lines]... DONE in < 1 second (0 errors, 1 warnings)
+    Processing AbstractParser.php [2360 tokens in 558 lines]... DONE in 2 seconds (0 errors, 1 warnings)
+    Processing ClassCommentParser.php [923 tokens in 296 lines]... DONE in < 1 second (2 errors, 0 warnings)
+    Processing CommentElement.php [988 tokens in 218 lines]... DONE in < 1 second (1 error, 5 warnings)
+    Processing FunctionCommentParser.php [525 tokens in 184 lines]... DONE in 1 second (0 errors, 6 warnings)
+    Processing File.php [10968 tokens in 1805 lines]... DONE in 5 seconds (0 errors, 5 warnings)
+    Processing Sniff.php [133 tokens in 94 lines]... DONE in < 1 second (0 errors, 0 warnings)
+    Processing SniffException.php [47 tokens in 36 lines]... DONE in < 1 second (1 errors, 3 warnings)
+
+## Specifying a Coding Standard
+
+PHP_CodeSniffer can have multiple coding standards installed to allow a single installation to be used with multiple projects. When checking PHP code, PHP_CodeSniffer can be told which coding standard to use. This is done using the `--standard` command line argument.
+
+The example below checks the `myfile.inc` file for violations of the _PEAR_ coding standard (installed by default).
+
+    $ phpcs --standard=PEAR /path/to/code/myfile.inc
+
+You can also tell PHP_CodeSniffer to use an external standard by specifying the full path to the standard's root directory on the command line. An external standard is one that is stored outside of PHP_CodeSniffer's `Standards` directory.
+
+    $ phpcs --standard=/path/to/MyStandard /path/to/code/myfile.inc
+
+Multiple coding standards can be checked at the same time by passing a list of comma separated standards on the command line. A mix of external and installed coding standards can be passed if required.
+
+    $ phpcs --standard=PEAR,Squiz,/path/to/MyStandard /path/to/code/myfile.inc
+
+## Printing a List of Installed Coding Standards
+
+PHP_CodeSniffer can print you a list of the coding standards that are installed so that you can correctly specify a coding standard to use for testing. You can print this list by specifying the `-i` command line argument.
+
+    $ phpcs -i
+    The installed coding standards are MySource, PEAR, PHPCS, PSR1, PSR2, Squiz and Zend
+
+## Listing Sniffs Inside a Coding Standard
+
+PHP_CodeSniffer can print you a list of the sniffs that a coding standard includes by specifying the `-e` command line argument along with the `--standard` argument. This allows you to see what checks will be applied when you use a given standard.
+
+    $ phpcs --standard=PSR1 -e
+
+    The PSR1 standard contains 7 sniffs
+
+    Generic (3 sniffs)
+    ------------------
+      Generic.Files.ByteOrderMark
+      Generic.NamingConventions.UpperCaseConstantName
+      Generic.PHP.DisallowShortOpenTag
+
+    PSR1 (3 sniffs)
+    ---------------
+      PSR1.Classes.ClassDeclaration
+      PSR1.Files.SideEffects
+      PSR1.Methods.CamelCapsMethodName
+
+    Squiz (1 sniff)
+    ----------------
+      Squiz.Classes.ValidClassName

--- a/docs/Documentation/Version-1.3.0-Upgrade-Guide.md
+++ b/docs/Documentation/Version-1.3.0-Upgrade-Guide.md
@@ -1,0 +1,166 @@
+PHP_CodeSniffer version 1.3.0 contains an important backwards compatibility break that all coding standard authors need to be aware of. Upgrading your coding standard to make use of the new `ruleset.xml` files is an easy process and this guide will show you how to get it done.
+
+> Note: Please note that if you have not created your own coding standard, you do not need to follow this guide. Users of PHP_CodeSniffer that use one of the built-in standards can continue to check their code as normal.
+
+This guide assumes your coding standard has the following directory structure:
+```
+MyStandard
+|_ MyStandardCodingStandard.php
+|_ Sniffs
+   |_ Commenting
+      |_ DisallowHashCommentsSniff.php
+```
+In this sample coding standard, we have a single sniff being included directly within the standard's sniff directory. But it doesn't matter how many sniffs you have as they are automatically included into the standard in all versions of PHP_CodeSniffer. Your standard may not even have any directly included sniffs, preferring to include sniffs from other standards via the `CodingStandard.php` class.
+
+The only thing we need to do to upgrade a custom coding standard is convert the `CodingStandard.php` class to a `ruleset.xml` file. We can leave all directly included sniffs alone and we don't have to change our directory structure.
+
+### The Basics
+
+The first thing you need to do is create a `ruleset.xml` file directly under your top-level directory. The name of the file must be `ruleset.xml`:
+```
+touch MyStandard/ruleset.xml
+```
+
+The contents of this file will be minimal if you are not including any sniffs from other standards. So the file content would look like this:
+```xml
+<?xml version="1.0"?>
+<ruleset name="My Standard">
+    <description>My custom coding standard</description>
+</ruleset>
+```
+
+A simple `ruleset.xml` file like this tells PHP_CodeSniffer that this directory contains a coding standard, the name of the standard is *My Standard* and the sniffs in the standard are sourced directly from the default `Sniffs` directory.
+
+Once you've created your `ruleset.xml` file, you can go ahead and delete the `CodingStandard.php` class file as it is no longer required. However, you can keep both files in the coding standard if you want to use your standard in both old and new versions of PHP_CodeSniffer. But be aware that you will need to make changes to both files and any advanced ruleset features you add to your `ruleset.xml` file can not be replicated in your `CodingStandard.php` class file.
+
+### A Simple Coding Standard Class
+
+You can build on a coding standard by including sniffs from other standards. A sample `CodingStandard.php` class from the PHP_CodeSniffer documentation contains this:
+```php
+public function getIncludedSniffs()
+{
+  return array(
+          'PEAR',
+          'Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php',
+          'Generic/Sniffs/Functions',
+         );
+
+}//end getIncludedSniffs()
+```
+
+The example above includes the `MultipleStatementAlignment` sniff from the `Generic` coding standard, all sniffs in the `Functions` category of the `Generic` coding standard and all sniffs defined in the `PEAR` coding standard.
+
+These rules would be replicated in a `ruleset.xml` file like this:
+```xml
+<?xml version="1.0"?>
+    <ruleset name="My Standard">
+    <description>My custom coding standard</description>
+    <rule ref="PEAR"/>
+    <rule ref="Generic.Formatting.MultipleStatementAlignment"/>
+    <rule ref="Generic/Sniffs/Functions"/>
+</ruleset>
+```
+
+The two changes here are the use of the `rule` tag to include sniffs and standards, and also the way we reference an individual sniff. Instead of specifying the path to the sniff we instead specify the internal code that PHP_CodeSniffer gives it, which is based on the path. It's actually a pretty easy conversion. Just just drop the `Sniffs` directory, convert the slashes to periods and remove `Sniff.php` from the end. Here are some more examples to make sure it is clear.
+```
+BEFORE: Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+AFTER:  Generic.VersionControl.SubversionProperties
+
+BEFORE: PEAR/Sniffs/ControlStructures/ControlSignatureSniff.php
+AFTER:  PEAR.ControlStructures.ControlSignature
+
+BEFORE: Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+AFTER:  Squiz.Strings.DoubleQuoteUsage
+```
+
+## Coding Standards with Exclusions
+
+Some coding standards include a set of sniffs from an external standard but then exclude some specific sniffs. A sample `CodingStandard.php` class with exclusions from the PHP_CodeSniffer documentation contains this:
+```php
+public function getIncludedSniffs()
+{
+  return array(
+          'PEAR',
+         );
+
+}//end getIncludedSniffs()
+
+public function getExcludedSniffs()
+{
+  return array(
+          'PEAR/Sniffs/ControlStructures/ControlSignatureSniff.php',
+         );
+
+}//end getExcludedSniffs()
+```
+
+The example above includes the whole `PEAR` coding standard except for the `ControlSignature` sniff.
+
+These rules would be replicated in a `ruleset.xml` file like this:
+```xml
+<?xml version="1.0"?>
+<ruleset name="My Standard">
+    <description>My custom coding standard</description>
+    <rule ref="PEAR">
+        <exclude name="PEAR.ControlStructures.ControlSignature"/>
+    </rule>
+</ruleset>
+```
+
+Notice how the exclusions are grouped with the standard they are being excluded from and how they again use the internal sniff codes instead of full paths to sniff files.
+
+## A Practical Example
+
+PHP_CodeSniffer comes with a coding standard called `PHPCS`, which is the entire `PEAR` standard as well as some `Squiz` sniffs thrown in. In version 1.2.2, the `PHPCSCodingStandard.php` file contained these two functions:
+```php
+public function getIncludedSniffs()
+{
+  return array(
+          'PEAR',
+          'Squiz',
+         );
+
+}//end getIncludedSniffs()
+
+public function getExcludedSniffs()
+{
+  return array(
+          'Squiz/Sniffs/Classes/ClassFileNameSniff.php',
+          'Squiz/Sniffs/Classes/ValidClassNameSniff.php',
+          'Squiz/Sniffs/Commenting/ClassCommentSniff.php',
+          'Squiz/Sniffs/Commenting/FileCommentSniff.php',
+          'Squiz/Sniffs/Commenting/FunctionCommentSniff.php',
+          'Squiz/Sniffs/Commenting/VariableCommentSniff.php',
+          'Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php',
+          'Squiz/Sniffs/Files/FileExtensionSniff.php',
+          'Squiz/Sniffs/NamingConventions/ConstantCaseSniff.php',
+          'Squiz/Sniffs/WhiteSpace/ScopeIndentSniff.php',
+         );
+
+}//end getExcludedSniffs()
+```
+
+To support version 1.3.0, the `ruleset.xml` file was created with this content:
+```xml
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <description>The coding standard for PHP_CodeSniffer.</description>
+
+    <!-- Include the whole PEAR standard -->
+    <rule ref="PEAR"/>
+
+    <!-- Include most of the Squiz standard -->
+    <rule ref="Squiz">
+        <exclude name="Squiz.Classes.ClassFileName"/>
+        <exclude name="Squiz.Classes.ValidClassName"/>
+        <exclude name="Squiz.Commenting.ClassComment"/>
+        <exclude name="Squiz.Commenting.FileComment"/>
+        <exclude name="Squiz.Commenting.FunctionComment"/>
+        <exclude name="Squiz.Commenting.VariableComment"/>
+        <exclude name="Squiz.ControlStructures.SwitchDeclaration"/>
+        <exclude name="Squiz.Files.FileExtension"/>
+        <exclude name="Squiz.NamingConventions.ConstantCase"/>
+        <exclude name="Squiz.WhiteSpace.ScopeIndent"/>
+    </rule>
+</ruleset>
+```

--- a/docs/Documentation/Version-3.0-Upgrade-Guide.md
+++ b/docs/Documentation/Version-3.0-Upgrade-Guide.md
@@ -1,0 +1,313 @@
+PHP_CodeSniffer version 3 contains a large number of core changes and breaks backwards compatibility for all custom sniffs and reports. The aim of this guide is to help developers upgrade their custom sniffs, unit tests, and reports from PHP_CodeSniffer version 2 to version 3.
+
+> Note: If you only use the built-in coding standards, or you have a custom ruleset.xml file that only makes use of the sniffs and reports distributed with PHP_CodeSniffer, you do not need to make any changes to begin using PHP_CodeSniffer version 3.
+
+***
+
+## Table of contents
+* [Upgrading Custom Sniffs](#upgrading-custom-sniffs)
+    * [Extending Other Sniffs](#extending-other-sniffs)
+    * [Extending the Included Abstract Sniffs](#extending-the-included-abstract-sniffs)
+        * [AbstractVariableSniff](#abstractvariablesniff)
+        * [AbstractPatternSniff](#abstractpatternsniff)
+        * [AbstractScopeSniff](#abstractscopesniff)
+* [New Class Names](#new-class-names)
+    * [PHP_CodeSniffer_File](#php_codesniffer_file)
+    * [PHP_CodeSniffer_Tokens](#php_codesniffer_tokens)
+    * [PHP_CodeSniffer](#php_codesniffer)
+* [Upgrading Unit Tests](#upgrading-unit-tests)
+    * [Setting CLI Values](#setting-cli-values)
+* [Upgrading Custom Reports](#upgrading-custom-reports)
+    * [Supporting Concurrency](#supporting-concurrency)
+
+***
+
+## Upgrading Custom Sniffs
+
+All sniffs must now be namespaced.
+
+> Note: It doesn't matter what namespace you use for your sniffs as long as the last part of the namespace is in the format `StandardName\Sniffs\Category` as this is used to determine the sniff code. The examples below use a very minimal namespace but you can prefix it with whatever makes sense for your project. If you aren't sure what namespace to use, try using the example format.
+
+> Note: If you decide to use a more complex prefix, or your prefix does not match the name of the directory containing your ruleset.xml file, you need to define the prefix in the ruleset tag of your ruleset.xml file. For example, if your namespace format for sniffs is `MyProject\CS\StandardName\Sniffs\Category`, set the namespace to `MyProject\CS\StandardName` (everything up to `\Sniffs\`). The ruleset tag would look like this: `<ruleset name="Custom Standard" namespace="MyProject\CS\StandardName">`
+
+Internal namespace changes to core classes require changes to all sniff class definitions. The old definition looked like this:
+```php
+class StandardName_Sniffs_Category_TestSniff implements PHP_CodeSniffer_Sniff {}
+```
+
+The sniff class definition above should now be rewritten like this:
+```php
+namespace StandardName\Sniffs\Category;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class TestSniff implements Sniff {}
+```
+
+### Extending Other Sniffs
+
+If your custom sniff extends another sniff, the class definition needs to change a bit more. Previously, a `class_exists()` call may have been used to autoload the sniff. Now, a `use` statement is used for autoloading, and the extended class name also changes.
+
+The old class definition for a sniff extending another looked like this:
+```php
+if (class_exists('OtherStandardName_Sniffs_Category_TestSniff', true) === false) {
+    throw new PHP_CodeSniffer_Exception('Class OtherStandardName_Sniffs_Category_TestSniff not found');
+}
+
+class StandardName_Sniffs_Category_TestSniff extends OtherStandardName_Sniffs_Category_TestSniff {}
+```
+
+The sniff class definition above should now be rewritten like this:
+```php
+namespace StandardName\Sniffs\Category;
+
+use OtherStandardName\Sniffs\Category\TestSniff as OtherTestSniff;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class TestSniff extends OtherTestSniff {}
+```
+
+### Extending the Included Abstract Sniffs
+
+#### AbstractVariableSniff
+If you previously extended the `AbstractVariableSniff`, your class definition will now look like this:
+```php
+namespace StandardName\Sniffs\Category;
+
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Files\File;
+
+class TestSniff extends AbstractVariableSniff {}
+```
+#### AbstractPatternSniff
+If you previously extended the `AbstractPatternSniff`, your class definition will now look like this:
+```php
+namespace StandardName\Sniffs\Category;
+
+use PHP_CodeSniffer\Sniffs\AbstractPatternSniff;
+
+class TestSniff extends AbstractPatternSniff {}
+```
+> Note: `PHP_CodeSniffer\Files\File` is not typically needed in a sniff that extends AbstractPatternSniff because these sniffs normally only override the `getPatterns()` method. If you are overriding a method that needs `File`, include the `use` statement as you would for any other sniff.
+
+#### AbstractScopeSniff
+If you previously extended the `AbstractScopeSniff`, your class definition will now look like this:
+```php
+namespace StandardName\Sniffs\Category;
+
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Files\File;
+
+class TestSniff extends AbstractScopeSniff {}
+```
+
+If you did not previously define the optional `processTokenOutsideScope()` method, you must now do so as it has been marked as abstract. Include the empty method below if you do not need to process tokens outside the specified scopes:
+```php
+protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
+{
+}
+```
+
+### New Class Names
+
+#### PHP_CodeSniffer_File
+Any references to `PHP_CodeSniffer_File` in your sniff should be changed to `File`. This includes the type hint that is normally used in the `process()` function definition. The old definition looked like this:
+```php
+public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {}
+```
+
+The `process()` function declaration should now be rewritten like this:
+```php
+public function process(File $phpcsFile, $stackPtr) {}
+```
+
+#### PHP_CodeSniffer_Tokens
+If your sniff currently uses the `PHP_CodeSniffer_Tokens` class, you will need to add a use statement for `PHP_CodeSniffer\Util\Tokens` and then change references of `PHP_CodeSniffer_Tokens::` to `Tokens::` inside your sniff. The below example shows a sniff that is registering the list of comment tokens using the new `Tokens` class. Note the additional `use` statement:
+```php
+namespace StandardName\Sniffs\Category;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class TestSniff implements Sniff
+{
+
+    public function register()
+    {
+        return Tokens::$commentTokens;
+    }
+
+    public function process(File $phpcsFile, $stackPtr) {}
+
+}
+```
+
+#### PHP_CodeSniffer
+If your sniff currently uses the `PHP_CodeSniffer` class to access utility functions such as `isCamelCaps()` and `suggestType()`, you will need to add a use statement for `PHP_CodeSniffer\Util\Common` and then change references of `PHP_CodeSniffer::` to `Common::` inside your sniff. Your class definition will look like this:
+```php
+namespace StandardName\Sniffs\Category;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Common;
+
+class TestSniff implements Sniff {}
+```
+
+## Upgrading Unit Tests
+
+Internal namespace changes to core classes require changes to all unit test class definitions. The old definition looked like this:
+```php
+class StandardName_Tests_Category_TestSniffUnitTest implements AbstractSniffUnitTest {}
+```
+
+The unit test class definition above should now be rewritten like this:
+```php
+namespace StandardName\Tests\Category;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class TestSniffUnitTest extends AbstractSniffUnitTest {}
+```
+
+### Setting CLI Values
+
+If your unit test class uses the `getCliValues()` method to specify CLI values to use during testing, you'll need to instead use the new `setCliValues()` method to set configuration values directly. A common use case for setting CLI values is to set the tab width, which was previously done using a method like this:
+```php
+public function getCliValues($testFile)
+{
+    return array('--tab-width=4');
+}
+```
+
+Tab width is now set using this method:
+```php
+public function setCliValues($testFile, $config)
+{
+    $config->tabWidth = 4;
+}
+```
+> Note: A complete list of configuration settings can be found in the documentation of the [Config class](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Config.php#L42).
+
+## Upgrading Custom Reports
+
+All reports must now be namespaced.
+
+> Note: It doesn't really matter what namespace you use for your custom reports, but the examples below use a basic namespace based on the standard name. If you aren't sure what to use, try using this format.
+
+Internal namespace changes to core classes require changes to all report class definitions. The old definition looked like this:
+```php
+class PHP_CodeSniffer_Reports_ReportName implements PHP_CodeSniffer_Report {}
+```
+
+The report class definition above should now be rewritten as this:
+```php
+namespace StandardName\Reports;
+
+use PHP_CodeSniffer\Files\File;
+
+class ReportName implements Report {}
+```
+
+The function signatures of the `generateFileReport()` and `generate()` methods are also slightly different. The `generateFileReport()` signature simply renames `PHP_CodeSniffer_File` to `File` due to namespace changes, while the `generate()` signature adds a new `$interactive` argument so reports know if PHP_CodeSniffer is running in interactive mode. This is useful so that reports can suppress output such as memory and time usage when they know they are printing in this mode, or even change their output completely as they know they are only printing a report for a single file.
+
+The old method signatures looked like this:
+```php
+public function generateFileReport(
+    $report,
+    PHP_CodeSniffer_File $phpcsFile,
+    $showSources=false,
+    $width=80
+) {
+    ...
+}
+
+public function generate(
+    $cachedData,
+    $totalFiles,
+    $totalErrors,
+    $totalWarnings,
+    $totalFixable,
+    $showSources=false,
+    $width=80,
+    $toScreen=true
+) {
+    ...
+}
+```
+
+They should now be written like this:
+```php
+public function generateFileReport(
+    $report,
+    File $phpcsFile,
+    $showSources=false,
+    $width=80
+) {
+    ...
+}
+
+public function generate(
+    $cachedData,
+    $totalFiles,
+    $totalErrors,
+    $totalWarnings,
+    $totalFixable,
+    $showSources=false,
+    $width=80,
+    $interactive=false,
+    $toScreen=true
+) {
+    ...
+}
+```
+
+### Supporting Concurrency
+
+PHP_CodeSniffer version 3 supports processing multiple files concurrently, so reports can no longer rely on getting file results one at a time. Reports that used to write to local member vars can no longer do so as multiple forks of the PHP_CodeSniffer process will all be writing to a different instance of the report class at the same time and these cache values will never be merged. Instead, reports need to output their cached data directly. They will later be given a chance to read in the entire cached output and generate a final clean report.
+
+> Note: Reports that output content in a way where the order or formatting is not important do not need to worry about caching data and can continue to produce reports they way they do now. Examples of these reports include the CSV report and the XML report.
+
+The Summary report is a good example of what changes need to be made. The summary report can't output a single final report line for each file it processes as it has to properly align all the values in the final screen report. Previously, it wrote the number of error and warnings found to a private member var array inside the `generateFileReport()` method and  later used that array to generate the final report. Even though it didn't output anything to screen, it had to return `true` to ensure the Reporter knew there were errors in the file:
+```php
+$this->_reportFiles[$report['filename']] = array(
+                                            'errors'   => $report['errors'],
+                                            'warnings' => $report['warnings'],
+                                            'strlen'   => strlen($report['filename']),
+                                           );
+return true;
+```
+
+Now, it outputs cache information directly using a single line of output per file:
+```php
+echo $report['filename'].'>>'.$report['errors'].'>>'.$report['warnings'].PHP_EOL;
+return true;
+```
+
+Previously, the Summary report would read it's private member var in the `generate()` method to get a list of all the cached data it has stored. It would then iterate over that data to generate the final report:
+```php
+if (empty($this->_reportFiles) === true) {
+    return;
+}
+
+foreach ($this->_reportFiles as $file => $data) {
+    ...
+}
+```
+
+Now, it receives all the output the various forks of the PHP_CodeSniffer process produced in one big string. It explodes the data and then iterates over it as before:
+```php
+$lines = explode(PHP_EOL, $cachedData);
+array_pop($lines);
+
+if (empty($lines) === true) {
+    return;
+}
+
+foreach ($lines as $line) {
+    ...
+}
+```

--- a/docs/Sniffs/PSR2/Classes/ClassDeclaration/OpenBraceNewLine.md
+++ b/docs/Sniffs/PSR2/Classes/ClassDeclaration/OpenBraceNewLine.md
@@ -1,0 +1,57 @@
+# OpenBraceNewLine
+
+PSR2 indicates:
+
+> Opening braces for classes MUST go on the next line, and closing braces MUST go on the next line after the body.
+
+## Correct
+
+The following example should pass lints, and is the correct way of formatting a class:
+
+```php
+class Foo
+{
+    public function __construct()
+    {
+        // ...
+    }
+}
+```
+
+The opening brace is placed directly after the `Foo` statement, on the next line.
+
+## Incorrect
+
+### Opening brace on the same line
+
+```php
+class Foo{
+    public function __construct()
+    {
+        // ...
+    }
+}
+```
+
+In this case, the opening brace is on the same line as the class declaration. This is not valid according to the PSR2
+specification
+
+### Multiple spaces between class and opening brace
+
+```php
+class Foo
+
+{
+    public function __construct()
+    {
+        // ...
+    }
+}
+```
+
+In this case, the brace is below the class declaration but not *directly* below it. Accordingly, this is also invalid
+according to the PSR2 specification.
+
+## References
+
+- https://www.php-fig.org/psr/psr-2/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+PHP_CodeSniffer is a set of two PHP scripts; the main phpcs script that tokenizes PHP, JavaScript and CSS files to detect violations of a defined coding standard, and a second phpcbf script to automatically correct coding standard violations. PHP_CodeSniffer is an essential development tool that ensures your code remains clean and consistent.
+
+A coding standard in PHP_CodeSniffer is a collection of sniff files. Each sniff file checks one part of the coding standard only. Multiple coding standards can be used within PHP_CodeSniffer so that the one installation can be used across multiple projects. The default coding standard used by PHP_CodeSniffer is the PEAR coding standard.
+
+## Example 
+To check a file against the PEAR coding standard, simply specify the file's location.
+
+    $ phpcs /path/to/code/myfile.php
+    
+    FILE: /path/to/code/myfile.php
+    --------------------------------------------------------------------------------
+    FOUND 5 ERROR(S) AFFECTING 2 LINE(S)
+    --------------------------------------------------------------------------------
+      2 | ERROR | Missing file doc comment
+     20 | ERROR | PHP keywords must be lowercase; expected "false" but found "FALSE"
+     47 | ERROR | Line not indented correctly; expected 4 spaces but found 1
+     51 | ERROR | Missing function doc comment
+     88 | ERROR | Line not indented correctly; expected 9 spaces but found 6
+    --------------------------------------------------------------------------------
+
+Or, if you wish to check an entire directory, you can specify the directory location instead of a file.
+
+    $ phpcs /path/to/code
+    
+    FILE: /path/to/code/myfile.php
+    --------------------------------------------------------------------------------
+    FOUND 5 ERROR(S) AFFECTING 5 LINE(S)
+    --------------------------------------------------------------------------------
+      2 | ERROR | Missing file doc comment
+     20 | ERROR | PHP keywords must be lowercase; expected "false" but found "FALSE"
+     47 | ERROR | Line not indented correctly; expected 4 spaces but found 1
+     51 | ERROR | Missing function doc comment
+     88 | ERROR | Line not indented correctly; expected 9 spaces but found 6
+    --------------------------------------------------------------------------------
+    
+    FILE: /path/to/code/yourfile.php
+    --------------------------------------------------------------------------------
+    FOUND 1 ERROR(S) AND 1 WARNING(S) AFFECTING 1 LINE(S)
+    --------------------------------------------------------------------------------
+     21 | ERROR   | PHP keywords must be lowercase; expected "false" but found
+        |         | "FALSE"
+     21 | WARNING | Equals sign not aligned with surrounding assignments
+    --------------------------------------------------------------------------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: PHP_CodeSniffer


### PR DESCRIPTION
See commit for design notes et. al. 

This effectively deprecates the wiki. 

Demo: https://phpcs.netlify.com/

 (just a build that runs `pip install mkdocs && mkdocs build`, and serves the generated `site` directory)