### PR TITLE
Girlscouting: various minor code fixes

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -895,9 +895,9 @@ class File
         // due to the use of the --sniffs command line argument.
         if ($includeAll === false
             && ((empty($this->configCache['sniffs']) === false
-            && in_array(strtolower($listenerCode), $this->configCache['sniffs']) === false)
+            && in_array(strtolower($listenerCode), $this->configCache['sniffs'], true) === false)
             || (empty($this->configCache['exclude']) === false
-            && in_array(strtolower($listenerCode), $this->configCache['exclude']) === true))
+            && in_array(strtolower($listenerCode), $this->configCache['exclude'], true) === true))
         ) {
             return false;
         }
@@ -2346,7 +2346,7 @@ class File
         $conditions = $this->tokens[$stackPtr]['conditions'];
 
         foreach ($types as $type) {
-            if (in_array($type, $conditions) === true) {
+            if (in_array($type, $conditions, true) === true) {
                 // We found a token with the required type.
                 return true;
             }

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -11,6 +11,7 @@
 
 namespace PHP_CodeSniffer\Files;
 
+use PHP_CodeSniffer\Autoload;
 use PHP_CodeSniffer\Util;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
@@ -151,7 +152,7 @@ class FileList implements \Iterator, \Countable
                     throw new DeepExitException($error, 3);
                 }
 
-                $filterClass = \PHP_CodeSniffer\Autoload::loadFile($filename);
+                $filterClass = Autoload::loadFile($filename);
             } else {
                 $filterClass = '\PHP_CodeSniffer\Filters\\'.$filterType;
             }

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -68,7 +68,7 @@ class Notifysend implements Report
 
         $showOk = Config::getConfigData('notifysend_showok');
         if ($showOk !== null) {
-            $this->showOk = (boolean) $showOk;
+            $this->showOk = (bool) $showOk;
         }
 
         $this->version = str_replace(

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -410,7 +410,7 @@ class Ruleset
                     }
                 } else if (empty($newSniffs) === false) {
                     $newSniff = $newSniffs[0];
-                    if (in_array($newSniff, $ownSniffs) === false) {
+                    if (in_array($newSniff, $ownSniffs, true) === false) {
                         // Including a sniff that hasn't been included higher up, but
                         // only including a single message from it. So turn off all messages in
                         // the sniff, except this one.
@@ -578,7 +578,7 @@ class Ruleset
         // sniff list, but filter out any excluded sniffs.
         $files = [];
         foreach ($includedSniffs as $sniff) {
-            if (in_array($sniff, $excludedSniffs) === true) {
+            if (in_array($sniff, $excludedSniffs, true) === true) {
                 continue;
             } else {
                 $files[] = Util\Common::realpath($sniff);

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -715,7 +715,7 @@ class Ruleset
             if (Util\Common::isPharFile($path) === true && strpos($path, 'ruleset.xml') === false) {
                 // If the ruleset exists inside the phar file, use it.
                 if (file_exists($path.DIRECTORY_SEPARATOR.'ruleset.xml') === true) {
-                    $path = $path.DIRECTORY_SEPARATOR.'ruleset.xml';
+                    $path .= DIRECTORY_SEPARATOR.'ruleset.xml';
                 } else {
                     $path = null;
                 }

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -195,7 +195,7 @@ abstract class AbstractPatternSniff implements Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if (in_array($tokens[$stackPtr]['code'], $this->supplementaryTokens) === true) {
+        if (in_array($tokens[$stackPtr]['code'], $this->supplementaryTokens, true) === true) {
             $this->processSupplementary($phpcsFile, $stackPtr);
         }
 

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -153,7 +153,7 @@ class InlineControlStructureSniff implements Sniff
                 break;
             }
 
-            if (in_array($tokens[$end]['code'], $fixableScopeOpeners) === true
+            if (in_array($tokens[$end]['code'], $fixableScopeOpeners, true) === true
                 && isset($tokens[$end]['scope_opener']) === false
             ) {
                 // The best way to fix nested inline scopes is middle-out.

--- a/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowAlternativePHPTagsSniff.php
@@ -48,7 +48,7 @@ class DisallowAlternativePHPTagsSniff implements Sniff
         }
 
         if ($this->phpVersion < 70000) {
-            $this->aspTags = (boolean) ini_get('asp_tags');
+            $this->aspTags = (bool) ini_get('asp_tags');
         }
 
         return [

--- a/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -29,7 +29,7 @@ class DisallowShortOpenTagSniff implements Sniff
             T_OPEN_TAG_WITH_ECHO,
         ];
 
-        $shortOpenTags = (boolean) ini_get('short_open_tag');
+        $shortOpenTags = (bool) ini_get('short_open_tag');
         if ($shortOpenTags === false) {
             $targets[] = T_INLINE_HTML;
         }

--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -173,7 +173,7 @@ class ForbiddenFunctionsSniff implements Sniff
             // Remove the pattern delimiters and modifier.
             $pattern = substr($pattern, 1, -2);
         } else {
-            if (in_array($function, $this->forbiddenFunctionNames) === false) {
+            if (in_array($function, $this->forbiddenFunctionNames, true) === false) {
                 return;
             }
         }//end if

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -776,7 +776,7 @@ class ScopeIndentSniff implements Sniff
 
             if ($checkToken !== null
                 && isset(Tokens::$scopeOpeners[$tokens[$checkToken]['code']]) === true
-                && in_array($tokens[$checkToken]['code'], $this->nonIndentingScopes) === false
+                && in_array($tokens[$checkToken]['code'], $this->nonIndentingScopes, true) === false
                 && isset($tokens[$checkToken]['scope_opener']) === true
             ) {
                 $exact = true;
@@ -1133,7 +1133,7 @@ class ScopeIndentSniff implements Sniff
 
                 $condition = $tokens[$tokens[$i]['scope_condition']]['code'];
                 if (isset(Tokens::$scopeOpeners[$condition]) === true
-                    && in_array($condition, $this->nonIndentingScopes) === false
+                    && in_array($condition, $this->nonIndentingScopes, true) === false
                 ) {
                     if ($this->debug === true) {
                         $line = $tokens[$i]['line'];

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -28,7 +28,7 @@ class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
 
         $aspTags = false;
         if (PHP_VERSION_ID < 70000) {
-            $aspTags = (boolean) ini_get('asp_tags');
+            $aspTags = (bool) ini_get('asp_tags');
         }
 
         if ($aspTags === true) {

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -26,7 +26,7 @@ class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
     {
         $testFiles = [$testFileBase.'1.inc'];
 
-        $option = (boolean) ini_get('short_open_tag');
+        $option = (bool) ini_get('short_open_tag');
         if ($option === true) {
             $testFiles[] = $testFileBase.'2.inc';
         } else {

--- a/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/SyntaxUnitTest.php
@@ -10,7 +10,6 @@
 
 namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 class SyntaxUnitTest extends AbstractSniffUnitTest

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -161,7 +161,7 @@ class FileCommentSniff implements Sniff
             T_PROPERTY,
         ];
 
-        if (in_array($tokens[$nextToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$nextToken]['code'], $ignore, true) === true) {
             $phpcsFile->addError('Missing file doc comment', $stackPtr, 'Missing');
             $phpcsFile->recordMetric($stackPtr, 'File has doc comment', 'no');
             return ($phpcsFile->numTokens + 1);

--- a/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
@@ -11,7 +11,6 @@ namespace PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Util\Tokens;
 
 class NullableTypeDeclarationSniff implements Sniff
 {

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -71,7 +71,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                 $blankSpace = substr($prevContent, strpos($prevContent, $phpcsFile->eolChar));
                 $spaces     = strlen($blankSpace);
 
-                if (in_array($tokens[($stackPtr - 2)]['code'], [T_ABSTRACT, T_FINAL]) === true
+                if (in_array($tokens[($stackPtr - 2)]['code'], [T_ABSTRACT, T_FINAL], true) === true
                     && $spaces !== 1
                 ) {
                     $prevContent = strtolower($tokens[($stackPtr - 2)]['content']);

--- a/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
@@ -115,7 +115,7 @@ class ForbiddenStylesSniff implements Sniff
             // Remove the pattern delimiters and modifier.
             $pattern = substr($pattern, 1, -2);
         } else {
-            if (in_array($style, $this->forbiddenStyleNames) === false) {
+            if (in_array($style, $this->forbiddenStyleNames, true) === false) {
                 return;
             }
         }//end if

--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -99,7 +99,7 @@ class FileCommentSniff implements Sniff
             T_REQUIRE_ONCE,
         ];
 
-        if (in_array($tokens[$nextToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$nextToken]['code'], $ignore, true) === true) {
             $phpcsFile->addError('Missing file doc comment', $stackPtr, 'Missing');
             $phpcsFile->recordMetric($stackPtr, 'File has doc comment', 'no');
             return ($phpcsFile->numTokens + 1);
@@ -133,7 +133,7 @@ class FileCommentSniff implements Sniff
             $name       = $tokens[$tag]['content'];
             $isRequired = isset($required[$name]);
 
-            if ($isRequired === true && in_array($name, $foundTags) === true) {
+            if ($isRequired === true && in_array($name, $foundTags, true) === true) {
                 $error = 'Only one %s tag is allowed in a file comment';
                 $data  = [$name];
                 $phpcsFile->addError($error, $tag, 'Duplicate'.ucfirst(substr($name, 1)).'Tag', $data);
@@ -183,7 +183,7 @@ class FileCommentSniff implements Sniff
         // Check if the tags are in the correct position.
         $pos = 0;
         foreach ($required as $tag => $true) {
-            if (in_array($tag, $foundTags) === false) {
+            if (in_array($tag, $foundTags, true) === false) {
                 $error = 'Missing %s tag in file comment';
                 $data  = [$tag];
                 $phpcsFile->addError($error, $commentEnd, 'Missing'.ucfirst(substr($tag, 1)).'Tag', $data);

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -78,7 +78,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 $suggestedNames = [];
                 foreach ($typeNames as $i => $typeName) {
                     $suggestedName = Common::suggestType($typeName);
-                    if (in_array($suggestedName, $suggestedNames) === false) {
+                    if (in_array($suggestedName, $suggestedNames, true) === false) {
                         $suggestedNames[] = $suggestedName;
                     }
                 }
@@ -397,7 +397,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     $suggestedTypeHint = 'callable';
                 } else if (strpos($suggestedName, 'callback') !== false) {
                     $suggestedTypeHint = 'callable';
-                } else if (in_array($suggestedName, Common::$allowedTypes) === false) {
+                } else if (in_array($suggestedName, Common::$allowedTypes, true) === false) {
                     $suggestedTypeHint = $suggestedName;
                 }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -86,7 +86,7 @@ class InlineCommentSniff implements Sniff
                 T_REQUIRE_ONCE,
             ];
 
-            if (in_array($tokens[$nextToken]['code'], $ignore) === true) {
+            if (in_array($tokens[$nextToken]['code'], $ignore, true) === true) {
                 return;
             }
 
@@ -266,7 +266,7 @@ class InlineCommentSniff implements Sniff
                 'or question marks' => '?',
             ];
 
-            if (in_array($commentCloser, $acceptedClosers) === false) {
+            if (in_array($commentCloser, $acceptedClosers, true) === false) {
                 $error = 'Inline comments must end in %s';
                 $ender = '';
                 foreach ($acceptedClosers as $closerName => $symbol) {

--- a/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -93,7 +93,7 @@ class LongConditionClosingCommentSniff implements Sniff
         $endBrace       = $tokens[$stackPtr];
 
         // We are only interested in some code blocks.
-        if (in_array($startCondition['code'], self::$openers) === false) {
+        if (in_array($startCondition['code'], self::$openers, true) === false) {
             return;
         }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -111,7 +111,7 @@ class VariableCommentSniff extends AbstractVariableSniff
         $suggestedNames = [];
         foreach ($typeNames as $i => $typeName) {
             $suggestedName = Common::suggestType($typeName);
-            if (in_array($suggestedName, $suggestedNames) === false) {
+            if (in_array($suggestedName, $suggestedNames, true) === false) {
                 $suggestedNames[] = $suggestedName;
             }
         }

--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -166,7 +166,7 @@ class OperatorBracketSniff implements Sniff
                     // We allow simple operations to not be bracketed.
                     // For example, ceil($one / $two).
                     for ($prev = ($stackPtr - 1); $prev > $bracket; $prev--) {
-                        if (in_array($tokens[$prev]['code'], $allowed) === true) {
+                        if (in_array($tokens[$prev]['code'], $allowed, true) === true) {
                             continue;
                         }
 
@@ -182,7 +182,7 @@ class OperatorBracketSniff implements Sniff
                     }
 
                     for ($next = ($stackPtr + 1); $next < $endBracket; $next++) {
-                        if (in_array($tokens[$next]['code'], $allowed) === true) {
+                        if (in_array($tokens[$next]['code'], $allowed, true) === true) {
                             continue;
                         }
 
@@ -198,7 +198,7 @@ class OperatorBracketSniff implements Sniff
                     }
                 }//end if
 
-                if (in_array($prevCode, Tokens::$scopeOpeners) === true) {
+                if (in_array($prevCode, Tokens::$scopeOpeners, true) === true) {
                     // This operation is inside a control structure like FOREACH
                     // or IF, but has no bracket of it's own.
                     // The only control structure allowed to do this is SWITCH.

--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDuplicateArgumentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDuplicateArgumentSniff.php
@@ -48,7 +48,7 @@ class FunctionDuplicateArgumentSniff implements Sniff
         for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
             if ($tokens[$i]['code'] === T_VARIABLE) {
                 $variable = $tokens[$i]['content'];
-                if (in_array($variable, $foundVariables) === true) {
+                if (in_array($variable, $foundVariables, true) === true) {
                     $error = 'Variable "%s" appears more than once in function declaration';
                     $data  = [$variable];
                     $phpcsFile->addError($error, $i, 'Found', $data);

--- a/src/Tokenizers/JS.php
+++ b/src/Tokenizers/JS.php
@@ -832,7 +832,7 @@ class JS extends Tokenizer
                 $numLines   = count($tokenLines);
 
                 for ($i = 0; $i < $numLines; $i++) {
-                    $newToken['content'] = $tokenLines[$i];
+                    $newToken = ['content' => $tokenLines[$i]];
                     if ($i === ($numLines - 1)) {
                         if ($tokenLines[$i] === '') {
                             break;

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -782,8 +782,8 @@ class PHP extends Tokenizer
                 && strtolower($tokens[($stackPtr + 2)][1]) === 'from'
             ) {
                 // Could be multi-line, so just the token stack.
-                $token[0] = T_YIELD_FROM;
-                $token[1] = $token[1].$tokens[($stackPtr + 1)][1].$tokens[($stackPtr + 2)][1];
+                $token[0]  = T_YIELD_FROM;
+                $token[1] .= $tokens[($stackPtr + 1)][1].$tokens[($stackPtr + 2)][1];
 
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
                     for ($i = ($stackPtr + 1); $i <= ($stackPtr + 2); $i++) {
@@ -816,8 +816,8 @@ class PHP extends Tokenizer
                     && strtolower($tokens[($stackPtr + 2)][1]) === 'from'
                 ) {
                     // Could be multi-line, so just just the token stack.
-                    $token[0] = T_YIELD_FROM;
-                    $token[1] = $token[1].$tokens[($stackPtr + 1)][1].$tokens[($stackPtr + 2)][1];
+                    $token[0]  = T_YIELD_FROM;
+                    $token[1] .= $tokens[($stackPtr + 1)][1].$tokens[($stackPtr + 2)][1];
 
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
                         for ($i = ($stackPtr + 1); $i <= ($stackPtr + 2); $i++) {

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1001,7 +1001,7 @@ class PHP extends Tokenizer
                         $newToken['code'] = T_NULLABLE;
                         $newToken['type'] = 'T_NULLABLE';
                         break;
-                    } else if (in_array($tokenType, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, '=', '{', ';']) === true) {
+                    } else if (in_array($tokenType, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, '=', '{', ';'], true) === true) {
                         $newToken['code'] = T_INLINE_THEN;
                         $newToken['type'] = 'T_INLINE_THEN';
 

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -226,31 +226,31 @@ class Common
     public static function prepareForOutput($content, $exclude=[])
     {
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            if (in_array("\r", $exclude) === false) {
+            if (in_array("\r", $exclude, true) === false) {
                 $content = str_replace("\r", '\r', $content);
             }
 
-            if (in_array("\n", $exclude) === false) {
+            if (in_array("\n", $exclude, true) === false) {
                 $content = str_replace("\n", '\n', $content);
             }
 
-            if (in_array("\t", $exclude) === false) {
+            if (in_array("\t", $exclude, true) === false) {
                 $content = str_replace("\t", '\t', $content);
             }
         } else {
-            if (in_array("\r", $exclude) === false) {
+            if (in_array("\r", $exclude, true) === false) {
                 $content = str_replace("\r", "\033[30;1m\\r\033[0m", $content);
             }
 
-            if (in_array("\n", $exclude) === false) {
+            if (in_array("\n", $exclude, true) === false) {
                 $content = str_replace("\n", "\033[30;1m\\n\033[0m", $content);
             }
 
-            if (in_array("\t", $exclude) === false) {
+            if (in_array("\t", $exclude, true) === false) {
                 $content = str_replace("\t", "\033[30;1m\\t\033[0m", $content);
             }
 
-            if (in_array(' ', $exclude) === false) {
+            if (in_array(' ', $exclude, true) === false) {
                 $content = str_replace(' ', "\033[30;1m·\033[0m", $content);
             }
         }//end if
@@ -399,7 +399,7 @@ class Common
             return '';
         }
 
-        if (in_array($varType, self::$allowedTypes) === true) {
+        if (in_array($varType, self::$allowedTypes, true) === true) {
             return $varType;
         } else {
             $lowerVarType = strtolower($varType);
@@ -445,7 +445,7 @@ class Common
                 } else {
                     return 'array';
                 }//end if
-            } else if (in_array($lowerVarType, self::$allowedTypes) === true) {
+            } else if (in_array($lowerVarType, self::$allowedTypes, true) === true) {
                 // A valid type, but not lower cased.
                 return $lowerVarType;
             } else {

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -9,8 +9,6 @@
 
 namespace PHP_CodeSniffer\Tests;
 
-use PHPUnit\TextUI\TestRunner;
-
 if (is_file(__DIR__.'/../autoload.php') === true) {
     include_once 'Core/AllTests.php';
     include_once 'Standards/AllSniffs.php';

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -12,7 +12,6 @@ namespace PHP_CodeSniffer\Tests\Core\File;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Files\DummyFile;
-use PHP_CodeSniffer\Exceptions\TokenizerException;
 use PHPUnit\Framework\TestCase;
 
 class GetMemberPropertiesTest extends TestCase

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -265,12 +265,12 @@ abstract class AbstractSniffUnitTest extends TestCase
                     $errorsTemp[] = $foundError['message'].' ('.$foundError['source'].')';
 
                     $source = $foundError['source'];
-                    if (in_array($source, $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES']) === false) {
+                    if (in_array($source, $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES'], true) === false) {
                         $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES'][] = $source;
                     }
 
                     if ($foundError['fixable'] === true
-                        && in_array($source, $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES']) === false
+                        && in_array($source, $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'], true) === false
                     ) {
                         $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'][] = $source;
                     }

--- a/tests/Standards/AllSniffs.php
+++ b/tests/Standards/AllSniffs.php
@@ -70,7 +70,7 @@ class AllSniffs
                 $testPath = $details['path'];
             }
 
-            if (in_array($standard, $ignoreTestsForStandards) === true) {
+            if (in_array($standard, $ignoreTestsForStandards, true) === true) {
                 continue;
             }
 


### PR DESCRIPTION
Minor code fixes for the following:
* Use short form type casts
    These were the only places were long form type casts were being used, so for consistency these have been replaced with short form.
* Remove unused `use` statements
* Add missing `use` statement
* Minor code simplifications for variable concatenations
* Declare variables
    The `$newToken` array variable was not (yet) initialized when `content` was being added.
* Use strict comparisons when using `in_array()`
    Prevent quirks caused by type juggling when using the default of `$strict = false`.
    Ref: http://php.net/manual/en/function.in-array.php