### PR TITLE
Girlscouting: various minor documentation fixes

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -23,7 +23,7 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
         /**
          * The composer autoloader.
          *
-         * @var Composer\Autoload\ClassLoader
+         * @var \Composer\Autoload\ClassLoader
          */
         private static $composerAutoloader = null;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -188,7 +188,7 @@ class Config
      * @param string $name The name of the property.
      *
      * @return mixed
-     * @throws RuntimeException If the setting name is invalid.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the setting name is invalid.
      */
     public function __get($name)
     {
@@ -208,7 +208,7 @@ class Config
      * @param mixed  $value The value of the property.
      *
      * @return void
-     * @throws RuntimeException If the setting name is invalid.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the setting name is invalid.
      */
     public function __set($name, $value)
     {
@@ -1555,7 +1555,7 @@ class Config
      *
      * @return bool
      * @see    getConfigData()
-     * @throws RuntimeException If the config file can not be written.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the config file can not be written.
      */
     public static function setConfigData($key, $value, $temp=false)
     {

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -92,7 +92,7 @@ class Reporter
      * @param \PHP_CodeSniffer\Config $config The config data for the run.
      *
      * @return void
-     * @throws RuntimeException If a report is not available.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If a report is not available.
      */
     public function __construct(Config $config)
     {

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -836,10 +836,10 @@ class Ruleset
     /**
      * Processes a rule from a ruleset XML file, overriding built-in defaults.
      *
-     * @param SimpleXMLElement $rule      The rule object from a ruleset XML file.
-     * @param string[]         $newSniffs An array of sniffs that got included by this rule.
-     * @param int              $depth     How many nested processing steps we are in.
-     *                                    This is only used for debug output.
+     * @param \SimpleXMLElement $rule      The rule object from a ruleset XML file.
+     * @param string[]          $newSniffs An array of sniffs that got included by this rule.
+     * @param int               $depth     How many nested processing steps we are in.
+     *                                     This is only used for debug output.
      *
      * @return void
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If rule settings are invalid.
@@ -1073,7 +1073,7 @@ class Ruleset
     /**
      * Determine if an element should be processed or ignored.
      *
-     * @param SimpleXMLElement $element An object from a ruleset XML file.
+     * @param \SimpleXMLElement $element An object from a ruleset XML file.
      *
      * @return bool
      */

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -305,7 +305,7 @@ class Ruleset
      *                            is only used for debug output.
      *
      * @return string[]
-     * @throws RuntimeException If the ruleset path is invalid.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the ruleset path is invalid.
      */
     public function processRuleset($rulesetPath, $depth=0)
     {
@@ -660,7 +660,7 @@ class Ruleset
      *                           is only used for debug output.
      *
      * @return array
-     * @throws RuntimeException If the reference is invalid.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the reference is invalid.
      */
     private function expandRulesetReference($ref, $rulesetDir, $depth=0)
     {
@@ -842,7 +842,7 @@ class Ruleset
      *                                    This is only used for debug output.
      *
      * @return void
-     * @throws RuntimeException If rule settings are invalid.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If rule settings are invalid.
      */
     private function processRule($rule, $newSniffs, $depth=0)
     {
@@ -1174,7 +1174,7 @@ class Ruleset
      * Populates the array of PHP_CodeSniffer_Sniff's for this file.
      *
      * @return void
-     * @throws RuntimeException If sniff registration fails.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If sniff registration fails.
      */
     public function populateTokenListeners()
     {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -732,14 +732,14 @@ class Runner
     /**
      * Print progress information for a single processed file.
      *
-     * @param File $file         The file that was processed.
-     * @param int  $numFiles     The total number of files to process.
-     * @param int  $numProcessed The number of files that have been processed,
-     *                           including this one.
+     * @param \PHP_CodeSniffer\Files\File $file         The file that was processed.
+     * @param int                         $numFiles     The total number of files to process.
+     * @param int                         $numProcessed The number of files that have been processed,
+     *                                                  including this one.
      *
      * @return void
      */
-    public function printProgress($file, $numFiles, $numProcessed)
+    public function printProgress(File $file, $numFiles, $numProcessed)
     {
         if (PHP_CODESNIFFER_VERBOSITY > 0
             || $this->config->showProgress === false

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -233,6 +233,7 @@ class Runner
      * Exits if the minimum requirements of PHP_CodSniffer are not met.
      *
      * @return array
+     * @throws \PHP_CodeSniffer\Exceptions\DeepExitException
      */
     public function checkRequirements()
     {
@@ -254,6 +255,7 @@ class Runner
      * Init the rulesets and other high-level settings.
      *
      * @return void
+     * @throws \PHP_CodeSniffer\Exceptions\DeepExitException
      */
     public function init()
     {
@@ -312,6 +314,8 @@ class Runner
      * Performs the run.
      *
      * @return int The number of errors and warnings found.
+     * @throws \PHP_CodeSniffer\Exceptions\DeepExitException
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
      */
     private function run()
     {
@@ -558,6 +562,7 @@ class Runner
      * @param int    $line    The line number the error was raised at.
      *
      * @return void
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
      */
     public function handleErrors($code, $message, $file, $line)
     {
@@ -577,6 +582,7 @@ class Runner
      * @param \PHP_CodeSniffer\Files\File $file The file to be processed.
      *
      * @return void
+     * @throws \PHP_CodeSniffer\Exceptions\DeepExitException
      */
     public function processFile($file)
     {

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -153,7 +153,7 @@ abstract class AbstractPatternSniff implements Sniff
      *
      * @return int The position in the pattern that this test should register
      *             as the listener.
-     * @throws RuntimeException If we could not determine a token to listen for.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If we could not determine a token to listen for.
      */
     private function getListenerTokenPos($pattern)
     {

--- a/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
@@ -42,7 +42,7 @@ class IncludeSystemSniff extends AbstractScopeSniff
 
 
     /**
-     * Constructs a Squiz_Sniffs_Scope_MethodScopeSniff.
+     * Constructs an AbstractScopeSniff.
      */
     public function __construct()
     {

--- a/src/Tokenizers/CSS.php
+++ b/src/Tokenizers/CSS.php
@@ -27,7 +27,7 @@ class CSS extends PHP
      * @param string                  $eolChar The EOL char used in the content.
      *
      * @return void
-     * @throws TokenizerException If the file appears to be minified.
+     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
     public function __construct($content, Config $config, $eolChar='\n')
     {

--- a/src/Tokenizers/JS.php
+++ b/src/Tokenizers/JS.php
@@ -257,7 +257,7 @@ class JS extends Tokenizer
      * @param string                  $eolChar The EOL char used in the content.
      *
      * @return void
-     * @throws TokenizerException If the file appears to be minified.
+     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
     public function __construct($content, Config $config, $eolChar='\n')
     {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -59,7 +59,7 @@ abstract class Tokenizer
      * @param string                         $eolChar The EOL char used in the content.
      *
      * @return void
-     * @throws TokenizerException If the file appears to be minified.
+     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
      */
     public function __construct($content, $config, $eolChar='\n')
     {


### PR DESCRIPTION
* Use FQN for exceptions in `@throws` tags and add missing `@throws` tags
* Use FQN in `@param` tags and add missing type declaration
* One minor documentation correction