### PR TITLE
Generic/DeprecatedFunctions: add missing unit tests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -567,6 +567,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="CharacterBeforePHPOpeningTagUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingPHPTagUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingPHPTagUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DeprecatedFunctionsUnitTest.inc" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DeprecatedFunctionsUnitTest.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsUnitTest.1.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsUnitTest.2.inc" role="test" />

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+create_function(); // Deprecated PHP 7.2.
+mbsplit(); // Deprecated PHP 7.3.

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Unit test class for the DeprecatedFunctions sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        $errors = [];
+
+        if (PHP_VERSION_ID >= 70200) {
+            $errors[3] = 1;
+        }
+
+        if (PHP_VERSION_ID >= 70300) {
+            $errors[4] = 1;
+        }
+
+        return $errors;
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
[Sniff completeness series PR]

Note: PHP internally doesn't always correctly register functions as deprecated, so this sniff will only work when it has (as the information is otherwise not available to the Reflection extension).

Some trial and error showed that the two functions now in the tests are correctly registered, but numerous other functions I tried to add to the test case file failed as PHP didn't provide the expected information.