### PR TITLE
Generic/SubversionProperties: add perfunctory unit test files

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -620,6 +620,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.6.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SubversionPropertiesUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SubversionPropertiesUnitTest.php" role="test" />
        </dir>
        <dir name="WhiteSpace">
         <file baseinstalldir="PHP/CodeSniffer" name="ArbitraryParenthesesSpacingUnitTest.inc" role="test" />

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.inc
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.inc
@@ -1,0 +1,3 @@
+<?php
+
+// This sniff cannot be tested as no SVN version control directory is available.

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Unit test class for the SubversionProperties sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\VersionControl;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class SubversionPropertiesUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return void
+     */
+    protected function shouldSkipTest()
+    {
+        // This sniff cannot be tested as no SVN version control directory is available.
+        return true;
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
[Sniff completeness series PR]

This sniff cannot be tested as it needs to read out information from files in a `.svn` directory which cannot easily be simulated.

The files now added just document why there are no unit tests.