### PR TITLE
Generic/CSSLint: add missing unit tests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -485,6 +485,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.php" role="test" />
        </dir>
        <dir name="Debug">
+        <file baseinstalldir="PHP/CodeSniffer" name="CSSLintUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="CSSLintUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ESLintUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ESLintUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="JSHintUnitTest.js" role="test" />

--- a/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.css
+++ b/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.css
@@ -1,0 +1,6 @@
+/*csslint important: true, order-alphabetical: true, zero-units: true */
+
+.selector-with-errors {
+    font-size: 10px !important;
+    border: 0px;
+}

--- a/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Unit test class for the CSSLint sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Config;
+
+class CSSLintUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return void
+     */
+    protected function shouldSkipTest()
+    {
+        $csslintPath = Config::getExecutablePath('csslint');
+        if ($csslintPath === null) {
+            return true;
+        }
+
+        return false;
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [
+            3 => 1,
+            4 => 1,
+            5 => 1,
+        ];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
[Sniff completeness series PR]

Note: it may be worth it to check if `csslint` is available on Travis by default or do a `npm i csslint` in the Travis `before_script` section to install it, so the sniff will actually be tested properly.