### PR TITLE
Generic/ESLint: add missing unit tests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -437,6 +437,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.php" role="test" />
        </dir>
+       <dir name="Debug">
+        <file baseinstalldir="PHP/CodeSniffer" name="ESLintUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ESLintUnitTest.php" role="test" />
+       </dir>
        <dir name="Files">
         <file baseinstalldir="PHP/CodeSniffer" name="ByteOrderMarkUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ByteOrderMarkUnitTest.php" role="test" />

--- a/src/Standards/Generic/Tests/Debug/ESLintUnitTest.js
+++ b/src/Standards/Generic/Tests/Debug/ESLintUnitTest.js
@@ -1,0 +1,1 @@
+var foo = bar;

--- a/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Unit test class for the ESLint sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Config;
+
+class ESLintUnitTest extends AbstractSniffUnitTest
+{
+
+    /**
+     * Basic ESLint config to use for testing the sniff.
+     *
+     * @var string
+     */
+    const ESLINT_CONFIG = '{
+    "parserOptions": {
+        "ecmaVersion": 5,
+        "sourceType": "script",
+        "ecmaFeatures": {}
+    },
+    "rules": {
+        "no-undef": 2,
+        "no-unused-vars": 2
+    }
+}';
+
+
+    /**
+     * Sets up this unit test.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $cwd = getcwd();
+        file_put_contents($cwd.'/.eslintrc.json', self::ESLINT_CONFIG);
+
+    }//end setUp()
+
+
+    /**
+     * Remove artifact.
+     *
+     * @return void
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $cwd = getcwd();
+        unlink($cwd.'/.eslintrc.json');
+
+    }//end tearDown()
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return void
+     */
+    protected function shouldSkipTest()
+    {
+        $eslintPath = Config::getExecutablePath('eslint');
+        if ($eslintPath === null) {
+            return true;
+        }
+
+        return false;
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [1 => 2];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
[Sniff completeness series PR]

Note: it may be worth it to check if `eslint` is available on Travis by default or do a `npm i eslint` in the Travis `before_script` section to install it, so the sniff will actually be tested properly.