### PR TITLE
Generic/JSHint: add missing unit tests + allow running without Rhino

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -437,6 +437,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.php" role="test" />
        </dir>
+       <dir name="Debug">
+        <file baseinstalldir="PHP/CodeSniffer" name="JSHintUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="JSHintUnitTest.php" role="test" />
+       </dir>
        <dir name="Files">
         <file baseinstalldir="PHP/CodeSniffer" name="ByteOrderMarkUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ByteOrderMarkUnitTest.php" role="test" />

--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -51,28 +51,36 @@ class JSHintSniff implements Sniff
     {
         $rhinoPath  = Config::getExecutablePath('rhino');
         $jshintPath = Config::getExecutablePath('jshint');
-        if ($rhinoPath === null || $jshintPath === null) {
+        if ($rhinoPath === null && $jshintPath === null) {
             return;
         }
 
-        $fileName = $phpcsFile->getFilename();
-
-        $rhinoPath  = escapeshellcmd($rhinoPath);
+        $fileName   = $phpcsFile->getFilename();
         $jshintPath = escapeshellcmd($jshintPath);
 
-        $cmd = "$rhinoPath \"$jshintPath\" ".escapeshellarg($fileName);
-        exec($cmd, $output, $retval);
+        if ($rhinoPath !== null) {
+            $rhinoPath = escapeshellcmd($rhinoPath);
+            $cmd       = "$rhinoPath \"$jshintPath\" ".escapeshellarg($fileName);
+            exec($cmd, $output, $retval);
+
+            $regex = '`^(?P<error>.+)\(.+:(?P<line>[0-9]+).*:[0-9]+\)$`';
+        } else {
+            $cmd = "$jshintPath ".escapeshellarg($fileName);
+            exec($cmd, $output, $retval);
+
+            $regex = '`^(.+?): line (?P<line>[0-9]+), col [0-9]+, (?P<error>.+)$`';
+        }
 
         if (is_array($output) === true) {
             foreach ($output as $finding) {
                 $matches    = [];
-                $numMatches = preg_match('/^(.+)\(.+:([0-9]+).*:[0-9]+\)$/', $finding, $matches);
+                $numMatches = preg_match($regex, $finding, $matches);
                 if ($numMatches === 0) {
                     continue;
                 }
 
-                $line    = (int) $matches[2];
-                $message = 'jshint says: '.trim($matches[1]);
+                $line    = (int) $matches['line'];
+                $message = 'jshint says: '.trim($matches['error']);
                 $phpcsFile->addWarningOnLine($message, $line, 'ExternalTool');
             }
         }

--- a/src/Standards/Generic/Tests/Debug/JSHintUnitTest.js
+++ b/src/Standards/Generic/Tests/Debug/JSHintUnitTest.js
@@ -1,0 +1,3 @@
+/* jshint undef: true, unused: true */
+
+var foo = bar;

--- a/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Unit test class for the JSHint sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Config;
+
+class JSHintUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return void
+     */
+    protected function shouldSkipTest()
+    {
+        $rhinoPath  = Config::getExecutablePath('rhino');
+        $jshintPath = Config::getExecutablePath('jshint');
+        if ($rhinoPath === null && $jshintPath === null) {
+            return true;
+        }
+
+        return false;
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [3 => 2];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
[Sniff completeness series PR]

Notes:
* The sniff, up to now, required `rhino` to run, but the `jshint` tool can also be run directly when installed via `npm`. I've now adjusted the sniff to allow for that, which makes providing the `rhino` path optional.
* It may be worth it to check if `jshint` is available on Travis by default or do a `npm i jshint` in the Travis `before_script` section to install it, so the sniff will actually be tested properly.