### PR TITLE
Generic/ClosureLinter: add missing unit tests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -485,6 +485,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.php" role="test" />
        </dir>
        <dir name="Debug">
+        <file baseinstalldir="PHP/CodeSniffer" name="ClosureLinterUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClosureLinterUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ESLintUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ESLintUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="JSHintUnitTest.js" role="test" />

--- a/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.js
+++ b/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.js
@@ -1,0 +1,6 @@
+/**
+ * My function
+ */
+function something() {
+	return a;
+}

--- a/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Unit test class for the ClosureLinter sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Debug;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+use PHP_CodeSniffer\Config;
+
+class ClosureLinterUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Should this test be skipped for some reason.
+     *
+     * @return void
+     */
+    protected function shouldSkipTest()
+    {
+        $lintPath = Config::getExecutablePath('gjslint');
+        if ($lintPath === null) {
+            return true;
+        }
+
+        return false;
+
+    }//end shouldSkipTest()
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [
+            3 => 1,
+            5 => 1,
+        ];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
[Sniff completeness series PR]

It may be worth it to add `sudo apt-get install python-pip && sudo pip install https://github.com/google/closure-linter/zipball/master` in the Travis `before_script` section to install it, so the sniff will actually be tested properly, though trying to get this running locally was quite a struggle as the tool is deprecated and has issues when run on Python 3.