### PR TITLE
Travis: add check to make sure that sniffs are "feature complete"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - php: 7.2
       env: PHPUNIT_INCOMPAT=1
     - php: 7.3
-      env: PHPUNIT_INCOMPAT=1
+      env: PHPUNIT_INCOMPAT=1 SNIFF_COMPLETE=1
     - php: "7.4snapshot"
       env: PHPSTAN=1 PHPUNIT_INCOMPAT=1
       addons:
@@ -62,6 +62,7 @@ script:
   - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php scripts/build-phar.php; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php phpcs.phar; fi
+  - if [[ $SNIFF_COMPLETE == "1" ]]; then php scripts/check-sniff-completeness.php -q; fi
   # Validate the xml ruleset files.
   # @link http://xmlsoft.org/xmllint.html
   - if [[ $XMLLINT == "1" ]]; then xmllint --noout --schema phpcs.xsd ./src/Standards/*/ruleset.xml; fi

--- a/scripts/SniffCompleteness/CheckSniffCompleteness.php
+++ b/scripts/SniffCompleteness/CheckSniffCompleteness.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Check that each sniff is complete, i.e. has unit tests and documentation.
+ *
+ * This script should be run from the root of a PHPCS standards repo and can
+ * be used by external standards as well.
+ *
+ * Configuration options:
+ * -q: quiet, don't show warnings about missing documentation files.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+/**
+ * Check that each sniff is complete, i.e. has unit tests and documentation.
+ */
+class CheckSniffCompleteness
+{
+
+    /**
+     * The root directory of the project.
+     *
+     * @var string
+     */
+    protected $projectRoot = '';
+
+    /**
+     * List of all files in the repo.
+     *
+     * @var array
+     */
+    protected $allFiles = [];
+
+    /**
+     * List of all sniff files in the repo.
+     *
+     * @var array
+     */
+    protected $allSniffs = [];
+
+    /**
+     * Whether to use "quiet" mode.
+     *
+     * This will silence all warnings, but still show the errors.
+     *
+     * To enable "quiet" mode, pass `-q` on the command line when calling
+     * the `check-sniff-completeness` script.
+     *
+     * @var boolean
+     */
+    private $quietMode = false;
+
+    /**
+     * Search & replace values to convert a sniff file path into a docs file path.
+     *
+     * Keys are the strings to search for, values the replacement values.
+     *
+     * @var array
+     */
+    private $sniffToDoc = [
+        '/Sniffs/'  => '/Docs/',
+        'Sniff.php' => 'Standard.xml',
+    ];
+
+    /**
+     * Search & replace values to convert a sniff file path into a unit test file path.
+     *
+     * Keys are the strings to search for, values the replacement values.
+     *
+     * @var array
+     */
+    private $sniffToUnitTest = [
+        '/Sniffs/' => '/Tests/',
+        'Sniff.'   => 'UnitTest.',
+    ];
+
+    /**
+     * Possible test case file extensions.
+     *
+     * @var array
+     */
+    private $testCaseExtensions = [
+        '.inc',
+        '.css',
+        '.js',
+        '.1.inc',
+        '.1.css',
+        '.1.js',
+    ];
+
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $args = $_SERVER['argv'];
+        if (isset($args[1]) === true && $args[1] === '-q') {
+            $this->quietMode = true;
+        }
+
+        $this->projectRoot = getcwd();
+
+        $allFiles = (new FileList($this->projectRoot, $this->projectRoot))->getList();
+        sort($allFiles, SORT_NATURAL);
+        $this->allFiles = array_flip($allFiles);
+
+        $allSniffs = (new FileList(
+            $this->projectRoot,
+            $this->projectRoot,
+            '`/Sniffs/(?!Abstract).+Sniff\.php$`Di'
+        ))->getList();
+
+        sort($allSniffs, SORT_NATURAL);
+        $this->allSniffs = $allSniffs;
+
+    }//end __construct()
+
+
+    /**
+     * Validate the completeness of the sniffs in the repository.
+     *
+     * @return void
+     */
+    public function validate()
+    {
+        if ($this->isComplete() !== true) {
+            exit(1);
+        }
+
+        exit(0);
+
+    }//end validate()
+
+
+    /**
+     * Verify if all files needed for a sniff to be considered complete are available.
+     *
+     * @return void
+     */
+    public function isComplete()
+    {
+        $valid = true;
+        foreach ($this->allSniffs as $file) {
+            if ($this->quietMode === false) {
+                $docFile = str_replace(array_keys($this->sniffToDoc), $this->sniffToDoc, $file);
+                if (isset($this->allFiles[$docFile]) === false) {
+                    echo "WARNING: Documentation missing for {$file}.".PHP_EOL;
+                    $valid = false;
+                }
+            }
+
+            $testFile = str_replace(array_keys($this->sniffToUnitTest), $this->sniffToUnitTest, $file);
+            if (isset($this->allFiles[$testFile]) === false) {
+                echo "ERROR: Unit tests missing for {$file}.".PHP_EOL;
+                $valid = false;
+            } else {
+                $fileFound = false;
+                foreach ($this->testCaseExtensions as $extension) {
+                    $testCaseFile = str_replace('.php', $extension, $testFile);
+                    if (isset($this->allFiles[$testCaseFile]) === true) {
+                        $fileFound = true;
+                        break;
+                    }
+                }
+
+                if ($fileFound === false) {
+                    echo "ERROR: Unit test case file missing for {$file}.".PHP_EOL;
+                    $valid = false;
+                }
+            }//end if
+        }//end foreach
+
+        if ($valid === true) {
+            if ($this->quietMode === false) {
+                echo 'All sniffs are accompanied by unit tests and documentation.'.PHP_EOL;
+            } else {
+                echo 'All sniffs are accompanied by unit tests.'.PHP_EOL;
+            }
+        }
+
+        return $valid;
+
+    }//end isComplete()
+
+
+}//end class

--- a/scripts/check-sniff-completeness.php
+++ b/scripts/check-sniff-completeness.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Validate that each sniff is complete, i.e. has unit tests and documentation.
+ *
+ * This script should be run from the root of a PHPCS standards repo and can
+ * be used by external standards as well.
+ *
+ * Configuration options:
+ * -q: quiet, don't show warnings about missing documentation files.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+require_once __DIR__.'/ValidatePEAR/FileList.php';
+require_once __DIR__.'/SniffCompleteness/CheckSniffCompleteness.php';
+
+$validate = new CheckSniffCompleteness();
+$validate->validate();


### PR DESCRIPTION
This PR adds a custom script which will check whether each and every sniff is accompanied by a documentation XML file (warning) as well as unit test files (error).

Notes:
* To only show errors, the script can be run in `quiet` mode by passing the `-q` flag on the command line.
* The script has been set up in such a way that it is not only suitable for use by PHPCS itself, but also for use by external standards which use the PHPCS native unit test suite.
    For external standards to use the tool, run it from the root of the external standards repo like so:
    `php -f "path/to/PHP_CodeSniffer/scripts/check-sniff-completeness.php"`
* The list of sniffs to check completeness for, is determined by getting a list of all files in `Sniffs` directories, where the files have a name ending with `Sniff.php` and not prefixed with `Abstract`.
* The "has tests" check verifies that a `UnitTest.php` file is present in the standard's `Tests` directory and _at least_ one test case file.
* The "has docs" check verifies that a `Standard.xml` file is present in the standard's `Docs` directory.

This check only needs to be run on one build as the results won't change between PHP versions.
For that reason, I've elected to add it to the fastest PHP version run to balance out the runs some more.

As quite a large number of sniffs at this moment do not have documentation files, `quiet` mode is currently enabled for the check in Travis.
If/when the missing documentation files have been added, the `-q` flag should be removed and having unit tests as well as documentation should be enforced for all sniffs.

**Note: the build for this won't pass until all sniffs are accompanied by unit tests.**

Currently, the [following sniffs do not have unit tests](https://travis-ci.org/jrfnl/PHP_CodeSniffer/jobs/478410647#L1194-L1202):
- [x] `Generic.Debug.ClosureLinter` - see PR #2363
- [x] `Generic.Debug.CSSLint` - see PR #2360
- [x] `Generic.Debug.ESLint` - see PR #2361
- [x] `Generic.Debug.JSHint` - see PR #2362
- [x] `Generic.PHP.DeprecatedFunctions` - see PR #2358
- [x] `Generic.VersionControl.SubversionProperties` - see PR #2359
- [ ] `MySource.Channels.IncludeOwnSystem` - to be addressed, possibly in the same way as #2359.
    As it isn't completely clear to me without access to the proprietary system for which this sniff was written, what and how it should be tested, this is for someone else to sort out.

Related: https://github.com/squizlabs/PHP_CodeSniffer/pull/2345#issuecomment-453264115
