### PR TITLE
MySource.PHP.AjaxNullComparison throws error when first function has no doc comment

### DIFF
--- a/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
+++ b/src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php
@@ -47,7 +47,12 @@ class AjaxNullComparisonSniff implements Sniff
         // Make sure it is an API function. We know this by the doc comment.
         $commentEnd   = $phpcsFile->findPrevious(T_DOC_COMMENT_CLOSE_TAG, $stackPtr);
         $commentStart = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, ($commentEnd - 1));
-        $comment      = $phpcsFile->getTokensAsString($commentStart, ($commentEnd - $commentStart));
+        // If function doesn't contain any doc comments - skip it.
+        if ($commentEnd === false || $commentStart === false) {
+            return;
+        }
+
+        $comment = $phpcsFile->getTokensAsString($commentStart, ($commentEnd - $commentStart));
         if (strpos($comment, '* @api') === false) {
             return;
         }


### PR DESCRIPTION
A RuntimeException is thrown in File::getTokensAsString() if the first parameter is not an int or if the supplied int does not exist as a position in the token stack.

AjaxNullComparisonSniff ends up throwing this exception on every file that contains functions with no comment blocks.