### PR TITLE
Fixed docblock

### DIFF
--- a/src/Sniffs/Sniff.php
+++ b/src/Sniffs/Sniff.php
@@ -34,7 +34,7 @@ interface Sniff
      *           );
      * </code>
      *
-     * @return int[]
+     * @return mixed[]
      * @see    Tokens.php
      */
     public function register();


### PR DESCRIPTION
Because custom tokens are strings.