### PR TITLE
Squiz.CSS.ShorthandSize: add missing fixed file and minor tweaks

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1520,6 +1520,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="SemicolonSpacingUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SemicolonSpacingUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ShorthandSizeUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ShorthandSizeUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ShorthandSizeUnitTest.php" role="test" />
        </dir>
        <dir name="Debug">

--- a/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php
@@ -69,10 +69,16 @@ class ShorthandSizeSniff implements Sniff
             return;
         }
 
+        $end = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
+        if ($end === false) {
+            // Live coding or parse error.
+            return;
+        }
+
         // Get the whole style content.
-        $end         = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
         $origContent = $phpcsFile->getTokensAsString(($stackPtr + 1), ($end - $stackPtr - 1));
-        $origContent = trim($origContent, ': ');
+        $origContent = trim($origContent, ':');
+        $origContent = trim($origContent);
 
         // Account for a !important annotation.
         $content = $origContent;
@@ -85,7 +91,7 @@ class ShorthandSizeSniff implements Sniff
         $content = preg_replace('/\s+/', ' ', $content);
         $values  = [];
         $num     = preg_match_all(
-            '/([0-9]+)([a-zA-Z]{2}\s+|%\s+|\s+)/',
+            '/(?:[0-9]+)(?:[a-zA-Z]{2}\s+|%\s+|\s+)/',
             $content.' ',
             $values,
             PREG_SET_ORDER
@@ -107,7 +113,7 @@ class ShorthandSizeSniff implements Sniff
         }
 
         if ($num === 3) {
-            $expected = trim($content.' '.$values[1][1].$values[1][2]);
+            $expected = trim($content.' '.$values[1][0]);
             $error    = 'Shorthand syntax not allowed here; use %s instead';
             $data     = [$expected];
             $fix      = $phpcsFile->addFixableError($error, $stackPtr, 'NotAllowed', $data);
@@ -142,12 +148,10 @@ class ShorthandSizeSniff implements Sniff
 
         if ($values[0][0] === $values[1][0]) {
             // All values are the same.
-            $expected = $values[0][0];
+            $expected = trim($values[0][0]);
         } else {
-            $expected = $values[0][0].' '.$values[1][0];
+            $expected = trim($values[0][0]).' '.trim($values[1][0]);
         }
-
-        $expected = preg_replace('/\s+/', ' ', trim($expected));
 
         $error = 'Size definitions must use shorthand if available; expected "%s" but found "%s"';
         $data  = [
@@ -162,8 +166,8 @@ class ShorthandSizeSniff implements Sniff
                 $expected .= ' !important';
             }
 
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 2), null, true);
-            $phpcsFile->fixer->replaceToken($next, $expected);
+            $next = $phpcsFile->findNext(T_COLON, ($stackPtr + 1));
+            $phpcsFile->fixer->addContent($next, ' '.$expected);
             for ($next++; $next < $end; $next++) {
                 $phpcsFile->fixer->replaceToken($next, '');
             }

--- a/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.css
@@ -4,7 +4,7 @@
     border-bottom: 1px dotted #F0F0F0;
     border-top: 1px dotted #FF00FF;
     background: #8fb7db url(diag_lines_bg.gif) top left;
-    page-break-inside: 1;
+    tab-size: 1;
     margin: 8px 8px 8px 8px;
     margin: 8px 8px;
     margin: 0 0 0 0;
@@ -18,9 +18,28 @@
     border-width: 1px 2px 2px 4px;
     margin: 97px auto 0 auto;
     text-shadow: 0 1px 0 #fff;
+    border-width:
+        2px
+        4px
+        2px
+        4px;
 
-    /* These are black-listed style names. */
+    /* These are style names excluded from this rule. */
     background-position: 0 0;
     box-shadow: 2px 2px 2px 2px;
     transform-origin: 0 110% 0;
+
+    /* Sizes with comments between them will be ignored for the purposes of this sniff. */
+    margin: 8px /*top*/ 8px /*right*/ 8px /*bottom*/ 8px /*left*/;
+
+    /* Same with PHPCS annotations. */
+    border-width:
+        2px /* phpcs:ignore Standard.Category.SniffName -- for reasons */
+        4px
+        2px /* phpcs:disable Standard.Category.SniffName -- for reasons */
+        4px;
 }
+
+/* Intentional parse error. Live coding resilience. This has to be the last test in the file. */
+#live-coding {
+    margin: 8px 8px 8px 8px

--- a/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.css.fixed
@@ -1,0 +1,41 @@
+#add-new-comment {
+    background-color: #333333;
+    padding: 10px;
+    border-bottom: 1px dotted #F0F0F0;
+    border-top: 1px dotted #FF00FF;
+    background: #8fb7db url(diag_lines_bg.gif) top left;
+    tab-size: 1;
+    margin: 8px;
+    margin: 8px;
+    margin: 0;
+    margin: 0 8px;
+    margin: 8px 4px;
+    margin: 8px 4%;
+    margin: 6px 2px 9px 2px;
+    margin: 6px 2px 9px 2px;
+    border-radius: 2px !important;
+    border-width: 2px;
+    border-width: 1px 2px 2px 4px;
+    margin: 97px auto 0 auto;
+    text-shadow: 0 1px 0 #fff;
+    border-width: 2px 4px;
+
+    /* These are style names excluded from this rule. */
+    background-position: 0 0;
+    box-shadow: 2px 2px 2px 2px;
+    transform-origin: 0 110% 0;
+
+    /* Sizes with comments between them will be ignored for the purposes of this sniff. */
+    margin: 8px /*top*/ 8px /*right*/ 8px /*bottom*/ 8px /*left*/;
+
+    /* Same with PHPCS annotations. */
+    border-width:
+        2px /* phpcs:ignore Standard.Category.SniffName -- for reasons */
+        4px
+        2px /* phpcs:disable Standard.Category.SniffName -- for reasons */
+        4px;
+}
+
+/* Intentional parse error. Live coding resilience. This has to be the last test in the file. */
+#live-coding {
+    margin: 8px 8px 8px 8px

--- a/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/ShorthandSizeUnitTest.php
@@ -35,6 +35,7 @@ class ShorthandSizeUnitTest extends AbstractSniffUnitTest
             15 => 1,
             16 => 1,
             17 => 1,
+            21 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
### Squiz/ShorthandSize: add more unit tests

* Fix a unit test which is invalid CSS.
    Valid values for `page-break-inside` are `auto|avoid|initial|inherit`, not a size indication, so changed the style to one which does take size indicators (`tab-size`).
* Add unit test with multi-line style values which should use shorthand.
* Minor improvement to the inline documentation of the tests.
* Add tests documenting how the sniff handles style values interlaced with comments and/or PHPCS annotations. Current behaviour is to ignore these completely.
* Add a parse error test.

### Squiz/ShorthandSize: add missing fixed file

### Squiz/ShorthandSize: various minor fixes/tweaks

* Bow out early for parse errors/live coding.
* Don't remember submatches of the regex which don't need to be used anyhow.
* Minor improvements in whitespace handling.