### PR TITLE
Squiz.CSS.ForbiddenStyles: add missing fixed file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1502,6 +1502,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStyleDefinitionUnitTest.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="EmptyStyleDefinitionUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenStylesUnitTest.css" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenStylesUnitTest.css.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenStylesUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="IndentationUnitTest.1.css" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="IndentationUnitTest.1.css.fixed" role="test" />

--- a/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php
@@ -26,7 +26,7 @@ class ForbiddenStylesSniff implements Sniff
      * A list of forbidden styles with their alternatives.
      *
      * The value is NULL if no alternative exists. i.e., the
-     * function should just not be used.
+     * style should just not be used.
      *
      * @var array<string, string|null>
      */

--- a/src/Standards/Squiz/Tests/CSS/ForbiddenStylesUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/ForbiddenStylesUnitTest.css.fixed
@@ -1,0 +1,18 @@
+#add-new-comment {
+    border-radius: 1px;
+    border-radius: 1px;
+    border-radius: 1px;
+
+    border-top-left-radius: 1px;
+    border-top-right-radius: 1px;
+    border-bottom-right-radius: 1px;
+    border-bottom-left-radius: 1px;
+    border-top-left-radius: 1px;
+    border-top-right-radius: 1px;
+    border-bottom-right-radius: 1px;
+    border-bottom-left-radius: 1px;
+
+    box-shadow: 1px;
+    box-shadow: 1px;
+    box-shadow: 1px;
+}


### PR DESCRIPTION
The sniff contains fixers, but didn't have a `fixed` file.

Includes minor docs fix.