### PR TITLE
Generic/DocComment: add missing fixed file and minor other improvements

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -463,7 +463,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
        </dir>
        <dir name="Commenting">
         <file baseinstalldir="PHP/CodeSniffer" name="DocCommentUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DocCommentUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DocCommentUnitTest.js" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DocCommentUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DocCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FixmeUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FixmeUnitTest.js" role="test" />

--- a/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -262,11 +262,12 @@ class DocCommentSniff implements Sniff
                 if ($paramGroupid === $groupid
                     && $tokens[$tag]['content'] !== '@param'
                 ) {
-                    $error = 'Tag cannot be grouped with parameter tags in a doc comment';
-                    $phpcsFile->addError($error, $tag, 'NonParamGroup');
+                    $error = 'Tag %s cannot be grouped with parameter tags in a doc comment';
+                    $data  = [$tokens[$tag]['content']];
+                    $phpcsFile->addError($error, $tag, 'NonParamGroup', $data);
                 }
 
-                $tagLength = strlen($tokens[$tag]['content']);
+                $tagLength = $tokens[$tag]['length'];
                 if ($tagLength > $maxLength) {
                     $maxLength = $tagLength;
                 }
@@ -274,7 +275,7 @@ class DocCommentSniff implements Sniff
                 // Check for a value. No value means no padding needed.
                 $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
                 if ($string !== false && $tokens[$string]['line'] === $tokens[$tag]['line']) {
-                    $paddings[$tag] = strlen($tokens[($tag + 1)]['content']);
+                    $paddings[$tag] = $tokens[($tag + 1)]['length'];
                 }
             }
 
@@ -306,11 +307,12 @@ class DocCommentSniff implements Sniff
 
             // Now check paddings.
             foreach ($paddings as $tag => $padding) {
-                $required = ($maxLength - strlen($tokens[$tag]['content']) + 1);
+                $required = ($maxLength - $tokens[$tag]['length'] + 1);
 
                 if ($padding !== $required) {
-                    $error = 'Tag value indented incorrectly; expected %s spaces but found %s';
+                    $error = 'Tag value for %s tag indented incorrectly; expected %s spaces but found %s';
                     $data  = [
+                        $tokens[$tag]['content'],
                         $required,
                         $padding,
                     ];

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc.fixed
@@ -15,30 +15,28 @@
  *
  * long description
  * over multiple lines.
+ *
  * @tag1 one
  */
 
 /**
- *
  * Short description
- *
  *
  * Long description
  * over multiple lines
  *
- *
  * @tag1 one
- *
  */
 
 /*
     This is not a doc block.
  */
 
-/** Short description.
+/**
+ * Short description.
  *
- * @tag one
- * @tag2 two
+ * @tag      one
+ * @tag2     two
  * @tagThree three
  * @tagFour  four
  */
@@ -50,26 +48,14 @@
  *
  * @param
  * @param
- *
- */
-
-/**
- * Short description.
- * @param
- * @param
- * @tag one
  */
 
 /**
  * Short description.
  *
- *
  * @param
- *
  * @param
- *
- *
- * @tag one
+ * @tag   one
  */
 
 /**
@@ -77,7 +63,17 @@
  *
  * @param
  *
+ * @param
+ *
  * @tag one
+ */
+
+/**
+ * Short description.
+ *
+ * @param
+ *
+ * @tag   one
  * @param
  */
 
@@ -85,14 +81,13 @@
  * Short description.
  *
  * @groupOne one
- * @groupOne  two
+ * @groupOne two
  *
  * @group2 one
  * @group2 two
  *
- *
  * @g3
- * @g3  two
+ * @g3 two
  */
 
 /**
@@ -167,8 +162,12 @@
  * @ var Comment
  */
 
-/** @var Database $mockedDatabase */
-/** @var Container $mockedContainer */
+/**
+ * @var Database $mockedDatabase 
+*/
+/**
+ * @var Container $mockedContainer 
+*/
 
 /**
  * 这是一条测试评论.
@@ -176,15 +175,17 @@
 
 /**
  * I'm a function short-description
+ *
  * @return boolean
  */
 
 /**
  * this is a test
+ *
  * @author test
- * @param boolean $foo blah
+ * @param  boolean $foo blah
  * @return boolean
- * @param boolean $bar Blah.
+ * @param  boolean $bar Blah.
  */
 
 /**
@@ -211,17 +212,21 @@
  * étude des ...
  */
 
-/**doc comment */
+/**
+* doc comment 
+*/
 
         /**
          * Document behaviour with missing blank lines with indented docblocks.
-         * @param
-         * @param
-         * @tag one
          *
+         * @param
+         * @param
+         * @tag   one
          */
 
-        /** Indented doc comment */
+        /**
+ * Indented doc comment 
+*/
 
 /**
  * Verify and document sniff behaviour when the "tag value" is indented with a mix of tabs and spaces.
@@ -240,13 +245,13 @@
  * Verify and document sniff behaviour when the "tag value" is indented with a mix of tabs and spaces.
  * The below is incorrectly aligned.
  *
- * @category		PHP
- * @package		  PHP_CodeSniffer
+ * @category  PHP
+ * @package   PHP_CodeSniffer
  * @author	  Greg Sherwood <gsherwood@squiz.net>
- * @author	Marc McIntyre <mmcintyre@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
  * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license	  	https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link		http://pear.php.net/package/PHP_CodeSniffer
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
 /** No docblock close tag. Must be last test without new line.

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js
@@ -212,3 +212,39 @@
  */
 
 /**doc comment */
+
+        /**
+         * Document behaviour with missing blank lines with indented docblocks.
+         * @param
+         * @param
+         * @tag one
+         *
+         */
+
+        /** Indented doc comment */
+
+/**
+ * Verify and document sniff behaviour when the "tag value" is indented with a mix of tabs and spaces.
+ * The below is "correctly" aligned.
+ *
+ * @category  PHP
+ * @package	  PHP_CodeSniffer
+ * @author	  Greg Sherwood <gsherwood@squiz.net>
+ * @author	  Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license	  https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link	  http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Verify and document sniff behaviour when the "tag value" is indented with a mix of tabs and spaces.
+ * The below is incorrectly aligned.
+ *
+ * @category		PHP
+ * @package		  PHP_CodeSniffer
+ * @author	  Greg Sherwood <gsherwood@squiz.net>
+ * @author	Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license	  	https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link		http://pear.php.net/package/PHP_CodeSniffer
+ */

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js.fixed
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.js.fixed
@@ -1,4 +1,4 @@
-<?php
+
 /**
  * Short description.
  *
@@ -15,30 +15,28 @@
  *
  * long description
  * over multiple lines.
+ *
  * @tag1 one
  */
 
 /**
- *
  * Short description
- *
  *
  * Long description
  * over multiple lines
  *
- *
  * @tag1 one
- *
  */
 
 /*
     This is not a doc block.
  */
 
-/** Short description.
+/**
+ * Short description.
  *
- * @tag one
- * @tag2 two
+ * @tag      one
+ * @tag2     two
  * @tagThree three
  * @tagFour  four
  */
@@ -50,26 +48,14 @@
  *
  * @param
  * @param
- *
- */
-
-/**
- * Short description.
- * @param
- * @param
- * @tag one
  */
 
 /**
  * Short description.
  *
- *
  * @param
- *
  * @param
- *
- *
- * @tag one
+ * @tag   one
  */
 
 /**
@@ -77,7 +63,17 @@
  *
  * @param
  *
+ * @param
+ *
  * @tag one
+ */
+
+ /**
+ * Short description.
+ *
+ * @param
+ *
+ * @tag   one
  * @param
  */
 
@@ -85,17 +81,16 @@
  * Short description.
  *
  * @groupOne one
- * @groupOne  two
+ * @groupOne two
  *
  * @group2 one
  * @group2 two
  *
- *
  * @g3
- * @g3  two
+ * @g3 two
  */
 
-/**
+ /**
  * Short description
  * over multiple lines.
  *
@@ -117,7 +112,7 @@
  *             multiple lines
  */
 
-/**
+ /**
  * Returns true if the specified string is in the camel caps format.
  *
  * @param boolean $classFormat If true, check to see if the string is in the
@@ -132,7 +127,7 @@
  * @return boolean
  */
 
-/**
+ /**
  * Verifies that a @throws tag exists for a function that throws exceptions.
  * Verifies the number of @throws tags and the number of throw tokens matches.
  * Verifies the exception type.
@@ -148,7 +143,7 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-/**
+ /**
  * Comment
  *
  * @one
@@ -163,12 +158,16 @@
  * @three bar
  */
 
-/**
+ /**
  * @ var Comment
  */
 
-/** @var Database $mockedDatabase */
-/** @var Container $mockedContainer */
+/**
+ * @var Database $mockedDatabase 
+*/
+/**
+ * @var Container $mockedContainer 
+*/
 
 /**
  * 这是一条测试评论.
@@ -176,15 +175,17 @@
 
 /**
  * I'm a function short-description
+ *
  * @return boolean
  */
 
 /**
  * this is a test
+ *
  * @author test
- * @param boolean $foo blah
+ * @param  boolean $foo blah
  * @return boolean
- * @param boolean $bar Blah.
+ * @param  boolean $bar Blah.
  */
 
 /**
@@ -211,17 +212,21 @@
  * étude des ...
  */
 
-/**doc comment */
+/**
+* doc comment 
+*/
 
         /**
          * Document behaviour with missing blank lines with indented docblocks.
-         * @param
-         * @param
-         * @tag one
          *
+         * @param
+         * @param
+         * @tag   one
          */
 
-        /** Indented doc comment */
+        /**
+ * Indented doc comment 
+*/
 
 /**
  * Verify and document sniff behaviour when the "tag value" is indented with a mix of tabs and spaces.
@@ -240,13 +245,11 @@
  * Verify and document sniff behaviour when the "tag value" is indented with a mix of tabs and spaces.
  * The below is incorrectly aligned.
  *
- * @category		PHP
- * @package		  PHP_CodeSniffer
+ * @category  PHP
+ * @package   PHP_CodeSniffer
  * @author	  Greg Sherwood <gsherwood@squiz.net>
- * @author	Marc McIntyre <mmcintyre@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
  * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license	  	https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link		http://pear.php.net/package/PHP_CodeSniffer
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-
-/** No docblock close tag. Must be last test without new line.

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.php
@@ -16,6 +16,21 @@ class DocCommentUnitTest extends AbstractSniffUnitTest
 
 
     /**
+     * Get a list of CLI values to set before the file is tested.
+     *
+     * @param string                  $testFile The name of the file being tested.
+     * @param \PHP_CodeSniffer\Config $config   The config data for the test run.
+     *
+     * @return void
+     */
+    public function setCliValues($testFile, $config)
+    {
+        $config->tabWidth = 4;
+
+    }//end setCliValues()
+
+
+    /**
      * Returns the lines where errors should occur.
      *
      * The key of the array should represent the line number and the value
@@ -64,6 +79,15 @@ class DocCommentUnitTest extends AbstractSniffUnitTest
             206 => 1,
             211 => 1,
             214 => 4,
+            218 => 1,
+            220 => 2,
+            222 => 1,
+            224 => 3,
+            243 => 1,
+            244 => 1,
+            246 => 1,
+            248 => 1,
+            249 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The sniff contains fixers, but didn't have `fixed` files.

Includes:
* Minor usability improvements for two error messages.
    These error message refer to tags without naming them. While there can't be much confusion anyway as there is normally only one tag per line, mentioning the name of the tag in the error message makes the message more descriptive.
* Defer to the `length` key in the token array instead of recalculating lengths.
    This is the same change as was made for other sniffs in #2290, which I'd kept back as I was afraid it would conflict with this PR otherwise.
* Adding extra unit test documenting the behaviour of the fixers with indented docblocks.
    The fact that the alignment/indentation of the fixes is off is not addressed in this PR and IMO doesn't need to be addressed by this sniff in the first place as the `Squiz.Commenting.DocCommentAlignment` sniff can handle that.
* Adding extra unit tests documenting the sniff and fixer behaviour when tabs are used to align tag values.