### PR TITLE
Generic/FunctionCallArgumentSpacing: minor tweaks + bug fix for anonymous classes

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -89,11 +89,14 @@ class FunctionCallArgumentSpacingSniff implements Sniff
             T_COMMA,
             T_VARIABLE,
             T_CLOSURE,
+            T_ANON_CLASS,
             T_OPEN_SHORT_ARRAY,
         ];
 
         while (($nextSeparator = $phpcsFile->findNext($find, ($nextSeparator + 1), $closeBracket)) !== false) {
-            if ($tokens[$nextSeparator]['code'] === T_CLOSURE) {
+            if ($tokens[$nextSeparator]['code'] === T_CLOSURE
+                || $tokens[$nextSeparator]['code'] === T_ANON_CLASS
+            ) {
                 // Skip closures.
                 $nextSeparator = $tokens[$nextSeparator]['scope_closer'];
                 continue;

--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -24,13 +24,16 @@ class FunctionCallArgumentSpacingSniff implements Sniff
      */
     public function register()
     {
-        $tokens = Tokens::$functionNameTokens;
-
-        $tokens[] = T_VARIABLE;
-        $tokens[] = T_CLOSE_CURLY_BRACKET;
-        $tokens[] = T_CLOSE_PARENTHESIS;
-
-        return $tokens;
+        return[
+            T_STRING,
+            T_ISSET,
+            T_UNSET,
+            T_SELF,
+            T_STATIC,
+            T_VARIABLE,
+            T_CLOSE_CURLY_BRACKET,
+            T_CLOSE_PARENTHESIS,
+        ];
 
     }//end register()
 

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
@@ -133,3 +133,8 @@ my_function_call(
     ,'e' // phpcs:ignore Standard.Category.Sniff -- for reasons.
     , 'f'
 );
+
+$foobar = php73_function_call_trailing_comma(
+    $foo,
+    $bar,
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
@@ -138,3 +138,14 @@ $foobar = php73_function_call_trailing_comma(
     $foo,
     $bar,
 );
+
+$foobar = functionCallAnonClassParam(
+    new class() {
+		public $foo=1;
+		public function methodName($param='foo',$paramTwo='bar') {
+			$bar=false;
+			$foo = array(1,2,3);
+		}
+	},
+	$args=array(),
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
@@ -133,3 +133,8 @@ my_function_call(
     'e', // phpcs:ignore Standard.Category.Sniff -- for reasons.
      'f'
 );
+
+$foobar = php73_function_call_trailing_comma(
+    $foo,
+    $bar,
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
@@ -138,3 +138,14 @@ $foobar = php73_function_call_trailing_comma(
     $foo,
     $bar,
 );
+
+$foobar = functionCallAnonClassParam(
+    new class() {
+		public $foo=1;
+		public function methodName($param='foo',$paramTwo='bar') {
+			$bar=false;
+			$foo = array(1,2,3);
+		}
+	},
+	$args = array(),
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -52,6 +52,7 @@ class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
             132 => 2,
             133 => 2,
             134 => 1,
+            150 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
### Make the sniff more efficient by sniffing for fewer tokens

The `Tokens::$functionNameTokens` array includes a number of tokens which will never trigger errors from this sniff as they only expect one parameter. Think: `empty()`, `exit()`.
However, as the tokens are registered for the sniff, the sniff will be triggered each time those tokens are encountered.

I have changed the `register()` method to only register the tokens which will/could actually trigger errors, making the sniff more efficient.

### Confirm correct behaviour with PHP 7.3 trailing commas in function calls

Added an extra unit test to confirm that the sniff handles PHP 7.3 trailing commas in function calls correctly.

### Improve handling of anonymous classes

Spacing around equal operators within anonymous classes should be ignored by this sniff, but wasn't.

This fixes false positives being thrown by this sniff and most likely also fixes a fixer conflict, though I haven't gone looking for specifics, but I imagine that the false positives caused a fixer conflict with a function declaration sniff which demands no spaces around the equal sign for parameter default values. (as is used in the PHPCS native standard)

Includes unit test.

As a sidenote, I wonder whether the check for spacing around the equal operator should even be included in this sniff as "default values" in function calls is not a thing.