### PR TITLE
Check paths are accepted if no exclude-pattern matches

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -138,6 +138,12 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="IsReferenceTest.inc" role="test" />
       <file baseinstalldir="" name="IsReferenceTest.php" role="test" />
      </dir>
+     <dir name="Filters">
+      <dir name="Filter">
+       <file baseinstalldir="" name="AcceptTest.xml" role="test" />
+       <file baseinstalldir="" name="AcceptTest.php" role="test" />
+      </dir>
+     </dir>
      <file baseinstalldir="" name="AllTests.php" role="test" />
      <file baseinstalldir="" name="ErrorSuppressionTest.php" role="test" />
      <file baseinstalldir="" name="IsCamelCapsTest.php" role="test" />
@@ -1856,6 +1862,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/GetMethodPropertiesTest.inc" name="tests/Core/File/GetMethodPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.php" name="tests/Core/File/IsReferenceTest.php" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.php" name="tests/Core/Filters/Filter/AcceptTest.php" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.xml" name="tests/Core/Filters/Filter/AcceptTest.xml" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
   </filelist>
@@ -1889,6 +1897,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/GetMethodPropertiesTest.inc" name="tests/Core/File/GetMethodPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.php" name="tests/Core/File/IsReferenceTest.php" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.php" name="tests/Core/Filters/Filter/AcceptTest.php" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.xml" name="tests/Core/Filters/Filter/AcceptTest.xml" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
    <ignore name="bin/phpcs.bat" />

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -229,6 +229,11 @@ class Filter extends \RecursiveFilterIterator
         }
 
         foreach ($ignorePatterns as $pattern => $type) {
+            // Ignore standard/sniff specific exclude rules.
+            if (is_array($type) === true) {
+                continue;
+            }
+
             // Maintains backwards compatibility in case the ignore pattern does
             // not have a relative/absolute value.
             if (is_int($pattern) === true) {

--- a/tests/Core/AllTests.php
+++ b/tests/Core/AllTests.php
@@ -21,6 +21,7 @@ require_once 'File/GetMemberPropertiesTest.php';
 require_once 'File/GetMethodParametersTest.php';
 require_once 'File/GetMethodPropertiesTest.php';
 require_once 'File/IsReferenceTest.php';
+require_once 'Filters/Filter/AcceptTest.php';
 
 class AllTests
 {
@@ -55,6 +56,7 @@ class AllTests
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodParametersTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\GetMethodPropertiesTest');
         $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\File\IsReferenceTest');
+        $suite->addTestSuite('PHP_CodeSniffer\Tests\Core\Filters\Filter\AcceptTest');
         return $suite;
 
     }//end suite()

--- a/tests/Core/Filters/Filter/AcceptTest.inc
+++ b/tests/Core/Filters/Filter/AcceptTest.inc
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>The coding standard for PHP_CodeSniffer itself.</description>
+
+    <rule ref="Generic">
+        <exclude-pattern>/anything/</exclude-pattern>
+    </rule>
+</ruleset>

--- a/tests/Core/Filters/Filter/AcceptTest.inc
+++ b/tests/Core/Filters/Filter/AcceptTest.inc
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-    <description>The coding standard for PHP_CodeSniffer itself.</description>
-
-    <rule ref="Generic">
-        <exclude-pattern>/anything/</exclude-pattern>
-    </rule>
-</ruleset>

--- a/tests/Core/Filters/Filter/AcceptTest.php
+++ b/tests/Core/Filters/Filter/AcceptTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Filters\Filter::accept method.
+ *
+ * @author    Willington Vega <wvega@wvega.com>
+ * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Filters\Filter;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Filters\Filter;
+use PHP_CodeSniffer\Ruleset;
+use PHPUnit\Framework\TestCase;
+
+class AcceptTest extends TestCase
+{
+
+
+    /**
+     * Test paths that include the name of a standard with associated
+     * exclude-patterns are still accepted.
+     *
+     * @return void
+     */
+    public function testExcludePatternsForStandards()
+    {
+        $standard = __DIR__.'/'.basename(__FILE__, '.php').'.inc';
+        $config   = new Config(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        $paths = ['/path/to/generic-project/src/Main.php'];
+
+        $fakeDI   = new \RecursiveArrayIterator($paths);
+        $filter   = new Filter($fakeDI, '/path/to/generic-project/src', $config, $ruleset);
+        $iterator = new \RecursiveIteratorIterator($filter);
+        $files    = [];
+
+        foreach ($iterator as $file) {
+            $files[] = $file;
+        }
+
+        $this->assertEquals($paths, $files);
+
+    }//end testExcludePatternsForStandards()
+
+
+}//end class

--- a/tests/Core/Filters/Filter/AcceptTest.xml
+++ b/tests/Core/Filters/Filter/AcceptTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="AcceptTest" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>Ruleset to test the filtering based on exclude patterns.</description>
+
+	<!-- Directory pattern. -->
+	<exclude-pattern>*/something/*</exclude-pattern>
+	<!-- File pattern. -->
+	<exclude-pattern>*/Other/Main\.php$</exclude-pattern>
+
+    <rule ref="Generic">
+    	<!-- Standard specific directory pattern. -->
+        <exclude-pattern>/anything/*</exclude-pattern>
+    	<!-- Standard specific file pattern. -->
+        <exclude-pattern>/YetAnother/Main\.php</exclude-pattern>
+    </rule>
+</ruleset>


### PR DESCRIPTION
This PR includes a test to check that paths that include the name of a standard with associated exclude-patterns are still accepted for the list of files to be checked.

The test reproduces https://github.com/squizlabs/PHP_CodeSniffer/issues/2391. 

I followed the coding standards (`php bin/phpcs` reports no problems) but I'm not sure if I added the test to the right place or used the correct approach by using `AcceptTest.inc` as the XML file with the custom standard that reproduces the problem.

I'll be happy to make modifications if the test is considered valid and additional instructions are provided.

As for the solution, I could try to provide one, but I'm not sure what's the right approach in this case. It seems to me that the ignore patterns that are specific to a standard, category or sniff shouldn't be considered on `Filter::shouldIgnorePath()` because that could cause some paths to be excluded entirely only because the custom standard says a subset of the sniffs shouldn't be used on that path.

What do you think?