### PR TITLE
The gitmodified filter will infinitely loop when encountering deleted file paths

### DIFF
--- a/src/Filters/GitModified.php
+++ b/src/Filters/GitModified.php
@@ -47,6 +47,11 @@ class GitModified extends ExactMatch
 
         foreach ($output as $path) {
             $path = Util\Common::realpath($path);
+
+            if ($path === false) {
+                continue;
+            }
+
             do {
                 $modified[$path] = true;
                 $path            = dirname($path);


### PR DESCRIPTION
Deleted files cause realpath($path) to return false. When this value
enters the while loop, it will run indefinitely as the condition will
never be matched.