### PR TITLE
Generic/FunctionCallArgumentSpacing: remove assignment operator spacing checks

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -87,7 +87,6 @@ class FunctionCallArgumentSpacingSniff implements Sniff
 
         $find = [
             T_COMMA,
-            T_VARIABLE,
             T_CLOSURE,
             T_ANON_CLASS,
             T_OPEN_SHORT_ARRAY,
@@ -157,28 +156,6 @@ class FunctionCallArgumentSpacingSniff implements Sniff
                         }
                     }
                 }//end if
-            } else {
-                // Token is a variable.
-                $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextSeparator + 1), $closeBracket, true);
-                if ($nextToken !== false) {
-                    if ($tokens[$nextToken]['code'] === T_EQUAL) {
-                        if (($tokens[($nextToken - 1)]['code']) !== T_WHITESPACE) {
-                            $error = 'Expected 1 space before = sign of default value';
-                            $fix   = $phpcsFile->addFixableError($error, $nextToken, 'NoSpaceBeforeEquals');
-                            if ($fix === true) {
-                                $phpcsFile->fixer->addContentBefore($nextToken, ' ');
-                            }
-                        }
-
-                        if ($tokens[($nextToken + 1)]['code'] !== T_WHITESPACE) {
-                            $error = 'Expected 1 space after = sign of default value';
-                            $fix   = $phpcsFile->addFixableError($error, $nextToken, 'NoSpaceAfterEquals');
-                            if ($fix === true) {
-                                $phpcsFile->fixer->addContent($nextToken, ' ');
-                            }
-                        }
-                    }
-                }
             }//end if
         }//end while
 

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
@@ -8,9 +8,9 @@ $result = myFunction($arg1, $arg2);
 $result = myFunction($arg1, $arg2, $arg3, $arg4, $arg5);
 $result = myFunction($arg1, $arg2, $arg3, $arg4, $arg5);
 $result = myFunction($arg1, $arg2 = array());
-$result = myFunction($arg1, $arg2 = array());
-$result = myFunction($arg1, $arg2 = array());
-$result = myFunction($arg1, $arg2 = array());
+$result = myFunction($arg1, $arg2 =array());
+$result = myFunction($arg1, $arg2= array());
+$result = myFunction($arg1, $arg2=array());
 
 $result = myFunction($arg1, 
                      $arg2 = array(), 
@@ -147,5 +147,5 @@ $foobar = functionCallAnonClassParam(
 			$foo = array(1,2,3);
 		}
 	},
-	$args = array(),
+	$args=array(),
 );

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -30,9 +30,9 @@ class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
             6   => 1,
             7   => 2,
             8   => 1,
-            11  => 2,
-            12  => 2,
-            13  => 3,
+            11  => 1,
+            12  => 1,
+            13  => 1,
             42  => 3,
             43  => 3,
             45  => 1,
@@ -52,7 +52,6 @@ class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
             132 => 2,
             133 => 2,
             134 => 1,
-            150 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
As discussed in #2387, there are dedicated sniffs for checking the spacing around assignment operators:
* `PSR12.Operators.OperatorSpacing`
* `Squiz.WhiteSpace.OperatorSpacing`

Both of these are more comprehensive and more appropriate to use than the limited assignment operator spacing check in this sniff.

Removing the assignment operator spacing checks from this sniff, lowers the risk of fixer conflicts regarding operator spacing and gets rid of duplicate notices in the `PSR12` and `Squiz` standard and inappropriate notices for the `PEAR`, `PSR2` and `Zend` standard.

Includes adjusted unit tests.