### PR TITLE
Squiz/DisallowMultipleAssignments: split errorcode

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -153,8 +153,28 @@ class DisallowMultipleAssignmentsSniff implements Sniff
             return;
         }
 
-        $error = 'Assignments must be the first block of code on a line';
-        $phpcsFile->addError($error, $stackPtr, 'Found');
+        $error     = 'Assignments must be the first block of code on a line';
+        $errorCode = 'Found';
+
+        if (isset($nested) === true) {
+            $controlStructures = [
+                T_IF     => T_IF,
+                T_ELSEIF => T_ELSEIF,
+                T_SWITCH => T_SWITCH,
+                T_CASE   => T_CASE,
+                T_FOR    => T_FOR,
+            ];
+            foreach ($nested as $opener => $closer) {
+                if (isset($tokens[$opener]['parenthesis_owner']) === true
+                    && isset($controlStructures[$tokens[$tokens[$opener]['parenthesis_owner']]['code']]) === true
+                ) {
+                    $errorCode .= 'InControlStructure';
+                    break;
+                }
+            }
+        }
+
+        $phpcsFile->addError($error, $stackPtr, $errorCode);
 
     }//end process()
 


### PR DESCRIPTION
As per the feature request in #2083, the errorcode of the sniff has now been split into two:
* `FoundInControlStructure` when the assignment is within a control structure (with the exception of `while` statements and the first leaf of a `for` statement as those won't be reported anyway).
* `Found` for all other cases.

Fixes #2083
Fixes #1679