### PR TITLE
Runner::checkRequirements(): check all required extensions

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -243,8 +243,34 @@ class Runner
             throw new DeepExitException($error, 3);
         }
 
-        if (extension_loaded('tokenizer') === false) {
-            $error = 'ERROR: PHP_CodeSniffer requires the tokenizer extension to be enabled.'.PHP_EOL;
+        $requiredExtensions = [
+            'tokenizer',
+            'xmlwriter',
+            'SimpleXML',
+        ];
+        $missingExtensions  = [];
+
+        foreach ($requiredExtensions as $extension) {
+            if (extension_loaded($extension) === false) {
+                $missingExtensions[] = $extension;
+            }
+        }
+
+        if (empty($missingExtensions) === false) {
+            $last      = array_pop($requiredExtensions);
+            $required  = implode(', ', $requiredExtensions);
+            $required .= ' and '.$last;
+
+            if (count($missingExtensions) === 1) {
+                $missing = $missingExtensions[0];
+            } else {
+                $last     = array_pop($missingExtensions);
+                $missing  = implode(', ', $missingExtensions);
+                $missing .= ' and '.$last;
+            }
+
+            $error = 'ERROR: PHP_CodeSniffer requires the %s extensions to be enabled. Please enable %s.'.PHP_EOL;
+            $error = sprintf($error, $required, $missing);
             throw new DeepExitException($error, 3);
         }
 


### PR DESCRIPTION
This adjusts the `Runner::checkRequirements()` method to check all PHP extension requirements as listed in the `composer.json` `require` section.

This ensures that requirements are also properly checked for PHAR, PEAR and git-clone based installs.

Fixes #2369

N.B.: While I've tested the message display, I have not been able to test the actual PR as I don't have a PHP compilation available which is missing any of the required three extensions....
@jrchamp Could you test the PR as you originally reported the issue ?
