### PR TITLE
Remove deprecated each() function from test examples

### DIFF
--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -183,7 +183,7 @@ $var2      = 12;
 
 // Valid
 $error = false;
-while (list($h, $f) = each($handle)) {
+while (list($h, $f) = getKeyAndValue($handle)) {
     $error = true;
 }
 

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -183,7 +183,7 @@ $var2     = 12;
 
 // Valid
 $error = false;
-while (list($h, $f) = each($handle)) {
+while (list($h, $f) = getKeyAndValue($handle)) {
     $error = true;
 }
 


### PR DESCRIPTION
``each()`` is deprecated from PHP 7.2 http://php.net/manual/en/function.each.php
My IDE was complaining about this in an example test file.
Even though the test examples are not required to be strictly-valid PHP (they are more for testing format parsing), it seems reasonable to remove this sort of deprecated stuff from examples.