### PR TITLE
Travis: test builds against PHP 7.4 & improve PHPUnit 8 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,26 +19,35 @@ matrix:
       env: CUSTOM_INI=1 PEAR_VALIDATE=1
     - php: 7.1
     - php: 7.2
+      env: PHPUNIT_INCOMPAT=1
     - php: 7.3
+      env: PHPUNIT_INCOMPAT=1
+    - php: "7.4snapshot"
+      env: PHPSTAN=1 PHPUNIT_INCOMPAT=1
+    # Nightly is PHP 8.0 since Feb 2019.
     - php: nightly
-      env: PHPSTAN=1
+      env: PHPUNIT_INCOMPAT=1
 
   allow_failures:
+    - php: "7.4snapshot"
     - php: nightly
 
 before_install:
   - export XMLLINT_INDENT="    "
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+  # PHPUnit 8.x is not (yet) supported, so prevent issues with Travis images using it.
+  - if [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then composer install; fi
 
 before_script:
   - if [[ $CUSTOM_INI == "1" && ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then phpenv config-add php5-testingConfig.ini; fi
   - if [[ $CUSTOM_INI == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then phpenv config-add php7-testingConfig.ini; fi
 
 script:
-  - composer install
   - php bin/phpcs --config-set php_path php
-  - vendor/bin/phpunit tests/AllTests.php
+  - if [[ $PHPUNIT_INCOMPAT != "1" ]]; then phpunit tests/AllTests.php; fi
+  # Don't run the unit tests on nightly (PHP 8.0) as there is no compatible PHPUnit version available yet.
+  - if [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then vendor/bin/phpunit tests/AllTests.php; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
   - if [[ $CUSTOM_INI != "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then pear package-validate package.xml; fi
   - if [[ $PEAR_VALIDATE == "1" ]]; then php scripts/validate-pear-package.php; fi


### PR DESCRIPTION
### Test builds against PHP 7.4

Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

As PHPStan can't currently be run (yet) on PHP 8, the environment variable for it has also been moved to PHP 7.4.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

### Improve PHPUnit 8 fix

PHPUnit 8 adds `void` return type declarations to the PHPUnit methods used by PHPCS, making it neigh impossible to make the unit test suite cross-version compatible for the PHP versions supported by PHPCS.

Officially, PHPUnit 7 is compatible with PHP 7.1, 7.2 and 7.3. However for the functionality used by the PHPCS test suite, it looks to be compatible with PHP 7.4 as well (for now).
Ref: https://phpunit.de/supported-versions.html

For this reason, for Travis images which come natively with PHPUnit 8 (PHP >= 7.2), PHPUnit 7 needs to be installed via Composer.
This is not necessary for older PHP versions and skipping the `composer install` when it's not needed, will make the build a little faster.

Note:  Doing the `composer install` in the `before_install` step will show a build as "errored" instead of "failed" if something would go wong with this install, which is more representative of the real build status.

As for `nightly`/PHP 8:
* The Travis native PHPUnit version for `nightly` is PHPUnit 8, which will not work.
* Running `composer install` for PHPUnit on `nightly` currently installs PHPUnit 4.1.6. Most likely because the PHPUnit 4.x `composer.json` file did not yet contain a PHP requirement, while any higher PHPUnit versions do. Anyways, that will most definitely not work.
* Running `composer install` for PHPUnit with an explicit requirement of PHPUnit 7.x will also not work as PHPUnit 7 will not install on PHP 8 based on the PHPUnit `composer.json` file.

All in all, the unit tests can not currently be run on PHP 8.

When the PHPUnit build step would be active on `nightly` it would automatically fail the build. This would mask any errors in other build steps.
So, for now, I've elected to skip running the unit tests on PHP 8 (`nightly`). This will allow all the other build tests which *can* be run on PHP 8 to still be tested and report appropriate statuses.