### PR TITLE
File::findStartOfStatement/findEndOfStatement(): minor tweak

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2129,9 +2129,7 @@ class File
         if ($ignore !== null) {
             $ignore = (array) $ignore;
             foreach ($ignore as $code) {
-                if (isset($endTokens[$code]) === true) {
-                    unset($endTokens[$code]);
-                }
+                unset($endTokens[$code]);
             }
         }
 
@@ -2197,9 +2195,7 @@ class File
         if ($ignore !== null) {
             $ignore = (array) $ignore;
             foreach ($ignore as $code) {
-                if (isset($endTokens[$code]) === true) {
-                    unset($endTokens[$code]);
-                }
+                unset($endTokens[$code]);
             }
         }
 


### PR DESCRIPTION
`unset()` will silently fail if the array key/variable to unset doesn't exist, so there is no need to wrap this in an `isset()`.