### PR TITLE
Native PHPCS ruleset: ignore Utility method test case files

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,8 @@
     <file>src</file>
     <file>tests</file>
 
-    <exclude-pattern>*/Standards/*/Tests/*\.(inc|css|js)</exclude-pattern>
+    <exclude-pattern>*/src/Standards/*/Tests/*\.(inc|css|js)$</exclude-pattern>
+    <exclude-pattern>*/tests/Core/*/*Test\.(inc|css|js)$</exclude-pattern>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>

--- a/tests/Core/File/FindEndOfStatementTest.inc
+++ b/tests/Core/File/FindEndOfStatementTest.inc
@@ -1,5 +1,4 @@
 <?php
-/* phpcs:ignoreFile */
 
 /* testSimpleAssignment */
 $a = false;

--- a/tests/Core/File/FindExtendedClassNameTest.inc
+++ b/tests/Core/File/FindExtendedClassNameTest.inc
@@ -1,5 +1,4 @@
 <?php
-/* phpcs:ignoreFile */
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.inc
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.inc
@@ -1,5 +1,4 @@
 <?php
-/* @codingStandardsIgnoreFile */
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -1,5 +1,4 @@
 <?php
-/* phpcs:ignoreFile */
 
 class TestMemberProperties
 {

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -1,5 +1,4 @@
 <?php
-/* phpcs:ignoreFile */
 
 /* testPassByReference */
 function passByReference(&$var) {}

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -1,5 +1,4 @@
 <?php
-/* phpcs:ignoreFile */
 
 /* testBasicFunction */
 function myFunction() {}

--- a/tests/Core/File/IsReferenceTest.inc
+++ b/tests/Core/File/IsReferenceTest.inc
@@ -1,5 +1,4 @@
 <?php
-/* phpcs:ignoreFile */
 
 namespace PHP_CodeSniffer\Tests\Core\File;
 


### PR DESCRIPTION
.. and make the pattern for ignoring the Sniff test case files slightly more specific.

Includes removing existing `phpcs:ignoreFile` comments from utility test case files.