### PR TITLE
Consistency fix to allow space after opening parenthesis in control structures

### DIFF
--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
@@ -36,6 +36,16 @@ if (
     $settingsUpdated = FALSE;
 }
 
+if ( // comment
+    $something
+) {
+}
+
+while ( /* comment */
+    true
+) {
+}
+
 // phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesAfterOpen 1
 // phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 1
 foreach ($something as $blah => $that) {}

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
@@ -35,6 +35,16 @@ if ($defaultPageDesign === 0
     $settingsUpdated = FALSE;
 }
 
+if ( // comment
+    $something
+) {
+}
+
+while ( /* comment */
+    true
+) {
+}
+
 // phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesAfterOpen 1
 // phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 1
 foreach ( $something as $blah => $that ) {}

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -31,8 +31,8 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
             26 => 2,
             27 => 2,
             31 => 1,
-            41 => 2,
-            43 => 2,
+            51 => 2,
+            53 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
For the consistency with other sniffs we should allow spaces after opening parenthesis in control structures when the next content is a comment.

Fixes #2411