### PR TITLE
Tokenizer: assign a parenthesis_owner for list() parenthesis

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -59,7 +59,6 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
 
         $this->ignoreTokens[T_ANON_CLASS] = T_ANON_CLASS;
         $this->ignoreTokens[T_USE]        = T_USE;
-        $this->ignoreTokens[T_LIST]       = T_LIST;
         $this->ignoreTokens[T_DECLARE]    = T_DECLARE;
         $this->ignoreTokens[T_THROW]      = T_THROW;
         $this->ignoreTokens[T_YIELD]      = T_YIELD;

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -340,6 +340,7 @@ final class Tokens
      */
     public static $parenthesisOpeners = [
         T_ARRAY    => T_ARRAY,
+        T_LIST     => T_LIST,
         T_FUNCTION => T_FUNCTION,
         T_CLOSURE  => T_CLOSURE,
         T_WHILE    => T_WHILE,


### PR DESCRIPTION
`list()`, just like `array()` is a language construct.

While the parentheses for `array()` would receive the `array` token as the `parenthesis_owner`, the parentheses for `list()` did not.

This commit fixes that inconsistency.

Tested by removing the `T_LIST` token from the "additional tokens indicating that parenthesis are not arbitrary" list in the `Generic.WhiteSpace.ArbitraryParenthesesSpacing` sniff.