### PR TITLE
Squiz/SemicolonSpacing: bug fix

### DIFF
--- a/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php
@@ -54,7 +54,13 @@ class SemicolonSpacingSniff implements Sniff
             return;
         }
 
-        $endOfThisStatement = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextStatement - 1), null, true);
+        $ignore = Tokens::$emptyTokens;
+        if ($tokens[$nextStatement]['code'] === T_STYLE) {
+            // Allow for star-prefix hack.
+            $ignore[] = T_MULTIPLY;
+        }
+
+        $endOfThisStatement = $phpcsFile->findPrevious($ignore, ($nextStatement - 1), null, true);
         if ($tokens[$endOfThisStatement]['code'] !== T_SEMICOLON) {
             $error = 'Style definitions must end with a semicolon';
             $phpcsFile->addError($error, $endOfThisStatement, 'NotAtEnd');

--- a/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css
@@ -51,6 +51,11 @@
 	;
 }
 
+.allow-for-star-hack {
+    cursor: pointer;
+    *cursor: hand;
+}
+
 /* Live coding. Has to be the last test in the file. */
 .intentional-parse-error {
 	float: left

--- a/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css.fixed
+++ b/src/Standards/Squiz/Tests/CSS/SemicolonSpacingUnitTest.css.fixed
@@ -48,6 +48,11 @@
 		0px;  /* right + left */
 }
 
+.allow-for-star-hack {
+    cursor: pointer;
+    *cursor: hand;
+}
+
 /* Live coding. Has to be the last test in the file. */
 .intentional-parse-error {
 	float: left


### PR DESCRIPTION
Allow for the IE < 7 star-prefix hack before style property names.

Fixes #2453