### PR TITLE
PSR-12: update the ruleset to reflect current version as under review

### DIFF
--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -10,6 +10,8 @@
     <!-- Code MUST follow all rules outlined in PSR-1. -->
     <rule ref="PSR1"/>
 
+    <!-- The term 'StudlyCaps' in PSR-1 MUST be interpreted as PascalCase where the first letter of each word is capitalized including the very first letter. -->
+
     <!-- 2.2 Files -->
 
     <!-- All PHP files MUST use the Unix LF (linefeed) line ending only. -->
@@ -85,7 +87,7 @@
 
     <!-- The header of a PHP file may consist of a number of different blocks. If present, each of the blocks below MUST be separated by a single blank line, and MUST NOT contain a blank line. Each block MUST be in the order listed below, although blocks that are not relevant may be omitted.
 
-    Opening PHP tag.
+    Opening <?php tag.
     File-level docblock.
     One or more declare statements.
     The namespace declaration of the file.
@@ -93,9 +95,10 @@
     One or more function-based use import statements.
     One or more constant-based use import statements.
     The remainder of the code in the file.
-    When a file contains a mix of HTML and PHP, any of the above sections may still be used. If so, they MUST be present at the top of the file, even if the remainder of the code consists a closing PHP tag and then a mixture of HTML and PHP. -->
 
-    <!-- When the opening PHP tag is on the first line of the file, it MUST be on its own line with no other statements unless it is a file containing markup outside of PHP opening and closing tags. -->
+    When a file contains a mix of HTML and PHP, any of the above sections may still be used. If so, they MUST be present at the top of the file, even if the remainder of the code consists of a closing PHP tag and then a mixture of HTML and PHP. -->
+
+    <!-- When the opening <?php tag is on the first line of the file, it MUST be on its own line with no other statements unless it is a file containing markup outside of PHP opening and closing tags. -->
 
     <!-- Import statements MUST never begin with a leading backslash as they must always be fully qualified. -->
 
@@ -128,9 +131,9 @@
 
     <!-- The use keyword used inside the classes to implement traits MUST be declared on the next line after the opening brace. -->
 
-    <!-- Each individual Trait that is imported into a class MUST be included one-per-line, and each inclusion MUST have its own use import statement. -->
+    <!-- Each individual Trait that is imported into a class MUST be included one-per-line and each inclusion MUST have its own use import statement. -->
 
-    <!-- When the class has nothing after the use import statement, the class closing brace MUST be on the next line after the use import statement. Otherwise it MUST have a blank line after the use import statement. -->
+    <!-- When the class has nothing after the use import statement, the class closing brace MUST be on the next line after the use import statement. Otherwise, it MUST have a blank line after the use import statement. -->
 
     <!-- When using the insteadof and as operators they must be used as follows taking note of indentation, spacing and new lines. -->
 
@@ -139,10 +142,13 @@
     <!-- Visibility MUST be declared on all properties. -->
     <!-- The var keyword MUST NOT be used to declare a property. -->
     <!-- There MUST NOT be more than one property declared per statement. -->
-    <!-- Property names MUST NOT be prefixed with a single underscore to indicate protected or private visibility. -->
+    <!-- Property names MUST NOT be prefixed with a single underscore to indicate protected or private visibility.
+    That is, an underscore prefix explicitly has no meaning. -->
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
 
     <!-- Visibility MUST be declared on all constants if your project PHP minimum version supports constant visibilities (PHP 7.1 or later). -->
+
+    <!-- There MUST be a space between type declaration and property name. -->
 
     <!-- 4.4 Methods and Functions -->
 
@@ -177,13 +183,20 @@
     <!-- Method and function arguments with default values MUST go at the end of the argument list. -->
     <rule ref="PEAR.Functions.ValidDefaultValue"/>
 
-    <!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+    <!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.
+    When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
     <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
 
     <!-- When you have a return type declaration present there MUST be one space after the colon followed by the type declaration. The colon and declaration MUST be on the same line as the argument list closing parentheses with no spaces between the two characters. -->
 
-    <!-- In nullable type declarations there MUST NOT be a space between the question mark and the type. -->
+    <!-- In nullable type declarations, there MUST NOT be a space between the question mark and the type. -->
     <!-- checked by PSR12.Functions.NullableTypeDeclaration -->
+
+    <!-- When using the reference operator & before an argument, there MUST NOT be a space after it. -->
+
+    <!-- There MUST NOT be a space between the variadic three dots and the argument name. -->
+
+    <!-- When combining both the reference operator and the variadic three dots, there MUST NOT be any space between the two of them. -->
 
     <!-- 4.6 abstract, final, and static -->
 
@@ -213,7 +226,7 @@
     There MUST be one space between the closing parenthesis and the opening brace
     The structure body MUST be indented once
     The closing brace MUST be on the next line after the body
-    The body of each structure MUST be enclosed by braces. This standardizes how the structures look, and reduces the likelihood of introducing errors as new lines get added to the body. -->
+    The body of each structure MUST be enclosed by braces. This standardizes how the structures look and reduces the likelihood of introducing errors as new lines get added to the body. -->
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
@@ -251,7 +264,11 @@
 
     <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line with one space between them. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both. -->
 
-    <!-- 5.3 while, do while -->
+    <!-- 5.3.1 while -->
+
+    <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line with one space between them. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both. -->
+
+    <!-- 5.3.2 do while -->
 
     <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both. -->
 
@@ -265,9 +282,13 @@
 
     <!-- 6. Operators -->
 
-    <!-- All binary and ternary (but not unary) operators MUST be preceded and followed by at least one space. This includes all arithmetic, comparison, assignment, bitwise, logical (excluding ! which is unary), string concatenation, type operators, trait operators (insteadof and as), and the single pipe operator (e.g. ExceptionType1 | ExceptionType2 $e). -->
-    <!-- Other operators are left undefined. -->
+    <!-- All binary and ternary operators MUST be preceded and followed by at least one space; multiple spaces MAY be used for readability purpose. This includes all arithmetic, comparison, assignment, bitwise, logical (excluding ! which is unary), string concatenation, type operators, trait operators (insteadof and as), and the single pipe operator (e.g. ExceptionType1 | ExceptionType2 $e). -->
     <!-- checked by PSR12.Operators.OperatorSpacing -->
+
+    <!-- There MUST NOT be any whitespace between the increment/decrement operators and the variable being incremented/decremented. -->
+    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
+
+    <!-- Other operators are left undefined. -->
 
     <!-- 7. Closures -->
 
@@ -280,10 +301,17 @@
     <!-- When the ending list (whether of arguments or variables) is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
     <!-- checked by Squiz.Functions.MultiLineFunctionDeclaration -->
 
+    <!-- If a return type is present, it MUST follow the same rules as with normal functions and methods; if the use keyword is present, the colon MUST follow the use list closing parentheses with no spaces between the two characters. -->
+
     <!-- 8. Anonymous Classes -->
 
     <!-- Anonymous Classes MUST follow the same guidelines and principles as closures in the above section. -->
 
-    <!-- The opening parenthesis MAY be on the same line as the class keyword so long as the list of implements interfaces does not wrap. If the list of interfaces wraps, the parenthesis MUST be placed on the line immediately following the last interface. -->
+    <!-- The opening brace MAY be on the same line as the class keyword so long as the list of implements interfaces does not wrap. If the list of interfaces wraps, the brace MUST be placed on the line immediately following the last interface. -->
+
+    <!-- 9. Type Casting -->
+
+    <!-- There MUST NOT be any spaces inside the type casting parentheses. -->
+    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
 
 </ruleset>


### PR DESCRIPTION
As [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md) is now [in review](https://www.php-fig.org/psr/#review) again, an update of the ruleset to reflect the current version was needed.

* Updated all inline documentation texts with the texts as currently in PSR-12.
* Added any new statements which were added to PSR-12.
* Added the `Generic.WhiteSpace.IncrementDecrementSpacing` sniff to satisfy the `There MUST NOT be any whitespace between the increment/decrement operators and the variable being incremented/decremented.` rule.
* Added the `Squiz.WhiteSpace.CastSpacing` sniff to satisfy the `There MUST NOT be any spaces inside the type casting parentheses.` rule.

Note: The `5.3.1`/`5.3.2` split is my doing as it is otherwise completely unclear what the difference is between the two statements.

While updating the inline documentation, I noticed a few issues in PSR-12 itself and have opened PRs to fix those. If and when those would be accepted, the inline documentation in the ruleset will need to be updated (again).

Refs:
* [PSR 12: minor grammatical fix / declare statements](https://github.com/php-fig/fig-standards/pull/1154)
* [PSR-12: minor clarification / object declarations](https://github.com/php-fig/fig-standards/pull/1155)
* [PSR-12: minor correction / multi-line do-while](https://github.com/php-fig/fig-standards/pull/1156)