### PR TITLE
Excluding a sniff by path is not working

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -588,7 +588,7 @@ class Ruleset
         // sniff list, but filter out any excluded sniffs.
         $files = [];
         foreach ($includedSniffs as $sniff) {
-            if (in_array($sniff, $excludedSniffs, true) === true) {
+            if (in_array($sniff, $excludedSniffs) === true) {
                 continue;
             } else {
                 $files[] = Util\Common::realpath($sniff);


### PR DESCRIPTION
This is one of the places where the strict comparison breaks things. If you exclude a sniff in the XML via this line, the strict = true causes in_array to return false as it is iterating over XMLElements.

There _might_ be other places where this is also wrong, so I suggest doublechecking every place affected by https://github.com/squizlabs/PHP_CodeSniffer/commit/c280c14885a73c9f0dc18036f13caa79e8b583e6 if the behavior is still the desired one. 