### PR TITLE
PHP_CodeSniffer\Exceptions\RuntimeException extends \RuntimeException

### DIFF
--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -9,7 +9,7 @@
 
 namespace PHP_CodeSniffer\Exceptions;
 
-class RuntimeException extends \Exception
+class RuntimeException extends \RuntimeException
 {
 
 }//end class


### PR DESCRIPTION
I'm not sure if this is a controversial change or not. 

I can fully understand it being rejected outright, however it is a change I would personally appreciate.

I develop a lot of sniffs in my work, and PhpStorm barks about `PHP_CodeSniffer\Exceptions\RuntimeException` being unhandled. I can add it to the list of handled exceptions but I end up doing this on every project, and I touch hundreds. 

PhpStorm however specifically does _not bark_ about things that extend \RuntimeException out of the box - and it my book it makes sense for `PHP_CodeSniffer\Exceptions\RuntimeException` to extend `\RuntimeException`

![Screen Shot 2019-04-08 at 2 53 44 PM](https://user-images.githubusercontent.com/133747/55752656-26e38e00-5a0e-11e9-85aa-0c119827f340.png)
