### PR TITLE
Allows indexes containing hyphens

### DIFF
--- a/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php
@@ -63,7 +63,7 @@ class DisallowObjectStringIndexSniff implements Sniff
         // Allow indexes that have dots in them because we can't write
         // them in dot notation.
         $content = trim($tokens[$index]['content'], '"\' ');
-        if (strpos($content, '.') !== false) {
+        if (strpos($content, '.') !== false || strpos($content, '-') !== false) {
             return;
         }
 

--- a/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.js
+++ b/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.js
@@ -8,14 +8,15 @@ function test(id)
 test.prototype = {
     init: function()
     {
-        var x      = {};
-        x.name     = 'test';
-        x['phone'] = 123124324;
-        var t      = ['test', 'this'].join('');
-        var y      = ['test'].join('');
-        var a      = x[0];
-        var z      = x[x['name']];
-        var p      = x[x.name];
+        var x       = {};
+        x.name      = 'test';
+        x['phone']  = 123124324;
+        x['e-mail'] = 'a@b.co';
+        var t       = ['test', 'this'].join('');
+        var y       = ['test'].join('');
+        var a       = x[0];
+        var z       = x[x['name']];
+        var p       = x[x.name];
     }
 
 };

--- a/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.js
+++ b/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.js
@@ -8,15 +8,14 @@ function test(id)
 test.prototype = {
     init: function()
     {
-        var x       = {};
-        x.name      = 'test';
-        x['phone']  = 123124324;
-        x['e-mail'] = 'a@b.co';
-        var t       = ['test', 'this'].join('');
-        var y       = ['test'].join('');
-        var a       = x[0];
-        var z       = x[x['name']];
-        var p       = x[x.name];
+        var x      = {};
+        x.name     = 'test';
+        x['phone'] = 123124324;
+        var t      = ['test', 'this'].join('');
+        var y      = ['test'].join('');
+        var a      = x[0];
+        var z      = x[x['name']];
+        var p      = x[x.name];
     }
 
 };
@@ -30,6 +29,7 @@ function test() {
     this.errors[y] = x;
     this.errors[y + z] = x;
     this.permissions['workflow.cancel'] = x;
+    this.errors['hyphenated-key-is-fine'] = 'hyphens all the way';
 }
 
 if (child.prototype) {

--- a/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
@@ -33,8 +33,8 @@ class DisallowObjectStringIndexUnitTest extends AbstractSniffUnitTest
 
         return [
             13 => 1,
-            18 => 1,
-            26 => 1,
+            17 => 1,
+            25 => 1,
             36 => 1,
         ];
 

--- a/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/DisallowObjectStringIndexUnitTest.php
@@ -33,9 +33,9 @@ class DisallowObjectStringIndexUnitTest extends AbstractSniffUnitTest
 
         return [
             13 => 1,
-            17 => 1,
-            25 => 1,
-            35 => 1,
+            18 => 1,
+            26 => 1,
+            36 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Fixes this code:
```js
foo['bar-baz']
```