### PR TITLE
Ruleset::processRule(): fix handling of rules included via path

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -239,6 +239,15 @@ http://pear.php.net/dtd/package-2.0.xsd">
        <file baseinstalldir="" name="AcceptTest.php" role="test" />
       </dir>
      </dir>
+     <dir name="Ruleset">
+      <file baseinstalldir="" name="RuleInclusionTest.php" role="test" />
+      <file baseinstalldir="" name="RuleInclusionTest.xml" role="test" />
+      <file baseinstalldir="" name="RuleInclusionTest-include.xml" role="test" />
+      <file baseinstalldir="" name="RuleInclusionAbsoluteLinuxTest.php" role="test" />
+      <file baseinstalldir="" name="RuleInclusionAbsoluteLinuxTest.xml" role="test" />
+      <file baseinstalldir="" name="RuleInclusionAbsoluteWindowsTest.php" role="test" />
+      <file baseinstalldir="" name="RuleInclusionAbsoluteWindowsTest.xml" role="test" />
+     </dir>
      <dir name="Tokenizer">
       <file baseinstalldir="" name="AnonClassParenthesisOwnerTest.inc" role="test" />
       <file baseinstalldir="" name="AnonClassParenthesisOwnerTest.php" role="test" />
@@ -2063,6 +2072,13 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
    <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.php" name="tests/Core/Filters/Filter/AcceptTest.php" />
    <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.xml" name="tests/Core/Filters/Filter/AcceptTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionTest.php" name="tests/Core/Ruleset/RuleInclusionTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionTest.xml" name="tests/Core/Ruleset/RuleInclusionTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionTest-include.xml" name="tests/Core/Ruleset/RuleInclusionTest-include.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php" name="tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
@@ -2102,6 +2118,13 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
    <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.php" name="tests/Core/Filters/Filter/AcceptTest.php" />
    <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.xml" name="tests/Core/Filters/Filter/AcceptTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionTest.php" name="tests/Core/Ruleset/RuleInclusionTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionTest.xml" name="tests/Core/Ruleset/RuleInclusionTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionTest-include.xml" name="tests/Core/Ruleset/RuleInclusionTest-include.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php" name="tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -861,11 +861,17 @@ class Ruleset
         $ref  = (string) $rule['ref'];
         $todo = [$ref];
 
-        $parts = explode('.', $ref);
-        if (count($parts) <= 2) {
-            // We are processing a standard or a category of sniffs.
+        $parts      = explode('.', $ref);
+        $partsCount = count($parts);
+        if ($partsCount <= 2 || $partsCount > count(array_filter($parts))) {
+            // We are processing a standard, a category of sniffs or a relative path inclusion.
             foreach ($newSniffs as $sniffFile) {
-                $parts         = explode(DIRECTORY_SEPARATOR, $sniffFile);
+                $parts = explode(DIRECTORY_SEPARATOR, $sniffFile);
+                if (count($parts) === 1 && DIRECTORY_SEPARATOR === '\\') {
+                    // Path using forward slashes while running on Windows.
+                    $parts = explode('/', $sniffFile);
+                }
+
                 $sniffName     = array_pop($parts);
                 $sniffCategory = array_pop($parts);
                 array_pop($parts);

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class using a Linux-style absolute path to include a sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHPUnit\Framework\TestCase;
+
+class RuleInclusionAbsoluteLinuxTest extends TestCase
+{
+
+    /**
+     * The Ruleset object.
+     *
+     * @var \PHP_CodeSniffer\Ruleset
+     */
+    protected $ruleset;
+
+    /**
+     * Path to the ruleset file.
+     *
+     * @var string
+     */
+    private $standard = '';
+
+    /**
+     * The original content of the ruleset.
+     *
+     * @var string
+     */
+    private $contents = '';
+
+
+    /**
+     * Initialize the config and ruleset objects.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->standard = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
+        $repoRootDir    = dirname(dirname(dirname(__DIR__)));
+
+        // On-the-fly adjust the ruleset test file to be able to test sniffs included with absolute paths.
+        $contents       = file_get_contents($this->standard);
+        $this->contents = $contents;
+
+        $newPath = $repoRootDir;
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $newPath = str_replace('\\', '/', $repoRootDir);
+        }
+
+        $adjusted = str_replace('%path_slash_forward%', $newPath, $contents);
+
+        if (file_put_contents($this->standard, $adjusted) === false) {
+            $this->markTestSkipped('On the fly ruleset adjustment failed');
+        }
+
+        // Initialize the config and ruleset objects for the test.
+        $config        = new Config(["--standard={$this->standard}"]);
+        $this->ruleset = new Ruleset($config);
+
+    }//end setUp()
+
+
+    /**
+     * Reset ruleset file.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        file_put_contents($this->standard, $this->contents);
+
+    }//end tearDown()
+
+
+    /**
+     * Test that sniffs registed with a Linux absolute path are correctly recognized and that
+     * properties are correctly set for them.
+     *
+     * @return void
+     */
+    public function testLinuxStylePathRuleInclusion()
+    {
+        // Test that the sniff is correctly registered.
+        $this->assertObjectHasAttribute('sniffCodes', $this->ruleset);
+        $this->assertCount(1, $this->ruleset->sniffCodes);
+        $this->assertArrayHasKey('Generic.Formatting.SpaceAfterNot', $this->ruleset->sniffCodes);
+        $this->assertSame(
+            'PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff',
+            $this->ruleset->sniffCodes['Generic.Formatting.SpaceAfterNot']
+        );
+
+        // Test that the sniff properties are correctly set.
+        $this->assertSame(
+            '10',
+            $this->ruleset->sniffs['PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff']->spacing
+        );
+
+    }//end testLinuxStylePathRuleInclusion()
+
+
+}//end class

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RuleInclusionAbsoluteLinuxTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<!-- %path_slash_forward% will be replaced on the fly -->
+	<rule ref="%path_slash_forward%/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php">
+	    <properties>
+	        <property name="spacing" value="10" />
+	    </properties>
+	</rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class using a Windows-style absolute path to include a sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHPUnit\Framework\TestCase;
+
+class RuleInclusionAbsoluteWindowsTest extends TestCase
+{
+
+    /**
+     * The Ruleset object.
+     *
+     * @var \PHP_CodeSniffer\Ruleset
+     */
+    protected $ruleset;
+
+    /**
+     * Path to the ruleset file.
+     *
+     * @var string
+     */
+    private $standard = '';
+
+    /**
+     * The original content of the ruleset.
+     *
+     * @var string
+     */
+    private $contents = '';
+
+
+    /**
+     * Initialize the config and ruleset objects.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        if (DIRECTORY_SEPARATOR === '/') {
+            $this->markTestSkipped('Windows specific test');
+        }
+
+        $this->standard = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
+        $repoRootDir    = dirname(dirname(dirname(__DIR__)));
+
+        // On-the-fly adjust the ruleset test file to be able to test sniffs included with absolute paths.
+        $contents       = file_get_contents($this->standard);
+        $this->contents = $contents;
+
+        $adjusted = str_replace('%path_slash_back%', $repoRootDir, $contents);
+
+        if (file_put_contents($this->standard, $adjusted) === false) {
+            $this->markTestSkipped('On the fly ruleset adjustment failed');
+        }
+
+        // Initialize the config and ruleset objects for the test.
+        $config        = new Config(["--standard={$this->standard}"]);
+        $this->ruleset = new Ruleset($config);
+
+    }//end setUp()
+
+
+    /**
+     * Reset ruleset file.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        if (DIRECTORY_SEPARATOR !== '/') {
+            file_put_contents($this->standard, $this->contents);
+        }
+
+    }//end tearDown()
+
+
+    /**
+     * Test that sniffs registed with a Windows absolute path are correctly recognized and that
+     * properties are correctly set for them.
+     *
+     * @return void
+     */
+    public function testWindowsStylePathRuleInclusion()
+    {
+        // Test that the sniff is correctly registered.
+        $this->assertObjectHasAttribute('sniffCodes', $this->ruleset);
+        $this->assertCount(1, $this->ruleset->sniffCodes);
+        $this->assertArrayHasKey('Generic.Formatting.SpaceAfterCast', $this->ruleset->sniffCodes);
+        $this->assertSame(
+            'PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff',
+            $this->ruleset->sniffCodes['Generic.Formatting.SpaceAfterCast']
+        );
+
+        // Test that the sniff property is correctly set.
+        $this->assertSame(
+            '10',
+            $this->ruleset->sniffs['PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff']->spacing
+        );
+
+    }//end testWindowsStylePathRuleInclusion()
+
+
+}//end class

--- a/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml
+++ b/tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RuleInclusionAbsoluteWindowsTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<!-- %path_slash_back% will be replaced on the fly -->
+	<rule ref="%path_slash_back%\src\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff.php">
+	    <properties>
+	        <property name="spacing" value="10" />
+	    </properties>
+	</rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/RuleInclusionTest-include.xml
+++ b/tests/Core/Ruleset/RuleInclusionTest-include.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RuleInclusionTest-include" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<rule ref="Generic.Metrics.NestingLevel">
+	    <properties>
+	        <property name="nestingLevel" value="2" />
+	    </properties>
+	</rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Ruleset class.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHPUnit\Framework\TestCase;
+
+class RuleInclusionTest extends TestCase
+{
+
+    /**
+     * The Ruleset object.
+     *
+     * @var \PHP_CodeSniffer\Ruleset
+     */
+    protected static $ruleset;
+
+
+    /**
+     * Initialize the config and ruleset objects based on the `RuleInclusionTest.xml` ruleset file.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        $standard      = __DIR__.'/'.basename(__FILE__, '.php').'.xml';
+        $config        = new Config(["--standard=$standard"]);
+        self::$ruleset = new Ruleset($config);
+
+    }//end setUpBeforeClass()
+
+
+    /**
+     * Test that sniffs are registered.
+     *
+     * @return void
+     */
+    public function testHasSniffCodes()
+    {
+        $this->assertObjectHasAttribute('sniffCodes', self::$ruleset);
+        $this->assertCount(14, self::$ruleset->sniffCodes);
+
+    }//end testHasSniffCodes()
+
+
+    /**
+     * Test that sniffs are correctly registered, independently on the syntax used to include the sniff.
+     *
+     * @param string $key   Expected array key.
+     * @param string $value Expected array value.
+     *
+     * @dataProvider dataRegisteredSniffCodes
+     *
+     * @return void
+     */
+    public function testRegisteredSniffCodes($key, $value)
+    {
+        $this->assertArrayHasKey($key, self::$ruleset->sniffCodes);
+        $this->assertSame($value, self::$ruleset->sniffCodes[$key]);
+
+    }//end testRegisteredSniffCodes()
+
+
+    /**
+     * Data provider.
+     *
+     * @see self::testRegisteredSniffCodes()
+     *
+     * @return array
+     */
+    public function dataRegisteredSniffCodes()
+    {
+        return [
+            [
+                'PSR1.Classes.ClassDeclaration',
+                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff',
+            ],
+            [
+                'PSR1.Files.SideEffects',
+                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Files\SideEffectsSniff',
+            ],
+            [
+                'PSR1.Methods.CamelCapsMethodName',
+                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Methods\CamelCapsMethodNameSniff',
+            ],
+            [
+                'Generic.PHP.DisallowAlternativePHPTags',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowAlternativePHPTagsSniff',
+            ],
+            [
+                'Generic.PHP.DisallowShortOpenTag',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DisallowShortOpenTagSniff',
+            ],
+            [
+                'Generic.Files.ByteOrderMark',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Files\ByteOrderMarkSniff',
+            ],
+            [
+                'Squiz.Classes.ValidClassName',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\Classes\ValidClassNameSniff',
+            ],
+            [
+                'Generic.NamingConventions.UpperCaseConstantName',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\UpperCaseConstantNameSniff',
+            ],
+            [
+                'Zend.NamingConventions.ValidVariableName',
+                'PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions\ValidVariableNameSniff',
+            ],
+            [
+                'Generic.Arrays.ArrayIndent',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\ArrayIndentSniff',
+            ],
+            [
+                'Generic.Metrics.CyclomaticComplexity',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff',
+            ],
+            [
+                'Generic.Files.LineLength',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff',
+            ],
+            [
+                'Generic.NamingConventions.CamelCapsFunctionName',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff',
+            ],
+            [
+                'Generic.Metrics.NestingLevel',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff',
+            ],
+        ];
+
+    }//end dataRegisteredSniffCodes()
+
+
+    /**
+     * Test that setting properties for standards, categories, sniffs works for all supported rule
+     * inclusion methods.
+     *
+     * @param string $sniffClass    The name of the sniff class.
+     * @param string $propertyName  The name of the changed property.
+     * @param mixed  $expectedValue The value expected for the property.
+     *
+     * @dataProvider dataSettingProperties
+     *
+     * @return void
+     */
+    public function testSettingProperties($sniffClass, $propertyName, $expectedValue)
+    {
+        $this->assertObjectHasAttribute('sniffs', self::$ruleset);
+        $this->assertArrayHasKey($sniffClass, self::$ruleset->sniffs);
+        $this->assertObjectHasAttribute($propertyName, self::$ruleset->sniffs[$sniffClass]);
+
+        $actualValue = self::$ruleset->sniffs[$sniffClass]->$propertyName;
+        $this->assertSame($expectedValue, $actualValue);
+
+    }//end testSettingProperties()
+
+
+    /**
+     * Data provider.
+     *
+     * @see self::testSettingProperties()
+     *
+     * @return array
+     */
+    public function dataSettingProperties()
+    {
+        return [
+            'ClassDeclarationSniff'                           => [
+                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff',
+                'setforallsniffs',
+                true,
+            ],
+            'SideEffectsSniff'                                => [
+                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Files\SideEffectsSniff',
+                'setforallsniffs',
+                true,
+            ],
+            'ValidVariableNameSniff'                          => [
+                'PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions\ValidVariableNameSniff',
+                'setforallincategory',
+                true,
+            ],
+            'ArrayIndentSniff'                                => [
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\ArrayIndentSniff',
+                'indent',
+                '2',
+            ],
+            'LineLengthSniff'                                 => [
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff',
+                'lineLimit',
+                '10',
+            ],
+            'CamelCapsFunctionNameSniff'                      => [
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff',
+                'strict',
+                false,
+            ],
+            'NestingLevelSniff-nestingLevel'                  => [
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff',
+                'nestingLevel',
+                '2',
+            ],
+            'NestingLevelSniff-setforsniffsinincludedruleset' => [
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff',
+                'setforsniffsinincludedruleset',
+                true,
+            ],
+
+            // Testing that setting a property at error code level does *not* work.
+            'CyclomaticComplexitySniff'                       => [
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff',
+                'complexity',
+                10,
+            ],
+        ];
+
+    }//end dataSettingProperties()
+
+
+}//end class

--- a/tests/Core/Ruleset/RuleInclusionTest.xml
+++ b/tests/Core/Ruleset/RuleInclusionTest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RuleInclusionTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+	<rule ref="PSR1">
+	    <properties>
+	        <property name="setforallsniffs" value="true" />
+	    </properties>
+	</rule>
+
+	<rule ref="Zend.NamingConventions">
+	    <properties>
+	        <property name="setforallincategory" value="true" />
+	    </properties>
+	</rule>
+
+	<rule ref="Generic.Arrays.ArrayIndent">
+	    <properties>
+	        <property name="indent" value="2" />
+	    </properties>
+	</rule>
+
+	<rule ref="Generic.Metrics.CyclomaticComplexity.MaxExceeded">
+	    <properties>
+	        <property name="complexity" value="50" />
+	    </properties>
+	</rule>
+
+	<rule ref="./src/Standards/Generic/Sniffs/Files/LineLengthSniff.php">
+	    <properties>
+	        <property name="lineLimit" value="10" />
+	    </properties>
+	</rule>
+
+	<rule ref="./../PHP_CodeSniffer/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php">
+	    <properties>
+	        <property name="strict" value="false" />
+	    </properties>
+	</rule>
+
+	<rule ref="./RuleInclusionTest-include.xml">
+	    <properties>
+	        <property name="setforsniffsinincludedruleset" value="true" />
+	    </properties>
+	</rule>
+
+</ruleset>


### PR DESCRIPTION
This fixes a bug where properties set for rules included via a path to the sniff file or to an included standards file, would be disregarded if the slashes used in the path did not match the slashes expected for the OS on which the ruleset is being run.

Includes adding initial integration tests for the Ruleset class.

Fixes #2497