### PR TITLE
Generic.WhiteSpace.ScopeIndent false positives with nested switch indentation and case fall-through

### DIFF
--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
@@ -1,0 +1,16 @@
+<?php
+
+function entity_permissions($entity_type_id, $operation) {
+    switch ($entity_type_id) {
+        case 'entity_test':
+            switch ($operation) {
+                case 'delete':
+                    return ['administer entity_test content'];
+            }
+        case 'node':
+            switch ($operation) {
+                case 'view':
+                    return ['access content'];
+            }
+    }
+}

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -86,6 +86,10 @@ class ScopeIndentUnitTest extends AbstractSniffUnitTest
             return [];
         }
 
+        if ($testFile === 'ScopeIndentUnitTest.5.inc') {
+            return [];
+        }
+
         return [
             7    => 1,
             10   => 1,


### PR DESCRIPTION
When you have a nested switch statement without break statements then the scope indent sniff gets confused. Here is a testcase to demonstrate the problem, I have not found a solution yet.