### PR TITLE
Generic.WhiteSpace.ScopeIndent false positives with nested arrays and nowdoc string

### DIFF
--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.5.inc
@@ -1,0 +1,44 @@
+<?php
+
+$tests = [
+    [
+        'original' => '$no_index_value_scalar = TRUE;',
+        'settings' => [
+            'no_index_value_scalar' => (object) [
+                'value' => FALSE,
+                'comment' => 'comment',
+            ],
+        ],
+        'expected' => '$no_index_value_scalar = false; // comment',
+    ],
+    [
+        'original' => '$no_index_value_scalar = TRUE;',
+        'settings' => [
+            'no_index_value_foo' => [
+                'foo' => [
+                    'value' => (object) [
+                        'value' => NULL,
+                        'required' => TRUE,
+                        'comment' => 'comment',
+                    ],
+                ],
+            ],
+        ],
+        'expected' => <<<'EXPECTED'
+$no_index_value_scalar = TRUE;
+$no_index_value_foo['foo']['value'] = NULL; // comment
+EXPECTED
+    ],
+    [
+        'original' => '$no_index_value_array = array("old" => "value");',
+        'settings' => [
+            'no_index_value_array' => (object) [
+                'value' => FALSE,
+                'required' => TRUE,
+                'comment' => 'comment',
+            ],
+        ],
+        'expected' => '$no_index_value_array = array("old" => "value");
+$no_index_value_array = false; // comment',
+    ],
+];

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -86,6 +86,10 @@ class ScopeIndentUnitTest extends AbstractSniffUnitTest
             return [];
         }
 
+        if ($testFile === 'ScopeIndentUnitTest.5.inc') {
+            return [];
+        }
+
         return [
             7    => 1,
             10   => 1,


### PR DESCRIPTION
Using nowdoc syntax in a nested array confuses the ScopeIndent sniff. Here is a test case that should not throw any indentation errors, but it does.