### PR TITLE
Add option to allow checking assignment operators

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -33,6 +33,13 @@ class OperatorSpacingSniff implements Sniff
      */
     public $ignoreNewlines = false;
 
+    /**
+     * Allow multiple assignment statements to be aligned (don't check space before assignment operator)
+     *
+     * @var boolean
+     */
+    public $allowMultipleStatementsAlignment = true;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -144,9 +151,11 @@ class OperatorSpacingSniff implements Sniff
             }
 
             $phpcsFile->recordMetric($stackPtr, 'Space before operator', 0);
-        } else if (isset(Tokens::$assignmentTokens[$tokens[$stackPtr]['code']]) === false) {
-            // Don't throw an error for assignments, because other standards allow
-            // multiple spaces there to align multiple assignments.
+        } else if (isset(Tokens::$assignmentTokens[$tokens[$stackPtr]['code']]) === false
+            || $this->allowMultipleStatementsAlignment === false
+        ) {
+            // Throw an error for assignments only if that behaviour is enabled using the sniff property,
+            // because other standards allow multiple spaces there to align multiple assignments.
             if ($tokens[($stackPtr - 2)]['line'] !== $tokens[$stackPtr]['line']) {
                 $found = 'newline';
             } else {

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -260,3 +260,6 @@ function bar(): array {}
 if ($line{-1} === ':') {
     $line = substr($line, 0, -1);
 }
+
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing allowMultipleStatementsAlignment false
+$a  =  3;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -254,3 +254,6 @@ function bar(): array {}
 if ($line{-1} === ':') {
     $line = substr($line, 0, -1);
 }
+
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing allowMultipleStatementsAlignment false
+$a = 3;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js
@@ -98,3 +98,6 @@ x = x >>> y;
 x >>>= y;
 
 var foo = bar.map(baz=> baz.length);
+
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing allowMultipleStatementsAlignment false
+a  =  3;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.js.fixed
@@ -92,3 +92,6 @@ x = x >>> y;
 x >>>= y;
 
 var foo = bar.map(baz => baz.length);
+
+// phpcs:set Squiz.WhiteSpace.OperatorSpacing allowMultipleStatementsAlignment false
+a = 3;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -96,6 +96,7 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                 201 => 2,
                 239 => 1,
                 246 => 1,
+                265 => 2,
             ];
             break;
         case 'OperatorSpacingUnitTest.js':
@@ -138,6 +139,7 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                 73  => 1,
                 74  => 1,
                 100 => 1,
+                103 => 2,
             ];
             break;
         default:


### PR DESCRIPTION
I would like to enforce checking of spaces around assignments as I'm not allowing statements alignment. This simple change (no BC-break) allows me to do so.