### PR TITLE
Squiz/NonExecutableCode: fix bug with alternative switch control structures

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -105,6 +105,7 @@ class NonExecutableCodeSniff implements Sniff
                         T_CASE,
                         T_DEFAULT,
                         T_CLOSE_CURLY_BRACKET,
+                        T_ENDSWITCH,
                     ],
                     ($end + 1)
                 );

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -257,3 +257,42 @@ switch ($var) {
 
 end:
 echo 'j hit 17';
+
+// Issue 2512.
+class TestAlternativeControlStructures {
+
+    public function alternative_switch_in_function( $var ) {
+
+        switch ( $var ) :
+            case 'value1':
+                do_something();
+                break;
+
+            default:
+            case 'value2':
+                do_something_else();
+                break;
+        endswitch;
+    }
+
+    public function various_alternative_control_structures() {
+        $_while = 1;
+
+        for ( $a = 0; $a++ < 1; ) :
+            foreach ( [ 1 ] as $b ) :
+                while ( $_while-- ) :
+                    if ( 1 ) :
+                        switch ( 1 ) :
+                            default:
+                                echo 'yay, we made it!';
+                                break;
+                        endswitch;
+                    endif;
+                endwhile;
+            endforeach;
+        endfor;
+    }
+}
+
+$var_after_class_in_global_space = 1;
+do_something_else();


### PR DESCRIPTION
The `T_ENDSWITCH` token wasn't being taken into account as a potential end token.

Includes unit tests.

Fixes #2512