### PR TITLE
Text generator throws error when code sample line is too long

### DIFF
--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -231,9 +231,9 @@ class Text extends Generator
             }
 
             echo '| ';
-            echo $firstLineText.str_repeat(' ', (47 - strlen($firstLineText)));
+            echo $firstLineText.str_repeat(' ', max(0, (47 - strlen($firstLineText))));
             echo '| ';
-            echo $secondLineText.str_repeat(' ', (48 - strlen($secondLineText)));
+            echo $secondLineText.str_repeat(' ', max(0, (48 - strlen($secondLineText))));
             echo '|'.PHP_EOL;
         }//end for
 


### PR DESCRIPTION
If an individual line of the code sample in the code comparison would be longer than 47/48 characters, a `Warning: str_repeat(): Second argument has to be greater than or equal to 0` would be thrown.

This fixes the error.

Note: this fix does not introduce code-wrapping as that would probably reduce the readability of the code too much.
Instead, the line will just be longer than other lines.

:bulb: **Idea**: should this class respect a `report_width` if set by the user either in their `CodeSniffer.conf` or via the command-line ?