### PR TITLE
Possibility to skip Use statement lines on LineLenghtSniff

### DIFF
--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
@@ -1,0 +1,6 @@
+phpcs:set Generic.Files.LineLength ignoreUseStatementsLines true
+phpcs:set Generic.Files.LineLength lineLimit 80
+phpcs:set Generic.Files.LineLength absoluteLineLimit 120
+<?php
+
+use This\Line\Is\Tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\Long\But\Its\Ok\Because\Will\Be\Skipped;

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.6.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.6.inc
@@ -1,0 +1,5 @@
+phpcs:set Generic.Files.LineLength lineLimit 80
+phpcs:set Generic.Files.LineLength absoluteLineLimit 120
+<?php
+
+use This\Line\Is\Tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\Long\But\Its\Ok\Because\Will\Be\Skipped;

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -43,21 +43,21 @@ class LineLengthUnitTest extends AbstractSniffUnitTest
     public function getErrorList($testFile='')
     {
         switch ($testFile) {
-        case 'LineLengthUnitTest.1.inc':
-            return [
-                31 => 1,
-                34 => 1,
-                45 => 1,
-                82 => 1,
-            ];
-            break;
-        case 'LineLengthUnitTest.2.inc':
-        case 'LineLengthUnitTest.3.inc':
-            return [7 => 1];
-            break;
-        default:
-            return [];
-            break;
+            case 'LineLengthUnitTest.1.inc':
+                return [
+                    31 => 1,
+                    34 => 1,
+                    45 => 1,
+                    82 => 1,
+                ];
+                break;
+            case 'LineLengthUnitTest.2.inc':
+            case 'LineLengthUnitTest.3.inc':
+                return [7 => 1];
+                break;
+            default:
+                return [];
+                break;
         }//end switch
 
     }//end getErrorList()
@@ -76,29 +76,35 @@ class LineLengthUnitTest extends AbstractSniffUnitTest
     public function getWarningList($testFile='')
     {
         switch ($testFile) {
-        case 'LineLengthUnitTest.1.inc':
-            return [
-                9  => 1,
-                15 => 1,
-                21 => 1,
-                24 => 1,
-                29 => 1,
-                37 => 1,
-                63 => 1,
-                73 => 1,
-                75 => 1,
-            ];
-            break;
-        case 'LineLengthUnitTest.2.inc':
-        case 'LineLengthUnitTest.3.inc':
-            return [6 => 1];
-            break;
-        case 'LineLengthUnitTest.4.inc':
-            return [10 => 1];
-            break;
-        default:
-            return [];
-            break;
+            case 'LineLengthUnitTest.1.inc':
+                return [
+                    9  => 1,
+                    15 => 1,
+                    21 => 1,
+                    24 => 1,
+                    29 => 1,
+                    37 => 1,
+                    63 => 1,
+                    73 => 1,
+                    75 => 1,
+                ];
+                break;
+            case 'LineLengthUnitTest.2.inc':
+            case 'LineLengthUnitTest.3.inc':
+                return [6 => 1];
+                break;
+            case 'LineLengthUnitTest.4.inc':
+                return [10 => 1];
+                break;
+            case 'LineLengthUnitTest.5.inc':
+                return [];
+                break;
+            case 'LineLengthUnitTest.6.inc':
+                return [5 => 1];
+                break;
+            default:
+                return [];
+                break;
         }//end switch
 
     }//end getWarningList()


### PR DESCRIPTION
We have in our project long names of namespaces. These names overlap line length limit on use statement lines. We won't increase limit for all lines so great solution for use is skip use statement lines for line length check like comment lines.