### PR TITLE
Add support to skip LineLengthSniff on Use lines

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -558,6 +558,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.4.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.5.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.6.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercasedFilenameUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercasedFilenameUnitTest.php" role="test" />

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
@@ -1,0 +1,14 @@
+phpcs:set Generic.Files.LineLength ignoreUseStatementsLines true
+phpcs:set Generic.Files.LineLength lineLimit 80
+phpcs:set Generic.Files.LineLength absoluteLineLimit 120
+<?php
+
+use This\Line\Is\Tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\Long\But\Its\Ok\Because\Will\Be\Skipped;
+
+class foo extends bar {
+    use thisIsToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLongNameOfTraitAndThisLineMustRaiseError;
+
+    $array->map(function (int $a) use ($thisIsToooooooooooooooooooooooooooLongVariableNameAndThisLIneMustRaiseError)) {
+        return
+    }
+}

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.6.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.6.inc
@@ -1,0 +1,14 @@
+phpcs:set Generic.Files.LineLength ignoreUseStatementsLines false
+phpcs:set Generic.Files.LineLength lineLimit 80
+phpcs:set Generic.Files.LineLength absoluteLineLimit 120
+<?php
+
+use This\Line\Is\Tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\Long\But\Its\Ok\Because\Will\Be\Skipped;
+
+class foo extends bar {
+    use thisIsToooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooLongNameOfTraitAndThisLineMustRaiseError;
+
+    $array->map(function (int $a) use ($thisIsToooooooooooooooooooooooooooLongVariableNameAndThisLIneMustRaiseError)) {
+        return
+    }
+}

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.php
@@ -96,6 +96,19 @@ class LineLengthUnitTest extends AbstractSniffUnitTest
         case 'LineLengthUnitTest.4.inc':
             return [10 => 1];
             break;
+        case 'LineLengthUnitTest.5.inc':
+            return [
+                9  => 1,
+                11 => 1,
+            ];
+            break;
+        case 'LineLengthUnitTest.6.inc':
+            return [
+                6  => 1,
+                9  => 1,
+                11 => 1,
+            ];
+            break;
         default:
             return [];
             break;


### PR DESCRIPTION
We have in our project long names of namespaces. These names overlap line length limit on use statement lines. We won't increase limit for all lines so great solution for use is skip use statement lines for line length check like comment lines.