### PR TITLE
Report/XML: bug fix for output on Windows

### DIFF
--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -75,7 +75,12 @@ class Xml implements Report
         // add that manually later. We only have it in here to
         // properly set the encoding.
         $content = $out->flush();
-        $content = substr($content, (strpos($content, PHP_EOL) + strlen(PHP_EOL)));
+        if (strpos($content, PHP_EOL) !== false) {
+            $content = substr($content, (strpos($content, PHP_EOL) + strlen(PHP_EOL)));
+        } else if (strpos($content, "\n") !== false) {
+            $content = substr($content, (strpos($content, "\n") + 1));
+        }
+
         echo $content;
 
         return true;


### PR DESCRIPTION
It looks like the `XMLWriter` extension does not respect the OS-specific `PHP_EOL` character, but always uses `\n`, though I have not been able to test this on various OS-es to confirm.
This could be regarded as a bug in PHP itself which may or may not be fixed at some point.

With the above in mind, I have created a fix which contains some redundancy, but should be stable on all OS-es, including if/when the PHP native issue would be fixed.

Alternatively, the whole snippet could be replaced by the code on line 81 of the patch.

Fixes #2526