### PR TITLE
Squiz.Commenting.FunctionComment.IncorrectTypeHint does not work with class aliases

### DIFF
--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -252,6 +252,18 @@ public function typeHint(MyClass $a1, $a2, myclass $a3, $a4)
 }//end typeHint()
 
 
+use MyOtherClass as MyAliasedClass;
+
+/**
+ * More type hint check for aliased type.
+ *
+ * @param MyOtherClass $a Comment here.
+ */
+public function aliasedTypeHint(MyAliasedClass $a) {
+
+}//end aliasedTypeHint()
+
+
 /**
  * Mixed variable type separated by a '|'.
  *
@@ -447,6 +459,9 @@ class MyClass() {
      * @return string[]
      */
     abstract final protected function myFunction();
+}
+
+class MyOtherClass() {
 }
 
 /**
@@ -666,7 +681,7 @@ class Baz {
  * Test
  *
  * @return void
- * @throws E 
+ * @throws E
  */
 function myFunction() {}
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -252,6 +252,18 @@ public function typeHint(MyClass $a1, $a2, myclass $a3, $a4)
 }//end typeHint()
 
 
+use MyOtherClass as MyAliasedClass;
+
+/**
+ * More type hint check for aliased type.
+ *
+ * @param MyOtherClass $a Comment here.
+ */
+public function aliasedTypeHint(MyAliasedClass $a) {
+
+}//end aliasedTypeHint()
+
+
 /**
  * Mixed variable type separated by a '|'.
  *
@@ -447,6 +459,9 @@ class MyClass() {
      * @return string[]
      */
     abstract final protected function myFunction();
+}
+
+class MyOtherClass() {
 }
 
 /**
@@ -666,7 +681,7 @@ class Baz {
  * Test
  *
  * @return void
- * @throws E 
+ * @throws E
  */
 function myFunction() {}
 


### PR DESCRIPTION
If you are using an aliased class in a typehint, `Squiz.Commenting.FunctionComment.IncorrectTypeHint` will complain even if the correct typehint is actually being used.