### PR TITLE
Generic.Files.LineLength: Add ignoring of phpcs:ignore

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -561,6 +561,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.4.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.5.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LineLengthUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercasedFilenameUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="LowercasedFilenameUnitTest.php" role="test" />

--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -134,6 +134,7 @@ class LineLengthSniff implements Sniff
 
         if ($tokens[$stackPtr]['code'] === T_COMMENT
             || $tokens[$stackPtr]['code'] === T_DOC_COMMENT_STRING
+            || $tokens[$stackPtr]['code'] === T_PHPCS_IGNORE
         ) {
             if ($this->ignoreComments === true) {
                 return;

--- a/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/Files/LineLengthUnitTest.5.inc
@@ -1,0 +1,7 @@
+phpcs:set Generic.Files.LineLength ignoreComments true
+phpcs:set Generic.Files.LineLength lineLimit 100
+phpcs:set Generic.Files.LineLength absoluteLineLimit 120
+<?php
+
+/* This line is too long but will be ignored. This line is too long but will be ignored. */
+if (($anotherReallyLongVarName === true) || (is_array($anotherReallyLongVarName) === false)) {} // phpcs:ignore Some.Sniff


### PR DESCRIPTION
## Goal
It would be nice to not count `// phpcs:ignore Some.Sniff` to total length of line because of writing something like  `// phpcs:ignore Some.Sniff, Generic.Files.LineLength` is a little bit useless I think.


## Use case

```php
Class Foo
{
    ...

    private function configurePreflightHandler(Application $application): void
    {
        /** @var RouteInterface $route */
        $route = $application->options(self::ROUTE_PATTERN, function (Request $request, Response $response) { // phpcs:ignore SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic
            return $response;
        });

        $route->setAttribute(Request::ROUTE_GENERIC, true);
    }
}
```

Rule settings:

```xml
<rule ref="Generic.Files.LineLength">
    <properties>
        <property name="lineLimit" value="130"/>
        <property name="absoluteLineLimit" value="0"/>
        <property name="ignoreComments" value="true"/>
    </properties>
</rule>
```

## Current state

```bash
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
-----------------------------------------------------------------------------------
 73 | WARNING | Line exceeds 130 characters; contains 189 characters
    |         | (Generic.Files.LineLength.TooLong)
 ...
-----------------------------------------------------------------------------------
```

## State with this patch
No warnings found.

## Additional info
I prepared this PR without new configuration but if you need it, just let me know and I'll add something similar like `$ignoreComments` :)
