### PR TITLE
Unresolvable installed_paths can lead to open_basedir errors

### DIFF
--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -16,7 +16,9 @@ class Standards
 
 
     /**
-     * Get a list paths where standards are installed.
+     * Get a list of paths where standards are installed.
+     *
+     * Unresolvable relative paths will be excluded from the results.
      *
      * @return array
      */
@@ -34,6 +36,9 @@ class Standards
         foreach ($installedPaths as $installedPath) {
             if (substr($installedPath, 0, 1) === '.') {
                 $installedPath = Common::realPath(__DIR__.$ds.'..'.$ds.'..'.$ds.$installedPath);
+                if ($installedPath === false) {
+                    continue;
+                }
             }
 
             $resolvedInstalledPaths[] = $installedPath;

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -234,6 +234,9 @@ class Standards
             // This could be a custom standard, installed outside our
             // standards directory.
             $standard = Common::realPath($standard);
+            if ($standard === false) {
+                return false;
+            }
 
             // Might be an actual ruleset file itUtil.
             // If it has an XML extension, let's at least try it.
@@ -287,7 +290,7 @@ class Standards
 
             $path = Common::realpath($standardPath.DIRECTORY_SEPARATOR.'ruleset.xml');
 
-            if (is_file($path) === true) {
+            if ($path !== false && is_file($path) === true) {
                 return $path;
             } else if (Common::isPharFile($standardPath) === true) {
                 $path = Common::realpath($standardPath);


### PR DESCRIPTION
Install paths defined via the `installed_paths` configuration option do sometimes contain relative paths that may not exist depending on the current environment.

Resolving such non-existent paths causes `false` to be included in the results, which when used for looking up files/folders, can cause wrong locations to be looked up, and/or errors being thrown. [**`\PHP_CodeSniffer\Util\Standards::getInstalledStandardDetails()`**](https://github.com/squizlabs/PHP_CodeSniffer/blob/3.4.2/src/Util/Standards.php#L85-L88) would for example look for `/ruleset.xml`, ie in the root of the current drive, which could trigger an open basedir restriction error.