### PR TITLE
Text doc generator does not allow for multi-line rule explanations

### DIFF
--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -75,18 +75,28 @@ class Text extends Generator
         $text = str_replace('<em>', '*', $text);
         $text = str_replace('</em>', '*', $text);
 
-        $lines    = [];
-        $tempLine = '';
-        $words    = explode(' ', $text);
+        $nodeLines = explode("\n", $text);
+        $lines     = [];
 
-        foreach ($words as $word) {
-            if (strlen($tempLine.$word) >= 99) {
-                if (strlen($tempLine.$word) === 99) {
-                    // Adding the extra space will push us to the edge
-                    // so we are done.
-                    $lines[]  = $tempLine.$word;
-                    $tempLine = '';
-                } else if (strlen($tempLine.$word) === 100) {
+        foreach ($nodeLines as $currentLine) {
+            $currentLine = trim($currentLine);
+            if ($currentLine === '') {
+                // The text contained a blank line. Respect this.
+                $lines[] = '';
+                continue;
+            }
+
+            $tempLine = '';
+            $words    = explode(' ', $currentLine);
+
+            foreach ($words as $word) {
+                $currentLength = strlen($tempLine.$word);
+                if ($currentLength < 99) {
+                    $tempLine .= $word.' ';
+                    continue;
+                }
+
+                if ($currentLength === 99 || $currentLength === 100) {
                     // We are already at the edge, so we are done.
                     $lines[]  = $tempLine.$word;
                     $tempLine = '';
@@ -94,14 +104,12 @@ class Text extends Generator
                     $lines[]  = rtrim($tempLine);
                     $tempLine = $word.' ';
                 }
-            } else {
-                $tempLine .= $word.' ';
+            }//end foreach
+
+            if ($tempLine !== '') {
+                $lines[] = rtrim($tempLine);
             }
         }//end foreach
-
-        if ($tempLine !== '') {
-            $lines[] = rtrim($tempLine);
-        }
 
         echo implode(PHP_EOL, $lines).PHP_EOL.PHP_EOL;
 


### PR DESCRIPTION
While new lines were (accidentally) being respected by the existing code, the line length count was not being reset when a new line character was encountered, causing weird line wrapping.

This has been fixed now by:
* First splitting the received text into individual lines.
* Then doing the line wrapping calculations for each line individually.

Includes:
* Reducing the code complexity by removing an `else` and using an early `continue` instead.
* Removing some duplicate function calls.

### To test this:
* Make sure you are on the `master` branch and:
    - Create a `Standard/Docs/Category/SomeSniffStandard.xml` file with the following content:
        <details>
            <summary>XML Documentation code sample</summary>

            ```xml
            <documentation title="Yoda Conditions">
                <standard>
                <![CDATA[
                  When doing logical comparisons involving variables, the variable must be placed on the right side. All constants, literals, and function calls must be placed on the left side. If neither side is a variable, the order is unimportant.

            For more information:
            https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#yoda-conditions
                ]]>
                </standard>
                <code_comparison>
                    <code title="Valid: The variable $the_force is placed on the right">
                    <![CDATA[
            if ( true === $the_force ) {
                $victorious = you_will( $be );
            }
                    ]]>
                    </code>
                    <code title="Invalid: The variable $the_force has been placed on the left">
                    <![CDATA[
            if ( $the_force === false ) {
                $victorious = you_will_not( $be );
            }
                    ]]>
                    </code>
                </code_comparison>
            </documentation>
            ```

        </details>
    - Run: `phpcs --generator=Text --sniffs=Standard.Category.SomeSniff`
    - Take note of the incorrect line wrapping for the `For more information` line.
        ![PHPCS Text wrong line wrapping](https://user-images.githubusercontent.com/663378/60279710-dc352c00-9901-11e9-9c1e-d31936b40253.png)
* Now, check out this branch and follow the same steps.
    - Take note of the now correct line wrapping for the `For more information` line.
        ![PHPCS Text correct line wrapping](https://user-images.githubusercontent.com/663378/60279823-14d50580-9902-11e9-9327-9978f4dfd290.png)
