### PR TITLE
New Generic.WhiteSpace.SpreadOperatorSpacingAfter sniff (PSR12 related)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -407,6 +407,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentStandard.xml" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpreadOperatorSpacingAfterStandard.xml" role="php" />
        </dir>
       </dir>
       <dir name="Sniffs">
@@ -514,6 +515,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="IncrementDecrementSpacingSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="LanguageConstructSpacingSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpreadOperatorSpacingAfterSniff.php" role="php" />
        </dir>
       </dir>
       <dir name="Tests">
@@ -833,6 +835,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentUnitTest.3.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentUnitTest.4.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ScopeIndentUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpreadOperatorSpacingAfterUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpreadOperatorSpacingAfterUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SpreadOperatorSpacingAfterUnitTest.php" role="test" />
        </dir>
       </dir>
       <file baseinstalldir="PHP/CodeSniffer" name="ruleset.xml" role="php" />

--- a/src/Standards/Generic/Docs/WhiteSpace/SpreadOperatorSpacingAfterStandard.xml
+++ b/src/Standards/Generic/Docs/WhiteSpace/SpreadOperatorSpacingAfterStandard.xml
@@ -1,0 +1,34 @@
+<documentation title="Spacing After Spread Operator">
+    <standard>
+    <![CDATA[
+    There should be no space between the spread operator and the variable/function call it applies to.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No space between the spread operator and the variable/function call it applies to.">
+        <![CDATA[
+function foo(<em>&...$spread</em>) {
+    bar(<em>...$spread</em>);
+
+    bar(
+        [<em>...$foo</em>],
+        <em>...array_values($keyedArray)</em>
+    );
+}
+        ]]>
+        </code>
+        <code title="Invalid: space found between the spread operator and the variable/function call it applies to.">
+        <![CDATA[
+function bar(<em>... </em>$spread) {
+    bar(<em>...
+        </em>$spread
+    );
+
+    bar(
+        [<em>...  </em>$foo ],<em>.../*comment*/</em>array_values($keyedArray)
+    );
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Verifies spacing between the spread operator and the variable/function call it applies to.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+class SpreadOperatorSpacingAfterSniff implements Sniff
+{
+
+    /**
+     * The number of spaces desired after a spread token.
+     *
+     * @var integer
+     */
+    public $spacing = 0;
+
+    /**
+     * Allow newlines instead of spaces.
+     *
+     * @var boolean
+     */
+    public $ignoreNewlines = false;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [T_ELLIPSIS];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens        = $phpcsFile->getTokens();
+        $this->spacing = (int) $this->spacing;
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            return;
+        }
+
+        if ($this->ignoreNewlines === true
+            && $tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']
+        ) {
+            $phpcsFile->recordMetric($stackPtr, 'Spacing after spread operator', 'newline');
+            return;
+        }
+
+        if ($this->spacing === 0 && $nextNonEmpty === ($stackPtr + 1)) {
+            $phpcsFile->recordMetric($stackPtr, 'Spacing after spread operator', 0);
+            return;
+        }
+
+        $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty !== $nextNonWhitespace) {
+            $error = 'Expected %s space(s) after the spread operator; comment found';
+            $data  = [$this->spacing];
+            $phpcsFile->addError($error, $stackPtr, 'CommentFound', $data);
+
+            if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                $phpcsFile->recordMetric($stackPtr, 'Spacing after spread operator', $tokens[($stackPtr + 1)]['length']);
+            } else {
+                $phpcsFile->recordMetric($stackPtr, 'Spacing after spread operator', 0);
+            }
+
+            return;
+        }
+
+        $found = 0;
+        if ($tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']) {
+            $found = 'newline';
+        } else if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+            $found = $tokens[($stackPtr + 1)]['length'];
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Spacing after spread operator', $found);
+
+        if ($found === $this->spacing) {
+            return;
+        }
+
+        $error = 'Expected %s space(s) after the spread operator; %s found';
+        $data  = [
+            $this->spacing,
+            $found,
+        ];
+
+        $errorCode = 'TooMuchSpace';
+        if ($this->spacing !== 0) {
+            if ($found === 0) {
+                $errorCode = 'NoSpace';
+            } else if ($found !== 'newline' && $found < $this->spacing) {
+                $errorCode = 'TooLittleSpace';
+            }
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, $errorCode, $data);
+
+        if ($fix === true) {
+            $padding = str_repeat(' ', $this->spacing);
+            if ($found === 0) {
+                $phpcsFile->fixer->addContent($stackPtr, $padding);
+            } else {
+                $phpcsFile->fixer->beginChangeset();
+                $start = ($stackPtr + 1);
+
+                if ($this->spacing > 0) {
+                    $phpcsFile->fixer->replaceToken($start, $padding);
+                    ++$start;
+                }
+
+                for ($i = $start; $i < $nextNonWhitespace; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc
@@ -1,0 +1,73 @@
+<?php
+
+function foo( &...$spread ) {
+    bar( ...$spread );
+
+    bar(
+        [ ...$foo ],
+        ...array_values($keyedArray)
+    );
+}
+
+function bar( &   ... $spread ) {
+    bar(...
+
+
+        $spread
+    );
+
+    bar(
+        [...  $foo ],.../*comment*/array_values($keyedArray)
+    );
+}
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter ignoreNewlines true
+    bar(...
+        $spread
+    );
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter ignoreNewlines false
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 1
+function foo( &... $spread ) {
+    bar( ... $spread );
+
+    bar(
+        [ ... $foo ],
+        ... array_values($keyedArray)
+    );
+}
+
+function bar( &   ...$spread ) {
+    bar(...
+        $spread
+    );
+
+    bar(
+        [...  $foo ],.../*comment*/array_values($keyedArray)
+    );
+}
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 2
+function foo( &...  $spread ) {
+    bar( ...  $spread );
+
+    bar(
+        [ ...  $foo ],
+        ...  array_values($keyedArray)
+    );
+}
+
+function bar( &   ... $spread ) {
+    bar(...
+        $spread
+    );
+
+    bar(
+        [...    $foo ],.../*comment*/array_values($keyedArray)
+    );
+}
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 0
+
+// Intentional parse error. This has to be the last test in the file.
+function bar( ...

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc.fixed
@@ -1,0 +1,68 @@
+<?php
+
+function foo( &...$spread ) {
+    bar( ...$spread );
+
+    bar(
+        [ ...$foo ],
+        ...array_values($keyedArray)
+    );
+}
+
+function bar( &   ...$spread ) {
+    bar(...$spread
+    );
+
+    bar(
+        [...$foo ],.../*comment*/array_values($keyedArray)
+    );
+}
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter ignoreNewlines true
+    bar(...
+        $spread
+    );
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter ignoreNewlines false
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 1
+function foo( &... $spread ) {
+    bar( ... $spread );
+
+    bar(
+        [ ... $foo ],
+        ... array_values($keyedArray)
+    );
+}
+
+function bar( &   ... $spread ) {
+    bar(... $spread
+    );
+
+    bar(
+        [... $foo ],.../*comment*/array_values($keyedArray)
+    );
+}
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 2
+function foo( &...  $spread ) {
+    bar( ...  $spread );
+
+    bar(
+        [ ...  $foo ],
+        ...  array_values($keyedArray)
+    );
+}
+
+function bar( &   ...  $spread ) {
+    bar(...  $spread
+    );
+
+    bar(
+        [...  $foo ],.../*comment*/array_values($keyedArray)
+    );
+}
+
+// phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 0
+
+// Intentional parse error. This has to be the last test in the file.
+function bar( ...

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Unit test class for the SpreadOperatorSpacingAfter sniff.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2019 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\WhiteSpace;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class SpreadOperatorSpacingAfterUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            12 => 1,
+            13 => 1,
+            20 => 2,
+            40 => 1,
+            41 => 1,
+            46 => 2,
+            60 => 1,
+            61 => 1,
+            66 => 2,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
This introduces a new sniff which checks the whitespace between the spread operator and the variable/function call it applies to.

This new sniff has two `public` properties:
* `$spacing` which defaults to `0`, i.e. no space.
* `$ignoreNewlines` which defaults to `false`.

Includes unit tests.
Includes fixers.
Includes documentation.

~~Includes adding this sniff to the PSR12 ruleset.~~

Note: PSR12 only specifies _There MUST NOT be a space between the variadic three dot operator and the argument name_ for **function declarations**.

This sniff, however, checks the spacing for the spread operator in all circumstances in which it can be used, i.e.:
* In function declarations (PHP 5.6).
* In function calls (PHP 5.6).
* In array declarations (PHP 7.4).