### PR TITLE
Tokenizer/PHP: fix recognition of T_NULLABLE

### DIFF
--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc
@@ -57,3 +57,11 @@ interface MyInterface {
 function testSelf( ? self $self ) : ? self {}
 function testParent( ? parent $parent ) : ? parent {}
 function testCallable( ? callable $callable ) : ? callable {}
+
+// Issue #2552.
+class TestTokenizingOfNullableVsInlineThen {
+    public function testStatic() {
+        $test = Something::one(self::CONSTANT) ?: '';
+        $test = Something::one(static::CONSTANT) ?: '';
+    }
+}

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc.fixed
@@ -55,3 +55,11 @@ interface MyInterface {
 function testSelf( ?self $self ) : ?self {}
 function testParent( ?parent $parent ) : ?parent {}
 function testCallable( ?callable $callable ) : ?callable {}
+
+// Issue #2552.
+class TestTokenizingOfNullableVsInlineThen {
+    public function testStatic() {
+        $test = Something::one(self::CONSTANT) ?: '';
+        $test = Something::one(static::CONSTANT) ?: '';
+    }
+}

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -978,12 +978,19 @@ class PHP extends Tokenizer
                 $newToken            = [];
                 $newToken['content'] = '?';
 
-                $prevNonEmpty = null;
+                $prevNonEmpty     = null;
+                $lastSeenNonEmpty = null;
+
                 for ($i = ($stackPtr - 1); $i >= 0; $i--) {
                     if (is_array($tokens[$i]) === true) {
                         $tokenType = $tokens[$i][0];
                     } else {
                         $tokenType = $tokens[$i];
+                    }
+
+                    if ($tokenType === T_STATIC && $lastSeenNonEmpty === T_DOUBLE_COLON) {
+                        $lastSeenNonEmpty = $tokenType;
+                        continue;
                     }
 
                     if ($prevNonEmpty === null
@@ -1011,6 +1018,10 @@ class PHP extends Tokenizer
 
                         $insideInlineIf[] = $stackPtr;
                         break;
+                    }
+
+                    if (isset(Util\Tokens::$emptyTokens[$tokenType]) === false) {
+                        $lastSeenNonEmpty = $tokenType;
                     }
                 }//end for
 


### PR DESCRIPTION
The `static` keyword is both used as a modifier keyword for functions and variables as well as for late static binding.

The tokenizer did not take late static binding into account when determining whether a `?` is a `T_NULLABLE` token and because of that would make the determination between `T_NULLABLE` and `T_INLINE_THEN` too early.

This has now been fixed.

Includes unit test via the `PSR12.Functions.NullableTypeDeclaration` sniff.

Fixes #2552