### PR TITLE
Squiz/OperatorSpacing: fix potential fixer conflict

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -99,6 +99,12 @@ class OperatorSpacingSniff implements Sniff
                 }
             }//end if
 
+            $hasNext = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+            if ($hasNext === false) {
+                // Live coding/parse error at end of file.
+                return;
+            }
+
             // Check there is one space after the & operator.
             if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
                 $error = 'Expected 1 space after "&" operator; 0 found';
@@ -179,7 +185,9 @@ class OperatorSpacingSniff implements Sniff
             }//end if
         }//end if
 
-        if (isset($tokens[($stackPtr + 1)]) === false) {
+        $hasNext = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($hasNext === false) {
+            // Live coding/parse error at end of file.
             return;
         }
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -260,3 +260,6 @@ function bar(): array {}
 if ($line{-1} === ':') {
     $line = substr($line, 0, -1);
 }
+
+/* Intentional parse error. This has to be the last test in the file. */
+$a = 10 +

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -254,3 +254,6 @@ function bar(): array {}
 if ($line{-1} === ':') {
     $line = substr($line, 0, -1);
 }
+
+/* Intentional parse error. This has to be the last test in the file. */
+$a = 10 +


### PR DESCRIPTION
[Fixer conflict series]

The sniff had a potential fixer conflict with the `SuperfluousWhiteSpace` and the `EndFileNewline` sniffs.

This minor change fixes this by bowing out from analysing the space after the operator if the operator is the last non-whitespace token in a file.

Fixer conflict can be reproduced by running the below command over the unit test added by this patch (without the included fix):
`phpcbf ./squiz/tests/whitespace/operatorspacingunittest.inc --standard=Squiz -vv`

Includes unit test.