### PR TITLE
PHP 7.4 compatibility fix / implode argument order

### DIFF
--- a/src/Reports/Gitblame.php
+++ b/src/Reports/Gitblame.php
@@ -51,7 +51,7 @@ class Gitblame extends VersionControl
         }
 
         $parts  = array_slice($parts, 0, (count($parts) - 2));
-        $author = preg_replace('|\(|', '', implode($parts, ' '));
+        $author = preg_replace('|\(|', '', implode(' ', $parts));
         return $author;
 
     }//end getAuthor()

--- a/src/Reports/Hgblame.php
+++ b/src/Reports/Hgblame.php
@@ -53,7 +53,7 @@ class Hgblame extends VersionControl
 
         $parts = array_slice($parts, 0, (count($parts) - 6));
 
-        return trim(preg_replace('|<.+>|', '', implode($parts, ' ')));
+        return trim(preg_replace('|<.+>|', '', implode(' ', $parts)));
 
     }//end getAuthor()
 
@@ -74,7 +74,7 @@ class Hgblame extends VersionControl
         $location  = '';
         while (empty($fileParts) === false) {
             array_pop($fileParts);
-            $location = implode($fileParts, DIRECTORY_SEPARATOR);
+            $location = implode(DIRECTORY_SEPARATOR, $fileParts);
             if (is_dir($location.DIRECTORY_SEPARATOR.'.hg') === true) {
                 $found = true;
                 break;

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -464,7 +464,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 }//end if
             }//end foreach
 
-            $suggestedType = implode($suggestedTypeNames, '|');
+            $suggestedType = implode('|', $suggestedTypeNames);
             if ($param['type'] !== $suggestedType) {
                 $error = 'Expected "%s" but found "%s" for parameter type';
                 $data  = [


### PR DESCRIPTION
`implode()` takes two parameters, `$glue` and `$pieces`.
For historical reasons, `implode()` accepted these parameters in either order, though it was recommended to use the documented argument order of `implode( $glue, $pieces )`.

PHP 7.4 is slated to deprecate the tolerance for passing the parameters for `implode()` in reverse order.
PHP 8.0 is expected to remove the tolerance for this completely.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
* https://php.net/manual/en/function.implode.php

These instances were discovered while testing a new PHPCompatibility sniff to detect this issue.