### PR TITLE
Squiz/ControlSignature: fix false positive with inline while()

### DIFF
--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -230,23 +230,26 @@ class ControlSignatureSniff implements Sniff
                 }
             }//end if
         } else if ($tokens[$stackPtr]['code'] === T_WHILE) {
-            // Zero spaces after parenthesis closer.
-            $closer = $tokens[$stackPtr]['parenthesis_closer'];
-            $found  = 0;
-            if ($tokens[($closer + 1)]['code'] === T_WHITESPACE) {
-                if (strpos($tokens[($closer + 1)]['content'], $phpcsFile->eolChar) !== false) {
-                    $found = 'newline';
-                } else {
-                    $found = $tokens[($closer + 1)]['length'];
+            // Zero spaces after parenthesis closer, but only if followed by a semicolon.
+            $closer       = $tokens[$stackPtr]['parenthesis_closer'];
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
+            if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_SEMICOLON) {
+                $found = 0;
+                if ($tokens[($closer + 1)]['code'] === T_WHITESPACE) {
+                    if (strpos($tokens[($closer + 1)]['content'], $phpcsFile->eolChar) !== false) {
+                        $found = 'newline';
+                    } else {
+                        $found = $tokens[($closer + 1)]['length'];
+                    }
                 }
-            }
 
-            if ($found !== 0) {
-                $error = 'Expected 0 spaces before semicolon; %s found';
-                $data  = [$found];
-                $fix   = $phpcsFile->addFixableError($error, $closer, 'SpaceBeforeSemicolon', $data);
-                if ($fix === true) {
-                    $phpcsFile->fixer->replaceToken(($closer + 1), '');
+                if ($found !== 0) {
+                    $error = 'Expected 0 spaces before semicolon; %s found';
+                    $data  = [$found];
+                    $fix   = $phpcsFile->addFixableError($error, $closer, 'SpaceBeforeSemicolon', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($closer + 1), '');
+                    }
                 }
             }
         }//end if

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
@@ -290,6 +290,15 @@ if ($this) {
         foo(${$a[$b]});
 }
 
+while ( $level-- ) ob_end_clean();
+
+while ( $level-- )
+	ob_end_clean();
+
+while ( $level-- ):
+	ob_end_clean();
+endwhile;
+
 // Intentional parse error. This should be the last test in the file.
 foreach
    // Some unrelated comment.

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
@@ -293,6 +293,15 @@ if ($this) {
         foo(${$a[$b]});
 }
 
+while ( $level-- ) ob_end_clean();
+
+while ( $level-- )
+	ob_end_clean();
+
+while ( $level-- ):
+	ob_end_clean();
+endwhile;
+
 // Intentional parse error. This should be the last test in the file.
 foreach
    // Some unrelated comment.


### PR DESCRIPTION
The `while()`control structure is special cased to deal with `do {} while();` syntax, but the special casing didn't allow for inline `while()` structures.

Includes unit tests.

Fixes #2562