### PR TITLE
Check if currentDir is readable on loop iteration when initializing Config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -357,7 +357,7 @@ class Config
 
                 $lastDir    = $currentDir;
                 $currentDir = dirname($currentDir);
-            } while ($currentDir !== '.' && $currentDir !== $lastDir);
+            } while ($currentDir !== '.' && $currentDir !== $lastDir && @is_readable($currentDir) === true);
         }//end if
 
         if (defined('STDIN') === false


### PR DESCRIPTION
Fixes #2549 

`is_readable` will return false if the passed directory falls outside of a set `open_basedir` php.ini directive, while also raising a warning that is suppressed here. I assume that phpcs is initially run from a directory inside the `open_basedir` directive. I wasn't sure if/how one might add tests for this.
