### PR TITLE
Generic/InlineControlStructure: bug fix

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -503,6 +503,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.4.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.5.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.6.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.7.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="InlineControlStructureUnitTest.php" role="test" />

--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -140,6 +140,16 @@ class InlineControlStructureSniff implements Sniff
             return;
         }
 
+        if ($tokens[$nextNonEmpty]['code'] === T_COLON) {
+            var_dump($tokens[$nextNonEmpty]);
+            // Alternative control structure.
+            // T_END... missing. Either live coding, parse error or end
+            // tag in short open tags and scan run with short_open_tag=Off.
+            // Bow out completely as any further detection will be unreliable
+            // and create incorrect fixes or cause fixer conflicts.
+            return ($phpcsFile->numTokens + 1);
+        }
+
         unset($nextNonEmpty, $start);
 
         // This is a control structure without an opening brace,

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.7.inc
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.7.inc
@@ -1,0 +1,16 @@
+<?php
+// Issue #2565.
+// Important note: this file intentionally does not have a ".fixed" version as
+// when `short_open_tag=Off`, no fixes will be made, while when `short_open_tag=On`
+// no fixes are necessary.
+?>
+
+<?php if (true) : ?>
+<? endif ?>
+<?php if (true) { ?>
+<? } ?>
+
+<? if (false) : ?>
+<? endif ?>
+<?php if (false) { ?>
+<?php } ?>


### PR DESCRIPTION
Prevent creating incorrect fixes and getting into a fixer conflict when both short and long open tags are used in combination with alternative control structures and the short open tags are not recognized because the system on which the scan is run has `short_open_tag=Off`.

Solved by bowing out early when an alternative control structure is detected which was not recognized as such (`scope_opener` not set).

Fixes #2565