### PR TITLE
PEAR/FileComment: remove the TLD character limit

### DIFF
--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -455,7 +455,7 @@ class FileCommentSniff implements Sniff
             $local   = '\da-zA-Z-_+';
             // Dot character cannot be the first or last character in the local-part.
             $localMiddle = $local.'.\w';
-            if (preg_match('/^([^<]*)\s+<(['.$local.'](['.$localMiddle.']*['.$local.'])*@[\da-zA-Z][-.\w]*[\da-zA-Z]\.[a-zA-Z]{2,7})>$/', $content) === 0) {
+            if (preg_match('/^([^<]*)\s+<(['.$local.'](['.$localMiddle.']*['.$local.'])*@[\da-zA-Z][-.\w]*[\da-zA-Z]\.[a-zA-Z]{2,})>$/', $content) === 0) {
                 $error = 'Content of the @author tag must be in the form "Display Name <username@example.com>"';
                 $phpcsFile->addError($error, $tag, 'InvalidAuthors');
             }

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.inc
@@ -39,6 +39,7 @@ declare(encoding='utf-8');
 * @summary    An unknown summary tag
 * @package    ''
 * @subpackage !!
+* @author     Code AUthor <author@gmail.consulting>
 */
 require_once '/some/path.php';
 ?>

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -40,7 +40,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
             35 => 1,
             40 => 2,
             41 => 2,
-            42 => 1,
+            43 => 1,
         ];
 
     }//end getErrorList()
@@ -60,7 +60,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
             29 => 1,
             30 => 1,
             34 => 1,
-            42 => 1,
+            43 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
What with new TLDs being accepted all the time and lots of them being longer then 7 characters, the character limit seems out of date.

Includes unit test.

Fixes #2566