### PR TITLE
Fix capitalization of getFilename function

### DIFF
--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -54,7 +54,7 @@ class SubversionPropertiesSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $path       = $phpcsFile->getFileName();
+        $path       = $phpcsFile->getFilename();
         $properties = $this->getProperties($path);
         if ($properties === null) {
             // Not under version control.

--- a/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
+++ b/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
@@ -40,7 +40,7 @@ class FileExtensionSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
-        $fileName  = $phpcsFile->getFileName();
+        $fileName  = $phpcsFile->getFilename();
         $extension = substr($fileName, strrpos($fileName, '.'));
         $nextClass = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT], $stackPtr);
 


### PR DESCRIPTION
s/getFileName/getFilename

I assume these two are trying to reference this function (like the other instances of the correct spelling/capitalization):
https://github.com/squizlabs/PHP_CodeSniffer/blob/a7403540490022691559380cfc8bfc1342890998/src/Files/File.php#L1212-L1216