### PR TITLE
Add simple usage section to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ You can also download the PHP_CodeSniffer source and run the `phpcs` and `phpcbf
     php bin/phpcs -h
     php bin/phpcbf -h
 
+## Simple Usage
+A few simple commands to run after a successful install are:
+
+    $ phpcs /path/to/code/myfile.php
+    $ phpcs /path/to/code-directory
+    
+More in-depth usage is available in the [phpcs wiki usage page](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage) or cli command help.
+
+
 ## Documentation
 
 The documentation for PHP_CodeSniffer is available on the [Github wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki).


### PR DESCRIPTION
To simplify running through the README install instructions and give a slight recommendation for use immediately after install.

Trivial readme change based on discussion in: https://github.com/squizlabs/PHP_CodeSniffer/issues/2581