### PR TITLE
Squiz/FunctionSpacing + MemberVarSpacing: add metrics

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -161,6 +161,12 @@ class FunctionSpacingSniff implements Sniff
             }
         }
 
+        if ($isLast === true) {
+            $phpcsFile->recordMetric($stackPtr, 'Function spacing after last', $foundLines);
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Function spacing after', $foundLines);
+        }
+
         if ($foundLines !== $requiredSpacing) {
             $error = 'Expected %s blank line';
             if ($requiredSpacing !== 1) {
@@ -280,6 +286,10 @@ class FunctionSpacingSniff implements Sniff
         if ($isFirst === true) {
             $requiredSpacing = $this->spacingBeforeFirst;
             $errorCode       = 'BeforeFirst';
+
+            $phpcsFile->recordMetric($stackPtr, 'Function spacing before first', $foundLines);
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Function spacing before', $foundLines);
         }
 
         if ($foundLines !== $requiredSpacing) {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -131,6 +131,13 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         }
 
         $foundLines = ($tokens[$first]['line'] - $tokens[$prev]['line'] - 1);
+
+        if ($errorCode === 'FirstIncorrect') {
+            $phpcsFile->recordMetric($stackPtr, 'Member var spacing before first', $foundLines);
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'Member var spacing before', $foundLines);
+        }
+
         if ($foundLines === $spacing) {
             if ($endOfStatement !== false) {
                 return $endOfStatement;


### PR DESCRIPTION
For repos not yet using these sniffs, having metrics available will be useful to find out what the prevalent number of blank lines between properties/functions is.

This will make it more easy to determine what to set for the value of the various properties available.