### PR TITLE
Allow newlines in control structures (PSR12)

### DIFF
--- a/src/Standards/PSR12/ruleset.xml
+++ b/src/Standards/PSR12/ruleset.xml
@@ -233,7 +233,11 @@
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
-    <rule ref="Squiz.ControlStructures.ForLoopDeclaration"/>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration">
+        <properties>
+            <property name="ignoreNewline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterOpen">
         <severity>0</severity>
     </rule>
@@ -241,7 +245,11 @@
         <severity>0</severity>
     </rule>
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
-    <rule ref="PSR2.ControlStructures.ControlStructureSpacing"/>
+    <rule ref="PSR2.ControlStructures.ControlStructureSpacing">
+        <properties>
+            <property name="ignoreNewline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
     <!-- exclude this message as it is already checked in Generic.PHP.LowerCaseKeyword -->

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -31,6 +31,13 @@ class ControlStructureSpacingSniff implements Sniff
      */
     public $requiredSpacesBeforeClose = 0;
 
+    /**
+     * If newlines should be ignored within parenthesis
+     *
+     * @var boolean
+     */
+    public $ignoreNewline = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -81,7 +88,9 @@ class ControlStructureSpacingSniff implements Sniff
         $nextContent = $phpcsFile->findNext(T_WHITESPACE, ($parenOpener + 1), null, true);
         if (in_array($tokens[$nextContent]['code'], Tokens::$commentTokens, true) === false) {
             $spaceAfterOpen = 0;
-            if ($tokens[($parenOpener + 1)]['code'] === T_WHITESPACE) {
+            if ($tokens[($parenOpener + 1)]['code'] === T_WHITESPACE
+                && $this->isIgnorableNewline($tokens[($parenOpener + 1)]['content'], $phpcsFile->eolChar) === false
+            ) {
                 if (strpos($tokens[($parenOpener + 1)]['content'], $phpcsFile->eolChar) !== false) {
                     $spaceAfterOpen = 'newline';
                 } else {
@@ -138,6 +147,21 @@ class ControlStructureSpacingSniff implements Sniff
         }//end if
 
     }//end process()
+
+
+    /**
+     * Check if whitespace is a newline and can be ignored
+     *
+     * @param string $content The whitespace string
+     * @param string $eolChar The EOL character
+     *
+     * @return bool
+     */
+    private function isIgnorableNewline($content, $eolChar)
+    {
+        return $this->ignoreNewline === true && strpos($content, $eolChar) !== false;
+
+    }//end isIgnorableNewline()
 
 
 }//end class

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
@@ -55,3 +55,35 @@ foreach (  $something as $blah => $that  ) {}
 // phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 0
 
 $binary = b"binary string";
+
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing ignoreNewline true
+if (true) {
+    if (
+        $defaultPageDesign === 0
+        && $defaultCascade === TRUE
+        && $defaultChildDesign === 0
+    ) {
+        $settingsUpdated = FALSE;
+    }
+
+    for (
+        $i = 0;
+        $i < 10;
+        $i++
+    ) {
+        // for body
+    }
+
+    foreach (
+        $this
+        as
+        $that
+    ) {
+    }
+
+    while (
+        true
+    ) {
+    }
+}
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing ignoreNewline false

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
@@ -54,3 +54,35 @@ foreach ( $something as $blah => $that ) {}
 // phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 0
 
 $binary = b"binary string";
+
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing ignoreNewline true
+if (true) {
+    if (
+        $defaultPageDesign === 0
+        && $defaultCascade === TRUE
+        && $defaultChildDesign === 0
+    ) {
+        $settingsUpdated = FALSE;
+    }
+
+    for (
+        $i = 0;
+        $i < 10;
+        $i++
+    ) {
+        // for body
+    }
+
+    foreach (
+        $this
+        as
+        $that
+    ) {
+    }
+
+    while (
+        true
+    ) {
+    }
+}
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing ignoreNewline false

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc
@@ -75,11 +75,11 @@ for (
 
 // Test fixing each error in one go. Note: lines 78 + 82 contain trailing whitespace on purpose.
 for (
-      
+
 
       $i = 0
 
-      ; 
+      ;
 
       $i < 10
 
@@ -110,6 +110,16 @@ for (
 ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
+
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration ignoreNewline true
+if (true) {
+    for (
+        $i = 0;
+        $i < 10;
+        $i++
+    ) {}
+}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration ignoreNewline false
 
 // Test with semi-colon not belonging to for.
 for ($i = function() { return $this->i  ;    }; $i < function() { return $this->max; }; $i++) {}

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.inc.fixed
@@ -77,6 +77,16 @@ for ( $i = 0; $i < 10; $i++ ) {}
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesAfterOpen 0
 // phpcs:set Squiz.ControlStructures.ForLoopDeclaration requiredSpacesBeforeClose 0
 
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration ignoreNewline true
+if (true) {
+    for (
+        $i = 0;
+        $i < 10;
+        $i++
+    ) {}
+}
+// phpcs:set Squiz.ControlStructures.ForLoopDeclaration ignoreNewline false
+
 // Test with semi-colon not belonging to for.
 for ($i = function() { return $this->i  ;    }; $i < function() { return $this->max; }; $i++) {}
 for ($i = function() { return $this->i; }; $i < function() { return $this->max; }; $i++) {}

--- a/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ForLoopDeclarationUnitTest.php
@@ -59,7 +59,7 @@ class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
                 101 => 2,
                 105 => 2,
                 110 => 1,
-                116 => 2,
+                126 => 2,
             ];
 
         case 'ForLoopDeclarationUnitTest.js':
@@ -117,7 +117,7 @@ class ForLoopDeclarationUnitTest extends AbstractSniffUnitTest
     {
         switch ($testFile) {
         case 'ForLoopDeclarationUnitTest.inc':
-            return [119 => 1];
+            return [129 => 1];
 
         case 'ForLoopDeclarationUnitTest.js':
             return [125 => 1];


### PR DESCRIPTION
I'd like to suggest this solution to fix #2113.

Adds properties to configure sniffs `Squiz.ControlStructures.ForLoopDeclaration` and `PSR2.ControlStructures.ControlStructureSpacing` to allow newlines after/before parentheses according to PSR12:

> Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line with one space between them. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both.

These properties are enabled in the PSR12 `ruleset.xml`.