### PR TITLE
Fix tokenizer scope resolution for inline statements followed by an anonymous block

### DIFF
--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
@@ -238,3 +238,9 @@ if ($bar)
 if (true) $callable = function () {
     return true;
 };
+
+foreach ([] as $a)
+echo 'bar';
+{
+    echo 'baz';
+}

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
@@ -273,3 +273,10 @@ if (true) { $callable = function () {
     return true;
 };
 }
+
+foreach ([] as $a) {
+echo 'bar';
+}
+{
+    echo 'baz';
+}

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -75,6 +75,7 @@ class InlineControlStructureUnitTest extends AbstractSniffUnitTest
                 235 => 1,
                 236 => 1,
                 238 => 1,
+                242 => 1,
             ];
 
         case 'InlineControlStructureUnitTest.js':

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -1291,6 +1291,7 @@ abstract class Tokenizer
                                     T_OBJECT_OPERATOR  => true,
                                     T_COMMA            => true,
                                     T_OPEN_PARENTHESIS => true,
+                                    T_SEMICOLON        => true,
                                 ];
 
                                 if (isset($disallowed[$this->tokens[$x]['code']]) === true) {


### PR DESCRIPTION
A case like the following was not picked up by the InlineControlStructureSniff because the scope resolution in the tokenizer fails to recognize that the curly braces are not related to the foreach.

```
foreach ([] as $a)
echo 'bar';
{
    echo 'baz';
} 
```

Since all tests are working I expect that this is not a breaking change.