### PR TITLE
Squiz.WhiteSpace.FunctionSpacing incorrect fix when spacing is 0

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -310,7 +310,7 @@ class FunctionSpacingSniff implements Sniff
                 if ($nextSpace === false) {
                     $nextSpace = ($stackPtr - 1);
                 }
-                
+
                 if ($requiredSpacing === 0) {
                     $nextSpace++;
                 }

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -310,6 +310,10 @@ class FunctionSpacingSniff implements Sniff
                 if ($nextSpace === false) {
                     $nextSpace = ($stackPtr - 1);
                 }
+                
+                if ($requiredSpacing === 0) {
+                    $nextSpace++;
+                }
 
                 if ($foundLines < $requiredSpacing) {
                     $padding = str_repeat($phpcsFile->eolChar, ($requiredSpacing - $foundLines));


### PR DESCRIPTION
Fix this usecase:

Settings
------------
spacing: 0
spacingBeforeFirst: 0
spacingAfterLast: 0

Code:
```php
<?php
declare(strict_types = 1);

namespace Nette\CodingStandard\Examples;

interface OneBlankLineBeforeFirstFunctionClassInterface
{


    /** @return mixed */
    public function interfaceMethod();
}
```

it was returning this:
```php
<?php
declare(strict_types = 1);

namespace Nette\CodingStandard\Examples;

interface OneBlankLineBeforeFirstFunctionClassInterface
{/** @return mixed */
    public function interfaceMethod();
}
```

it return now correct this:

```php
<?php
declare(strict_types = 1);

namespace Nette\CodingStandard\Examples;

interface OneBlankLineBeforeFirstFunctionClassInterface
{
    /** @return mixed */
    public function interfaceMethod();
}
```