### PR TITLE
Add extra testcase for PSR2.Classes.ClassDeclaration.SpaceAfterKeyword

### DIFF
--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -231,3 +231,8 @@ class C7 extends // comment
     \Foo\Bar implements \Baz\Bar
 {
 }
+
+class
+C8
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -225,3 +225,7 @@ interface I6 extends // comment
 class C7 extends \Foo\Bar implements \Baz\Bar // comment
 {
 }
+
+class C8
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -62,6 +62,7 @@ class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             215 => 2,
             216 => 1,
             231 => 2,
+            235 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
MR for an extra testcase, as mentioned in #2609 