### PR TITLE
[PSR12] Add failing test for valid code

### DIFF
--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.7.inc
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.7.inc
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+
+use Psr\Container\ContainerInterface;
+
+/** @var ContainerInterface $container */
+$container = require __DIR__ . "/../bootstrap.php";


### PR DESCRIPTION
More if an issue than a pull request sorry.

The following code is valid as per PSR-12, however phpcs reports the following issues:
```
------------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
------------------------------------------------------------------------------------------------------
 2 | ERROR | [ ] The file header must be the first content in the file
 6 | ERROR | [ ] The file-level docblock must follow the opening PHP tag in the file header
 6 | ERROR | [x] Header blocks must be followed by a single blank line
```

It recognises the inline docblock as a file header, which is incorrect. The fix for this is simple, however that affected the check for leading blank lines in `FileHeaderUnitTest.2.inc`.

The code for the opening PHP tag also doesn't seem to be correct, PSR-12 only talks about mixed HTML and PHP files, it doesn't require the opening tag to be the first thing in the file in all scenarios (eg the hashbang seen here is valid)