### PR TITLE
Update Squiz.CSS.DuplicateClassDefinitionSniff

### DIFF
--- a/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
+++ b/src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php
@@ -88,6 +88,7 @@ class DuplicateClassDefinitionSniff implements Sniff
             $name = trim($name);
             $name = str_replace("\n", ' ', $name);
             $name = preg_replace('|[\s]+|', ' ', $name);
+            $name = preg_replace('|\s*/\*.*\*/\s*|', '', $name);
             $name = str_replace(', ', ',', $name);
 
             $names = explode(',', $name);

--- a/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.css
+++ b/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.css
@@ -71,3 +71,33 @@
 
 .foo /* any comment */
 { color: red; }
+
+/* print comment */
+@media print {
+    /* any comment */
+    td {
+    }
+
+    /* any comment */
+    img {
+    }
+
+    /* any comment */
+    td {
+    }
+}
+
+@media handheld /* handheld comment */
+{
+    td /* any comment */
+    {
+    }
+
+    img /* any comment */
+    {
+    }
+
+    td /* any comment */
+    {
+    }
+}

--- a/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
+++ b/src/Standards/Squiz/Tests/CSS/DuplicateClassDefinitionUnitTest.php
@@ -26,9 +26,11 @@ class DuplicateClassDefinitionUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            9  => 1,
-            29 => 1,
-            57 => 1,
+            9   => 1,
+            29  => 1,
+            57  => 1,
+            86  => 1,
+            101 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Remove comments from class names, before searching for `@media` and checking for duplicates.

This closes #2638.
The fix of #1657 is still in place.