### PR TITLE
Suggest sniff code if invalid

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -834,6 +834,7 @@ class Config
                 foreach ($sniffs as $sniff) {
                     if (substr_count($sniff, '.') !== 2) {
                         $error  = 'ERROR: The specified sniff code "'.$sniff.'" is invalid'.PHP_EOL.PHP_EOL;
+                        $error .= 'Perhaps try following sniff code: '.$this->getSuggestedSniffCode($sniff).PHP_EOL.PHP_EOL;
                         $error .= $this->printShortUsage(true);
                         throw new DeepExitException($error, 3);
                     }
@@ -850,6 +851,7 @@ class Config
                 foreach ($sniffs as $sniff) {
                     if (substr_count($sniff, '.') !== 2) {
                         $error  = 'ERROR: The specified sniff code "'.$sniff.'" is invalid'.PHP_EOL.PHP_EOL;
+                        $error .= 'Perhaps try following sniff code: '.$this->getSuggestedSniffCode($sniff).PHP_EOL.PHP_EOL;
                         $error .= $this->printShortUsage(true);
                         throw new DeepExitException($error, 3);
                     }
@@ -1353,6 +1355,19 @@ class Config
 
     }//end printShortUsage()
 
+    /**
+     * Suggest a sniff code by only combining first three elements.
+     *
+     * @param string $sniff
+     * @return string
+     */
+    public function getSuggestedSniffCode($sniff)
+    {
+        $elements = explode('.', $sniff);
+        $elements = array_slice($elements, 0, 3);
+
+        return implode('.', $elements);
+    }
 
     /**
      * Prints out the usage information for PHPCS.

--- a/src/Config.php
+++ b/src/Config.php
@@ -1355,10 +1355,12 @@ class Config
 
     }//end printShortUsage()
 
+
     /**
      * Suggest a sniff code by only combining first three elements.
      *
-     * @param string $sniff
+     * @param string $sniff Sniff code
+     *
      * @return string
      */
     public function getSuggestedSniffCode($sniff)
@@ -1367,7 +1369,9 @@ class Config
         $elements = array_slice($elements, 0, 3);
 
         return implode('.', $elements);
-    }
+
+    }//end getSuggestedSniffCode()
+
 
     /**
      * Prints out the usage information for PHPCS.


### PR DESCRIPTION
This change is a quality of life improvement. I wanted to exclude a sniff, namely `Generic.WhiteSpace.ScopeIndent.Incorrect`. This sniff code came from the phpcs report that showed an error I wanted to ignore. When I entered this, phpcs told me: 
```
ERROR: The specified sniff code "Generic.WhiteSpace.ScopeIndent.Incorrect" is invalid

Run "phpcs --help" for usage information
```

So why is the sniff code invalid? After digging in the source code, I found that a sniff code may consist of only 2 periods. 

With this change, the output will look like the following:
```
ERROR: The specified sniff code "Generic.WhiteSpace.ScopeIndent.Incorrect" is invalid

Perhaps try following sniff code: Generic.WhiteSpace.ScopeIndent

Run "phpcs --help" for usage information
```

