### PR TITLE
'Undefined offset: -1' if findPrevious '$end = false'

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2113,7 +2113,7 @@ class File
     ) {
         $types = (array) $types;
 
-        if ($end === null) {
+        if ($end === null || \is_bool($end) === true) {
             $end = 0;
         }
 

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2100,6 +2100,8 @@ class File
      *                                  will not be checked. IE. checking will stop
      *                                  at the previous semi-colon found.
      *
+     * @thorw \InvalidArgumentException
+     *
      * @return int|bool
      * @see    findNext()
      */
@@ -2113,8 +2115,11 @@ class File
     ) {
         $types = (array) $types;
 
-        if ($end === null || \is_bool($end) === true) {
+        if ($end === null) {
             $end = 0;
+        } elseif (\is_bool($end) === true) {
+            throw new \InvalidArgumentException('$end must be a boolean. 
+                Maybe you\'ve used findPrevious and he did not found anything.');
         }
 
         for ($i = $start; $i >= $end; $i--) {


### PR DESCRIPTION
Hi,

If you try to find a previous token with `$end = false` you've got this error :

```
----------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message was:
   |       | Undefined offset: -1 in
   |       | /home/babeuloula/***/vendor/squizlabs/php_codesniffer/src/Files/File.php on line 2123
----------------------------------------------------------------------------------------------------------
```

My code :

```php
$findPreviousPtr = $phpcsFile->findPrevious(
    [T_USE, T_OPEN_USE_GROUP],
    $stackPtr,
    $phpcsFile->findPrevious([T_OPEN_CURLY_BRACKET], $stackPtr)
);
```

Because `$phpcsFile->findPrevious([T_OPEN_CURLY_BRACKET], $stackPtr)` return `false` if he did not find any token.

I have not write a unit test because I don't understand how you write your tests. And I have find anything on your documentation.

Have a nice day.

