### PR TITLE
Squiz.WhiteSpace.MemberVarSpacing removes comments before first member var during auto fixing

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -110,7 +110,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
         }
 
         // Determine if this is the first member var.
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($first - 1), null, true);
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($first - 1), null, true);
         if ($tokens[$prev]['code'] === T_CLOSE_CURLY_BRACKET
             && isset($tokens[$prev]['scope_condition']) === true
             && $tokens[$tokens[$prev]['scope_condition']]['code'] === T_FUNCTION

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
@@ -304,3 +304,31 @@ class Foo
     /* no error here because after function */
     private $bar = false;
 }
+
+class CommentedOutCodeAtStartOfClass {
+
+    /**
+     * Description.
+     *
+     * @var bool
+     */
+    //public $commented_out_property = true;
+
+    /**
+     * Description.
+     *
+     * @var bool
+     */
+    public $property = true;
+}
+
+class CommentedOutCodeAtStartOfClassNoBlankLine {
+
+    // phpcs:disable Stnd.Cat.Sniff -- For reasons.
+    /**
+     * Description.
+     *
+     * @var bool
+     */
+    public $property = true;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -290,3 +290,32 @@ class Foo
     /* no error here because after function */
     private $bar = false;
 }
+
+class CommentedOutCodeAtStartOfClass {
+
+    /**
+     * Description.
+     *
+     * @var bool
+     */
+    //public $commented_out_property = true;
+
+    /**
+     * Description.
+     *
+     * @var bool
+     */
+    public $property = true;
+}
+
+class CommentedOutCodeAtStartOfClassNoBlankLine {
+
+    // phpcs:disable Stnd.Cat.Sniff -- For reasons.
+
+    /**
+     * Description.
+     *
+     * @var bool
+     */
+    public $property = true;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -56,6 +56,7 @@ class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
             276 => 1,
             288 => 1,
             292 => 1,
+            333 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Squiz/MemberVarSpacing: bug fix - don't remove comments before first member var

If there would be comments (or commented out code) before the first member variable, the fixer as it was, would remove those comments, including potential PHPCS annotations.

By allowing for other comments between the class opener/trait import `use` statement and a property, this is prevented.

The fix now implemented means that if there is anything between the class opener/trait import `use` and the first property, other than a property docblock/comment, the property will be treated as any property and won't get the special "first property" treatment.

Includes unit test.