### PR TITLE
Clarify that blocks should be separated rather than followed by a blank line

### DIFF
--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -173,7 +173,7 @@ class FileHeaderSniff implements Sniff
                 // this block.
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($line['end'] + 1), null, true);
                 if ($next !== false && $tokens[$next]['line'] !== ($tokens[$line['end']]['line'] + 2)) {
-                    $error = 'Header blocks must be followed by a single blank line';
+                    $error = 'Header blocks must be separated by a single blank line';
                     $fix   = $phpcsFile->addFixableError($error, $line['end'], 'SpacingAfterBlock');
                     if ($fix === true) {
                         if ($tokens[$next]['line'] === $tokens[$line['end']]['line']) {


### PR DESCRIPTION
When dealing with the following code:
```php
<?php
namespace Example\Project;
```
The error message `Header blocks must be followed by a single blank line` was confusing to me.
I realise that PSR-12 calls `<?php` a block, but intuitively it's not, so this PR aims to make the message easier to understand in this situation