### PR TITLE
Improves Squiz\Sniffs\Commenting\FunctionCommentThrowTagSniff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/*
 /vendor/
 composer.lock
+/nbproject/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Before you contribute code to PHP\_CodeSniffer, please make sure it conforms to 
 
 Which should display no coding standard errors. And then:
 
-    phpunit
+    ./vendor/bin/phpunit
 
 Which should give you no failures or errors. You can ignore any skipped tests as these are for external tools.
+
+Check the [README](./README.md) for and how to get the dependencies.


### PR DESCRIPTION
+ Adds property to switch between error and warning output. (We need it
  for CI purpose, Option for third party usage)
+ Adds ignoreing netbeans (editor) configs
+ Improves CONTRIBUTING.md to not stay alone on first run ;-)

Happy sniffing :-)

btw: sniffs and unit tests where tested on: 7.3.11-1+0~20191026.48+debian10~1.gbpf71ca0