### PR TITLE
File::getMethodParameters() setting typeHintEndToken for vars with no type hint

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1496,16 +1496,18 @@ class File
                 }
 
                 // Reset the vars, as we are about to process the next parameter.
-                $defaultStart    = null;
-                $equalToken      = null;
-                $paramStart      = ($i + 1);
-                $passByReference = false;
-                $referenceToken  = false;
-                $variableLength  = false;
-                $variadicToken   = false;
-                $typeHint        = '';
-                $typeHintToken   = false;
-                $nullableType    = false;
+                $currVar          = null;
+                $paramStart       = ($i + 1);
+                $defaultStart     = null;
+                $equalToken       = null;
+                $passByReference  = false;
+                $referenceToken   = false;
+                $variableLength   = false;
+                $variadicToken    = false;
+                $typeHint         = '';
+                $typeHintToken    = false;
+                $typeHintEndToken = false;
+                $nullableType     = false;
 
                 $paramCount++;
                 break;


### PR DESCRIPTION
Given the following code sample:
```php
function foo( ?bool $a, $b ) {}
```

In the resulting array, the second parameter `$b` will have the `'type_hint_end_token'` index set to the stack pointer for the end of the type declaration for `$a`, instead of it being the expected `false`.

Caused by the `$typeHintEndToken` not being reset for the next parameter.

I've re-ordered the variable reset now to be the same as the order used for the initial variable declarations before the loop to make it more obvious.

While not necessarily a bug, the `$currVar` variable was also not being reset. That's also been fixed now.

I've not added a unit test as the existing tests do not check the token positions in the array.