### PR TITLE
Add "insteadof" and "as" to Squiz\WhiteSpace\OperatorSpacing

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -118,6 +118,8 @@ class OperatorSpacingSniff implements Sniff
         $targets[] = T_INLINE_THEN;
         $targets[] = T_INLINE_ELSE;
         $targets[] = T_INSTANCEOF;
+        $targets[] = T_INSTEADOF;
+        $targets[] = T_AS;
 
         return $targets;
 

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -463,5 +463,12 @@ $a = [$a, - $b];
 $a = $a[- $b];
 $a = $a ? - $b : - $b;
 
+class HelloWorld {
+    use HelloTrait {
+        method1  as  methodA;
+        method2  insteadof  methodB;
+    }
+}
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -457,5 +457,12 @@ $a = [$a, - $b];
 $a = $a[- $b];
 $a = $a ? - $b : - $b;
 
+class HelloWorld {
+    use HelloTrait {
+        method1 as methodA;
+        method2 insteadof methodB;
+    }
+}
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -99,6 +99,8 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                 265 => 2,
                 266 => 2,
                 271 => 2,
+                468 => 2,
+                469 => 2,
             ];
             break;
         case 'OperatorSpacingUnitTest.js':


### PR DESCRIPTION
As we have added `instanceof` we should probably have also `insteadof` and `as` here.