### PR TITLE
Hotfix: correct array indicies when using ternary or coalesce ops

### DIFF
--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -89,6 +89,13 @@ abstract class AbstractArraySniff implements Sniff
                 continue;
             }
 
+            if ($tokens[$checkToken]['code'] === T_INLINE_THEN
+                || $tokens[$checkToken]['code'] === T_COALESCE
+            ) {
+                $checkToken = $phpcsFile->findEndOfStatement($checkToken);
+                continue;
+            }
+
             if ($tokens[$checkToken]['code'] === T_ARRAY
                 || $tokens[$checkToken]['code'] === T_OPEN_SHORT_ARRAY
                 || $tokens[$checkToken]['code'] === T_CLOSURE

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
@@ -56,3 +56,13 @@ $var = [
         2 => 'two',
     /* three */ 3 => 'three',
     ];
+
+$array = [
+    'foo' => 'foo',
+    'bar' => $baz ?
+        ['abc'] :
+        ['def'],
+    'hey' => $baz ??
+        ['one'] ??
+        ['two'],
+];

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
@@ -57,3 +57,13 @@ $var = [
   2 => 'two',
   /* three */ 3 => 'three',
 ];
+
+$array = [
+  'foo' => 'foo',
+  'bar' => $baz ?
+        ['abc'] :
+        ['def'],
+  'hey' => $baz ??
+        ['one'] ??
+        ['two'],
+];

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -37,6 +37,9 @@ class ArrayIndentUnitTest extends AbstractSniffUnitTest
             56 => 1,
             57 => 1,
             58 => 1,
+            61 => 1,
+            62 => 1,
+            65 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Fixes #2694

I have find out that the issue is also when using coalesce operator.
Example, which is valid code, but has no sens would be:

```php
$array = [
    'foo' => 'foo',
    'bar' => $baz ? ['abc'] : ['def'],
    'hey' => $baz ?? ['one'] ?? ['two'],
];
```

Without fix we have 5 elements in `$indices` but we should have 3.

Added tests to cover changes.