### PR TITLE
PSR12/OperatorSpacing: hot fix

### DIFF
--- a/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php
@@ -24,6 +24,8 @@ class OperatorSpacingSniff extends SquizOperatorSpacingSniff
      */
     public function register()
     {
+        parent::register();
+
         $targets   = Tokens::$comparisonTokens;
         $targets  += Tokens::$operators;
         $targets  += Tokens::$assignmentTokens;

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
@@ -46,3 +46,13 @@ $foo = $foo?:'bar';
 try {
 } catch (ExceptionType1|ExceptionType2 $e) {
 }
+
+if (strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"') {}
+
+$oldConstructorPos = +1;
+return -$content;
+
+function name($a = -1) {}
+
+$a =& $ref;
+$a = [ 'a' => &$something ];

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
@@ -46,3 +46,13 @@ $foo = $foo ?: 'bar';
 try {
 } catch (ExceptionType1 | ExceptionType2 $e) {
 }
+
+if (strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"') {}
+
+$oldConstructorPos = +1;
+return -$content;
+
+function name($a = -1) {}
+
+$a =& $ref;
+$a = [ 'a' => &$something ];


### PR DESCRIPTION
PR #2640 made it so the `Squiz.WhiteSpace.OperatorSpacing` sniff now sets a property with the `$nonOperandTokens` from the `register()` method.

However, the PSR12 sniff for the same extends the Squiz sniff, but overloads the `register()` method to set different targets.

This means that the `$nonOperandTokens` array was empty and therefore the `isOperator()` method would nearly always return `true`, which was often incorrect.

Fixed by calling the `parent::register()` method before setting the `$targets` for the PSR12 sniff.

Includes adding unit tests to the PSR12 sniff related to the exclusions handled via the `isOperator()` method, to prevent breakage like this from being able to be merged in the future.

Fixes #2696