### PR TITLE
Hotfix: array indices with PHP 7.4 fn closure

### DIFF
--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -99,6 +99,7 @@ abstract class AbstractArraySniff implements Sniff
             if ($tokens[$checkToken]['code'] === T_ARRAY
                 || $tokens[$checkToken]['code'] === T_OPEN_SHORT_ARRAY
                 || $tokens[$checkToken]['code'] === T_CLOSURE
+                || $tokens[$checkToken]['code'] === T_FN
             ) {
                 // Let subsequent calls of this test handle nested arrays.
                 if ($tokens[$lastToken]['code'] !== T_DOUBLE_ARROW) {

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
@@ -57,6 +57,8 @@ $array = [
     'hey' => $baz ??
         ['one'] ??
         ['two'],
+    'fn' =>
+        fn ($x) => yield 'k' => $x,
 ];
 
 // phpcs:set Generic.Arrays.ArrayIndent indent 2

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
@@ -58,6 +58,8 @@ $array = [
     'hey' => $baz ??
         ['one'] ??
         ['two'],
+    'fn' =>
+        fn ($x) => yield 'k' => $x,
 ];
 
 // phpcs:set Generic.Arrays.ArrayIndent indent 2

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -33,10 +33,10 @@ class ArrayIndentUnitTest extends AbstractSniffUnitTest
             31 => 1,
             33 => 1,
             41 => 1,
-            65 => 1,
-            66 => 1,
             67 => 1,
             68 => 1,
+            69 => 1,
+            70 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Example code:

```php
<?php

$array = [
    1 => '1',
    2 => fn ($x) => yield 'a' => $x,
    3 => '3',
];
```

Array indices:
```
Array
(
    [0] => Array
        (
            [index_start] => 9
            [index_end] => 9
            [arrow] => 11
            [value_start] => 13
        )

    [1] => Array
        (
            [index_start] => 17
            [index_end] => 17
            [arrow] => 19
            [value_start] => 21
        )

    [2] => Array
        (
            [index_start] => 21  // <---- the same as value start in 1, WRONG
            [index_end] => 31
            [arrow] => 33
            [value_start] => 35
        )

    [3] => Array
        (
            [index_start] => 39
            [index_end] => 39
            [arrow] => 41
            [value_start] => 43
        )

)
```