### PR TITLE
Hotfix: adds T_FN_ARROW to assignmentTokens list

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -463,5 +463,7 @@ $a = [$a, - $b];
 $a = $a[- $b];
 $a = $a ? - $b : - $b;
 
+static fn ($x)  =>  yield 'k'  =>  $x;
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -457,5 +457,7 @@ $a = [$a, - $b];
 $a = $a[- $b];
 $a = $a ? - $b : - $b;
 
+static fn ($x) => yield 'k' => $x;
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -99,6 +99,7 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
                 265 => 2,
                 266 => 2,
                 271 => 2,
+                466 => 4,
             ];
             break;
         case 'OperatorSpacingUnitTest.js':

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -245,6 +245,7 @@ final class Tokens
         T_SR_EQUAL       => T_SR_EQUAL,
         T_COALESCE_EQUAL => T_COALESCE_EQUAL,
         T_ZSR_EQUAL      => T_ZSR_EQUAL,
+        T_FN_ARROW       => T_FN_ARROW,
     ];
 
     /**


### PR DESCRIPTION
We have there also T_DOUBLE_ARROW so I believe it is right place.