### PR TITLE
Hotfix: PHP 7.4 fn keyword should be lowercase

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -56,6 +56,7 @@ class LowerCaseKeywordSniff implements Sniff
             T_EXTENDS,
             T_FINAL,
             T_FINALLY,
+            T_FN,
             T_FOR,
             T_FOREACH,
             T_FUNCTION,

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
@@ -28,4 +28,5 @@ class X extends Y {
         Self::n();
     }
 }
+FN ($x) => $x;
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
@@ -28,4 +28,5 @@ class X extends Y {
         self::n();
     }
 }
+fn ($x) => $x;
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -37,6 +37,7 @@ class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
             21 => 1,
             25 => 1,
             28 => 1,
+            31 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/LowercaseFunctionKeywordsSniff.php
@@ -27,6 +27,7 @@ class LowercaseFunctionKeywordsSniff implements Sniff
         $tokens   = Tokens::$methodPrefixes;
         $tokens[] = T_FUNCTION;
         $tokens[] = T_CLOSURE;
+        $tokens[] = T_FN;
 
         return $tokens;
 

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.inc
@@ -24,3 +24,5 @@ abstract class Bar {
 	ABSTRACT proTECted FUNCTION AbstractProtectedFunction();
 	Final STATIC PUBLIC Function FinalStaticPublicFunction() {}
 }
+
+$a = FN($x) => $x;

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.inc.fixed
@@ -24,3 +24,5 @@ abstract class Bar {
 	abstract protected function AbstractProtectedFunction();
 	final static public function FinalStaticPublicFunction() {}
 }
+
+$a = fn($x) => $x;

--- a/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/LowercaseFunctionKeywordsUnitTest.php
@@ -34,6 +34,7 @@ class LowercaseFunctionKeywordsUnitTest extends AbstractSniffUnitTest
             23 => 1,
             24 => 3,
             25 => 4,
+            28 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Updated sniffs:
- Generic.PHP.LowerCaseKeyword
- Squiz.Functions.LowercaseFunctionKeywords