### PR TITLE
Hotfix: PHP 7.4 fn closure Return type hint tokens

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1712,6 +1712,9 @@ class PHP extends Tokenizer
                         T_COLON        => T_COLON,
                         T_NS_SEPARATOR => T_NS_SEPARATOR,
                         T_NULLABLE     => T_NULLABLE,
+                        T_CALLABLE     => T_CALLABLE,
+                        T_PARENT       => T_PARENT,
+                        T_SELF         => T_SELF,
                     ];
 
                     $closer = $this->tokens[$x]['parenthesis_closer'];


### PR DESCRIPTION
For type hints and return type we usually have T_STRING, but we have couple
different tokens, and these are:

- T_CALLABLE
- T_PARENT
- T_SELF

We need to skip them here.

Related to #2523 