### PR TITLE
Hotfix: PHP 7.4 fn closure tokenizer with ternary

### DIFF
--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.inc
@@ -14,3 +14,5 @@ class Example {
 }
 
 $a = fn(?\DateTime $x) : ?\DateTime => $x;
+
+$b = fn ($b) => $b ? true : false;

--- a/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowInlineIfUnitTest.php
@@ -29,7 +29,10 @@ class DisallowInlineIfUnitTest extends AbstractSniffUnitTest
     {
         switch ($testFile) {
         case 'DisallowInlineIfUnitTest.inc':
-            return [8 => 1];
+            return [
+                8  => 1,
+                18 => 1,
+            ];
             break;
         case 'DisallowInlineIfUnitTest.js':
             return [1 => 1];

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1083,7 +1083,7 @@ class PHP extends Tokenizer
                         $newToken['code'] = T_NULLABLE;
                         $newToken['type'] = 'T_NULLABLE';
                         break;
-                    } else if (in_array($tokenType, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, '=', '{', ';'], true) === true) {
+                    } else if (in_array($tokenType, [T_DOUBLE_ARROW, T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, '=', '{', ';'], true) === true) {
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
                             echo "\t\t* token $stackPtr changed from ? to T_INLINE_THEN".PHP_EOL;
                         }
@@ -1486,7 +1486,7 @@ class PHP extends Tokenizer
                             }
                         }
 
-                        if ($tokens[$i][0] === T_FUNCTION || $tokens[$i][0] === T_USE) {
+                        if ($tokens[$i][0] === T_FUNCTION || $tokens[$i][0] === T_FN || $tokens[$i][0] === T_USE) {
                             $isReturnType = true;
                         }
                     }//end if


### PR DESCRIPTION
Fix #2713

Missing unit test for:
```php
$fn = fn ($a) => $a ? fn () : string => 'a' : fn () : string => 'b';
```