### PR TITLE
Adds support for PHP 7.4 arrow functions in PEAR.Functions.ValidDefaultValue sniff

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/ValidDefaultValueSniff.php
@@ -26,6 +26,7 @@ class ValidDefaultValueSniff implements Sniff
         return [
             T_FUNCTION,
             T_CLOSURE,
+            T_FN,
         ];
 
     }//end register()

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.inc
@@ -98,5 +98,7 @@ $closure = function ($arg1, $arg2='hello') {};
 // Invalid closure
 $closure = function(array $arg2=array(), array $arg1) {}
 
+$fn = fn($a = [], $b) => $a[] = $b;
+
 // Intentional syntax error. Must be last thing in the file.
 function

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -26,14 +26,14 @@ class ValidDefaultValueUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            29 => 1,
-            34 => 1,
-            39 => 1,
-            71 => 1,
-            76 => 1,
-            81 => 1,
-            91 => 1,
-            99 => 1,
+            29  => 1,
+            34  => 1,
+            39  => 1,
+            71  => 1,
+            76  => 1,
+            81  => 1,
+            91  => 1,
+            99  => 1,
             101 => 1,
         ];
 

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -34,6 +34,7 @@ class ValidDefaultValueUnitTest extends AbstractSniffUnitTest
             81 => 1,
             91 => 1,
             99 => 1,
+            101 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Related to #2523