### PR TITLE
Hotfix: fn arrow closure - Squiz.Scope.StaticThisUsage

### DIFF
--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -69,13 +69,10 @@ class StaticThisUsageSniff extends AbstractScopeSniff
         $end  = $tokens[$stackPtr]['scope_closer'];
 
         do {
-            $next = $phpcsFile->findNext([T_VARIABLE, T_CLOSURE, T_FN, T_ANON_CLASS], ($next + 1), $end);
+            $next = $phpcsFile->findNext([T_VARIABLE, T_ANON_CLASS], ($next + 1), $end);
             if ($next === false) {
                 continue;
-            } else if ($tokens[$next]['code'] === T_CLOSURE
-                || $tokens[$next]['code'] === T_FN
-                || $tokens[$next]['code'] === T_ANON_CLASS
-            ) {
+            } else if ($tokens[$next]['code'] === T_ANON_CLASS) {
                 $next = $tokens[$next]['scope_closer'];
                 continue;
             } else if (strtolower($tokens[$next]['content']) !== '$this') {

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -68,14 +68,37 @@ class StaticThisUsageSniff extends AbstractScopeSniff
         $next = $stackPtr;
         $end  = $tokens[$stackPtr]['scope_closer'];
 
+        $this->checkThisUsage($phpcsFile, $next, $end);
+
+    }//end processTokenWithinScope()
+
+
+    /**
+     * Check for $this variable usage between $next and $end tokens.
+     *
+     * @param File $phpcsFile The current file being scanned.
+     * @param int  $next      The position of the next token to check.
+     * @param int  $end       The position of the last token to check.
+     *
+     * @return void
+     */
+    private function checkThisUsage(File $phpcsFile, $next, $end)
+    {
+        $tokens = $phpcsFile->getTokens();
+
         do {
             $next = $phpcsFile->findNext([T_VARIABLE, T_ANON_CLASS], ($next + 1), $end);
             if ($next === false) {
                 continue;
-            } else if ($tokens[$next]['code'] === T_ANON_CLASS) {
+            }
+
+            if ($tokens[$next]['code'] === T_ANON_CLASS) {
+                $this->checkThisUsage($phpcsFile, $next, $tokens[$next]['scope_opener']);
                 $next = $tokens[$next]['scope_closer'];
                 continue;
-            } else if ($tokens[$next]['content'] !== '$this') {
+            }
+
+            if ($tokens[$next]['content'] !== '$this') {
                 continue;
             }
 
@@ -83,7 +106,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
             $phpcsFile->addError($error, $next, 'Found');
         } while ($next !== false);
 
-    }//end processTokenWithinScope()
+    }//end checkThisUsage()
 
 
     /**

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -69,10 +69,11 @@ class StaticThisUsageSniff extends AbstractScopeSniff
         $end  = $tokens[$stackPtr]['scope_closer'];
 
         do {
-            $next = $phpcsFile->findNext([T_VARIABLE, T_CLOSURE, T_ANON_CLASS], ($next + 1), $end);
+            $next = $phpcsFile->findNext([T_VARIABLE, T_CLOSURE, T_FN, T_ANON_CLASS], ($next + 1), $end);
             if ($next === false) {
                 continue;
             } else if ($tokens[$next]['code'] === T_CLOSURE
+                || $tokens[$next]['code'] === T_FN
                 || $tokens[$next]['code'] === T_ANON_CLASS
             ) {
                 $next = $tokens[$next]['scope_closer'];

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -75,7 +75,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
             } else if ($tokens[$next]['code'] === T_ANON_CLASS) {
                 $next = $tokens[$next]['scope_closer'];
                 continue;
-            } else if (strtolower($tokens[$next]['content']) !== '$this') {
+            } else if ($tokens[$next]['content'] !== '$this') {
                 continue;
             }
 

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -75,4 +75,8 @@ $b = new class()
 	public static function myFunc() {
 		$this->doSomething();
 	}
+
+	public static function other() {
+	    return fn () => $this->name;
+    }
 }

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -108,4 +108,10 @@ $b = new class()
         }) {
         };
     }
+
+    public static function thisMustBeLowercase() {
+        $This = 'hey';
+
+        return $This;
+    }
 }

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -57,26 +57,55 @@ class MyClass
 
     public function getAnonymousClass() {
         return new class() {
-			public static function something() {
-				$this->doSomething();
+            public static function something() {
+                $this->doSomething();
             }
         };
     }
 }
 
 trait MyTrait {
-	public static function myFunc() {
-		$this->doSomething();
-	}
+    public static function myFunc() {
+        $this->doSomething();
+    }
 }
 
 $b = new class()
 {
-	public static function myFunc() {
-		$this->doSomething();
-	}
+    public static function myFunc() {
+        $this->doSomething();
+    }
 
-	public static function other() {
-	    return fn () => $this->name;
+    public static function other() {
+        return fn () => $this->name;
+    }
+
+    public static function anonClassUseThis() {
+        return new class($this) {
+            public function __construct($class) {
+            }
+        };
+    }
+
+    public static function anonClassAnotherThis() {
+        return new class() {
+            public function __construct() {
+                $this->id = 1;
+            }
+        };
+    }
+
+    public static function anonClassNestedUseThis() {
+        return new class(new class($this) {}) {
+        };
+    }
+
+    public static function anonClassNestedAnotherThis() {
+        return new class(new class() {
+            public function __construct() {
+                $this->id = 1;
+            }
+        }) {
+        };
     }
 }

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -31,9 +31,13 @@ class StaticThisUsageUnitTest extends AbstractSniffUnitTest
             9  => 1,
             14 => 1,
             20 => 1,
+            41 => 1,
             61 => 1,
             69 => 1,
             76 => 1,
+            80 => 1,
+            84 => 1,
+            99 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Related #2523

I am not sure about this change as this is actually invalid code.
We cannot use `$this` even inside closure, as then closure is not gonna
be usable. The same in case of normal closure.

Maybe here we should have another fix then?