### PR TITLE
PSR12/FileHeader: make "SpacingAfter" and "SpacingInside" errorcodes modular

### DIFF
--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -178,8 +178,9 @@ class FileHeaderSniff implements Sniff
                 // this block.
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($line['end'] + 1), null, true);
                 if ($next !== false && $tokens[$next]['line'] !== ($tokens[$line['end']]['line'] + 2)) {
-                    $error = 'Header blocks must be separated by a single blank line';
-                    $fix   = $phpcsFile->addFixableError($error, $line['end'], 'SpacingAfterBlock');
+                    $error     = 'Header blocks must be separated by a single blank line';
+                    $errorCode = 'SpacingAfter'.str_replace(' ', '', ucwords($line['type'])).'Block';
+                    $fix       = $phpcsFile->addFixableError($error, $line['end'], $errorCode);
                     if ($fix === true) {
                         if ($tokens[$next]['line'] === $tokens[$line['end']]['line']) {
                             $phpcsFile->fixer->addNewlineBefore($next);
@@ -218,8 +219,9 @@ class FileHeaderSniff implements Sniff
                 // blank line after this statement.
                 $next = $phpcsFile->findNext(T_WHITESPACE, ($line['end'] + 1), null, true);
                 if ($tokens[$next]['line'] > ($tokens[$line['end']]['line'] + 1)) {
-                    $error = 'Header blocks must not contain blank lines';
-                    $fix   = $phpcsFile->addFixableError($error, $line['end'], 'SpacingInsideBlock');
+                    $error     = 'Header blocks must not contain blank lines';
+                    $errorCode = 'SpacingInside'.str_replace(' ', '', ucwords($line['type'])).'Block';
+                    $fix       = $phpcsFile->addFixableError($error, $line['end'], $errorCode);
                     if ($fix === true) {
                         $phpcsFile->fixer->beginChangeset();
                         for ($i = ($line['end'] + 1); $i < $next; $i++) {
@@ -236,7 +238,7 @@ class FileHeaderSniff implements Sniff
 
                         $phpcsFile->fixer->endChangeset();
                     }
-                }
+                }//end if
             }//end if
 
             if (isset($found[$line['type']]) === false) {


### PR DESCRIPTION
This changes the error codes for the `SpacingAfterBlock` and `SpacingInsideBlock` errors to modular error codes which include a reference to the type of header block, i.e. `SpacingAfterDeclareBlock`, `SpacingInsideUseFunctionBlock` etc.

This allows for more selective application of the rules.

Take for instance the quite common case of the header blocks all being separated by blank lines, except for the open tag and file docblock.
```php
<?php
/**
 * File docblock.
 */

namespace A\B\C;

use B\C;
```

The modular errorcodes I'm proposing in this PR will allow for the sniff to be used to safeguard the blank lines between each section without enforcing a blank line between the PHP open tag and the file docblock using:
```xml
<rule ref="PSR12.Files.FileHeader">
   <exclude name="PSR12.Files.FileHeader.SpacingAfterTagBlock"/>
</rule>
```

Fixes #3453