### PR TITLE
PSR12.ControlStructures.ControlStructureSpacing does not ignore comments between conditions

### DIFF
--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -95,6 +95,7 @@ class ControlStructureSpacingSniff implements Sniff
         for ($i = $parenOpener; $i < $parenCloser; $i++) {
             if ($tokens[$i]['column'] !== 1
                 || $tokens[($i + 1)]['line'] > $tokens[$i]['line']
+                || isset(Tokens::$commentTokens[$tokens[$i]['code']]) === true
             ) {
                 continue;
             }

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
@@ -73,3 +73,14 @@ EOD
 ) {
     return;
 }
+
+    if (
+        isset($foo) === true
+        && $bar > $foo
+        /*
+         * A multi-line comment.
+         */
+        && $foo === true
+    ) {
+        break;
+    }

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
@@ -74,3 +74,14 @@ EOD
 ) {
     return;
 }
+
+    if (
+        isset($foo) === true
+        && $bar > $foo
+        /*
+         * A multi-line comment.
+         */
+        && $foo === true
+    ) {
+        break;
+    }


### PR DESCRIPTION
PSR12 does not forbid comments interlaced in the conditions of a (multi-line) control structure.

However, the sniff didn't handle those correctly.

With the example code added to the unit test case file, the sniff, as it was, would throw an unsolvable error which would also cause fixer conflicts with the sniff itself:
```
 82 | ERROR | [x] Each line in a multi-line control structure must be indented at least once; expected at least 8 spaces, but found 0
    |       |     (PSR12.ControlStructures.ControlStructureSpacing.LineIndent)
```

```
# phpcbf ./psr12/tests/controlstructures/controlstructurespacingunittest.inc --standard=psr12 --sniffs=psr12.controlstructures.controlstructurespacing

PHP_CodeSniffer version 3.5.3 (stable) by Squiz (http://www.squiz.net)

PHPCBF RESULT SUMMARY
----------------------------------------------------------------------------------------------------------------------------------------
FILE                                                                                                                    FIXED  REMAINING
----------------------------------------------------------------------------------------------------------------------------------------
/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc     FAILED TO FIX
----------------------------------------------------------------------------------------------------------------------------------------
A TOTAL OF 17 ERRORS WERE FIXED IN 1 FILE
----------------------------------------------------------------------------------------------------------------------------------------
PHPCBF FAILED TO FIX 1 FILE
----------------------------------------------------------------------------------------------------------------------------------------
```

By ignoring lines where the first token is a comment, this issue will be fixed.