### PR TITLE
Travis: don't allow PHP 7.4 build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     - php: 7.3
       env: PHPUNIT_INCOMPAT=1
     - php: "7.4snapshot"
+      env: PHPUNIT_INCOMPAT=1
+    - php: "7.4snapshot"
       env: PHPSTAN=1 PHPUNIT_INCOMPAT=1
       addons:
         apt:
@@ -38,6 +40,7 @@ matrix:
 
   allow_failures:
     - php: "7.4snapshot"
+      env: PHPSTAN=1 PHPUNIT_INCOMPAT=1
     - php: nightly
 
 before_install:


### PR DESCRIPTION
As [PHP 7.4 has been released](https://www.php.net/archive/2019.php#2019-11-28-1), the build against PHP 7.4 should no longer be allowed to fail.

As that build was combined with the PHPStan check which - for now - should be allowed to fail, I've split the build into two:
1. a "normal" PHP 7.4 build which is not allowed to fail.
2. a PHPStan specific build which is allowed to fail.