### PR TITLE
Fix warning determining shell width on system without shell_exec

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -219,7 +219,10 @@ class Config
         switch ($name) {
         case 'reportWidth' :
             // Support auto terminal width.
-            if ($value === 'auto' && preg_match('|\d+ (\d+)|', shell_exec('stty size 2>&1'), $matches) === 1) {
+            if ($value === 'auto'
+                && function_exists('shell_exec') === true
+                && preg_match('|\d+ (\d+)|', shell_exec('stty size 2>&1'), $matches) === 1
+            ) {
                 $value = (int) $matches[1];
             } else {
                 $value = (int) $value;


### PR DESCRIPTION
Closes #2698

Checks for the existence of the `shell_exec` function before attempting to use it to determine shell width, falling into the `else` clause where the width will be set to `0`, similar to what would happen if `stty` program did not exist or failed to run if `shell_exec` did exist.