### PR TITLE
Hotfix: correct array indices

### DIFF
--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
@@ -59,6 +59,8 @@ $array = [
         ['two'],
     'fn' =>
         fn ($x) => yield 'k' => $x,
+  $a ?? $b,
+  $c ? $d : $e,
 ];
 
 // phpcs:set Generic.Arrays.ArrayIndent indent 2

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
@@ -60,6 +60,8 @@ $array = [
         ['two'],
     'fn' =>
         fn ($x) => yield 'k' => $x,
+    $a ?? $b,
+    $c ? $d : $e,
 ];
 
 // phpcs:set Generic.Arrays.ArrayIndent indent 2

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -33,10 +33,12 @@ class ArrayIndentUnitTest extends AbstractSniffUnitTest
             31 => 1,
             33 => 1,
             41 => 1,
-            67 => 1,
-            68 => 1,
+            62 => 1,
+            63 => 1,
             69 => 1,
             70 => 1,
+            71 => 1,
+            72 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
I've changed the approach completely. In my opinion it much clearer.
Added tests to cover the issue described in #2745.

Fixes #2745

It solves also the problem when we had `["value_start" => false]` for an empty array.