### PR TITLE
Disallow the use of $_Request

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -292,6 +292,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingPHPTagStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DeprecatedFunctionsStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsStandard.xml" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowRequestSuperGlobalStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DiscourageGotoStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ForbiddenFunctionsStandard.xml" role="php" />
@@ -395,6 +396,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="CharacterBeforePHPOpeningTagSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClosingPHPTagSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DeprecatedFunctionsSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowRequestSuperGlobalSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DiscourageGotoSniff.php" role="php" />
@@ -654,6 +656,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsUnitTest.2.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowAlternativePHPTagsUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowRequestSuperGlobalUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowRequestSuperGlobalUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagUnitTest.1.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortOpenTagUnitTest.2.inc" role="test" />

--- a/src/Standards/Generic/Docs/PHP/DisallowRequestSuperGlobalStandard.xml
+++ b/src/Standards/Generic/Docs/PHP/DisallowRequestSuperGlobalStandard.xml
@@ -1,0 +1,7 @@
+<documentation title="$_REQUEST Super Global">
+    <standard>
+        <![CDATA[
+    $_REQUEST should never be used due to the ambiguity created to identify where the data is coming from. Use $_POST, $_GET or $_COOKIE instead
+    ]]>
+    </standard>
+</documentation>

--- a/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperGlobalSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperGlobalSniff.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Ensures the $_REQUEST super global is not used
+ *
+ * @author    Jeantwan Teuma <jeant.m24@gmail.com>
+ * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class DisallowRequestSuperGlobalSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [T_VARIABLE];
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $varName = $tokens[$stackPtr]['content'];
+        if ($varName !== '$_REQUEST') {
+            return;
+        }
+
+        $type  = 'RequestSuperGlobalAccessed';
+        $error = 'The $_REQUEST super global should not be used. Use $_GET, $_POST or $_COOKIE instead';
+        $phpcsFile->addError($error, $stackPtr, $type, []);
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperGlobalSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperGlobalSniff.php
@@ -45,9 +45,8 @@ class DisallowRequestSuperGlobalSniff implements Sniff
             return;
         }
 
-        $type  = 'RequestSuperGlobalAccessed';
         $error = 'The $_REQUEST super global should not be used. Use $_GET, $_POST or $_COOKIE instead';
-        $phpcsFile->addError($error, $stackPtr, $type, []);
+        $phpcsFile->addError($error, $stackPtr, 'Found');
 
     }//end process()
 

--- a/src/Standards/Generic/Tests/PHP/DisallowRequestSuperGlobalUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/DisallowRequestSuperGlobalUnitTest.inc
@@ -1,0 +1,16 @@
+<?php
+echo $_REQUEST['action'];
+
+echo '$_REQUEST';
+
+echo $_POST['action'];
+
+echo $_GET[$action];
+
+echo $_COOKIE['action'];
+
+$sample = Util::getArrayIndex($_REQUEST, 'sample', '');
+$syntax = Util::getArrayIndex($_REQUEST, 'syntax', '');
+$value  = Util::getArrayIndex($_FILES, $key, $default);
+
+?>

--- a/src/Standards/Generic/Tests/PHP/DisallowRequestSuperGlobalUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowRequestSuperGlobalUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Unit test class for the DisallowRequestSuperGlobal sniff.
+ *
+ * @author    Jeantwan Teuma <jeant.m24@gmail.com>
+ * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+namespace PHP_CodeSniffer\Standards\Generic\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class DisallowRequestSuperGlobalUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    protected function getErrorList()
+    {
+        return [
+            2  => 1,
+            12 => 1,
+            13 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    protected function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Create a new sniff which will listen on the variable constant ($). If the $_REQUEST super global is detected, add the following error: 

> The $_REQUEST super global should not be used. Use $_GET, $_POST or $_COOKIE instead

This implements #2373 