### PR TITLE
Autoload relative paths first to avoid confusion with files from the global include path

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -356,11 +356,13 @@ class Ruleset
             }
 
             $autoloadPath = (string) $autoload;
-            if (is_file($autoloadPath) === false) {
-                $autoloadPath = Util\Common::realPath(dirname($rulesetPath).DIRECTORY_SEPARATOR.$autoloadPath);
-            }
 
-            if ($autoloadPath === false) {
+            // Try relative autoload paths first.
+            $relativePath = Util\Common::realPath(dirname($rulesetPath).DIRECTORY_SEPARATOR.$autoloadPath);
+
+            if ($relativePath !== false && is_file($$relativePath) === true) {
+                $autoloadPath = $relativePath;
+            } else if (is_file($autoloadPath) === false) {
                 throw new RuntimeException('The specified autoload file "'.$autoload.'" does not exist');
             }
 


### PR DESCRIPTION
Problem: autoload files are confused with globally available files. See https://github.com/pfrenssen/coder/issues/54

If you specify `<autoload>./autoload.php</autoload>` in your ruleset.xml file then a completely different autoload.php file from your system might be executed, even although you specified a relative path.

Steps to reproduce:
1. Clone https://github.com/klausi/test_phpcs
2. Run `composer install`
3. Run `./vendor/bin/phpcs --standard=./standard test.php`

Output:
`PHP Parse error:  syntax error, unexpected 'invalid' (T_STRING) in test_phpcs/autoload.php on line 3`

Which means the wrong autoload.php file was included.

Proposed solution: Try to include relative paths first, then try global paths.

Not sure how we can test this, any tips for that?