### PR TITLE
[Hotfix] Tokenizer / numeric separators backfill: fix all known issues

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -992,14 +992,24 @@ class PHP extends Tokenizer
 
                     if ($tokens[$i][0] === T_LNUMBER
                         || $tokens[$i][0] === T_DNUMBER
-                        || ($tokens[$i][0] === T_STRING
-                        && $tokens[$i][1][0] === '_')
+                    ) {
+                        $newContent .= $tokens[$i][1];
+                        continue;
+                    }
+
+                    if ($tokens[$i][0] === T_STRING
+                        && $tokens[$i][1][0] === '_'
+                        && ((strpos($newContent, '0x') === 0
+                        && preg_match('`^((?<!\.)_[0-9A-F][0-9A-F\.]*)+$`iD', $tokens[$i][1]) === 1)
+                        || (strpos($newContent, '0x') !== 0
+                        && substr($newContent, -1) !== '.'
+                        && substr(strtolower($newContent), -1) !== 'e'
+                        && preg_match('`^(?:(?<![\.e])_[0-9][0-9e\.]*)+$`iD', $tokens[$i][1]) === 1))
                     ) {
                         $newContent .= $tokens[$i][1];
 
                         // Support floats.
-                        if ($tokens[$i][0] === T_STRING
-                            && substr(strtolower($tokens[$i][1]), -1) === 'e'
+                        if (substr(strtolower($tokens[$i][1]), -1) === 'e'
                             && ($tokens[($i + 1)] === '-'
                             || $tokens[($i + 1)] === '+')
                         ) {

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc
@@ -1,10 +1,14 @@
 <?php
 
+/*
+ * Numbers with PHP 7.4 underscore separators.
+ */
+
 /* testSimpleLNumber */
 $foo = 1_000_000_000;
 
 /* testSimpleDNumber */
-‪$foo = 107_925_284.88;
+$foo = 107_925_284.88;
 
 /* testFloat */
 $foo = 6.674_083e-11;
@@ -12,14 +16,67 @@ $foo = 6.674_083e-11;
 /* testFloat2 */
 $foo = 6.674_083e+11;
 
+/* testFloat3 */
+$foo = 1_2.3_4e1_23;
+
 /* testHex */
 $foo = 0xCAFE_F00D;
 
 /* testHexMultiple */
 $foo = 0x42_72_6F_77_6E;
 
+/* testHexInt */
+$foo = 0x42_72_6F;
+
 /* testBinary */
 $foo = 0b0101_1111;
 
 /* testOctal */
 $foo = 0137_041;
+
+/* testIntMoreThanMax */
+$foo = 10_223_372_036_854_775_807;
+
+/*
+ * Invalid use of numeric separators. These should not be touched by the backfill.
+ */
+
+/* testInvalid1 */
+$a = 100_;   // trailing
+
+/* testInvalid2 */
+$a = 1__1;   // next to underscore
+
+/* testInvalid3 */
+$a = 1_.0;   // next to decimal point
+
+/* testInvalid4 */
+$a = 1._0;   // next to decimal point
+
+/* testInvalid5 */
+$a = 0x_123; // next to x
+
+/* testInvalid6 */
+$a = 0b_101; // next to b
+
+/* testInvalid7 */
+$a = 1_e2;   // next to e
+
+/* testInvalid8 */
+$a = 1e_2;   // next to e
+
+/* testInvalid9 */
+$testValue = 107_925_284 .88;
+
+/* testInvalid10 */
+$testValue = 107_925_284/*comment*/.88;
+
+/*
+ * Ensure that legitimate calculations are not touched by the backfill.
+ */
+
+/* testCalc1 */
+$a = 667_083 - 11; // Calculation.
+
+/* test Calc2 */
+$a = 6.674_08e3 + 11; // Calculation.


### PR DESCRIPTION
## Tokenizer / numeric separators backfill: improve the unit tests

### Test case file:
1. Remove a stray invisible whitespace character/null byte from the test case file.
2. Add a large number of additional test cases.

### Test file `testBackfill()`:
1. Fixed reversed order of the parameters in the `assertSame()`. The first parameter is `$expected`, the second `$result`.
    Having the parameters in the correct order makes debugging the tests easier as the messages send by PHPUnit will be correct.
2. Test that the final token has the correct code **and** the correct type.
3. Correct the expected type for two test cases based on how PHP 7.4 tokenizes these.
4. Add datasets for the new test cases which are to be handled by the backfill.

### Test file new `testNoBackfill()`
Add tests to verify that numbers using numeric separators which are considered parse errors and/or which aren't relevant to the backfill, do not incorrectly trigger the backfill anyway.

This test verifies that the final token sequence is in line with the token sequence PHP 7.4 would give.

## Tokenizer / numeric separators backfill: fix incorrect token types

Tokenizer / numeric separators backfill: fix incorrect token types

When the final content of a numeric token is more than PHP_INT_MAX or when a numeric token contains a `.` or an `E/e`, it should be tokenized as `T_DNUMBER`.

This fixes the first set of the unit test failures.

### Tokenizer / numeric separators backfill: fix parse errors being handled by the backfill

The prevents the backfill from kicking in when confronted with invalid use of the numeric literal separator which would be a parse error in PHP 7.4 anyway.

This fixes the remaining unit test failures.


Fixes all currently known issues which remained after #2546 

---

Note: on Windows the unit tests will currently not pass when run against PHP 7.4.0 due to a bug in PHP itself. See: https://bugs.php.net/bug.php?id=78978
