### PR TITLE
Squiz/DisallowMultipleAssignments: fix ignoring of property declarations

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -64,6 +64,16 @@ class DisallowMultipleAssignmentsSniff implements Sniff
             }
         }
 
+        // Ignore member var definitions.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            $conditions = $tokens[$stackPtr]['conditions'];
+            end($conditions);
+            $deepestScope = key($conditions);
+            if (isset(Tokens::$ooScopeTokens[$tokens[$deepestScope]['code']]) === true) {
+                return;
+            }
+        }
+
         /*
             The general rule is:
             Find an equal sign and go backwards along the line. If you hit an
@@ -122,14 +132,6 @@ class DisallowMultipleAssignmentsSniff implements Sniff
             && $tokens[$varToken]['code'] !== T_OPEN_SQUARE_BRACKET
         ) {
             $varToken = $start;
-        }
-
-        // Ignore member var definitions.
-        if (isset(Tokens::$scopeModifiers[$tokens[$varToken]['code']]) === true
-            || $tokens[$varToken]['code'] === T_VAR
-            || $tokens[$varToken]['code'] === T_STATIC
-        ) {
-            return;
         }
 
         // Ignore the first part of FOR loops as we are allowed to

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
@@ -62,3 +62,16 @@ $closureWithDefaultParamter = function(array $testArray=array()) {};
 while ( ( $csvdata = fgetcsv( $handle, 2000, $separator ) ) !== false ) {
 	// Do something.
 }
+
+// Issue #2787.
+class Foo {
+    protected ?int $id = null;
+}
+
+class Bar
+{
+    // Multi-property assignments.
+    private $a = false, $b = true; // Non-typed.
+    public bool $c = false, $d = true;
+    protected int $e = 123, $f = 987;
+}


### PR DESCRIPTION
The `Squiz.PHP.DisallowMultipleAssignments` intended to ignore property declarations, but did not allow for PHP 7.4 typed properties.

I've now moved the _"is this a property ?"_ check up to bow out earlier for all properties.

Includes unit test.

I've also added tests for multi-property declarations. While it is debatable whether or not this sniff should report on these, the existing behaviour was to ignore them. This behaviour has been maintained and is now documented and safeguarded via the test.

Fixes #2787