### PR TITLE
Generic/ExecutableFile: skip tests on Windows

### DIFF
--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -24,7 +24,8 @@ class ExecutableFileUnitTest extends AbstractSniffUnitTest
     {
         // PEAR doesn't preserve the executable flag, so skip
         // tests when running in a PEAR install.
-        return $GLOBALS['PHP_CODESNIFFER_PEAR'];
+        // Also skip on Windows which doesn't have the concept of executable files.
+        return ($GLOBALS['PHP_CODESNIFFER_PEAR'] || (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'));
 
     }//end shouldSkipTest()
 


### PR DESCRIPTION
Windows doesn't have the concept of executable files this sniff targets, so the test would always fail.