### PR TITLE
Squiz/FileComment: update the "fixed" files copyright year

### DIFF
--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.inc.fixed
@@ -25,7 +25,7 @@
 * @author
 * @copyright  1997 Squiz Pty Ltd (ABN 77 084 670 600)
 * @copyright  1994-1997 Squiz Pty Ltd (ABN 77 084 670 600)
-* @copyright  2019 Squiz Pty Ltd (ABN 77 084 670 600)
+* @copyright  2020 Squiz Pty Ltd (ABN 77 084 670 600)
 * @license    http://www.php.net/license/3_0.txt
 * @summary    An unknown summary tag
 *

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.js.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.js.fixed
@@ -25,7 +25,7 @@
 * @author
 * @copyright  1997 Squiz Pty Ltd (ABN 77 084 670 600)
 * @copyright  1994-1997 Squiz Pty Ltd (ABN 77 084 670 600)
-* @copyright  2019 Squiz Pty Ltd (ABN 77 084 670 600)
+* @copyright  2020 Squiz Pty Ltd (ABN 77 084 670 600)
 * @license    http://www.php.net/license/3_0.txt
 * @summary    An unknown summary tag
 *


### PR DESCRIPTION
These tests need an update each time the year changes as the `.fixed` file checks for the hard-coded current year.

Happy new year!