### PR TITLE
Tokenizer: improve tokenization of T_NULLABLE vs T_INLINE_THEN

### DIFF
--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc
@@ -66,7 +66,19 @@ class TestTokenizingOfNullableVsInlineThen {
     }
 }
 
+// Issue #2641.
 $foo = new static(
     is_null($a) ? foo($a) : $a,
     is_null($b) ? $b : $c
 );
+
+// Issue #2791.
+class testInstanceOf() {
+    function testIt() {
+        $foo = $value instanceof static ? '(' . $value . ')' : $value;
+        $bar = $value instanceof static ? function_call($value) : $value;
+        $baz = $value instanceof static ? array($value) : $value;
+        $bal = $value instanceof static ? \className::$property : $value;
+        $bal = $value instanceof static ? CONSTANT_NAME : $value;
+    }
+}

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc.fixed
@@ -64,7 +64,19 @@ class TestTokenizingOfNullableVsInlineThen {
     }
 }
 
+// Issue #2641.
 $foo = new static(
     is_null($a) ? foo($a) : $a,
     is_null($b) ? $b : $c
 );
+
+// Issue #2791.
+class testInstanceOf() {
+    function testIt() {
+        $foo = $value instanceof static ? '(' . $value . ')' : $value;
+        $bar = $value instanceof static ? function_call($value) : $value;
+        $baz = $value instanceof static ? array($value) : $value;
+        $bal = $value instanceof static ? \className::$property : $value;
+        $bal = $value instanceof static ? CONSTANT_NAME : $value;
+    }
+}


### PR DESCRIPTION
This is an attempt to make the differentiation between `T_NULLABLE` and `T_INLINE_THEN` more stable.

There is only a limited set of tokens which can be used for type declarations. If a `?` is not followed by one of these, we can be certain that it is a ternary operator `T_INLINE_THEN`.

The more resource intensive "walking back" check will now only be done when it could be either.
The "walking back" token logic could probably still do with an additional check for `T_INSTANCEOF`, but the changes now made, should prevent the majority of issues where `T_INLINE_THEN` is misidentified as `T_NULLABLE`.

Includes unit tests via the PSR12.Functions.NullableTypeDeclaration sniff.

Fixes #2791

Note: the build failure is unrelated to this PR and will be fixed via #2793