### PR TITLE
Add empty array check

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -180,6 +180,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        <dir name="Arrays">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowLongArraySyntaxStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxStandard.xml" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyArrayStandard.xml" role="php" />
        </dir>
        <dir name="Classes">
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassNameStandard.xml" role="php" />
@@ -283,6 +284,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ArrayIndentSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowLongArraySyntaxSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyArraySniff.php" role="php" />
        </dir>
        <dir name="Classes">
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassNameSniff.php" role="php" />
@@ -401,6 +403,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyArrayUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyArrayUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="EmptyArrayUnitTest.php" role="test" />
        </dir>
        <dir name="Classes">
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassNameUnitTest.1.inc" role="test" />

--- a/src/Standards/Generic/Docs/Arrays/EmptyArrayStandard.xml
+++ b/src/Standards/Generic/Docs/Arrays/EmptyArrayStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Long Array Syntax">
+    <standard>
+    <![CDATA[
+    Empty arrays should not have space between the parentheses.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: no spaces between the parentheses">
+        <![CDATA[
+$arr = array();
+        ]]>
+        </code>
+        <code title="Invalid: spaces between the parentheses">
+        <![CDATA[
+$arr = array(     );
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/Arrays/EmptyArraySniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/EmptyArraySniff.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Ensures that empty arrays have no space between parentheses.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class EmptyArraySniff implements Sniff
+{
+
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [
+            T_ARRAY,
+            T_OPEN_SHORT_ARRAY,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_ARRAY) {
+            $arrayStart = $tokens[$stackPtr]['parenthesis_opener'];
+
+            if (isset($tokens[$arrayStart]['parenthesis_closer']) === false) {
+                return;
+            }
+
+            $arrayEnd = $tokens[$arrayStart]['parenthesis_closer'];
+        } else {
+            $arrayStart = $stackPtr;
+            $arrayEnd   = $tokens[$stackPtr]['bracket_closer'];
+        }
+
+        $content = $phpcsFile->findNext(T_WHITESPACE, ($arrayStart + 1), ($arrayEnd + 1), true);
+        if ($content === $arrayEnd) {
+            // Empty array, but if the brackets aren't together, there's a problem.
+            if (($arrayEnd - $arrayStart) !== 1) {
+                $error = 'Empty array declaration must have no space between the parentheses';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceInEmptyArray');
+
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($arrayStart + 1); $i < $arrayEnd; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/Arrays/EmptyArrayUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/EmptyArrayUnitTest.inc
@@ -1,0 +1,21 @@
+<?php
+
+$a = array();
+$a = array(   );
+$a = array( /* with comment */  );
+$a = array(
+
+);
+$a = array(
+    // comment
+);
+
+$b = [];
+$b = [   ];
+$b = [ /* with comment */  ];
+$b = [
+
+];
+$b = [
+    // comment
+];

--- a/src/Standards/Generic/Tests/Arrays/EmptyArrayUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/EmptyArrayUnitTest.inc.fixed
@@ -1,0 +1,17 @@
+<?php
+
+$a = array();
+$a = array();
+$a = array( /* with comment */  );
+$a = array();
+$a = array(
+    // comment
+);
+
+$b = [];
+$b = [];
+$b = [ /* with comment */  ];
+$b = [];
+$b = [
+    // comment
+];

--- a/src/Standards/Generic/Tests/Arrays/EmptyArrayUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/EmptyArrayUnitTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Unit test class for the EmptyArray sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class EmptyArrayUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            4  => 1,
+            6  => 1,
+            14 => 1,
+            16 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Trying to fix the issue https://github.com/squizlabs/PHP_CodeSniffer/issues/582 by splitting the check made by the Squizz.Arrays.ArrayDeclarationSniff.