### PR TITLE
Add array keyword sniff

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -180,6 +180,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        <dir name="Arrays">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowLongArraySyntaxStandard.xml" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxStandard.xml" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="NoSpaceAfterArrayKeywordStandard.xml" role="php" />
        </dir>
        <dir name="Classes">
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassNameStandard.xml" role="php" />
@@ -283,6 +284,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ArrayIndentSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowLongArraySyntaxSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="NoSpaceAfterArrayKeywordSniff.php" role="php" />
        </dir>
        <dir name="Classes">
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassNameSniff.php" role="php" />
@@ -401,6 +403,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxUnitTest.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowShortArraySyntaxUnitTest.php" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="NoSpaceAfterArrayKeywordUnitTest.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="NoSpaceAfterArrayKeywordUnitTest.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="NoSpaceAfterArrayKeywordUnitTest.php" role="test" />
        </dir>
        <dir name="Classes">
         <file baseinstalldir="PHP/CodeSniffer" name="DuplicateClassNameUnitTest.1.inc" role="test" />

--- a/src/Standards/Generic/Docs/Arrays/NoSpaceAfterArrayKeywordStandard.xml
+++ b/src/Standards/Generic/Docs/Arrays/NoSpaceAfterArrayKeywordStandard.xml
@@ -1,0 +1,23 @@
+<documentation title="No Space after array keyword">
+    <standard>
+    <![CDATA[
+    There must be no space between the "array" keyword and the opening parenthesis.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: No spaces between the array keyword and the opening parenthesis">
+        <![CDATA[
+$arr = <em>array(</em>
+    'foo' => 'bar',
+);
+        ]]>
+        </code>
+        <code title="Invalid: spaces between the array keyword and the opening parenthesis">
+        <![CDATA[
+$arr = <em>array   (</em>
+    'foo' => 'bar',
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/src/Standards/Generic/Sniffs/Arrays/NoSpaceAfterArrayKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/NoSpaceAfterArrayKeywordSniff.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Ensure there is no space after the "array" keyword
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+class NoSpaceAfterArrayKeywordSniff implements Sniff
+{
+
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [T_ARRAY];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $arrayStart = $tokens[$stackPtr]['parenthesis_opener'];
+        if (isset($tokens[$arrayStart]['parenthesis_closer']) === false) {
+            return;
+        }
+
+        if ($arrayStart !== ($stackPtr + 1)) {
+            $error = 'There must be no space between the "array" keyword and the opening parenthesis';
+
+            $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $arrayStart, true);
+            if (isset(Tokens::$commentTokens[$tokens[$next]['code']]) === true) {
+                // We don't have anywhere to put the comment, so don't attempt to fix it.
+                $phpcsFile->addError($error, $stackPtr, 'SpaceAfterKeyword');
+            } else {
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterKeyword');
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($stackPtr + 1); $i < $arrayStart; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/Generic/Tests/Arrays/NoSpaceAfterArrayKeywordUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/NoSpaceAfterArrayKeywordUnitTest.inc
@@ -1,0 +1,8 @@
+<?php
+
+$var = array(1,2,3);
+$var = array (1,2,3);
+$var = array
+(1,2,3);
+$var = array //comment
+(1,2,3);

--- a/src/Standards/Generic/Tests/Arrays/NoSpaceAfterArrayKeywordUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/NoSpaceAfterArrayKeywordUnitTest.inc.fixed
@@ -1,0 +1,7 @@
+<?php
+
+$var = array(1,2,3);
+$var = array(1,2,3);
+$var = array(1,2,3);
+$var = array //comment
+(1,2,3);

--- a/src/Standards/Generic/Tests/Arrays/NoSpaceAfterArrayKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/NoSpaceAfterArrayKeywordUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Unit test class for the NoSpaceAfterArrayKeyword sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Generic\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class NoSpaceAfterArrayKeywordUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getErrorList()
+    {
+        return [
+            4 => 1,
+            5 => 1,
+            7 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    public function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
Trying to fix the issue #582 by splitting the check made by the Squizz.Arrays.ArrayDeclarationSniff.

The LowerCaseKeyword rule is already check by another sniff.