### PR TITLE
Return int|false instead of int|bool

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2115,7 +2115,7 @@ class File
      *                                  will not be checked. IE. checking will stop
      *                                  at the previous semi-colon found.
      *
-     * @return int|bool
+     * @return int|false
      * @see    findNext()
      */
     public function findPrevious(
@@ -2196,7 +2196,7 @@ class File
      *                                  will not be checked. i.e., checking will stop
      *                                  at the next semi-colon found.
      *
-     * @return int|bool
+     * @return int|false
      * @see    findPrevious()
      */
     public function findNext(
@@ -2404,7 +2404,7 @@ class File
      *                                  If value is omitted, tokens with any value will
      *                                  be returned.
      *
-     * @return int|bool
+     * @return int|false
      */
     public function findFirstOnLine($types, $start, $exclude=false, $value=null)
     {
@@ -2491,7 +2491,7 @@ class File
      * @param int        $stackPtr The position of the token we are checking.
      * @param int|string $type     The type of token to search for.
      *
-     * @return int
+     * @return int|false
      */
     public function getCondition($stackPtr, $type)
     {

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -208,7 +208,7 @@ class SwitchDeclarationSniff implements Sniff
      * @param int                         $stackPtr  The position to start looking at.
      * @param int                         $end       The position to stop looking at.
      *
-     * @return int|bool
+     * @return int|false
      */
     private function findNextCase($phpcsFile, $stackPtr, $end)
     {

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -626,7 +626,7 @@ final class Tokens
      * @param array<int|string> $tokens The token types to get the highest weighted
      *                                  type for.
      *
-     * @return int The highest weighted token.
+     * @return int|false The highest weighted token.
      */
     public static function getHighestWeightedToken(array $tokens)
     {


### PR DESCRIPTION
I'm integrating [Psalm](https://psalm.dev/) into my custom standard, and code like this:

```php
// Find the position of each EOL sequence.
while (($pos = $phpcsFile->findNext(T_WHITESPACE, $start, null, false, $phpcsFile->eolChar))) {
    // Count the number of EOL sequences directly following the current token.
    $innerStart = ($pos + 1);
```

... is an issue, because `findNext` is documented to return `int|bool`, when in fact it returns `int|false`. The `while` loop removes `false` from the type, so `$pos` is then `int|true` when it should be just `int`, and adding `1` to a variable that is possibly `true` is a problem.

I decided to fix all cases of `int|bool` that I could find where the method only returns `false` and not `true`. There were also two cases where `bool` wasn't even included in the return type, which I've fixed.