### PR TITLE
PHP4-style typed properties not tokenized correctly

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1152,6 +1152,7 @@ class PHP extends Tokenizer
                     if ($tokenType === T_FUNCTION
                         || $tokenType === T_FN
                         || isset(Util\Tokens::$methodPrefixes[$tokenType]) === true
+                        || $tokenType === T_VAR
                     ) {
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
                             echo "\t\t* token $stackPtr changed from ? to T_NULLABLE".PHP_EOL;

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -6,7 +6,7 @@ class TestMemberProperties
     var $varA = true;
 
     /* testVarType */
-    var int $varA = true;
+    var ?int $varA = true;
 
     /* testPublic */
     public $varB = true;
@@ -30,7 +30,7 @@ class TestMemberProperties
     static $varE = true;
 
     /* testStaticType */
-    static string $varE = true;
+    static ?string $varE = true;
 
     /* testStaticVar */
     static var $varF = true;

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -61,8 +61,8 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
-                    'type'            => 'int',
-                    'nullable_type'   => false,
+                    'type'            => '?int',
+                    'nullable_type'   => true,
                 ],
             ],
             [
@@ -141,8 +141,8 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => true,
-                    'type'            => 'string',
-                    'nullable_type'   => false,
+                    'type'            => '?string',
+                    'nullable_type'   => true,
                 ],
             ],
             [


### PR DESCRIPTION
Typed properties are explicitly also supported for PHP 4-style properties using just the `var` or `static` keyword.

However, in that case, the nullable indicator `?` was not converted from `T_INLINE_THEN` to `T_NULLABLE`.

Fixed now.

Includes unit tests via the `File::getMemberProperties()` method.

Ref: https://wiki.php.net/rfc/typed_properties_v2