### PR TITLE
docs(File): Fix data type of token types that can also be string

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2243,8 +2243,8 @@ class File
     /**
      * Returns the position of the first non-whitespace token in a statement.
      *
-     * @param int       $start  The position to start searching from in the token stack.
-     * @param int|array $ignore Token types that should not be considered stop points.
+     * @param int              $start  The position to start searching from in the token stack.
+     * @param int|string|array $ignore Token types that should not be considered stop points.
      *
      * @return int
      */
@@ -2306,8 +2306,8 @@ class File
     /**
      * Returns the position of the last non-whitespace token in a statement.
      *
-     * @param int       $start  The position to start searching from in the token stack.
-     * @param int|array $ignore Token types that should not be considered stop points.
+     * @param int              $start  The position to start searching from in the token stack.
+     * @param int|string|array $ignore Token types that should not be considered stop points.
      *
      * @return int
      */


### PR DESCRIPTION
PHPStan error report in Coder:
```
Parameter #2 $ignore of method PHP_CodeSniffer\Files\File::findStartOfStatement() expects array|int|null, string given.
```
But token types can also be strings, let's fix the data types in the doc blocks here.