### PR TITLE
[PEAR.Commenting.FunctionComment] Add option to disable the check for protected/private function

### DIFF
--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -53,10 +53,10 @@ class FunctionCommentSniff implements Sniff
         $ignore   = Tokens::$emptyTokens;
         $ignore[] = T_STATIC;
 
-        $scopeModifier = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
-        if ($tokens[$scopeModifier]['code'] === T_PROTECTED
+        $scopeModifier = $phpcsFile->getMethodProperties($stackPtr)['scope'];
+        if ($scopeModifier === 'protected'
             && $this->minimumVisibility === 'public'
-            || $tokens[$scopeModifier]['code'] === T_PRIVATE
+            || $scopeModifier === 'private'
             && ($this->minimumVisibility === 'public' || $this->minimumVisibility === 'protected')
         ) {
             return;

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -381,3 +381,20 @@ public function setTranslator($a, &$b): void
 {
     $this->translator = $translator;
 }
+
+// phpcs:set PEAR.Commenting.FunctionComment minimumVisibility protected
+private function setTranslator2($a, &$b): void
+{
+    $this->translator = $translator;
+}
+
+// phpcs:set PEAR.Commenting.FunctionComment minimumVisibility public
+protected function setTranslator3($a, &$b): void
+{
+    $this->translator = $translator;
+}
+
+private function setTranslator4($a, &$b): void
+{
+    $this->translator = $translator;
+}

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -381,3 +381,20 @@ public function setTranslator($a, &$b): void
 {
     $this->translator = $translator;
 }
+
+// phpcs:set PEAR.Commenting.FunctionComment minimumVisibility protected
+private function setTranslator2($a, &$b): void
+{
+    $this->translator = $translator;
+}
+
+// phpcs:set PEAR.Commenting.FunctionComment minimumVisibility public
+protected function setTranslator3($a, &$b): void
+{
+    $this->translator = $translator;
+}
+
+private function setTranslator4($a, &$b): void
+{
+    $this->translator = $translator;
+}


### PR DESCRIPTION
Close https://github.com/squizlabs/PHP_CodeSniffer/issues/2077