### PR TITLE
docs(LineLength): Method does not return anything, so return type is void

### DIFF
--- a/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineLengthSniff.php
@@ -92,7 +92,7 @@ class LineLengthSniff implements Sniff
      * @param array                       $tokens    The token stack.
      * @param int                         $stackPtr  The first token on the next line.
      *
-     * @return null|false
+     * @return void
      */
     protected function checkLineLength($phpcsFile, $tokens, $stackPtr)
     {


### PR DESCRIPTION
I'm overriding this method in Coder and then PHPStan complains that the return type is not correct. Should be void.