### PR TITLE
NullableTypeDeclaration: fix CLI documentation

### DIFF
--- a/src/Standards/PSR12/Docs/Functions/NullableTypeDeclarationStandard.xml
+++ b/src/Standards/PSR12/Docs/Functions/NullableTypeDeclarationStandard.xml
@@ -7,21 +7,34 @@
     <code_comparison>
         <code title="Valid: no whitespace used.">
             <![CDATA[
-public function functionName(?string $arg1, ?int $arg2): ?string
-{
+public function functionName(
+    ?string $arg1,
+    ?int $arg2
+): ?string {
 }
         ]]>
         </code>
         <code title="Invalid: superfluous whitespace used.">
         <![CDATA[
-public function functionName(? string $arg1, ? int $arg2): ? string
+public function functionName(
+    ? string $arg1,
+    ? int $arg2
+): ? string {
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: no unexpected characters.">
+            <![CDATA[
+public function foo(?int $arg): ?string
 {
 }
         ]]>
         </code>
         <code title="Invalid: unexpected characters used.">
             <![CDATA[
-public function functionName(? /* nullable for a reason */ string $arg1): ?
+public function bar(? /* comment */ int $arg): ?
     // nullable for a reason
     string
 {


### PR DESCRIPTION
* The line length of the code samples was too long.
* The second code sample would not be shown as it was not accompanied by a `valid` case, nor wrapped in its own `code_comparison` block.

#### Was:
![image](https://user-images.githubusercontent.com/663378/73148211-62de0180-40bb-11ea-8c78-f71a4613ceb7.png)

#### Fixed to:
![image](https://user-images.githubusercontent.com/663378/73148225-7721fe80-40bb-11ea-8555-994cdb82dfac.png)
