### PR TITLE
Tokenizer does not support alternative syntax for declare statements

### DIFF
--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -151,6 +151,12 @@ class SideEffectsSniff implements Sniff
             ) {
                 if (isset($tokens[$i]['scope_opener']) === true) {
                     $i = $tokens[$i]['scope_closer'];
+                    if ($tokens[$i]['code'] === T_ENDDECLARE) {
+                        $semicolon = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                        if ($semicolon !== false && $tokens[$semicolon]['code'] === T_SEMICOLON) {
+                            $i = $semicolon;
+                        }
+                    }
                 } else {
                     $semicolon = $phpcsFile->findNext(T_SEMICOLON, ($i + 1));
                     if ($semicolon !== false) {

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.1.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.1.inc
@@ -10,8 +10,12 @@ use SomethingElse;
 declare(ticks=1);
 
 declare(ticks=1) {
-    // Code.
+    echo $i;
 }
+
+declare(ticks=1) :
+    echo $i;
+enddeclare;
 
 define("MAXSIZE", 100);
 if (defined('MINSIZE') === false) {

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -160,8 +160,14 @@ class PHP extends Tokenizer
             'with'   => [],
         ],
         T_DECLARE       => [
-            'start'  => [T_OPEN_CURLY_BRACKET => T_OPEN_CURLY_BRACKET],
-            'end'    => [T_CLOSE_CURLY_BRACKET => T_CLOSE_CURLY_BRACKET],
+            'start'  => [
+                T_OPEN_CURLY_BRACKET => T_OPEN_CURLY_BRACKET,
+                T_COLON              => T_COLON,
+            ],
+            'end'    => [
+                T_CLOSE_CURLY_BRACKET => T_CLOSE_CURLY_BRACKET,
+                T_ENDDECLARE          => T_ENDDECLARE,
+            ],
             'strict' => false,
             'shared' => false,
             'with'   => [],


### PR DESCRIPTION
The `declare` language construct can also use the alternative control structure syntax, but in that case would not get assigned `scope_opener` or `scope_closer` indexes.

This fixes that.

Includes unit test via the `PSR1.Files.SideEffects` sniff, which also needed as small tweak to disregard the semicolon after the `enddeclare`.