### PR TITLE
Fix path

### DIFF
--- a/tests/Core/Ruleset/RuleInclusionTest.xml
+++ b/tests/Core/Ruleset/RuleInclusionTest.xml
@@ -31,7 +31,7 @@
 	    </properties>
 	</rule>
 
-	<rule ref="./../PHP_CodeSniffer/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php">
+	<rule ref="./src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php">
 	    <properties>
 	        <property name="strict" value="false" />
 	    </properties>


### PR DESCRIPTION
Consistency with others, (and `PHP_CodeSniffer` directory may have different name, e.g. PHP_CodeSniffer-3.5.4 from pear Archive)