### PR TITLE
Allow to force PHP_CODESNIFFER_PEAR from env

### DIFF
--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -9,7 +9,7 @@
 
 namespace PHP_CodeSniffer\Tests;
 
-$GLOBALS['PHP_CODESNIFFER_PEAR'] = false;
+$GLOBALS['PHP_CODESNIFFER_PEAR'] = (getenv("PHP_CODESNIFFER_PEAR") ? true : false);
 
 if (is_file(__DIR__.'/../autoload.php') === true) {
     include_once 'Core/AllTests.php';


### PR DESCRIPTION
Needed when test suite run from pear archive (not from pear installation tree)