### PR TITLE
Undefined variable error when using Info report

### DIFF
--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -116,7 +116,9 @@ class Info implements Report
 
                 // Length of the total string, plus however many
                 // thousands separators there are.
-                $countWidth = (strlen($totalCount) + floor($countWidth / 3));
+                $countWidth       = strlen($totalCount);
+                $nrOfThousandSeps = floor($countWidth / 3);
+                $countWidth      += $nrOfThousandSeps;
 
                 // Account for 'total' line.
                 $valueWidth = max(5, $valueWidth);


### PR DESCRIPTION
This partially reverts the change made to this particular file in e9ebf5253a3e6dd3cc4b584ce54b1f4c34fcb1f3

The `floor( $countWidth / 3)` was causing an _undefined variable_ notice as the original definition of the variable was removed.