### PR TITLE
Tokenizer arrow functions backfill tests: fix it ;-)

### DIFF
--- a/tests/Core/Tokenizer/BackfillFnTokenTest.inc
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.inc
@@ -74,7 +74,7 @@ fn(array $a) : array => $a;
 $fn = fn($a) => $a ? /* testTernaryThen */ fn() : string => 'a' : /* testTernaryElse */ fn() : string => 'b';
 
 /* testConstantDeclaration */
-const fn = 'a';
+const FN = 'a';
 
 class Foo {
     /* testStaticMethodName */
@@ -91,27 +91,21 @@ class Foo {
 
 $anon = new class() {
     /* testAnonClassMethodName */
-    protected function fn($param) {
+    protected function fN($param) {
     }
 }
 
 /* testNonArrowStaticMethodCall */
 $a = Foo::fn($param);
 
-/* testNonArrowStaticMethodCallWithChaining */
-$a = Foo::fn($param)->another();
-
-/* testNonArrowStaticConstant */
-$a = MyClass::fn;
-
-/* testNonArrowStaticConstantDeref */
-$a = MyClass::fn[$a];
+/* testNonArrowConstantAccess */
+$a = MyClass::FN;
 
 /* testNonArrowObjectMethodCall */
 $a = $obj->fn($param);
 
 /* testNonArrowNamespacedFunctionCall */
-$a = MyNS\Sub\fn($param);
+$a = MyNS\Sub\Fn($param);
 
 /* testNonArrowNamespaceOperatorFunctionCall */
 $a = namespace\fn($param);

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -562,18 +562,19 @@ class BackfillFnTokenTest extends AbstractMethodUnitTest
      * Verify that "fn" keywords which are not arrow functions get tokenized as T_STRING and don't
      * have the extra token array indexes.
      *
-     * @param string $testMarker The comment prefacing the target token.
+     * @param string $testMarker  The comment prefacing the target token.
+     * @param string $testContent The token content to look for.
      *
      * @dataProvider dataNotAnArrowFunction
      * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
      *
      * @return void
      */
-    public function testNotAnArrowFunction($testMarker)
+    public function testNotAnArrowFunction($testMarker, $testContent='fn')
     {
         $tokens = self::$phpcsFile->getTokens();
 
-        $token      = $this->getTargetToken($testMarker, [T_STRING, T_FN], 'fn');
+        $token      = $this->getTargetToken($testMarker, [T_STRING, T_FN], $testContent);
         $tokenArray = $tokens[$token];
 
         $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING');
@@ -598,16 +599,27 @@ class BackfillFnTokenTest extends AbstractMethodUnitTest
     public function dataNotAnArrowFunction()
     {
         return [
-            ['/* testConstantDeclaration */'],
             ['/* testFunctionName */'],
+            [
+                '/* testConstantDeclaration */',
+                'FN',
+            ],
             ['/* testStaticMethodName */'],
-            ['/* testAnonClassMethodName */'],
+            ['/* testPropertyAssignment */'],
+            [
+                '/* testAnonClassMethodName */',
+                'fN',
+            ],
             ['/* testNonArrowStaticMethodCall */'],
-            ['/* testNonArrowStaticMethodCallWithChaining */'],
-            ['/* testNonArrowStaticConstant */'],
-            ['/* testNonArrowStaticConstantDeref */'],
+            [
+                '/* testNonArrowConstantAccess */',
+                'FN',
+            ],
             ['/* testNonArrowObjectMethodCall */'],
-            ['/* testNonArrowNamespacedFunctionCall */'],
+            [
+                '/* testNonArrowNamespacedFunctionCall */',
+                'Fn',
+            ],
             ['/* testNonArrowNamespaceOperatorFunctionCall */'],
             ['/* testLiveCoding */'],
         ];


### PR DESCRIPTION
Follow up on #2860. This fixes the tests.

#### Test case file:
* Adds tests with mixed case `fn` keyword.
* Removes a few redundant tests (weren't testing anything which wasn't covered already).

#### Test file:
* Adds a couple of tests which were missing from the data provider.
* Updates the test itself to use a `$testContent` parameter to allow for the `fn` in the tests being non-lowercase.