### PR TITLE
FindEndOfStatementTest: simplify the tests

### DIFF
--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -22,11 +22,10 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testSimpleAssignment()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSimpleAssignment */') + 2);
+        $start = $this->getTargetToken('/* testSimpleAssignment */', T_VARIABLE);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 5)], $tokens[$found]);
+        $this->assertSame(($start + 5), $found);
 
     }//end testSimpleAssignment()
 
@@ -38,11 +37,10 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testControlStructure()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testControlStructure */') + 2);
+        $start = $this->getTargetToken('/* testControlStructure */', T_WHILE);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 6)], $tokens[$found]);
+        $this->assertSame(($start + 6), $found);
 
     }//end testControlStructure()
 
@@ -54,11 +52,10 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testClosureAssignment()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testClosureAssignment */') + 2);
+        $start = $this->getTargetToken('/* testClosureAssignment */', T_VARIABLE, '$a');
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 13)], $tokens[$found]);
+        $this->assertSame(($start + 13), $found);
 
     }//end testClosureAssignment()
 
@@ -71,25 +68,22 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     public function testHeredocFunctionArg()
     {
         // Find the end of the function.
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testHeredocFunctionArg */') + 2);
+        $start = $this->getTargetToken('/* testHeredocFunctionArg */', T_STRING, 'myFunction');
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 10)], $tokens[$found]);
+        $this->assertSame(($start + 10), $found);
 
         // Find the end of the heredoc.
         $start += 2;
         $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 4)], $tokens[$found]);
+        $this->assertSame(($start + 4), $found);
 
         // Find the end of the last arg.
         $start = ($found + 2);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[$start], $tokens[$found]);
+        $this->assertSame($start, $found);
 
     }//end testHeredocFunctionArg()
 
@@ -102,25 +96,22 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     public function testSwitch()
     {
         // Find the end of the switch.
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSwitch */') + 2);
+        $start = $this->getTargetToken('/* testSwitch */', T_SWITCH);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 28)], $tokens[$found]);
+        $this->assertSame(($start + 28), $found);
 
         // Find the end of the case.
         $start += 9;
         $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 8)], $tokens[$found]);
+        $this->assertSame(($start + 8), $found);
 
         // Find the end of default case.
         $start += 11;
         $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 6)], $tokens[$found]);
+        $this->assertSame(($start + 6), $found);
 
     }//end testSwitch()
 
@@ -133,25 +124,22 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     public function testStatementAsArrayValue()
     {
         // Test short array syntax.
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStatementAsArrayValue */') + 7);
+        $start = $this->getTargetToken('/* testStatementAsArrayValue */', T_NEW);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 2)], $tokens[$found]);
+        $this->assertSame(($start + 2), $found);
 
         // Test long array syntax.
         $start += 12;
         $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 2)], $tokens[$found]);
+        $this->assertSame(($start + 2), $found);
 
         // Test same statement outside of array.
         $start += 10;
         $found  = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 3)], $tokens[$found]);
+        $this->assertSame(($start + 3), $found);
 
     }//end testStatementAsArrayValue()
 
@@ -163,27 +151,25 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testUseGroup()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testUseGroup */') + 2);
+        $start = $this->getTargetToken('/* testUseGroup */', T_USE);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 23)], $tokens[$found]);
+        $this->assertSame(($start + 23), $found);
 
     }//end testUseGroup()
 
 
     /**
-     * Test a use group.
+     * Test arrow function as array value.
      *
      * @return void
      */
     public function testArrowFunctionArrayValue()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionArrayValue */') + 7);
+        $start = $this->getTargetToken('/* testArrowFunctionArrayValue */', T_FN);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 9)], $tokens[$found]);
+        $this->assertSame(($start + 9), $found);
 
     }//end testArrowFunctionArrayValue()
 
@@ -195,8 +181,8 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testStaticArrowFunction()
     {
-        $static = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStaticArrowFunction */') + 2);
-        $fn     = self::$phpcsFile->findNext(T_FN, ($static + 1));
+        $static = $this->getTargetToken('/* testStaticArrowFunction */', T_STATIC);
+        $fn     = $this->getTargetToken('/* testStaticArrowFunction */', T_FN);
 
         $endOfStatementStatic = self::$phpcsFile->findEndOfStatement($static);
         $endOfStatementFn     = self::$phpcsFile->findEndOfStatement($fn);
@@ -213,11 +199,10 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testArrowFunctionReturnValue()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionReturnValue */') + 2);
+        $start = $this->getTargetToken('/* testArrowFunctionReturnValue */', T_FN);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 18)], $tokens[$found]);
+        $this->assertSame(($start + 18), $found);
 
     }//end testArrowFunctionReturnValue()
 
@@ -229,11 +214,10 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testArrowFunctionAsArgument()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionAsArgument */') + 10);
+        $start = $this->getTargetToken('/* testArrowFunctionAsArgument */', T_FN);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 8)], $tokens[$found]);
+        $this->assertSame(($start + 8), $found);
 
     }//end testArrowFunctionAsArgument()
 
@@ -245,11 +229,10 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
      */
     public function testArrowFunctionWithArrayAsArgument()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionWithArrayAsArgument */') + 10);
+        $start = $this->getTargetToken('/* testArrowFunctionWithArrayAsArgument */', T_FN);
         $found = self::$phpcsFile->findEndOfStatement($start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 17)], $tokens[$found]);
+        $this->assertSame(($start + 17), $found);
 
     }//end testArrowFunctionWithArrayAsArgument()
 


### PR DESCRIPTION
* Use the `AbstractMethodUnitTest::getTargetToken()` method instead of doing a `findNext()` with a calculation.
    This makes the `$start` token retrieval more descriptive.
* Assert based on the token pointers, not the sub-array value.
    As for both the "expected" as well as "found" values, the token sub-array is retrieved from the same `$tokens` variable, if the token pointers are the same, the sub-arrays will be too, so doing the comparison based on the sub-array doesn't add any extra value to the test.
    Also: doing an array assertion is more expensive than doing a simple integer based assertion.
* Remove redundant calls to the `getTokens()` method.