### PR TITLE
Travis: add check to make sure that sniffs are "feature complete"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - php: 7.3
       env: PHPUNIT_INCOMPAT=1
     - php: 7.4
-      env: PHPUNIT_INCOMPAT=1
+      env: PHPUNIT_INCOMPAT=1 SNIFF_COMPLETE=1
     - php: 7.4
       env: PHPSTAN=1 PHPUNIT_INCOMPAT=1
       addons:
@@ -65,6 +65,10 @@ script:
   - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php scripts/build-phar.php; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php phpcs.phar; fi
+  - |
+    if [[ $SNIFF_COMPLETE == "1" ]]; then
+      composer global require phpcsstandards/phpcsdevtools:"^1.0" && php ~/.config/composer/vendor/bin/phpcs-check-feature-completeness -q ./src/Standards/Generic ./src/Standards/PEAR ./src/Standards/PSR1 ./src/Standards/PSR2 ./src/Standards/PSR12 ./src/Standards/Squiz ./src/Standards/Zend
+    fi
   # Validate the xml ruleset files.
   # @link http://xmlsoft.org/xmllint.html
   - if [[ $XMLLINT == "1" ]]; then xmllint --noout --schema phpcs.xsd ./src/Standards/*/ruleset.xml; fi


### PR DESCRIPTION
This is a follow-up/replacement PR for #2364.

The tooling which was previously pulled (and never merged) has been enhanced and been released in a separate package `PHPCSDevTools` and can be used both by PHPCS itself as well as by external standards.

Full details of the features this offers: https://github.com/PHPCSStandards/PHPCSDevTools#checking-whether-all-sniffs-in-a-phpcs-standard-are-feature-complete

Notes:
* This check only needs to be run on one build as the results won't change between PHP versions.
    For that reason, I've elected to add it to the fastest PHP version run to balance out the runs some more.
* The script is currently being run in `quiet` mode which will only error on missing unit tests and will not report on missing documentation.
    In "normal" mode, the build would fail as there are currently 104 sniffs without documentation in the standards being checked (excluding `MySource`).
    If/when the missing documentation files have been added, the `-q` flag should be removed and having unit tests as well as documentation should be enforced for all sniffs.
* The `MySource` standard is not checked for two reasons:
    1. The `MySource.Channels.IncludeOwnSystem` sniff is missing unit tests and would fail the build.
    2. The `MySource` standard is being removed in PHPCS 4.0 anyway, so making it feature complete is redundant.
* I've not added the tooling as a dependency to the `composer.json` file and am using a `global` install in the Travis script on purpose.
    For another feature within the package, the package `require`s PHPCS itself, so this circular dependency would be troublesome for composer.
    As the _feature complete_ script doesn't depend on PHPCS, this isn't a real issue and using a `global` install allows the script to run without problems.

---
<details>
  <summary>List of sniffs missing documentation (generated by the feature complete tool)</summary>

This is the current output of the script if the `-q` (quiet) flag would be removed. Includes the `MySource` standard.

```
PHPCSDevTools: Sniff feature completeness checker version 1.0.0                                                                
by Juliette Reinders Folmer                                                                                                    
                                                                                                                               
............................................................  60 / 244 ( 25%)                                                  
............................................................ 120 / 244 ( 49%)                                                  
............................................................ 180 / 244 ( 74%)                                                  
............................................................ 240 / 244 ( 98%)                                                  
....                                                         244 / 244 (100%)                                                  
                                                                                                                               
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php.                                  
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/CodeAnalysis/EmptyPHPStatementSniff.php.                      
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php.                               
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/Debug/ESLintSniff.php.                                        
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/Formatting/SpaceBeforeCastSniff.php.                          
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php.                              
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php.                                          
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php.                     
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/WhiteSpace/IncrementDecrementSpacingSniff.php.                
WARNING: Documentation missing for /src/Standards/Generic/Sniffs/WhiteSpace/LanguageConstructSpacingSniff.php.                 
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/CSS/BrowserSpecificStylesSniff.php.                          
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Channels/DisallowSelfActionsSniff.php.                       
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php.                          
ERROR: Unit tests missing for /src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php.                               
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php.                             
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Channels/UnusedSystemSniff.php.                              
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Commenting/FunctionCommentSniff.php.                         
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Debug/DebugCodeSniff.php.                                    
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Debug/FirebugConsoleSniff.php.                               
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Objects/AssignThisSniff.php.                                 
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Objects/CreateWidgetTypeCallbackSniff.php.                   
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Objects/DisallowNewWidgetSniff.php.                          
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/PHP/AjaxNullComparisonSniff.php.                             
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/PHP/EvalObjectFactorySniff.php.                              
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/PHP/GetRequestDataSniff.php.                                 
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/PHP/ReturnFunctionValueSniff.php.                            
WARNING: Documentation missing for /src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php.                                
WARNING: Documentation missing for /src/Standards/PSR2/Sniffs/Files/ClosingTagSniff.php.                                       
WARNING: Documentation missing for /src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php.                          
WARNING: Documentation missing for /src/Standards/PSR2/Sniffs/Methods/FunctionClosingBraceSniff.php.                           
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php.                          
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Classes/ClosingBraceSniff.php.                                  
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php.            
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php.             
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Files/DeclareStatementSniff.php.                                
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php.                                      
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Files/ImportStatementSniff.php.                                 
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php.                                         
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Functions/ReturnTypeDeclarationSniff.php.                       
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php.                         
WARNING: Documentation missing for /src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php.                                 
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/ClassDefinitionClosingBraceSpaceSniff.php.                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php.                        
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/ClassDefinitionOpeningBraceSpaceSniff.php.                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/ColonSpacingSniff.php.                                      
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/ColourDefinitionSniff.php.                                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/DisallowMultipleStyleDefinitionsSniff.php.                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/DuplicateClassDefinitionSniff.php.                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/DuplicateStyleDefinitionSniff.php.                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/EmptyClassDefinitionSniff.php.                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/EmptyStyleDefinitionSniff.php.                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/ForbiddenStylesSniff.php.                                   
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/IndentationSniff.php.                                       
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/LowercaseStyleDefinitionSniff.php.                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/MissingColonSniff.php.                                      
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/NamedColoursSniff.php.                                      
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/OpacitySniff.php.                                           
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/SemicolonSpacingSniff.php.                                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/CSS/ShorthandSizeSniff.php.                                     
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php.                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php.                                 
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Classes/DuplicatePropertySniff.php.                             
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php.                                
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php.                               
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php.                               
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php.                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/EmptyCatchCommentSniff.php.                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php.                                
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php.                            
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php.                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/LongConditionClosingCommentSniff.php.                
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php.                       
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php.                            
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php.                    
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/ControlStructures/ElseIfDeclarationSniff.php.                   
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/ControlStructures/InlineIfDeclarationSniff.php.                 
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/ControlStructures/SwitchDeclarationSniff.php.                   
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php.                                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php.                                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php.                                   
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php.                            
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php.          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationSniff.php.                         
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Functions/GlobalFunctionSniff.php.                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php.                
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/NamingConventions/ValidFunctionNameSniff.php.                   
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php.                   
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Objects/DisallowObjectStringIndexSniff.php.                     
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php.                           
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Objects/ObjectMemberCommaSniff.php.                             
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php.                     
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php.                     
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Operators/ValidLogicalOperatorsSniff.php.                       
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/CommentedOutCodeSniff.php.                                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/DisallowBooleanStatementSniff.php.                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php.                      
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/DisallowInlineIfSniff.php.                                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php.                       
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php.                      
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/DiscouragedFunctionsSniff.php.                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/EmbeddedPhpSniff.php.                                       
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/EvalSniff.php.                                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/GlobalKeywordSniff.php.                                     
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/HeredocSniff.php.                                           
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/InnerFunctionsSniff.php.                                    
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php.                             
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php.                                 
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Scope/MemberVarScopeSniff.php.                                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php.                                     
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php.                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php.                              
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php.                    
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php.                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/FunctionOpeningBraceSpaceSniff.php.                  
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/FunctionSpacingSniff.php.                            
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/LogicalOperatorSpacingSniff.php.                     
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php.                           
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php.                            
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/PropertyLabelSpacingSniff.php.                       
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php.                          
WARNING: Documentation missing for /src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php.                      
                                                                                                                               
-----------------------------------------                                                                                      
Found 1 errors and 120 warnings                                                                                                
                                                                                                                               
```
</details>

---