### PR TITLE
Generic/DeprecatedFunctions: remove redundant `method_exists()`

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -35,9 +35,6 @@ class DeprecatedFunctionsSniff extends ForbiddenFunctionsSniff
 
         foreach ($functions['internal'] as $functionName) {
             $function = new \ReflectionFunction($functionName);
-            if (method_exists($function, 'isDeprecated') === false) {
-                break;
-            }
 
             if ($function->isDeprecated() === true) {
                 $this->forbiddenFunctions[$functionName] = null;


### PR DESCRIPTION
This code snippet was introduced in ec29df437d7ce83bf63f73cdf6c4583b5ea91d8e to allow for running the sniff on HHVM, but HHVM support has been dropped in PHPCS 3.3.1.

In native PHP, the `ReflectionFunctionAbstract::isDeprecated()` method is available since PHP 5.2, so this check is redundant.

Ref: https://www.php.net/manual/en/reflectionfunctionabstract.isdeprecated.php

Loosely related to #2742