### PR TITLE
Add usage example to Generators

### DIFF
--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -104,10 +104,10 @@ abstract class Generator
      *
      * Doc generators must implement this function to produce output.
      *
-     * @param \DOMNode $doc The DOMNode object for the sniff.
-     *                      It represents the "documentation" tag in the XML
-     *                      standard file.
-     * @param string $ruleName Name of the rule for usage example.
+     * @param \DOMNode $doc      The DOMNode object for the sniff.
+     *                           It represents the "documentation"
+     *                           tag in the XML standard file.
+     * @param string   $ruleName Name of the rule for usage example.
      *
      * @return void
      * @see    generate()

--- a/src/Generators/Generator.php
+++ b/src/Generators/Generator.php
@@ -54,7 +54,7 @@ abstract class Generator
             $docFile = str_replace('Sniff.php', 'Standard.xml', $docFile);
 
             if (is_file($docFile) === true) {
-                $this->docFiles[] = $docFile;
+                $this->docFiles[array_search($className, $ruleset->sniffCodes)] = $docFile;
             }
         }
 
@@ -89,11 +89,11 @@ abstract class Generator
      */
     public function generate()
     {
-        foreach ($this->docFiles as $file) {
+        foreach ($this->docFiles as $ruleName => $file) {
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            $this->processSniff($documentation);
+            $this->processSniff($documentation, $ruleName);
         }
 
     }//end generate()
@@ -107,11 +107,12 @@ abstract class Generator
      * @param \DOMNode $doc The DOMNode object for the sniff.
      *                      It represents the "documentation" tag in the XML
      *                      standard file.
+     * @param string $ruleName Name of the rule for usage example.
      *
      * @return void
      * @see    generate()
      */
-    abstract protected function processSniff(\DOMNode $doc);
+    abstract protected function processSniff(\DOMNode $doc, $ruleName);
 
 
 }//end class

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -31,11 +31,11 @@ class HTML extends Generator
         $this->printHeader();
         $this->printToc();
 
-        foreach ($this->docFiles as $file) {
+        foreach ($this->docFiles as $ruleName => $file) {
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            $this->processSniff($documentation);
+            $this->processSniff($documentation, $ruleName);
         }
 
         $this->printFooter();
@@ -82,6 +82,11 @@ class HTML extends Generator
                         font-size: 16px;
                         font-weight: normal;
                         margin-top: 50px;
+                    }
+
+                    h3 {
+                        font-size: 15px;
+                        font-weight: normal;
                     }
 
                     .code-comparison {
@@ -185,14 +190,16 @@ class HTML extends Generator
      * @param \DOMNode $doc The DOMNode object for the sniff.
      *                      It represents the "documentation" tag in the XML
      *                      standard file.
+     * @param string $ruleName Name of the rule for usage example.
      *
      * @return void
      */
-    public function processSniff(\DOMNode $doc)
+    public function processSniff(\DOMNode $doc, $ruleName)
     {
         $title = $this->getTitle($doc);
         echo '  <a name="'.str_replace(' ', '-', $title).'" />'.PHP_EOL;
         echo "  <h2>$title</h2>".PHP_EOL;
+        echo "  <h3>Usage: <span class='code-comparison-code'>{$ruleName}</span></h3>".PHP_EOL;
 
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {

--- a/src/Generators/HTML.php
+++ b/src/Generators/HTML.php
@@ -187,10 +187,10 @@ class HTML extends Generator
     /**
      * Process the documentation for a single sniff.
      *
-     * @param \DOMNode $doc The DOMNode object for the sniff.
-     *                      It represents the "documentation" tag in the XML
-     *                      standard file.
-     * @param string $ruleName Name of the rule for usage example.
+     * @param \DOMNode $doc      The DOMNode object for the sniff.
+     *                           It represents the "documentation"
+     *                           tag in the XML standard file.
+     * @param string   $ruleName Name of the rule for usage example.
      *
      * @return void
      */

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -26,11 +26,11 @@ class Markdown extends Generator
         ob_start();
         $this->printHeader();
 
-        foreach ($this->docFiles as $file) {
+        foreach ($this->docFiles as $ruleName => $file) {
             $doc = new \DOMDocument();
             $doc->load($file);
             $documentation = $doc->getElementsByTagName('documentation')->item(0);
-            $this->processSniff($documentation);
+            $this->processSniff($documentation, $ruleName);
         }
 
         $this->printFooter();
@@ -78,13 +78,15 @@ class Markdown extends Generator
      * @param \DOMNode $doc The DOMNode object for the sniff.
      *                      It represents the "documentation" tag in the XML
      *                      standard file.
+     * @param string $ruleName Name of the rule for usage example.
      *
      * @return void
      */
-    protected function processSniff(\DOMNode $doc)
+    protected function processSniff(\DOMNode $doc, $ruleName)
     {
         $title = $this->getTitle($doc);
         echo "## $title".PHP_EOL;
+        echo "### Usage: `$ruleName`".PHP_EOL;
 
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {

--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -75,10 +75,10 @@ class Markdown extends Generator
     /**
      * Process the documentation for a single sniff.
      *
-     * @param \DOMNode $doc The DOMNode object for the sniff.
-     *                      It represents the "documentation" tag in the XML
-     *                      standard file.
-     * @param string $ruleName Name of the rule for usage example.
+     * @param \DOMNode $doc      The DOMNode object for the sniff.
+     *                           It represents the "documentation"
+     *                           tag in the XML standard file.
+     * @param string   $ruleName Name of the rule for usage example.
      *
      * @return void
      */

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -18,10 +18,10 @@ class Text extends Generator
     /**
      * Process the documentation for a single sniff.
      *
-     * @param \DOMNode $doc The DOMNode object for the sniff.
-     *                      It represents the "documentation" tag in the XML
-     *                      standard file.
-     * @param string $ruleName Name of the rule for usage example.
+     * @param \DOMNode $doc      The DOMNode object for the sniff.
+     *                           It represents the "documentation"
+     *                           tag in the XML standard file.
+     * @param string   $ruleName Name of the rule for usage example.
      *
      * @return void
      */
@@ -43,10 +43,10 @@ class Text extends Generator
     /**
      * Prints the title area for a single sniff.
      *
-     * @param \DOMNode $doc The DOMNode object for the sniff.
-     *                      It represents the "documentation" tag in the XML
-     *                      standard file.
-     * @param string $ruleName Name of the rule for usage example.
+     * @param \DOMNode $doc      The DOMNode object for the sniff.
+     *                           It represents the "documentation"
+     *                           tag in the XML standard file.
+     * @param string   $ruleName Name of the rule for usage example.
      *
      * @return void
      */
@@ -59,7 +59,7 @@ class Text extends Generator
         echo str_repeat('-', (strlen("$standard CODING STANDARD: $title") + 4));
         echo strtoupper(PHP_EOL."| $standard CODING STANDARD: $title |".PHP_EOL);
         echo str_repeat('-', (strlen("$standard CODING STANDARD: $title") + 4)).PHP_EOL;
-        echo 'Usage: ' . $ruleName;
+        echo 'Usage: '.$ruleName;
         echo PHP_EOL.PHP_EOL;
 
     }//end printTitle()

--- a/src/Generators/Text.php
+++ b/src/Generators/Text.php
@@ -21,12 +21,13 @@ class Text extends Generator
      * @param \DOMNode $doc The DOMNode object for the sniff.
      *                      It represents the "documentation" tag in the XML
      *                      standard file.
+     * @param string $ruleName Name of the rule for usage example.
      *
      * @return void
      */
-    public function processSniff(\DOMNode $doc)
+    public function processSniff(\DOMNode $doc, $ruleName)
     {
-        $this->printTitle($doc);
+        $this->printTitle($doc, $ruleName);
 
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {
@@ -45,10 +46,11 @@ class Text extends Generator
      * @param \DOMNode $doc The DOMNode object for the sniff.
      *                      It represents the "documentation" tag in the XML
      *                      standard file.
+     * @param string $ruleName Name of the rule for usage example.
      *
      * @return void
      */
-    protected function printTitle(\DOMNode $doc)
+    protected function printTitle(\DOMNode $doc, $ruleName)
     {
         $title    = $this->getTitle($doc);
         $standard = $this->ruleset->name;
@@ -56,7 +58,8 @@ class Text extends Generator
         echo PHP_EOL;
         echo str_repeat('-', (strlen("$standard CODING STANDARD: $title") + 4));
         echo strtoupper(PHP_EOL."| $standard CODING STANDARD: $title |".PHP_EOL);
-        echo str_repeat('-', (strlen("$standard CODING STANDARD: $title") + 4));
+        echo str_repeat('-', (strlen("$standard CODING STANDARD: $title") + 4)).PHP_EOL;
+        echo 'Usage: ' . $ruleName;
         echo PHP_EOL.PHP_EOL;
 
     }//end printTitle()


### PR DESCRIPTION
To make the current way of generating documentation (CLI) a little bit more useful, I've added `Usage` example to all available Generators. 

A simple change in waiting for #2880.