### PR TITLE
Add configuration to MultipleStatementAlignmentSniff for changing alignment reference

### DIFF
--- a/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -47,6 +47,23 @@ class MultipleStatementAlignmentSniff implements Sniff
      */
     public $maxPadding = 1000;
 
+    /**
+     * Controls which side of the assignment token is used for alignment
+     *
+     * The default is to use the end of the assignemnt token:
+     *
+     * $test  = 'Hello';
+     * $test .= ' World';
+     *
+     * Setting to false reverses the alignment:
+     *
+     * $test = 'Hello';
+     * $test .= 'World';
+     *
+     * @var boolean
+     */
+    public $alignAtEndOfAssignToken = true;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -253,6 +270,10 @@ class MultipleStatementAlignmentSniff implements Sniff
             // padding length if they aligned with us.
             $varEnd    = $tokens[($var + 1)]['column'];
             $assignLen = $tokens[$assign]['length'];
+            if ($this->alignAtEndOfAssignToken !== true) {
+                $assignLen = 1;
+            }
+
             if ($assign !== $stackPtr) {
                 if ($prevAssign === null) {
                     // Processing an inner block but no assignments found.

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -406,3 +406,57 @@ $foofoo   = new Foo([
 
 $i = 0;
 echo "TEST: ".($i += 1)."\n";
+
+// Valid
+$foo      = 'Hello';
+$variable = 12;
+$foo     .= ' World';
+$test     = 1;
+$test   <<= 6;
+
+// Invalid
+$foo      = 'Hello';
+$variable = 12;
+$foo      .= ' World';
+$test     = 1;
+$test     <<= 6;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment alignAtEndOfAssignToken false
+
+// Valid
+$foo      = 'Hello';
+$variable = 12;
+$foo      .= ' World';
+$test     = 1;
+$test     <<= 6;
+
+// Invalid
+$foo      = 'Hello';
+$variable = 12;
+$foo     .= ' World';
+$test     = 1;
+$test   <<= 6;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment maxPadding 8
+
+$one                = 'one';
+$varonetwo          = 'two';
+$varonetwothree     = 'three';
+$varonetwothreefour = 'four';
+
+$one       = 'one';
+$varonetwo .= 'two';
+$varonetwo = 'two';
+$varonetwo .= 'two';
+$varonetwothree     = 'three';
+$varonetwothreefour = 'four';
+
+$one         <<= 8;
+$onetwothree = 3;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment alignAtEndOfAssignToken true
+
+$one       <<= 8;
+$onetwothree = 3;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment maxPadding 1000

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -406,3 +406,57 @@ $foofoo = new Foo([
 
 $i = 0;
 echo "TEST: ".($i += 1)."\n";
+
+// Valid
+$foo      = 'Hello';
+$variable = 12;
+$foo     .= ' World';
+$test     = 1;
+$test   <<= 6;
+
+// Invalid
+$foo      = 'Hello';
+$variable = 12;
+$foo     .= ' World';
+$test     = 1;
+$test   <<= 6;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment alignAtEndOfAssignToken false
+
+// Valid
+$foo      = 'Hello';
+$variable = 12;
+$foo      .= ' World';
+$test     = 1;
+$test     <<= 6;
+
+// Invalid
+$foo      = 'Hello';
+$variable = 12;
+$foo      .= ' World';
+$test     = 1;
+$test     <<= 6;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment maxPadding 8
+
+$one       = 'one';
+$varonetwo = 'two';
+$varonetwothree     = 'three';
+$varonetwothreefour = 'four';
+
+$one       = 'one';
+$varonetwo .= 'two';
+$varonetwo = 'two';
+$varonetwo .= 'two';
+$varonetwothree     = 'three';
+$varonetwothreefour = 'four';
+
+$one <<= 8;
+$onetwothree = 3;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment alignAtEndOfAssignToken true
+
+$one       <<= 8;
+$onetwothree = 3;
+
+// phpcs:set Generic.Formatting.MultipleStatementAlignment maxPadding 1000

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -111,6 +111,13 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
                 398 => 1,
                 399 => 1,
                 401 => 1,
+                420 => 1,
+                422 => 1,
+                436 => 1,
+                438 => 1,
+                442 => 1,
+                443 => 1,
+                454 => 1,
             ];
         break;
         case 'MultipleStatementAlignmentUnitTest.js':


### PR DESCRIPTION
Hi there! First off, thanks for your work on phpcs!

This is more or less a fix the underlying issue in #1941. This PR adds a configuation option to `\PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\MultipleStatementAlignmentSniff` which shifts the reference point for alignment from the end of the assignment token to the beginning. The current behavior is, of course, the default. With this change, though, someone could add this to their config:

```xml
<rule ref="Generic.Formatting.MultipleStatementAlignment">
    <properties>
        <property name="alignAtEndOfAssignToken" value="false"/>
    </properties>
</rule>
```

phpcs would then identify this as passing the sniff:

```php
$test = 'Hello';
$test .= ' World';
```

Thanks for considering this pull request!