### PR TITLE
AbstractSniffUnitTest: bugfix - don't save config between tests

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -134,7 +134,6 @@ abstract class AbstractSniffUnitTest extends TestCase
         } else {
             $config        = new Config();
             $config->cache = false;
-            $GLOBALS['PHP_CODESNIFFER_CONFIG'] = $config;
         }
 
         $config->standards = [$standardName];


### PR DESCRIPTION
The `setCliValues()` method allows for changing the PHPCS configuration for specific test case files, but the `AbstractSniffUnitTest` does not offer a mechanism to undo those changes for subsequent tests as the instance of the `Config` class is saved and reused.

In effect, that means that any change in the `config` values is carried through to all subsequent tests unless a subsequent test specifically overrules the change again.

While setting up the config anew for each test will make the tests slightly slower, it will prevent this "bleed through" of config values between tests.

I've left the check for the global variable in place in case external standards would set it themselves intentionally. At least this way, this change will not break those tests.

Alternatively a `tearDown()`-like method could be offered from the `AbstractSniffUnitTest` class to allow for resetting any config values set by tests.