### PR TITLE
AbstractSniffUnitTest: bug fix - warnings not counted in total

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -320,6 +320,17 @@ abstract class AbstractSniffUnitTest extends TestCase
                 $warningsTemp = [];
                 foreach ($warnings as $warning) {
                     $warningsTemp[] = $warning['message'].' ('.$warning['source'].')';
+
+                    $source = $warning['source'];
+                    if (in_array($source, $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES'], true) === false) {
+                        $GLOBALS['PHP_CODESNIFFER_SNIFF_CODES'][] = $source;
+                    }
+
+                    if ($warning['fixable'] === true
+                        && in_array($source, $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'], true) === false
+                    ) {
+                        $GLOBALS['PHP_CODESNIFFER_FIXABLE_CODES'][] = $source;
+                    }
                 }
 
                 $allProblems[$line]['found_warnings'] = array_merge($foundWarningsTemp, $warningsTemp);


### PR DESCRIPTION
At the bottom of a test run a message along the lines of `4 sniff test files generated 2 unique error codes; 0 were fixable (0%)` is shown.

The unique error codes, as well as the fixable count and percentage would only include `error` codes and would totally disregard the codes coming from `warning`s.

Fixed now.