### PR TITLE
PHP tokenizer: add missing verbose message

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1931,6 +1931,12 @@ class PHP extends Tokenizer
 
                 // If after all that, the extra tokens are not set, this is not an arrow function.
                 if (isset($this->tokens[$i]['scope_closer']) === false) {
+                    if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                        $line    = $this->tokens[$i]['line'];
+                        $oldCode = $this->tokens[$i]['code'];
+                        echo "\t\t* token $i on line $line changed from $oldCode to T_STRING: not an arrow function after all".PHP_EOL;
+                    }
+
                     $this->tokens[$i]['code'] = T_STRING;
                     $this->tokens[$i]['type'] = 'T_STRING';
                 }


### PR DESCRIPTION
PR #2860 made a change to the tokenizer which changes the token type of an `fn` keyword (back) to `T_STRING` if it turns out not to be an arrow function.

That change did not include a verbose message for tokenizer debugging. Fixed now.