### PR TITLE
Generic/ArbitraryParenthesesSpacing: minor clean up

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -58,7 +58,6 @@ class ArbitraryParenthesesSpacingSniff implements Sniff
         $this->ignoreTokens[T_CLOSE_SHORT_ARRAY]    = T_CLOSE_SHORT_ARRAY;
 
         $this->ignoreTokens[T_USE]        = T_USE;
-        $this->ignoreTokens[T_DECLARE]    = T_DECLARE;
         $this->ignoreTokens[T_THROW]      = T_THROW;
         $this->ignoreTokens[T_YIELD]      = T_YIELD;
         $this->ignoreTokens[T_YIELD_FROM] = T_YIELD_FROM;


### PR DESCRIPTION
As `declare()` is recognized as a parentheses owner, there is no need for it to be listed in the "additional tokens indicating that parenthesis are not arbitrary" list.

Tested via an existing test: https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc#L29