### PR TITLE
Fix intersection type annotations

### DIFF
--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Util\Tokens;
 
 class FunctionCommentSniff implements Sniff
 {
-
+    const PARAMS_REGEX = '/((?:(?![$.]|&(?=\$)).)*)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/';
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -217,7 +217,7 @@ class FunctionCommentSniff implements Sniff
 
             if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
                 $matches = [];
-                preg_match('/((?:(?![$.]|&(?=\$)).)*)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
+                preg_match(self::PARAMS_REGEX, $tokens[($tag + 2)]['content'], $matches);
 
                 if (empty($matches) === false) {
                     $typeLen   = strlen($matches[1]);

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -280,7 +280,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
             $commentLines = [];
             if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
                 $matches = [];
-                preg_match('/([^$&.]+)(?:((?:\.\.\.)?(?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
+                preg_match(self::PARAMS_REGEX, $tokens[($tag + 2)]['content'], $matches);
 
                 if (empty($matches) === false) {
                     $typeLen   = strlen($matches[1]);

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1000,3 +1000,14 @@ public function foo(object $a, ?object $b) {}
  * @return void
  */
 function foo($foo) {}
+
+/**
+ * @param (Foo&Bar)|null $a Comment.
+ * @param string         $b Comment.
+ *
+ * @return void
+ */
+public function setTranslator($a, &$b): void
+{
+    $this->translator = $translator;
+}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1000,3 +1000,14 @@ public function foo(object $a, ?object $b) {}
  * @return void
  */
 function foo($foo) {}
+
+/**
+ * @param (Foo&Bar)|null $a Comment.
+ * @param string         $b Comment.
+ *
+ * @return void
+ */
+public function setTranslator($a, &$b): void
+{
+    $this->translator = $translator;
+}


### PR DESCRIPTION
This PR fixes intersection type annotations for `Squiz.Commenting.FunctionComment`.

Fixes  #2887, #2806