### PR TITLE
Removing Waning caused by "continue 2"

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1464,7 +1464,7 @@ class File
                 // If it's null, then there must be no parameters for this
                 // method.
                 if ($currVar === null) {
-                    continue 2;
+                    break;
                 }
 
                 $vars[$paramCount]            = [];


### PR DESCRIPTION
I was installed the codesniffer, then i run the command to validate my classes his warning about this:

PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /home/gabriel/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/File.php on line 1763
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /home/gabriel/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/File.php on line 2723