### PR TITLE
File::getMethodProperties(): allow for return type "static"

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1629,6 +1629,7 @@ class File
                 T_CALLABLE     => T_CALLABLE,
                 T_SELF         => T_SELF,
                 T_PARENT       => T_PARENT,
+                T_STATIC       => T_STATIC,
                 T_NS_SEPARATOR => T_NS_SEPARATOR,
             ];
 

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -66,3 +66,10 @@ $result = array_map(
     static fn(int $number) : int => $number + 1,
     $numbers
 );
+
+class ReturnMe {
+    /* testReturnTypeStatic */
+    private function myFunction(): static {
+        return $this;
+    }
+}

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -384,6 +384,29 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test a function with return type "static".
+     *
+     * @return void
+     */
+    public function testReturnTypeStatic()
+    {
+        $expected = [
+            'scope'                => 'private',
+            'scope_specified'      => true,
+            'return_type'          => 'static',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testReturnTypeStatic()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.


### PR DESCRIPTION
As of PHP 8.0, `static` will be allowed as a return type.

Ref: https://wiki.php.net/rfc/static_return_type

This commit adjusts the `File::getMethodProperties()` utility method to allow for that.

Includes unit test.