### PR TITLE
PHPCS 4.x: test against nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
             - libonig-dev
     # Nightly is PHP 8.0 since Feb 2019.
     - php: nightly
-      env: PHPUNIT_INCOMPAT=1
       addons:
         apt:
           packages:
@@ -37,15 +36,20 @@ before_install:
   - export XMLLINT_INDENT="    "
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-  - if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then composer install; fi
+  - |
+    if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+      composer install
+    else
+      // Allow installing "incompatible" PHPUnit version on PHP 8/nightly.
+      composer install --ignore-platform-reqs
+    fi
 
 before_script:
   - if [[ $CUSTOM_INI == "1" ]]; then phpenv config-add testingConfig.ini; fi
 
 script:
   - php bin/phpcs --config-set php_path php
-  # Don't run the unit tests on nightly (PHP 8.0) as there is no compatible PHPUnit version available yet.
-  - if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then vendor/bin/phpunit tests/AllTests.php; fi
+  - vendor/bin/phpunit tests/AllTests.php
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
   - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php scripts/build-phar.php; fi


### PR DESCRIPTION
In contrast to 60a91b37cb1705468439798856e5ce3e026d53f2, testing against PHP `nightly` can actually be done already, we just need to tell Composer to ignore the PHPUnit PHP requirements ;-)

Currently testing against nightly results in two failed tests:
```
1) PHP_CodeSniffer\Standards\Generic\Tests\PHP\DeprecatedFunctionsUnitTest::testSniff

[LINE 3] Expected 1 error(s) in DeprecatedFunctionsUnitTest.inc but found 0 error(s).

[LINE 4] Expected 1 error(s) in DeprecatedFunctionsUnitTest.inc but found 0 error(s).
```

Both test failures are caused by PHP 8 having removed the functions being tested, i.e. Reflection doesn't see them as deprecated anymore as the function doesn't exist anymore.