### PR TITLE
Modernize junit report

### DIFF
--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -4,7 +4,8 @@
  *
  * @author    Oleg Lobach <oleg@lobach.info>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @author    Alexander Skiba <alexander.skiba@timetac.com>
+ * @copyright 2006-2020 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -120,11 +120,30 @@ class Junit implements Report
         }
 
         $failures = ($totalErrors + $totalWarnings);
-        echo '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL;
-        echo '<testsuites name="PHP_CodeSniffer '.Config::VERSION.'" errors="0" tests="'.$tests.'" failures="'.$failures.'">'.PHP_EOL;
-        echo $cachedData;
-        echo '</testsuites>'.PHP_EOL;
 
+        $dom = new \DOMDocument();
+        $dom->formatOutput = True;
+        $dom->encoding = "UTF-8";
+        $dom->preserveWhiteSpace = False;
+
+        $testsuites = $dom->createElement("testsuites");
+        $testsuites->setAttribute("name", 'PHP_CodeSniffer '.Config::VERSION);
+        $testsuites->setAttribute("errors", 0);
+        $testsuites->setAttribute("tests", $tests);
+        $testsuites->setAttribute("failures", $failures);
+
+        $fragment = $dom->createDocumentFragment();
+        # using XML that is partially formatted in appendXML() results in
+        # dom->formatOutput ignoring the fragment during formatting
+        $fragment->appendXML($cachedData);
+
+        $testsuites->appendChild($fragment);
+        $dom->appendChild($testsuites);
+
+        # saving and loading the string forces pretty formatting
+        $tmp = $dom->saveXML();
+        $dom->loadXML($tmp);
+        echo $dom->saveXML();
     }//end generate()
 
 

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -44,20 +44,19 @@ class Junit implements Report
 
         $classname = pathinfo($report['filename'])['filename'];
 
-        # successful tests
         if (count($report['messages']) === 0) {
+            // Handle successful tests.
             $out->writeAttribute('tests', 1);
             $out->writeAttribute('failures', 0);
 
             $out->startElement('testcase');
             $out->writeAttribute('classname', $classname);
             $out->writeAttribute('file', $report['filename']);
-            # use a generic testcase name if no sniffs were triggered
+            // Use a generic testcase name if no sniffs were triggered.
             $out->writeAttribute('name', 'PHP_CodeSniffer');
             $out->endElement();
-
-        # test failures
         } else {
+            // Handle test failures.
             $failures = ($report['errors'] + $report['warnings']);
             $out->writeAttribute('tests', $failures);
             $out->writeAttribute('failures', $failures);
@@ -69,8 +68,11 @@ class Junit implements Report
                         $out->writeAttribute('classname', $classname);
                         $out->writeAttribute('file', $report['filename']);
 
-                        # add line and column to the sniff name to ensure a testcase has a unique
-                        # name even if the same sniff reports more than one violation per file
+                        /*
+                         * Add line and column to the sniff name to ensure a testcase has a unique
+                         * name even if the same sniff reports more than one violation per file.
+                         */
+
                         $out->writeAttribute('name', $error['source']." ($line:$column)");
 
                         $error['type'] = strtolower($error['type']);
@@ -84,9 +86,9 @@ class Junit implements Report
                         $out->endElement();
 
                         $out->endElement();
-                    }
-                }
-            }
+                    }//end foreach
+                }//end foreach
+            }//end foreach
         }//end if
 
         $out->endElement();
@@ -136,9 +138,9 @@ class Junit implements Report
         $failures = ($totalErrors + $totalWarnings);
 
         $dom = new \DOMDocument();
-        $dom->formatOutput = True;
-        $dom->encoding = "UTF-8";
-        $dom->preserveWhiteSpace = False;
+        $dom->formatOutput       = true;
+        $dom->encoding           = "UTF-8";
+        $dom->preserveWhiteSpace = false;
 
         $testsuites = $dom->createElement("testsuites");
         $testsuites->setAttribute("name", 'PHP_CodeSniffer '.Config::VERSION);
@@ -147,17 +149,22 @@ class Junit implements Report
         $testsuites->setAttribute("failures", $failures);
 
         $fragment = $dom->createDocumentFragment();
-        # using XML that is partially formatted in appendXML() results in
-        # dom->formatOutput ignoring the fragment during formatting
+
+        /*
+         * Using XML that is partially formatted in appendXML() results in
+         * dom->formatOutput ignoring the fragment during formatting.
+         */
+
         $fragment->appendXML($cachedData);
 
         $testsuites->appendChild($fragment);
         $dom->appendChild($testsuites);
 
-        # saving and loading the string forces pretty formatting
+        // Saving and loading the string forces pretty formatting.
         $tmp = $dom->saveXML();
         $dom->loadXML($tmp);
         echo $dom->saveXML();
+
     }//end generate()
 
 


### PR DESCRIPTION
This PR improves on the existing Junit report by implementing further attributes of the spec. I have attached samples of the output as well as examples how the results are parsed by a consumer, in this case GitLab.

- `classname` and `file` are added to `testcase` elements
- a generic "PHP_CodeSniffer" string is now used instead of the file name if all tests passed
- Indention of the generated XML is now consistent. 
---
- I have run the CS checker and fixed all issues.
- I have **not** run the phpunit test because no tests cover generating Junit reports as far as I saw.
- I have tried implementing this as a custom report before, but I could not find a way to do both print a custom report to a file AND print a builtin report to stdout at the same time, so I sent this PR (The builtin report would also end up in my `--report-file`).
---
examples:

```xml
<!--BEFORE: inconsistently indented fragment of report.xml -->

<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="PHP_CodeSniffer 3.5.4" errors="0" tests="104" failures="1">
<testsuite name="tests/unit/MiscUtilTest.php" errors="0" tests="1" failures="0">
    <testcase name="tests/unit/MiscUtilTest.php"/>
</testsuite>
[...]
```

```xml
<!-- AFTER: consistently indented fragment of report.xml -->

<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="PHP_CodeSniffer 3.5.4" errors="0" tests="104" failures="1">
  <testsuite name="tests/unit/MiscUtilTest.php" errors="0" tests="1" failures="0">
    <testcase name="tests/unit/MiscUtilTest.php"/>
  </testsuite>
[...]
```

```xml
<!-- BEFORE: all information is contained only in "name" -->
<!-- line breaks added for readability of PR -->
<testcase name="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket at tests/unit/DeploymentCommandsTest.php (44:35)">
  <failure type="error" 
           message="Space after opening parenthesis of function call prohibited"/>
</testcase>
```

```xml
<!-- AFTER: information goes into their relevant attributes -->
<!-- line breaks added for readability of PR-->
<testcase classname="DeploymentCommandsTest" 
          file="tests/unit/DeploymentCommandsTest.php" 
          name="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket (44:35)">
  <failure type="error" 
           message="Space after opening parenthesis of function call prohibited (line 44, column 35)"/>
</testcase>
```

Before:
![01-tests-tab-before](https://user-images.githubusercontent.com/259911/82130235-d5d5ca00-97c9-11ea-93e3-df2dea9d0980.png)
After: 
<img width="1273" alt="01-tests-tab-after" src="https://user-images.githubusercontent.com/259911/82130237-da9a7e00-97c9-11ea-847c-4da9f8d45247.png">
