### PR TITLE
Markdown generator does not output headings correctly

### DIFF
--- a/src/Generators/Markdown.php
+++ b/src/Generators/Markdown.php
@@ -84,7 +84,7 @@ class Markdown extends Generator
     protected function processSniff(\DOMNode $doc)
     {
         $title = $this->getTitle($doc);
-        echo "## $title".PHP_EOL;
+        echo PHP_EOL."## $title".PHP_EOL;
 
         foreach ($doc->childNodes as $node) {
             if ($node->nodeName === 'standard') {


### PR DESCRIPTION
## Before
![before](https://user-images.githubusercontent.com/218562/82675739-8bc76b00-9c45-11ea-8900-9623995643ec.png)

## After
![after](https://user-images.githubusercontent.com/218562/82675636-63d80780-9c45-11ea-8ebd-f6caa26d42f7.png)

## Tested in GitHub, GitLab, Bitbucket and PHPStorm Markdown Plugin.
