### PR TITLE
File::isReference() does not detect return by reference for closures

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1936,6 +1936,7 @@ class File
         );
 
         if ($this->tokens[$tokenBefore]['code'] === T_FUNCTION
+            || $this->tokens[$tokenBefore]['code'] === T_CLOSURE
             || $this->tokens[$tokenBefore]['code'] === T_FN
         ) {
             // Function returns a reference.

--- a/tests/Core/File/IsReferenceTest.inc
+++ b/tests/Core/File/IsReferenceTest.inc
@@ -139,3 +139,6 @@ $closure = function() use (&$var){};
 
 /* testArrowFunctionReturnByReference */
 fn&($x) => $x;
+
+/* testClosureReturnByReference */
+$closure = function &($param) use ($value) {};

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -228,6 +228,10 @@ class IsReferenceTest extends AbstractMethodUnitTest
                 '/* testArrowFunctionReturnByReference */',
                 true,
             ],
+            [
+                '/* testClosureReturnByReference */',
+                true,
+            ],
         ];
 
     }//end dataIsReference()


### PR DESCRIPTION
The `&` in a closure declared to return by reference was not recognized as a reference.

Fixed now.

Includes unit test.