### PR TITLE
Improve error message of BooleanOperatorPlacementSniff when using allowOnly

### DIFF
--- a/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
@@ -135,8 +135,18 @@ class BooleanOperatorPlacementSniff implements Sniff
             return;
         }
 
-        $error = 'Boolean operators between conditions must be at the beginning or end of the line, but not both';
-        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'FoundMixed');
+        switch ($this->allowOnly) {
+        case 'first':
+            $error = 'Boolean operators between conditions must be at the beginning of the line';
+            break;
+        case 'last':
+            $error = 'Boolean operators between conditions must be at the end of the line';
+            break;
+        default:
+            $error = 'Boolean operators between conditions must be at the beginning or end of the line, but not both';
+        }
+
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'FoundMixed');
         if ($fix === false) {
             return;
         }


### PR DESCRIPTION
When you're using `allowOnly = first`, you dont expect `'Boolean operators between conditions must be at the beginning or end of the line, but not both'` as error message because end of line is not allowed.

So I improved it.