### PR TITLE
Invalidate the cache when a different set of PHP extensions are loaded

### DIFF
--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -143,16 +143,18 @@ class Cache
         // Along with the code hash, use various settings that can affect
         // the results of a run to create a new hash. This hash will be used
         // in the cache file name.
-        $rulesetHash = md5(var_export($ruleset->ignorePatterns, true).var_export($ruleset->includePatterns, true));
-        $configData  = [
-            'phpVersion'   => PHP_VERSION_ID,
-            'tabWidth'     => $config->tabWidth,
-            'encoding'     => $config->encoding,
-            'recordErrors' => $config->recordErrors,
-            'annotations'  => $config->annotations,
-            'configData'   => Config::getAllConfigData(),
-            'codeHash'     => $codeHash,
-            'rulesetHash'  => $rulesetHash,
+        $rulesetHash       = md5(var_export($ruleset->ignorePatterns, true).var_export($ruleset->includePatterns, true));
+        $phpExtensionsHash = md5(var_export(get_loaded_extensions(), true));
+        $configData        = [
+            'phpVersion'    => PHP_VERSION_ID,
+            'phpExtensions' => $phpExtensionsHash,
+            'tabWidth'      => $config->tabWidth,
+            'encoding'      => $config->encoding,
+            'recordErrors'  => $config->recordErrors,
+            'annotations'   => $config->annotations,
+            'configData'    => Config::getAllConfigData(),
+            'codeHash'      => $codeHash,
+            'rulesetHash'   => $rulesetHash,
         ];
 
         $configString = var_export($configData, true);


### PR DESCRIPTION
#### Basic justification:
PHPCS uses the `iconv` extension, if available, to determine the length of tokens. The results of sniffs can be different if the length has changed.

#### Additional use-case:
While not in use in PHPCS itself, external standards _may_ use additional PHP extension which may or may not be loaded and can influence the results of a run.
Think: a sniff which checks the naming conventions of function/class/variable names and takes the file encoding into account. This sniff may be using the Mbstring PHP extension and the sniff could either be skipped if Mbstring is not available or fall back to a less reliable way of determining compliance with the naming conventions.

#### Solution
With the above in mind, I believe the cache should keep a hash of the loaded PHP extensions and invalidate the cache if the set of loaded extensions has changed.

As in reality, it will probably be a limited set of extensions which will ever be used in sniffs, a choice could be made to keep track of just those extensions instead of the complete list of loaded extensions.
I've decided against doing that though, as 1) this makes maintenance more fiddly as a list of "tracked extensions" would need to be maintained and 2) this may limit the imagination of sniff writers.

Invalidating the cache whenever the set of extensions loaded changes is the more stable solution.