### PR TITLE
Undefined offset in Squiz.Strings.ConcatenationSpacing during live coding

### DIFF
--- a/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -79,10 +79,14 @@ class ConcatenationSpacingSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, 'Spacing before string concat', $before);
         }
 
-        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+        if (isset($tokens[($stackPtr + 1)]) === false
+            || $tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE
+        ) {
             $after = 0;
         } else {
-            if ($tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']) {
+            if (isset($tokens[($stackPtr + 2)]) === true
+                && $tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']
+            ) {
                 $after = 'newline';
             } else {
                 $after = $tokens[($stackPtr + 1)]['length'];

--- a/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -55,6 +55,10 @@ class ConcatenationSpacingSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[($stackPtr + 2)]) === false) {
+            // Syntax error or live coding, bow out.
+            return;
+        }
 
         $ignoreBefore = false;
         $prev         = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
@@ -79,14 +83,10 @@ class ConcatenationSpacingSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, 'Spacing before string concat', $before);
         }
 
-        if (isset($tokens[($stackPtr + 1)]) === false
-            || $tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE
-        ) {
+        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
             $after = 0;
         } else {
-            if (isset($tokens[($stackPtr + 2)]) === true
-                && $tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']
-            ) {
+            if ($tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']) {
                 $after = 'newline';
             } else {
                 $after = $tokens[($stackPtr + 1)]['length'];


### PR DESCRIPTION
This can happen when PHPCS runs on a file that is currently being worked on, but not yet completed. The file might end with a dot. We can not assume there are always 2 more tokens after a dot.