### PR TITLE
Incorrect auto-fixing in Generic.ControlStructures.InlineControlStructure during live coding

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -142,8 +142,10 @@ class InlineControlStructureSniff implements Sniff
             return;
         }
 
-        if ($tokens[$nextNonEmpty]['code'] === T_COLON) {
-            // Alternative control structure.
+        if ($tokens[$nextNonEmpty]['code'] === T_OPEN_CURLY_BRACKET
+            || $tokens[$nextNonEmpty]['code'] === T_COLON
+        ) {
+            // T_CLOSE_CURLY_BRACKET missing, or alternative control structure with
             // T_END... missing. Either live coding, parse error or end
             // tag in short open tags and scan run with short_open_tag=Off.
             // Bow out completely as any further detection will be unreliable


### PR DESCRIPTION
… a bracket

While live coding, there might not only be an incomplete `if ():` at the end of a file, it might as well be an incomplete `if () {`. The most minimal example I found is `<?php if ( 1 ) { break;`. The auto-fix currently turns this into `<?php if ( 1 ) { { { { { { { { { { { { { { { { { { { { { { { { { { break;}}}}}}}}}}}}}}}}}}}}}}}}}`. 😲