### PR TITLE
Fix possible index error in NonExecutableCodeSniff

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -216,7 +216,9 @@ class NonExecutableCodeSniff implements Sniff
                 continue;
             }
 
-            if (isset($tokens[$start]['bracket_closer']) === true) {
+            if (isset($tokens[$start]['bracket_closer']) === true
+                && $tokens[$start]['code'] === T_OPEN_CURLY_BRACKET
+            ) {
                 $start = $tokens[$start]['bracket_closer'];
                 continue;
             }

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -211,7 +211,9 @@ class NonExecutableCodeSniff implements Sniff
                 break;
             }
 
-            if (isset($tokens[$start]['parenthesis_closer']) === true) {
+            if (isset($tokens[$start]['parenthesis_closer']) === true
+                && $tokens[$start]['code'] === T_OPEN_PARENTHESIS
+            ) {
                 $start = $tokens[$start]['parenthesis_closer'];
                 continue;
             }

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -211,12 +211,12 @@ class NonExecutableCodeSniff implements Sniff
                 break;
             }
 
-            if ($tokens[$start]['code'] === T_OPEN_PARENTHESIS) {
+            if (isset($tokens[$start]['parenthesis_closer']) === true) {
                 $start = $tokens[$start]['parenthesis_closer'];
                 continue;
             }
 
-            if ($tokens[$start]['code'] === T_OPEN_CURLY_BRACKET) {
+            if (isset($tokens[$start]['bracket_closer']) === true) {
                 $start = $tokens[$start]['bracket_closer'];
                 continue;
             }


### PR DESCRIPTION
I was running into this while working on another sniff. One trivial example I found to demonstrate the bug is `<?php return array_map(`. This can happen when PHPCS runs on a file I'm currently typing in, but the file is not complete yet.

~~I believe it's safe to assume the `parenthesis_closer` array key only exists on T_OPEN_PARENTHESIS tokens, and the `bracket_closer` key only on T_OPEN_CURLY_BRACKET tokens. I had a quick look at the tokenizer and I believe this is indeed the case. But I might be wrong.~~

Sorry for not providing a test. I would love to, but I'm not familiar enough with the test setup here.