### PR TITLE
Result caching: minor optimization tweak

### DIFF
--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -105,6 +105,11 @@ class Cache
                     return false;
                 }
 
+                // Skip non-php files.
+                if ($file->isFile() === true && substr($filename, -4) !== '.php') {
+                    return false;
+                }
+
                 $filePath = Common::realpath($file->getPathname());
                 if ($filePath === false) {
                     return false;

--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -95,27 +95,25 @@ class Cache
         // hash. This ensures that core PHPCS changes will also invalidate the cache.
         // Note that we ignore sniffs here, and any files that don't affect
         // the outcome of the run.
-        $di     = new \RecursiveDirectoryIterator($installDir);
+        $di     = new \RecursiveDirectoryIterator(
+            $installDir,
+            (\FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS)
+        );
         $filter = new \RecursiveCallbackFilterIterator(
             $di,
             function ($file, $key, $iterator) {
-                // Skip hidden files.
-                $filename = $file->getFilename();
-                if (substr($filename, 0, 1) === '.') {
-                    return false;
-                }
-
                 // Skip non-php files.
+                $filename = $file->getFilename();
                 if ($file->isFile() === true && substr($filename, -4) !== '.php') {
                     return false;
                 }
 
-                $filePath = Common::realpath($file->getPathname());
+                $filePath = Common::realpath($key);
                 if ($filePath === false) {
                     return false;
                 }
 
-                if (is_dir($filePath) === true
+                if ($iterator->hasChildren() === true
                     && ($filename === 'Standards'
                     || $filename === 'Exceptions'
                     || $filename === 'Reports'


### PR DESCRIPTION
While debugging #2992, I noticed that `.bak` files were being used for the "PHPCS native file hash".

As non-php files in the PHPCS directories have no effect on the actual run output, we may as well skip them from being part of the hash.