### PR TITLE
Invalidate the cache when different `--sniffs` or `--exclude` settings are being used

### DIFF
--- a/src/Util/Cache.php
+++ b/src/Util/Cache.php
@@ -150,6 +150,8 @@ class Cache
             'encoding'     => $config->encoding,
             'recordErrors' => $config->recordErrors,
             'annotations'  => $config->annotations,
+            'sniffs'       => $config->sniffs,
+            'exclude'      => $config->exclude,
             'configData'   => Config::getAllConfigData(),
             'codeHash'     => $codeHash,
             'rulesetHash'  => $rulesetHash,


### PR DESCRIPTION
Fixes #2992 

See the issue for a detailed write-up of the problem.