### PR TITLE
Tests: stabilize an expected global

### DIFF
--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -9,16 +9,13 @@
 
 namespace PHP_CodeSniffer\Tests;
 
-$GLOBALS['PHP_CODESNIFFER_PEAR'] = false;
-
-if (is_file(__DIR__.'/../autoload.php') === true) {
+if ($GLOBALS['PHP_CODESNIFFER_PEAR'] === false) {
     include_once 'Core/AllTests.php';
     include_once 'Standards/AllSniffs.php';
 } else {
     include_once 'CodeSniffer/Core/AllTests.php';
     include_once 'CodeSniffer/Standards/AllSniffs.php';
     include_once 'FileList.php';
-    $GLOBALS['PHP_CODESNIFFER_PEAR'] = true;
 }
 
 // PHPUnit 7 made the TestSuite run() method incompatible with

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,6 +44,13 @@ if (class_exists('PHPUnit_Framework_TestResult') === true && class_exists('PHPUn
     class_alias('PHPUnit_Framework_TestResult', 'PHPUnit'.'\Framework\TestResult');
 }
 
+// Determine whether this is a PEAR install or not.
+$GLOBALS['PHP_CODESNIFFER_PEAR'] = false;
+
+if (is_file(__DIR__.'/../autoload.php') === false) {
+    $GLOBALS['PHP_CODESNIFFER_PEAR'] = true;
+}
+
 
 /**
  * A global util function to help print unit test fixing data.


### PR DESCRIPTION
The global `$PHP_CODESNIFFER_PEAR` variable is used by the `Core` test and those test don't necessarily need to use the generic `AllTests` file as an entry point.
They can also be run using `phpunit ./tests/Core/AllTests.php`.

In that case, however, the `$PHP_CODESNIFFER_PEAR` variable is not defined leading to `Undefined index: PHP_CODESNIFFER_PEAR` errors.

By setting the global in the bootstrap, which is always loaded, this is avoided.