### PR TITLE
Fixed bug #3007: Directory exclude pattern improperly excludes directories with names that start the same

### DIFF
--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -218,7 +218,7 @@ class Filter extends \RecursiveFilterIterator
                     // Need to check this pattern for dirs as well as individual file paths.
                     $this->ignoreFilePatterns[$pattern] = $type;
 
-                    $pattern = substr($pattern, 0, -2);
+                    $pattern = substr($pattern, 0, -2) . '(?=/|$)';
                     $this->ignoreDirPatterns[$pattern] = $type;
                 } else {
                     // This is a file-specific pattern, so only need to check this

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -218,7 +218,7 @@ class Filter extends \RecursiveFilterIterator
                     // Need to check this pattern for dirs as well as individual file paths.
                     $this->ignoreFilePatterns[$pattern] = $type;
 
-                    $pattern = substr($pattern, 0, -2) . '(?=/|$)';
+                    $pattern = substr($pattern, 0, -2).'(?=/|$)';
                     $this->ignoreDirPatterns[$pattern] = $type;
                 } else {
                     // This is a file-specific pattern, so only need to check this

--- a/tests/Core/Filters/Filter/AcceptTest.php
+++ b/tests/Core/Filters/Filter/AcceptTest.php
@@ -111,9 +111,13 @@ class AcceptTest extends TestCase
                     '/path/to/src/Main.php',
                     '/path/to/src/Something/Main.php',
                     '/path/to/src/Somethingelse/Main.php',
+                    '/path/to/src/SomethingelseEvenLonger/Main.php',
                     '/path/to/src/Other/Main.php',
                 ],
-                ['/path/to/src/Main.php'],
+                [
+                    '/path/to/src/Main.php',
+                    '/path/to/src/SomethingelseEvenLonger/Main.php',
+                ],
             ],
 
             // Test ignoring standard/sniff specific exclude patterns.


### PR DESCRIPTION
This is a suggested fix for #3007 

To unit test this properly, you'd need to mock the `is_dir` function on [Filter.php#L237](https://github.com/squizlabs/PHP_CodeSniffer/blob/a957a73e3533353451eb9fd62ee58bd0aba2773c/src/Filters/Filter.php#L237).  Sorry, I couldn't find a neat way to do that in the time I had available.
