### PR TITLE
PHP 8.0 | File::getMethodParameters(): support mixed type and union types

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1442,6 +1442,9 @@ class File
                 }
                 break;
             case T_NS_SEPARATOR:
+            case T_BITWISE_OR:
+            case T_FALSE:
+            case T_NULL:
                 // Part of a type hint or default value.
                 if ($defaultStart === null) {
                     if ($typeHintToken === false) {

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1288,7 +1288,8 @@ class File
      *                                           // or FALSE if there is no type hint.
      *         'type_hint_end_token' => integer, // The stack pointer to the end of the type hint
      *                                           // or FALSE if there is no type hint.
-     *         'nullable_type'       => boolean, // TRUE if the var type is nullable.
+     *         'nullable_type'       => boolean, // TRUE if the type is preceded by the nullability
+     *                                           // operator.
      *         'comma_token'         => integer, // The stack pointer to the comma after the param
      *                                           // or FALSE if this is the last param.
      *        )

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -31,3 +31,10 @@ function myFunction($a = 10 & 20) {}
 
 /* testArrowFunction */
 fn(int $a, ...$b) => $b;
+
+/* testPHP8MixedTypeHint */
+function mixedTypeHint(mixed &...$var1) {}
+
+/* testPHP8MixedTypeHintNullable */
+// Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+function mixedTypeHintNullable(?Mixed $var1) {}

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -38,3 +38,47 @@ function mixedTypeHint(mixed &...$var1) {}
 /* testPHP8MixedTypeHintNullable */
 // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
 function mixedTypeHintNullable(?Mixed $var1) {}
+
+/* testPHP8UnionTypesSimple */
+function unionTypeSimple(int|float $number) {}
+
+/* testPHP8UnionTypesSimpleWithBitwiseOrInDefault */
+function unionTypeSimpleWithBitwiseOrInDefault(int|float $var = CONSTANT_A | CONSTANT_B) {}
+
+/* testPHP8UnionTypesTwoClasses */
+function unionTypesTwoClasses(MyClassA|\Package\MyClassB $var) {}
+
+/* testPHP8UnionTypesAllBaseTypes */
+function unionTypesAllBaseTypes(array|bool|callable|int|float|null|object|string $var) {}
+
+/* testPHP8UnionTypesAllPseudoTypes */
+// Intentional fatal error - mixing types which cannot be combined, but that's not the concern of the method.
+function unionTypesAllPseudoTypes(false|mixed|self|parent|iterable|Resource $var) {}
+
+/* testPHP8UnionTypesNullable */
+// Intentional fatal error - nullability is not allowed with union types, but that's not the concern of the method.
+$closure = function (?int|float $number) {};
+
+/* testPHP8PseudoTypeNull */
+// Intentional fatal error - null pseudotype is only allowed in union types, but that's not the concern of the method.
+function pseudoTypeNull(null $var = null) {}
+
+/* testPHP8PseudoTypeFalse */
+// Intentional fatal error - false pseudotype is only allowed in union types, but that's not the concern of the method.
+function pseudoTypeFalse(false $var = false) {}
+
+/* testPHP8PseudoTypeFalseAndBool */
+// Intentional fatal error - false pseudotype is not allowed in combination with bool, but that's not the concern of the method.
+function pseudoTypeFalseAndBool(bool|false $var = false) {}
+
+/* testPHP8ObjectAndClass */
+// Intentional fatal error - object is not allowed in combination with class name, but that's not the concern of the method.
+function objectAndClass(object|ClassName $var) {}
+
+/* testPHP8PseudoTypeIterableAndArray */
+// Intentional fatal error - iterable pseudotype is not allowed in combination with array or Traversable, but that's not the concern of the method.
+function pseudoTypeIterableAndArray(iterable|array|Traversable $var) {}
+
+/* testPHP8DuplicateTypeInUnion */
+// Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
+function duplicateTypeInUnion(int|string|INT $var) {}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -275,6 +275,50 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of PHP8 mixed type declaration.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => 'mixed &...$var1',
+            'pass_by_reference' => true,
+            'variable_length'   => true,
+            'type_hint'         => 'mixed',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHint()
+
+
+    /**
+     * Verify recognition of PHP8 mixed type declaration with nullability.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHintNullable()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '?Mixed $var1',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '?Mixed',
+            'nullable_type'     => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHintNullable()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -319,6 +319,276 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of PHP8 union type declaration.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesSimple()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$number',
+            'content'           => 'int|float $number',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'int|float',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesSimple()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with a bitwise or in the default value.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesSimpleWithBitwiseOrInDefault()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'int|float $var = CONSTANT_A | CONSTANT_B',
+            'default'           => 'CONSTANT_A | CONSTANT_B',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'int|float',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesSimpleWithBitwiseOrInDefault()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with two classes.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesTwoClasses()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'MyClassA|\Package\MyClassB $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'MyClassA|\Package\MyClassB',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesTwoClasses()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with all base types.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesAllBaseTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'array|bool|callable|int|float|null|object|string $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'array|bool|callable|int|float|null|object|string',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesAllBaseTypes()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with all pseudo types.
+     *
+     * Note: "Resource" is not a type, but seen as a class name.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesAllPseudoTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'false|mixed|self|parent|iterable|Resource $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'false|mixed|self|parent|iterable|Resource',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesAllPseudoTypes()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with (illegal) nullability.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesNullable()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$number',
+            'content'           => '?int|float $number',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '?int|float',
+            'nullable_type'     => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesNullable()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) single type null.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeNull()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'null $var = null',
+            'default'           => 'null',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'null',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeNull()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) single type false.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeFalse()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'false $var = false',
+            'default'           => 'false',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'false',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeFalse()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) type false combined with type bool.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeFalseAndBool()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'bool|false $var = false',
+            'default'           => 'false',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'bool|false',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeFalseAndBool()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) type object combined with a class name.
+     *
+     * @return void
+     */
+    public function testPHP8ObjectAndClass()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'object|ClassName $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'object|ClassName',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8ObjectAndClass()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) type iterable combined with array/Traversable.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeIterableAndArray()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'iterable|array|Traversable $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'iterable|array|Traversable',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeIterableAndArray()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) duplicate types.
+     *
+     * @return void
+     */
+    public function testPHP8DuplicateTypeInUnion()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'int|string|INT $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'int|string|INT',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8DuplicateTypeInUnion()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.
@@ -328,7 +598,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
      */
     private function getMethodParametersTestHelper($commentString, $expected)
     {
-        $function = $this->getTargetToken($commentString, [T_FUNCTION, T_FN]);
+        $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE, T_FN]);
         $found    = self::$phpcsFile->getMethodParameters($function);
 
         $this->assertArraySubset($expected, $found, true);


### PR DESCRIPTION
PHP 8.0 will introduce a new pseudo-type `mixed` as well as union types.

This PR adds tests for these to the `File::getMethodParameters()` method and makes minor changes to the method to allow for supporting these new type declarations.

Refs:
* https://wiki.php.net/rfc/mixed_type_v2
* https://wiki.php.net/rfc/union_types_v2

:point_right: **Important**: all sniffs using this method will need to be checked to see if they use the `type_hint` index and if so, if the check being done needs to take union types into account.

Partially addresses #2968