### PR TITLE
PHP 8.0 | File::getMethodProperties(): support mixed type and union types

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1630,7 +1630,10 @@ class File
                 T_SELF         => T_SELF,
                 T_PARENT       => T_PARENT,
                 T_STATIC       => T_STATIC,
+                T_FALSE        => T_FALSE,
+                T_NULL         => T_NULL,
                 T_NS_SEPARATOR => T_NS_SEPARATOR,
+                T_BITWISE_OR   => T_BITWISE_OR,
             ];
 
             for ($i = $this->tokens[$stackPtr]['parenthesis_closer']; $i < $this->numTokens; $i++) {

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1532,7 +1532,8 @@ class File
      *    'return_type'          => '',       // The return type of the method.
      *    'return_type_token'    => integer,  // The stack pointer to the start of the return type
      *                                        // or FALSE if there is no return type.
-     *    'nullable_return_type' => false,    // TRUE if the return type is nullable.
+     *    'nullable_return_type' => false,    // TRUE if the return type is preceded by the
+     *                                        // nullability operator.
      *    'is_abstract'          => false,    // TRUE if the abstract keyword was found.
      *    'is_final'             => false,    // TRUE if the final keyword was found.
      *    'is_static'            => false,    // TRUE if the static keyword was found.

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1315,6 +1315,7 @@ class PHP extends Tokenizer
                             T_CALLABLE     => T_CALLABLE,
                             T_SELF         => T_SELF,
                             T_PARENT       => T_PARENT,
+                            T_STATIC       => T_STATIC,
                             T_NS_SEPARATOR => T_NS_SEPARATOR,
                         ];
 
@@ -1352,9 +1353,11 @@ class PHP extends Tokenizer
                         // token that can't be part of the return type need to be
                         // converted to T_STRING tokens.
                         for ($x; $x < $numTokens; $x++) {
-                            if (is_array($tokens[$x]) === false || isset($allowed[$tokens[$x][0]]) === false) {
+                            if ((is_array($tokens[$x]) === false && $tokens[$x] !== '|')
+                                || (is_array($tokens[$x]) === true && isset($allowed[$tokens[$x][0]]) === false)
+                            ) {
                                 break;
-                            } else if ($tokens[$x][0] === T_ARRAY) {
+                            } else if (is_array($tokens[$x]) === true && $tokens[$x][0] === T_ARRAY) {
                                 $tokens[$x][0] = T_STRING;
 
                                 if (PHP_CODESNIFFER_VERBOSITY > 1) {

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -73,3 +73,10 @@ class ReturnMe {
         return $this;
     }
 }
+
+/* testPHP8MixedTypeHint */
+function mixedTypeHint() :mixed {}
+
+/* testPHP8MixedTypeHintNullable */
+// Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+function mixedTypeHintNullable(): ?mixed {}

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -80,3 +80,46 @@ function mixedTypeHint() :mixed {}
 /* testPHP8MixedTypeHintNullable */
 // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
 function mixedTypeHintNullable(): ?mixed {}
+
+/* testPHP8UnionTypesSimple */
+function unionTypeSimple($number) : int|float {}
+
+/* testPHP8UnionTypesTwoClasses */
+function unionTypesTwoClasses($var): MyClassA|\Package\MyClassB {}
+
+/* testPHP8UnionTypesAllBaseTypes */
+function unionTypesAllBaseTypes() : array|bool|callable|int|float|null|Object|string {}
+
+/* testPHP8UnionTypesAllPseudoTypes */
+// Intentional fatal error - mixing types which cannot be combined, but that's not the concern of the method.
+function unionTypesAllPseudoTypes($var) : false|MIXED|self|parent|static|iterable|Resource|void {}
+
+/* testPHP8UnionTypesNullable */
+// Intentional fatal error - nullability is not allowed with union types, but that's not the concern of the method.
+$closure = function () use($a) :?int|float {};
+
+/* testPHP8PseudoTypeNull */
+// Intentional fatal error - null pseudotype is only allowed in union types, but that's not the concern of the method.
+function pseudoTypeNull(): null {}
+
+/* testPHP8PseudoTypeFalse */
+// Intentional fatal error - false pseudotype is only allowed in union types, but that's not the concern of the method.
+function pseudoTypeFalse(): false {}
+
+/* testPHP8PseudoTypeFalseAndBool */
+// Intentional fatal error - false pseudotype is not allowed in combination with bool, but that's not the concern of the method.
+function pseudoTypeFalseAndBool(): bool|false {}
+
+/* testPHP8ObjectAndClass */
+// Intentional fatal error - object is not allowed in combination with class name, but that's not the concern of the method.
+function objectAndClass(): object|ClassName {}
+
+/* testPHP8PseudoTypeIterableAndArray */
+// Intentional fatal error - iterable pseudotype is not allowed in combination with array or Traversable, but that's not the concern of the method.
+interface FooBar {
+    public function pseudoTypeIterableAndArray(): iterable|array|Traversable;
+}
+
+/* testPHP8DuplicateTypeInUnion */
+// Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
+function duplicateTypeInUnion(): int|string|INT {}

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -407,6 +407,52 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test a function with return type "mixed".
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHint()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'mixed',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHint()
+
+
+    /**
+     * Test a function with return type "mixed" and nullability.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHintNullable()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '?mixed',
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHintNullable()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -453,6 +453,261 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of PHP8 union type declaration.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesSimple()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'int|float',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesSimple()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with two classes.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesTwoClasses()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'MyClassA|\Package\MyClassB',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesTwoClasses()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with all base types.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesAllBaseTypes()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'array|bool|callable|int|float|null|Object|string',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesAllBaseTypes()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with all pseudo types.
+     *
+     * Note: "Resource" is not a type, but seen as a class name.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesAllPseudoTypes()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'false|MIXED|self|parent|static|iterable|Resource|void',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesAllPseudoTypes()
+
+
+    /**
+     * Verify recognition of PHP8 union type declaration with (illegal) nullability.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesNullable()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '?int|float',
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesNullable()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) single type null.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeNull()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'null',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeNull()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) single type false.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeFalse()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'false',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeFalse()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) type false combined with type bool.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeFalseAndBool()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'bool|false',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeFalseAndBool()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) type object combined with a class name.
+     *
+     * @return void
+     */
+    public function testPHP8ObjectAndClass()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'object|ClassName',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8ObjectAndClass()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) type iterable combined with array/Traversable.
+     *
+     * @return void
+     */
+    public function testPHP8PseudoTypeIterableAndArray()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => true,
+            'return_type'          => 'iterable|array|Traversable',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => false,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8PseudoTypeIterableAndArray()
+
+
+    /**
+     * Verify recognition of PHP8 type declaration with (illegal) duplicate types.
+     *
+     * @return void
+     */
+    public function testPHP8DuplicateTypeInUnion()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'int|string|INT',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8DuplicateTypeInUnion()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.


### PR DESCRIPTION
PHP 8.0 will introduce a new pseudo-type `mixed` as well as union types.

This PR adds tests for these to the `File::getMethodProperties()` method and makes minor changes to the method to allow for supporting these new type declarations.

Includes a change to the PHP tokenizer to make sure that the `array` keyword in union return types is changed to `T_STRING`.

Refs:
* https://wiki.php.net/rfc/mixed_type_v2
* https://wiki.php.net/rfc/union_types_v2

:point_right: **Important**: all sniffs using this method will need to be checked to see if they use the `return_type` index and if so, if the check being done needs to take union types into account.

Partially addresses #2968