### PR TITLE
PHPCS 3.x: test against nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,13 @@ before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   # PHPUnit 8.x is not (yet) supported, so prevent issues with Travis images using it.
-  - if [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then composer install; fi
+  - |
+    if [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
+      composer install
+    elif [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      // Allow installing "incompatible" PHPUnit version on PHP 8/nightly.
+      composer install --ignore-platform-reqs
+    fi
 
 before_script:
   - if [[ $CUSTOM_INI == "1" && ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then phpenv config-add php5-testingConfig.ini; fi
@@ -56,9 +62,12 @@ before_script:
 
 script:
   - php bin/phpcs --config-set php_path php
-  - if [[ $PHPUNIT_INCOMPAT != "1" ]]; then phpunit tests/AllTests.php; fi
-  # Don't run the unit tests on nightly (PHP 8.0) as there is no compatible PHPUnit version available yet.
-  - if [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then vendor/bin/phpunit tests/AllTests.php; fi
+  - |
+    if [[ $PHPUNIT_INCOMPAT != "1" ]]; then
+      phpunit tests/AllTests.php
+    else
+      vendor/bin/phpunit tests/AllTests.php
+    fi
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
   - if [[ $CUSTOM_INI != "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then pear package-validate package.xml; fi
   - if [[ $PEAR_VALIDATE == "1" ]]; then php scripts/validate-pear-package.php; fi

--- a/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DeprecatedFunctionsUnitTest.php
@@ -27,11 +27,11 @@ class DeprecatedFunctionsUnitTest extends AbstractSniffUnitTest
     {
         $errors = [];
 
-        if (PHP_VERSION_ID >= 70200) {
+        if (PHP_VERSION_ID >= 70200 && PHP_VERSION_ID < 80000) {
             $errors[3] = 1;
         }
 
-        if (PHP_VERSION_ID >= 70300) {
+        if (PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 80000) {
             $errors[4] = 1;
         }
 


### PR DESCRIPTION
PR #2958 turned running the unit tests on for the PHPCS 4.x branch, but this wasn't done for the PHPCS 3.x branch yet.

This commit basically does the same for PHPCS 3.x. PHPUnit 7 will run on PHP 8, even though unsupported, so ignoring platform requirements when installing via Composer allows for the tests for PHPCS 3.x to run on PHP 8.

Include applying the same fix for the failing tests as was applied in the PHPCS 4.x branch.


Loosely related to PR #3009, #3010, #3011 and #3013

