### PR TITLE
Generic.CodeAnalysis.UnusedFunctionParameter: Add possibility to specify excludes

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -23,6 +23,13 @@ use PHP_CodeSniffer\Util\Tokens;
 class UnusedFunctionParameterSniff implements Sniff
 {
 
+    /**
+     * The list of class type hints which will be ignored.
+     *
+     * @var array
+     */
+    public $ignoreTypeHints = [];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -191,6 +198,10 @@ class UnusedFunctionParameterSniff implements Sniff
             // If there is only one parameter and it is unused, no need for additional errorcode toggling logic.
             if ($methodParamsCount === 1) {
                 foreach ($params as $paramName => $position) {
+                    if (in_array($methodParams[0]['type_hint'], $this->ignoreTypeHints, true) === true) {
+                        continue;
+                    }
+
                     $data = [$paramName];
                     $phpcsFile->addWarning($error, $position, $errorCode, $data);
                 }
@@ -207,6 +218,7 @@ class UnusedFunctionParameterSniff implements Sniff
                         $errorInfo[$methodParams[$i]['name']] = [
                             'position'  => $params[$methodParams[$i]['name']],
                             'errorcode' => $errorCode.'BeforeLastUsed',
+                            'typehint'  => $methodParams[$i]['type_hint'],
                         ];
                     }
                 } else {
@@ -216,14 +228,19 @@ class UnusedFunctionParameterSniff implements Sniff
                         $errorInfo[$methodParams[$i]['name']] = [
                             'position'  => $params[$methodParams[$i]['name']],
                             'errorcode' => $errorCode.'AfterLastUsed',
+                            'typehint'  => $methodParams[$i]['type_hint'],
                         ];
                     }
                 }
-            }
+            }//end for
 
             if (count($errorInfo) > 0) {
                 $errorInfo = array_reverse($errorInfo);
                 foreach ($errorInfo as $paramName => $info) {
+                    if (in_array($info['typehint'], $this->ignoreTypeHints, true) === true) {
+                        continue;
+                    }
+
                     $data = [$paramName];
                     $phpcsFile->addWarning($error, $info['position'], $info['errorcode'], $data);
                 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -123,3 +123,17 @@ function myCallback($a, $b, $c, $d) {
 }
 
 fn ($a, $b, $c) => $b;
+
+// phpcs:set Generic.CodeAnalysis.UnusedFunctionParameter ignoreTypeHints[] Exception
+
+function oneParam(Exception $foo) {
+    return 'foobar';
+}
+
+function moreParamFirst(Exception $foo, LogicException $bar) {
+    return 'foobar' . $bar;
+}
+
+function moreParamSecond(LogicException $bar, Exception $foo) {
+    return 'foobar' . $bar;
+}


### PR DESCRIPTION
Sometimes you have to implement interface but not all required parameters are needed to use. For example in symfony/console.

```php
public function execute(InputInterface $input, OutputInterface $output): int
{
    $output->writeln('Do something without using of $input');
    return 0;
}
```