### PR TITLE
PHP 8.0 | File::get[Method|Member][Parameters|Properties](): add unit test with "mixed" type

### DIFF
--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -179,3 +179,12 @@ function_call( 'param', new class {
     /* testNestedMethodParam 2 */
     public function __construct( $open, $post_id ) {}
 }, 10, 2 );
+
+class PHP8Mixed {
+    /* testPHP8MixedTypeHint */
+    public static miXed $mixed;
+
+    /* testPHP8MixedTypeHintNullable */
+    // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+    private ?mixed $nullableMixed;
+}

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -459,6 +459,26 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'nullable_type'   => false,
                 ],
             ],
+            [
+                '/* testPHP8MixedTypeHint */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => 'miXed',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPHP8MixedTypeHintNullable */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?mixed',
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
 
     }//end dataGetMemberProperties()

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -31,3 +31,10 @@ function myFunction($a = 10 & 20) {}
 
 /* testArrowFunction */
 fn(int $a, ...$b) => $b;
+
+/* testPHP8MixedTypeHint */
+function mixedTypeHint(mixed &...$var1) {}
+
+/* testPHP8MixedTypeHintNullable */
+// Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+function mixedTypeHintNullable(?Mixed $var1) {}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -275,6 +275,50 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of PHP8 mixed type declaration.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => 'mixed &...$var1',
+            'pass_by_reference' => true,
+            'variable_length'   => true,
+            'type_hint'         => 'mixed',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHint()
+
+
+    /**
+     * Verify recognition of PHP8 mixed type declaration with nullability.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHintNullable()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '?Mixed $var1',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '?Mixed',
+            'nullable_type'     => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHintNullable()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -73,3 +73,10 @@ class ReturnMe {
         return $this;
     }
 }
+
+/* testPHP8MixedTypeHint */
+function mixedTypeHint() :mixed {}
+
+/* testPHP8MixedTypeHintNullable */
+// Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+function mixedTypeHintNullable(): ?mixed {}

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -407,6 +407,52 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test a function with return type "mixed".
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHint()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'mixed',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHint()
+
+
+    /**
+     * Test a function with return type "mixed" and nullability.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHintNullable()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '?mixed',
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8MixedTypeHintNullable()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.


### PR DESCRIPTION
PHP 8.0 will introduce a new pseudo-type `mixed`.

This PR adds tests to the `Core` testsuite for the `File::getMethodParameters()`, `File::getMethodProperties()` and `File::getMemberProperties()` utility methods confirming that the `mixed` type is handled correctly by these methods without further changes.

Refs:
* https://wiki.php.net/rfc/mixed_type_v2

Partially addresses #2968

Partially replaces  PR #3009, #3010, #3011