### PR TITLE
PHP 8.0 | Tokenizer/PHP: add support for `static` return type to arrow functions

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1829,6 +1829,7 @@ class PHP extends Tokenizer
                         T_CALLABLE     => T_CALLABLE,
                         T_PARENT       => T_PARENT,
                         T_SELF         => T_SELF,
+                        T_STATIC       => T_STATIC,
                     ];
 
                     $closer = $this->tokens[$x]['parenthesis_closer'];

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.inc
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.inc
@@ -75,6 +75,9 @@ fn(callable $a) : callable => $a;
 /* testArrayReturnType */
 fn(array $a) : array => $a;
 
+/* testStaticReturnType */
+fn(array $a) : static => $a;
+
 /* testTernary */
 $fn = fn($a) => $a ? /* testTernaryThen */ fn() : string => 'a' : /* testTernaryElse */ fn() : string => 'b';
 

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -466,7 +466,7 @@ class BackfillFnTokenTest extends AbstractMethodUnitTest
 
 
     /**
-     * Test arrow functions that use self/parent/callable return types.
+     * Test arrow functions that use self/parent/callable/array/static return types.
      *
      * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional
      *
@@ -481,6 +481,7 @@ class BackfillFnTokenTest extends AbstractMethodUnitTest
             'Parent',
             'Callable',
             'Array',
+            'Static',
         ];
 
         foreach ($testMarkers as $marker) {


### PR DESCRIPTION
Follow up on #2952 which was merged for PHPCS `3.5.6` - @gsherwood with that in mind, can this PR also be earmarked for PHPCS 3.5.6 ?

Includes unit test.
