### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-sudo: false
+os: linux
+dist: xenial
 language: php
-dist: trusty
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.5
+      dist: trusty
       env: CUSTOM_INI=1 XMLLINT=1
       addons:
         apt:
@@ -19,20 +22,16 @@ matrix:
       env: CUSTOM_INI=1 PEAR_VALIDATE=1
     - php: 7.1
     - php: 7.2
-      env: PHPUNIT_INCOMPAT=1
     - php: 7.3
-      env: PHPUNIT_INCOMPAT=1
     - php: 7.4
-      env: PHPUNIT_INCOMPAT=1
     - php: 7.4
-      env: PHPSTAN=1 PHPUNIT_INCOMPAT=1
+      env: PHPSTAN=1
       addons:
         apt:
           packages:
             - libonig-dev
     # Nightly is PHP 8.0 since Feb 2019.
     - php: nightly
-      env: PHPUNIT_INCOMPAT=1
       addons:
         apt:
           packages:
@@ -40,7 +39,7 @@ matrix:
 
   allow_failures:
     - php: 7.4
-      env: PHPSTAN=1 PHPUNIT_INCOMPAT=1
+      env: PHPSTAN=1
     - php: nightly
 
 before_install:
@@ -49,9 +48,9 @@ before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   # PHPUnit 8.x is not (yet) supported, so prevent issues with Travis images using it.
   - |
-    if [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
+    if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
       composer install
-    elif [[ $PHPUNIT_INCOMPAT == "1" && $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    elif [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
       // Allow installing "incompatible" PHPUnit version on PHP 8/nightly.
       composer install --ignore-platform-reqs
     fi
@@ -62,12 +61,7 @@ before_script:
 
 script:
   - php bin/phpcs --config-set php_path php
-  - |
-    if [[ $PHPUNIT_INCOMPAT != "1" ]]; then
-      phpunit tests/AllTests.php
-    else
-      vendor/bin/phpunit tests/AllTests.php
-    fi
+  - vendor/bin/phpunit tests/AllTests.php
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
   - if [[ $CUSTOM_INI != "1" && $TRAVIS_PHP_VERSION != "nightly" ]]; then pear package-validate package.xml; fi
   - if [[ $PEAR_VALIDATE == "1" ]]; then php scripts/validate-pear-package.php; fi


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Sets the distro for low PHP versions explicitly to `trusty`.
* Makes the expected OS explicit (linux).
* Updates the `matrix` key to `jobs`, which is the canonical for which `matrix` is an alias.
* Removed `sudo: false` - this hasn't been supported for over a year now.

As the `xenial` images (again) appear to randomly be shipped with incompatible PHPUnit versions, I'm changing the setup to always run `composer install` and use the PHPUnit in the `vendor` directory.
This will make the build less prone to error out on incompatible Travis image changes in the future and should hardly make a difference in build time.

Note: the build against PHP nightly will now fail as it is run against a much more recent PHP build. This build failure will be fixed once the comment tokenizer change has been pulled & merged.
To pull that PR, merging this one is a prerequisite.

@gsherwood If you like, I'll rebase the other PHP 8 related PRs once this one has been merged to proof they are sound for PHP 8, though I have already tested that locally, so we should be good.