### PR TITLE
PHP 8.0 | Tokenizer/PHP: stabilize comment tokenization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@ package.xml export-ignore
 phpunit.xml.dist export-ignore
 php5-testingConfig.ini export-ignore
 php7-testingConfig.ini export-ignore
+
+# Declare files that should always have CRLF line endings on checkout.
+*WinTest.inc text eol=crlf
+*WinTest.php text eol=crlf

--- a/package.xml
+++ b/package.xml
@@ -119,6 +119,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="BackfillNumericSeparatorTest.php" role="test" />
       <file baseinstalldir="" name="ShortArrayTest.inc" role="test" />
       <file baseinstalldir="" name="ShortArrayTest.php" role="test" />
+      <file baseinstalldir="" name="StableCommentWhitespaceTest.inc" role="test" />
+      <file baseinstalldir="" name="StableCommentWhitespaceTest.php" role="test" />
+      <file baseinstalldir="" name="StableCommentWhitespaceWinTest.inc" role="test" />
+      <file baseinstalldir="" name="StableCommentWhitespaceWinTest.php" role="test" />
      </dir>
      <file baseinstalldir="" name="AbstractMethodUnitTest.php" role="test" />
      <file baseinstalldir="" name="AllTests.php" role="test" />
@@ -1985,6 +1989,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.php" name="tests/Core/Tokenizer/ShortArrayTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.inc" name="tests/Core/Tokenizer/ShortArrayTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
   </filelist>
@@ -2040,6 +2048,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.php" name="tests/Core/Tokenizer/ShortArrayTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.inc" name="tests/Core/Tokenizer/ShortArrayTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
    <ignore name="bin/phpcs.bat" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -143,7 +143,12 @@
 
     <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->
     <rule ref="Generic.Strings.UnnecessaryStringConcat">
-        <exclude-pattern>tests/bootstrap.php</exclude-pattern>
+        <exclude-pattern>tests/bootstrap\.php</exclude-pattern>
+    </rule>
+
+    <!-- This test file specifically *needs* Windows line endings for testing purposes. -->
+    <rule ref="Generic.Files.LineEndings.InvalidEOLChar">
+        <exclude-pattern>tests/Core/Tokenizer/StableCommentWhitespaceWinTest\.php</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.inc
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.inc
@@ -1,0 +1,119 @@
+<?php
+
+/* testSingleLineSlashComment */
+// Comment
+
+/* testSingleLineSlashCommentTrailing */
+echo 'a'; // Comment
+
+/* testSingleLineSlashAnnotation */
+// phpcs:disable Stnd.Cat
+
+/* testMultiLineSlashComment */
+// Comment1
+// Comment2
+// Comment3
+
+/* testMultiLineSlashCommentWithIndent */
+    // Comment1
+    // Comment2
+    // Comment3
+
+/* testMultiLineSlashCommentWithAnnotationStart */
+// phpcs:ignore Stnd.Cat
+// Comment2
+// Comment3
+
+/* testMultiLineSlashCommentWithAnnotationMiddle */
+// Comment1
+// @phpcs:ignore Stnd.Cat
+// Comment3
+
+/* testMultiLineSlashCommentWithAnnotationEnd */
+// Comment1
+// Comment2
+// phpcs:ignore Stnd.Cat
+
+
+/* testSingleLineStarComment */
+/* Single line star comment */
+
+/* testSingleLineStarCommentTrailing */
+echo 'a'; /* Comment */
+
+/* testSingleLineStarAnnotation */
+/* phpcs:ignore Stnd.Cat */
+
+/* testMultiLineStarComment */
+/* Comment1
+ * Comment2
+ * Comment3 */
+
+/* testMultiLineStarCommentWithIndent */
+        /* Comment1
+         * Comment2
+         * Comment3 */
+
+/* testMultiLineStarCommentWithAnnotationStart */
+/* @phpcs:ignore Stnd.Cat
+ * Comment2
+ * Comment3 */
+
+/* testMultiLineStarCommentWithAnnotationMiddle */
+/* Comment1
+ * phpcs:ignore Stnd.Cat
+ * Comment3 */
+
+/* testMultiLineStarCommentWithAnnotationEnd */
+/* Comment1
+ * Comment2
+ * phpcs:ignore Stnd.Cat */
+
+
+/* testSingleLineDocblockComment */
+/** Comment */
+
+/* testSingleLineDocblockCommentTrailing */
+$prop = 123; /** Comment */
+
+/* testSingleLineDocblockAnnotation */
+/** phpcs:ignore Stnd.Cat.Sniff */
+
+/* testMultiLineDocblockComment */
+/**
+ * Comment1
+ * Comment2
+ *
+ * @tag Comment
+ */
+
+/* testMultiLineDocblockCommentWithIndent */
+    /**
+     * Comment1
+     * Comment2
+     *
+     * @tag Comment
+     */
+
+/* testMultiLineDocblockCommentWithAnnotation */
+/**
+ * Comment
+ *
+ * phpcs:ignore Stnd.Cat
+ * @tag Comment
+ */
+
+/* testMultiLineDocblockCommentWithTagAnnotation */
+/**
+ * Comment
+ *
+ * @phpcs:ignore Stnd.Cat
+ * @tag Comment
+ */
+
+/* testSingleLineSlashCommentNoNewLineAtEnd */
+// Slash ?>
+<?php
+
+/* testCommentAtEndOfFile */
+/* Comment

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
@@ -1,0 +1,954 @@
+<?php
+/**
+ * Tests the comment tokenization.
+ *
+ * Comment have their own tokenization in PHPCS anyhow, including the PHPCS annotations.
+ * However, as of PHP 8, the PHP native comment tokenization has changed.
+ * Natively T_COMMENT tokens will no longer include a trailing newline.
+ * PHPCS "forward-fills" the original tokenization to PHP 8.
+ * This test file safeguards that.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
+
+class StableCommentWhitespaceTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that comment tokenization with new lines at the end of the comment is stable.
+     *
+     * @param string $testMarker     The comment prefacing the test.
+     * @param array  $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataCommentTokenization
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testCommentTokenization($testMarker, $expectedTokens)
+    {
+        $tokens  = self::$phpcsFile->getTokens();
+        $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
+
+        foreach ($expectedTokens as $key => $tokenInfo) {
+            $this->assertSame(constant($tokenInfo['type']), $tokens[$comment]['code']);
+            $this->assertSame($tokenInfo['type'], $tokens[$comment]['type']);
+            $this->assertSame($tokenInfo['content'], $tokens[$comment]['content']);
+
+            ++$comment;
+        }
+
+    }//end testCommentTokenization()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testCommentTokenization()
+     *
+     * @return array
+     */
+    public function dataCommentTokenization()
+    {
+        return [
+            [
+                '/* testSingleLineSlashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineSlashCommentTrailing */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineSlashAnnotation */',
+                [
+                    [
+                        'type'    => 'T_PHPCS_DISABLE',
+                        'content' => '// phpcs:disable Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithIndent */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithAnnotationStart */',
+                [
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '// phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithAnnotationMiddle */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '// @phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithAnnotationEnd */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '// phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineStarComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Single line star comment */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineStarCommentTrailing */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Comment */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineStarAnnotation */',
+                [
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '/* phpcs:ignore Stnd.Cat */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineStarComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => ' * Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => ' * Comment3 */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineStarCommentWithIndent */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '         * Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '         * Comment3 */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineStarCommentWithAnnotationStart */',
+                [
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '/* @phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => ' * Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => ' * Comment3 */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineStarCommentWithAnnotationMiddle */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => ' * phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => ' * Comment3 */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineStarCommentWithAnnotationEnd */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => ' * Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => ' * phpcs:ignore Stnd.Cat */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+
+            [
+                '/* testSingleLineDocblockComment */',
+                [
+                    [
+                        'type'    => 'T_DOC_COMMENT_OPEN_TAG',
+                        'content' => '/**',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_CLOSE_TAG',
+                        'content' => '*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineDocblockCommentTrailing */',
+                [
+                    [
+                        'type'    => 'T_DOC_COMMENT_OPEN_TAG',
+                        'content' => '/**',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_CLOSE_TAG',
+                        'content' => '*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineDocblockAnnotation */',
+                [
+                    [
+                        'type'    => 'T_DOC_COMMENT_OPEN_TAG',
+                        'content' => '/**',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => 'phpcs:ignore Stnd.Cat.Sniff ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_CLOSE_TAG',
+                        'content' => '*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+
+            [
+                '/* testMultiLineDocblockComment */',
+                [
+                    [
+                        'type'    => 'T_DOC_COMMENT_OPEN_TAG',
+                        'content' => '/**',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment1',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment2',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_TAG',
+                        'content' => '@tag',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_CLOSE_TAG',
+                        'content' => '*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineDocblockCommentWithIndent */',
+                [
+                    [
+                        'type'    => 'T_DOC_COMMENT_OPEN_TAG',
+                        'content' => '/**',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '     ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment1',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '     ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment2',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '     ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '     ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_TAG',
+                        'content' => '@tag',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '     ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_CLOSE_TAG',
+                        'content' => '*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineDocblockCommentWithAnnotation */',
+                [
+                    [
+                        'type'    => 'T_DOC_COMMENT_OPEN_TAG',
+                        'content' => '/**',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => 'phpcs:ignore Stnd.Cat',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_TAG',
+                        'content' => '@tag',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_CLOSE_TAG',
+                        'content' => '*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineDocblockCommentWithTagAnnotation */',
+                [
+                    [
+                        'type'    => 'T_DOC_COMMENT_OPEN_TAG',
+                        'content' => '/**',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '@phpcs:ignore Stnd.Cat',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STAR',
+                        'content' => '*',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_TAG',
+                        'content' => '@tag',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_STRING',
+                        'content' => 'Comment',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_DOC_COMMENT_CLOSE_TAG',
+                        'content' => '*/',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineSlashCommentNoNewLineAtEnd */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Slash ',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_TAG',
+                        'content' => '?>
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testCommentAtEndOfFile */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Comment',
+                    ],
+                ],
+            ],
+        ];
+
+    }//end dataCommentTokenization()
+
+
+}//end class

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc
@@ -1,0 +1,43 @@
+<?php
+
+/* testSingleLineSlashComment */
+// Comment
+
+/* testSingleLineSlashCommentTrailing */
+echo 'a'; // Comment
+
+/* testSingleLineSlashAnnotation */
+// phpcs:disable Stnd.Cat
+
+/* testMultiLineSlashComment */
+// Comment1
+// Comment2
+// Comment3
+
+/* testMultiLineSlashCommentWithIndent */
+    // Comment1
+    // Comment2
+    // Comment3
+
+/* testMultiLineSlashCommentWithAnnotationStart */
+// phpcs:ignore Stnd.Cat
+// Comment2
+// Comment3
+
+/* testMultiLineSlashCommentWithAnnotationMiddle */
+// Comment1
+// @phpcs:ignore Stnd.Cat
+// Comment3
+
+/* testMultiLineSlashCommentWithAnnotationEnd */
+// Comment1
+// Comment2
+// phpcs:ignore Stnd.Cat
+
+
+/* testSingleLineSlashCommentNoNewLineAtEnd */
+// Slash ?>
+<?php
+
+/* testCommentAtEndOfFile */
+/* Comment

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Tests the comment tokenization with Windows line endings.
+ *
+ * Basically the same as the StableCommentWhitespaceTest, but now for
+ * Windows line endings.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
+
+class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that comment tokenization with new lines at the end of the comment is stable.
+     *
+     * @param string $testMarker     The comment prefacing the test.
+     * @param array  $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataCommentTokenization
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testCommentTokenization($testMarker, $expectedTokens)
+    {
+        $tokens  = self::$phpcsFile->getTokens();
+        $comment = $this->getTargetToken($testMarker, Tokens::$commentTokens);
+
+        foreach ($expectedTokens as $key => $tokenInfo) {
+            $this->assertSame(constant($tokenInfo['type']), $tokens[$comment]['code']);
+            $this->assertSame($tokenInfo['type'], $tokens[$comment]['type']);
+            $this->assertSame($tokenInfo['content'], $tokens[$comment]['content']);
+
+            ++$comment;
+        }
+
+    }//end testCommentTokenization()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testCommentTokenization()
+     *
+     * @return array
+     */
+    public function dataCommentTokenization()
+    {
+        return [
+            [
+                '/* testSingleLineSlashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineSlashCommentTrailing */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineSlashAnnotation */',
+                [
+                    [
+                        'type'    => 'T_PHPCS_DISABLE',
+                        'content' => '// phpcs:disable Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithIndent */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithAnnotationStart */',
+                [
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '// phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithAnnotationMiddle */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '// @phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineSlashCommentWithAnnotationEnd */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '// phpcs:ignore Stnd.Cat
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineSlashCommentNoNewLineAtEnd */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '// Slash ',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_TAG',
+                        'content' => '?>
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testCommentAtEndOfFile */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* Comment',
+                    ],
+                ],
+            ],
+        ];
+
+    }//end dataCommentTokenization()
+
+
+}//end class


### PR DESCRIPTION
As described in issue #3002, in PHP 8 a trailing new line is no longer included in a `T_COMMENT` token.

This commit "forward-fills" the PHP 5/7 tokenization of `T_COMMENT` tokens for PHP 8, i.e. the PHP 8 comment tokenization is undone and changed back to how comments followed by a new line were tokenized in PHP 5/7.

Includes extensive unit tests. I'm hoping to have caught everything affected :fingers_crossed:

The initial set of unit tests `StableCommentWhitespaceTest` use Linux line endings `\n`.
The secondary set of unit tests `StableCommentWhitespaceWinTest` use Windows line endings `\r\n` to test that the fix is stable for files using different line ending.

For the tests with Windows line endings, both the test case file as well as the actual test file have been set up to use Windows line endings for all lines, not just the test data lines, to make it simpler to manage the line endings for the files.

The test file has been excluded from the line endings CS check for that reason and a directive has been added to the `.gitattributes` file to safeguard that the line endings of those files will remain Windows line endings.

Fixes #3002

This PR incidentally (well, not really) fixes the current build failure on PHP 8.