### PR TITLE
Add option to allow variable usage in double quoted strings

### DIFF
--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -15,6 +15,13 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class DoubleQuoteUsageSniff implements Sniff
 {
 
+    /**
+     * Allow variables in double quoted strings
+     *
+     * @var boolean
+     */
+    public $allowVariables = false;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -42,6 +49,7 @@ class DoubleQuoteUsageSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        $this->allowVariables = (bool) $this->allowVariables;
         $tokens = $phpcsFile->getTokens();
 
         // If tabs are being converted to spaces by the tokeniser, the
@@ -82,6 +90,10 @@ class DoubleQuoteUsageSniff implements Sniff
             $stringTokens = token_get_all('<?php '.$workingString);
             foreach ($stringTokens as $token) {
                 if (is_array($token) === true && $token[0] === T_VARIABLE) {
+                    if ($this->allowVariables === true) {
+                        return $skipTo;
+                    }
+
                     $error = 'Variable "%s" not allowed in double quoted string; use concatenation instead';
                     $data  = [$token[1]];
                     $phpcsFile->addError($error, $stackPtr, 'ContainsVar', $data);

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
@@ -32,6 +32,12 @@ echo ""
 $string = "Hello
 			there";
 
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables 1
+$string = "Hello $there";
+$string = 'Hello'."$there '".'hi';
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables 0
+
 function test() {
+    // this syntax error is here on purpose
     echo "It Worked';
 }

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
@@ -32,6 +32,12 @@ echo ''
 $string = 'Hello
 			there';
 
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables 1
+$string = "Hello $there";
+$string = 'Hello'."$there '".'hi';
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables 0
+
 function test() {
+    // this syntax error is here on purpose
     echo "It Worked';
 }


### PR DESCRIPTION
The default for Squiz.Strings.DoubleQuoteUsage "allowVariables" is "false" so
everything stays the way it was.

I added an additional comment about the syntax error, because it cost me
20 minutes of debugging.

This PR needs a new entry in https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties