### PR TITLE
Add serialize and unserialize to list of known magic methods

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -26,7 +26,7 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
         'construct'   => true,
         'destruct'    => true,
         'call'        => true,
-        'callstatic ' => true,
+        'callstatic'  => true,
         'get'         => true,
         'set'         => true,
         'isset'       => true,

--- a/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/CamelCapsFunctionNameSniff.php
@@ -23,21 +23,23 @@ class CamelCapsFunctionNameSniff extends AbstractScopeSniff
      * @var array
      */
     protected $magicMethods = [
-        'construct'  => true,
-        'destruct'   => true,
-        'call'       => true,
-        'callstatic' => true,
-        'get'        => true,
-        'set'        => true,
-        'isset'      => true,
-        'unset'      => true,
-        'sleep'      => true,
-        'wakeup'     => true,
-        'tostring'   => true,
-        'set_state'  => true,
-        'clone'      => true,
-        'invoke'     => true,
-        'debuginfo'  => true,
+        'construct'   => true,
+        'destruct'    => true,
+        'call'        => true,
+        'callstatic ' => true,
+        'get'         => true,
+        'set'         => true,
+        'isset'       => true,
+        'unset'       => true,
+        'sleep'       => true,
+        'wakeup'      => true,
+        'serialize'   => true,
+        'unserialize' => true,
+        'tostring'    => true,
+        'invoke'      => true,
+        'set_state'   => true,
+        'clone'       => true,
+        'debuginfo'   => true,
     ];
 
     /**

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -23,21 +23,23 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
      * @var array
      */
     protected $magicMethods = [
-        'construct'  => true,
-        'destruct'   => true,
-        'call'       => true,
-        'callstatic' => true,
-        'get'        => true,
-        'set'        => true,
-        'isset'      => true,
-        'unset'      => true,
-        'sleep'      => true,
-        'wakeup'     => true,
-        'tostring'   => true,
-        'set_state'  => true,
-        'clone'      => true,
-        'invoke'     => true,
-        'debuginfo'  => true,
+        'construct'   => true,
+        'destruct'    => true,
+        'call'        => true,
+        'callstatic ' => true,
+        'get'         => true,
+        'set'         => true,
+        'isset'       => true,
+        'unset'       => true,
+        'sleep'       => true,
+        'wakeup'      => true,
+        'serialize'   => true,
+        'unserialize' => true,
+        'tostring'    => true,
+        'invoke'      => true,
+        'set_state'   => true,
+        'clone'       => true,
+        'debuginfo'   => true,
     ];
 
     /**

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -26,7 +26,7 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
         'construct'   => true,
         'destruct'    => true,
         'call'        => true,
-        'callstatic ' => true,
+        'callstatic'  => true,
         'get'         => true,
         'set'         => true,
         'isset'       => true,


### PR DESCRIPTION
This adds `serialize` and `unserialize` to list of known magic methods and fixes #3029. I also updated list a bit to match the same order as [list in PHP documentation](https://www.php.net/manual/en/language.oop5.magic.php) to make comparing lists in the future easier.