### PR TITLE
Error generated during tokenizing of goto statements on PHP 8

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1441,7 +1441,8 @@ class PHP extends Tokenizer
                 && $token[0] === T_STRING
                 && isset($tokens[($stackPtr + 1)]) === true
                 && $tokens[($stackPtr + 1)] === ':'
-                && $tokens[($stackPtr - 1)][0] !== T_PAAMAYIM_NEKUDOTAYIM
+                && (is_array($tokens[($stackPtr - 1)]) === false
+                || $tokens[($stackPtr - 1)][0] !== T_PAAMAYIM_NEKUDOTAYIM)
             ) {
                 $stopTokens = [
                     T_CASE               => true,


### PR DESCRIPTION
PHP 8.0 elevates a number of notices/warnings to errors, which now exposes a bug in the `goto` tokenizer logic.

Error: `Trying to access array offset on value of type null`

Fixed by making sure that the token being accessed is an array before trying to access it.

Discovered via a failing unit test in WordPressCS.