### PR TITLE
PHP 8.0 | Tokenizer/PHP: add support for nullsafe object operator

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -121,6 +121,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="BackfillFnTokenTest.php" role="test" />
       <file baseinstalldir="" name="BackfillNumericSeparatorTest.inc" role="test" />
       <file baseinstalldir="" name="BackfillNumericSeparatorTest.php" role="test" />
+      <file baseinstalldir="" name="NullsafeObjectOperatorTest.inc" role="test" />
+      <file baseinstalldir="" name="NullsafeObjectOperatorTest.php" role="test" />
       <file baseinstalldir="" name="ShortArrayTest.inc" role="test" />
       <file baseinstalldir="" name="ShortArrayTest.php" role="test" />
       <file baseinstalldir="" name="StableCommentWhitespaceTest.inc" role="test" />
@@ -1991,6 +1993,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.inc" name="tests/Core/Tokenizer/BackfillFnTokenTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.php" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.php" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.inc" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.php" name="tests/Core/Tokenizer/ShortArrayTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.inc" name="tests/Core/Tokenizer/ShortArrayTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.php" />
@@ -2050,6 +2054,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.inc" name="tests/Core/Tokenizer/BackfillFnTokenTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.php" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.php" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.inc" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.php" name="tests/Core/Tokenizer/ShortArrayTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.inc" name="tests/Core/Tokenizer/ShortArrayTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.php" />

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -370,6 +370,7 @@ class PHP extends Tokenizer
         T_NS_C                     => 13,
         T_NS_SEPARATOR             => 1,
         T_NEW                      => 3,
+        T_NULLSAFE_OBJECT_OPERATOR => 3,
         T_OBJECT_OPERATOR          => 2,
         T_OPEN_TAG_WITH_ECHO       => 3,
         T_OR_EQUAL                 => 2,
@@ -1016,6 +1017,29 @@ class PHP extends Tokenizer
             }
 
             /*
+                Before PHP 8, the ?-> operator was tokenized as
+                T_INLINE_THEN followed by T_OBJECT_OPERATOR.
+                So look for and combine these tokens in earlier versions.
+            */
+
+            if ($tokenIsArray === false
+                && $token[0] === '?'
+                && isset($tokens[($stackPtr + 1)]) === true
+                && is_array($tokens[($stackPtr + 1)]) === true
+                && $tokens[($stackPtr + 1)][0] === T_OBJECT_OPERATOR
+            ) {
+                $newToken            = [];
+                $newToken['code']    = T_NULLSAFE_OBJECT_OPERATOR;
+                $newToken['type']    = 'T_NULLSAFE_OBJECT_OPERATOR';
+                $newToken['content'] = '?->';
+                $finalTokens[$newStackPtr] = $newToken;
+
+                $newStackPtr++;
+                $stackPtr++;
+                continue;
+            }
+
+            /*
                 Before PHP 7.4, underscores inside T_LNUMBER and T_DNUMBER
                 tokens split the token with a T_STRING. So look for
                 and change these tokens in earlier versions.
@@ -1510,17 +1534,18 @@ class PHP extends Tokenizer
                     // Some T_STRING tokens should remain that way
                     // due to their context.
                     $context = [
-                        T_OBJECT_OPERATOR      => true,
-                        T_FUNCTION             => true,
-                        T_CLASS                => true,
-                        T_EXTENDS              => true,
-                        T_IMPLEMENTS           => true,
-                        T_NEW                  => true,
-                        T_CONST                => true,
-                        T_NS_SEPARATOR         => true,
-                        T_USE                  => true,
-                        T_NAMESPACE            => true,
-                        T_PAAMAYIM_NEKUDOTAYIM => true,
+                        T_OBJECT_OPERATOR          => true,
+                        T_NULLSAFE_OBJECT_OPERATOR => true,
+                        T_FUNCTION                 => true,
+                        T_CLASS                    => true,
+                        T_EXTENDS                  => true,
+                        T_IMPLEMENTS               => true,
+                        T_NEW                      => true,
+                        T_CONST                    => true,
+                        T_NS_SEPARATOR             => true,
+                        T_USE                      => true,
+                        T_NAMESPACE                => true,
+                        T_PAAMAYIM_NEKUDOTAYIM     => true,
                     ];
 
                     if (isset($context[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
@@ -2012,6 +2037,7 @@ class PHP extends Tokenizer
                     T_CLOSE_PARENTHESIS        => T_CLOSE_PARENTHESIS,
                     T_VARIABLE                 => T_VARIABLE,
                     T_OBJECT_OPERATOR          => T_OBJECT_OPERATOR,
+                    T_NULLSAFE_OBJECT_OPERATOR => T_NULLSAFE_OBJECT_OPERATOR,
                     T_STRING                   => T_STRING,
                     T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
                 ];
@@ -2081,9 +2107,10 @@ class PHP extends Tokenizer
                 }
 
                 $context = [
-                    T_OBJECT_OPERATOR      => true,
-                    T_NS_SEPARATOR         => true,
-                    T_PAAMAYIM_NEKUDOTAYIM => true,
+                    T_OBJECT_OPERATOR          => true,
+                    T_NULLSAFE_OBJECT_OPERATOR => true,
+                    T_NS_SEPARATOR             => true,
+                    T_PAAMAYIM_NEKUDOTAYIM     => true,
                 ];
                 if (isset($context[$this->tokens[$x]['code']]) === true) {
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -1291,11 +1291,12 @@ abstract class Tokenizer
                                 // a new statement, it isn't a scope opener.
                                 $disallowed  = Util\Tokens::$assignmentTokens;
                                 $disallowed += [
-                                    T_DOLLAR           => true,
-                                    T_VARIABLE         => true,
-                                    T_OBJECT_OPERATOR  => true,
-                                    T_COMMA            => true,
-                                    T_OPEN_PARENTHESIS => true,
+                                    T_DOLLAR                   => true,
+                                    T_VARIABLE                 => true,
+                                    T_OBJECT_OPERATOR          => true,
+                                    T_NULLSAFE_OBJECT_OPERATOR => true,
+                                    T_COMMA                    => true,
+                                    T_OPEN_PARENTHESIS         => true,
                                 ];
 
                                 if (isset($disallowed[$this->tokens[$x]['code']]) === true) {

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -124,6 +124,11 @@ if (defined('T_FN') === false) {
     define('T_FN', 'PHPCS_T_FN');
 }
 
+// Some PHP 8.0 tokens, replicated for lower versions.
+if (defined('T_NULLSAFE_OBJECT_OPERATOR') === false) {
+    define('T_NULLSAFE_OBJECT_OPERATOR', 'PHPCS_T_NULLSAFE_OBJECT_OPERATOR');
+}
+
 // Tokens used for parsing doc blocks.
 define('T_DOC_COMMENT_STAR', 'PHPCS_T_DOC_COMMENT_STAR');
 define('T_DOC_COMMENT_WHITESPACE', 'PHPCS_T_DOC_COMMENT_WHITESPACE');

--- a/tests/Core/Tokenizer/NullsafeObjectOperatorTest.inc
+++ b/tests/Core/Tokenizer/NullsafeObjectOperatorTest.inc
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Null safe operator.
+ */
+
+/* testObjectOperator */
+echo $obj->foo;
+
+/* testNullsafeObjectOperator */
+echo $obj?->foo;
+
+/* testNullsafeObjectOperatorWriteContext */
+// Intentional parse error, but not the concern of the tokenizer.
+$foo?->bar->baz = 'baz';
+
+/* testTernaryThen */
+echo $obj ? $obj->prop : $other->prop;
+
+/* testParseErrorWhitespaceNotAllowed */
+echo $obj ?
+    -> foo;
+
+/* testParseErrorCommentNotAllowed */
+echo $obj ?/*comment*/-> foo;
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+echo $obj?

--- a/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
+++ b/tests/Core/Tokenizer/NullsafeObjectOperatorTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Tests the backfill for the PHP >= 8.0 nullsafe object operator.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
+
+class NullsafeObjectOperatorTest extends AbstractMethodUnitTest
+{
+
+    /**
+     * Tokens to search for.
+     *
+     * @var array
+     */
+    protected $find = [
+        T_NULLSAFE_OBJECT_OPERATOR,
+        T_OBJECT_OPERATOR,
+        T_INLINE_THEN,
+    ];
+
+
+    /**
+     * Test that a normal object operator is still tokenized as such.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testObjectOperator()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $operator = $this->getTargetToken('/* testObjectOperator */', $this->find);
+        $this->assertSame(T_OBJECT_OPERATOR, $tokens[$operator]['code'], 'Failed asserting code is object operator');
+        $this->assertSame('T_OBJECT_OPERATOR', $tokens[$operator]['type'], 'Failed asserting type is object operator');
+
+    }//end testObjectOperator()
+
+
+    /**
+     * Test that a nullsafe object operator is tokenized as such.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @dataProvider dataNullsafeObjectOperator
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testNullsafeObjectOperator($testMarker)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $operator = $this->getTargetToken($testMarker, $this->find);
+        $this->assertSame(T_NULLSAFE_OBJECT_OPERATOR, $tokens[$operator]['code'], 'Failed asserting code is nullsafe object operator');
+        $this->assertSame('T_NULLSAFE_OBJECT_OPERATOR', $tokens[$operator]['type'], 'Failed asserting type is nullsafe object operator');
+
+    }//end testNullsafeObjectOperator()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testNullsafeObjectOperator()
+     *
+     * @return array
+     */
+    public function dataNullsafeObjectOperator()
+    {
+        return [
+            ['/* testNullsafeObjectOperator */'],
+            ['/* testNullsafeObjectOperatorWriteContext */'],
+        ];
+
+    }//end dataNullsafeObjectOperator()
+
+
+    /**
+     * Test that a question mark not followed by an object operator is tokenized as T_TERNARY_THEN.
+     *
+     * @param string $testMarker         The comment which prefaces the target token in the test file.
+     * @param bool   $testObjectOperator Whether to test for the next non-empty token being tokenized
+     *                                   as an object operator.
+     *
+     * @dataProvider dataTernaryThen
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testTernaryThen($testMarker, $testObjectOperator=false)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $operator = $this->getTargetToken($testMarker, $this->find);
+        $this->assertSame(T_INLINE_THEN, $tokens[$operator]['code'], 'Failed asserting code is inline then');
+        $this->assertSame('T_INLINE_THEN', $tokens[$operator]['type'], 'Failed asserting type is inline then');
+
+        if ($testObjectOperator === true) {
+            $next = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($operator + 1), null, true);
+            $this->assertSame(T_OBJECT_OPERATOR, $tokens[$next]['code'], 'Failed asserting code is object operator');
+            $this->assertSame('T_OBJECT_OPERATOR', $tokens[$next]['type'], 'Failed asserting type is object operator');
+        }
+
+    }//end testTernaryThen()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testTernaryThen()
+     *
+     * @return array
+     */
+    public function dataTernaryThen()
+    {
+        return [
+            ['/* testTernaryThen */'],
+            [
+                '/* testParseErrorWhitespaceNotAllowed */',
+                true,
+            ],
+            [
+                '/* testParseErrorCommentNotAllowed */',
+                true,
+            ],
+            ['/* testLiveCoding */'],
+        ];
+
+    }//end dataTernaryThen()
+
+
+}//end class

--- a/tests/Core/Tokenizer/ShortArrayTest.inc
+++ b/tests/Core/Tokenizer/ShortArrayTest.inc
@@ -62,6 +62,8 @@ $a = (new Foo( array(1, array(4, 5), 3) ))[1][0];
 /* testClassMemberDereferencingOnClone */
 echo (clone $iterable)[20];
 
+/* testNullsafeMethodCallDereferencing */
+$var = $obj?->function_call()[$x];
 
 /*
  * Short array brackets.

--- a/tests/Core/Tokenizer/ShortArrayTest.php
+++ b/tests/Core/Tokenizer/ShortArrayTest.php
@@ -72,6 +72,7 @@ class ShortArrayTest extends AbstractMethodUnitTest
             ['/* testClassMemberDereferencingOnInstantiation1 */'],
             ['/* testClassMemberDereferencingOnInstantiation2 */'],
             ['/* testClassMemberDereferencingOnClone */'],
+            ['/* testNullsafeMethodCallDereferencing */'],
             ['/* testLiveCoding */'],
         ];
 


### PR DESCRIPTION
This PR addresses the tokenizer changes needed for #3040. Once this PR has been merged, the sniff specific changes will be pulled with a PR per sniff.

PHP 8 introduces a new object chaining operator `?->` which short-circuits moving to the next expression if the left-hand side evaluates to `null`.

This operator can not be used in write-context, but that is not the concern of the PHPCS `Tokenizers\PHP` class.

This commit:
* Defines the token constant for PHP < 8.0.
* Adds a backfill for the nullsafe object operator for PHP < 8.0 to the PHP tokenizer.
* Adds the token to applicable token lists in the PHP and base tokenizer class, like the one used in the short array re-tokenization.
* Adds perfunctory unit tests for the nullsafe object operator backfill.
* Adds a unit test using the operator to the tokenizer tests for the short array re-tokenization.

Refs:
* https://wiki.php.net/rfc/nullsafe_operator
* https://github.com/php/php-src/commit/9bf119832dbf625174794834c71b1e793450d87f

