### PR TITLE
Add a property to Squiz.Commenting.FunctionComment to skip processing for {@inheritdoc} (issue #2770)

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -18,6 +18,13 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 {
 
     /**
+     * Whether to skip inheritdoc comments.
+     *
+     * @var bool
+     */
+    public $skipIfInheritdoc = false;
+
+    /**
      * The current PHP version.
      *
      * @var integer
@@ -40,6 +47,14 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         $tokens = $phpcsFile->getTokens();
         $return = null;
 
+        if ($this->skipIfInheritdoc) {
+            for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
+                $trimmedContent = strtolower(trim($tokens[$i]['content']));
+                if ($trimmedContent === '{@inheritdoc}') {
+                    return;
+                }
+            }
+        }
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
             if ($tokens[$tag]['content'] === '@return') {
                 if ($return !== null) {
@@ -189,6 +204,15 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        if ($this->skipIfInheritdoc) {
+            for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
+                $trimmedContent = strtolower(trim($tokens[$i]['content']));
+                if ($trimmedContent === '{@inheritdoc}') {
+                    return;
+                }
+            }
+        }
+
         foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
             if ($tokens[$tag]['content'] !== '@throws') {
                 continue;
@@ -263,6 +287,15 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         }
 
         $tokens = $phpcsFile->getTokens();
+
+        if ($this->skipIfInheritdoc) {
+            for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
+                $trimmedContent = strtolower(trim($tokens[$i]['content']));
+                if ($trimmedContent === '{@inheritdoc}') {
+                    return;
+                }
+            }
+        }
 
         $params  = [];
         $maxType = 0;

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -48,11 +48,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         $return = null;
 
         if ($this->skipIfInheritdoc === true) {
-            for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
-                $trimmedContent = strtolower(trim($tokens[$i]['content']));
-                if ($trimmedContent === '{@inheritdoc}') {
-                    return;
-                }
+            if ($this->checkInheritdoc($phpcsFile, $stackPtr, $commentStart) === true) {
+                return;
             }
         }
 
@@ -206,11 +203,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         $tokens = $phpcsFile->getTokens();
 
         if ($this->skipIfInheritdoc === true) {
-            for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
-                $trimmedContent = strtolower(trim($tokens[$i]['content']));
-                if ($trimmedContent === '{@inheritdoc}') {
-                    return;
-                }
+            if ($this->checkInheritdoc($phpcsFile, $stackPtr, $commentStart) === true) {
+                return;
             }
         }
 
@@ -290,11 +284,8 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         $tokens = $phpcsFile->getTokens();
 
         if ($this->skipIfInheritdoc === true) {
-            for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
-                $trimmedContent = strtolower(trim($tokens[$i]['content']));
-                if ($trimmedContent === '{@inheritdoc}') {
-                    return;
-                }
+            if ($this->checkInheritdoc($phpcsFile, $stackPtr, $commentStart) === true) {
+                return;
             }
         }
 
@@ -727,6 +718,40 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         }//end if
 
     }//end checkSpacingAfterParamName()
+
+
+    /**
+     * Determines whether the whole comment is an inheritdoc comment.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function checkInheritdoc(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $allowedTokens = [
+            T_DOC_COMMENT_OPEN_TAG,
+            T_DOC_COMMENT_WHITESPACE,
+            T_DOC_COMMENT_STAR,
+        ];
+        for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
+            if (in_array($tokens[$i]['code'], $allowedTokens) === false) {
+                $trimmedContent = strtolower(trim($tokens[$i]['content']));
+
+                if ($trimmedContent === '{@inheritdoc}') {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+    }//end checkInheritdoc()
 
 
 }//end class

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -728,7 +728,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
      *                                                  in the stack passed in $tokens.
      * @param int                         $commentStart The position in the stack where the comment started.
      *
-     * @return void
+     * @return boolean TRUE if the docblock contains only {@inheritdoc} (case-insensitive).
      */
     protected function checkInheritdoc(File $phpcsFile, $stackPtr, $commentStart)
     {

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -20,7 +20,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
     /**
      * Whether to skip inheritdoc comments.
      *
-     * @var bool
+     * @var boolean
      */
     public $skipIfInheritdoc = false;
 
@@ -47,7 +47,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
         $tokens = $phpcsFile->getTokens();
         $return = null;
 
-        if ($this->skipIfInheritdoc) {
+        if ($this->skipIfInheritdoc === true) {
             for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
                 $trimmedContent = strtolower(trim($tokens[$i]['content']));
                 if ($trimmedContent === '{@inheritdoc}') {
@@ -55,6 +55,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 }
             }
         }
+
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
             if ($tokens[$tag]['content'] === '@return') {
                 if ($return !== null) {
@@ -204,7 +205,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($this->skipIfInheritdoc) {
+        if ($this->skipIfInheritdoc === true) {
             for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
                 $trimmedContent = strtolower(trim($tokens[$i]['content']));
                 if ($trimmedContent === '{@inheritdoc}') {
@@ -288,7 +289,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($this->skipIfInheritdoc) {
+        if ($this->skipIfInheritdoc === true) {
             for ($i = $commentStart; $i <= $tokens[$commentStart]['comment_closer']; $i++) {
                 $trimmedContent = strtolower(trim($tokens[$i]['content']));
                 if ($trimmedContent === '{@inheritdoc}') {


### PR DESCRIPTION
https://github.com/squizlabs/PHP_CodeSniffer/issues/2770 and numerous previous closed issues have requested supporting `{@inheritdoc}` for function comments. This PR adds an optional property to the sniff that skips erroring on missing `@param`, `@return`, or `@throws` if the whole contents of the docblock are exactly `{@inheritdoc}` (case-insensitive).

Example usage:
```
    <rule ref="Squiz.Commenting.FunctionComment">                               
        <properties>
            <property name="skipIfInheritdoc" value="true"/>
        </properties>
    </rule>
```