### PR TITLE
Work around get_declared_classes() unpredictability on PHP 7.4

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -169,6 +169,17 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
             $className  = null;
             $newClasses = array_reverse(array_diff(get_declared_classes(), $classes));
             foreach ($newClasses as $name) {
+                // With PHP 7.4 the behavior of method get_declared_classes() has changed
+                // please visit https://www.php.net/manual/en/function.get-declared-classes.php for details.
+                // With this in mind it is not possible to overwrite a sniff that extends a certain one, thus it is
+                // simply checked, whether the current name is the same as the path name (only working with PSR-0 or
+                // PSR-4) and if not, it continues to the next class, thus the parent class is not registered and
+                // would set it as a "loaded" file. Furthermore the overwritten class has to have a different name than
+                // the parent class.
+                if (substr($name, (strrpos($name, '\\') + 1)) !== basename($path, '.php')) {
+                    continue;
+                }
+
                 if (isset(self::$loadedFiles[$name]) === false) {
                     $className = $name;
                     break;


### PR DESCRIPTION
With PHP 7.4 the behavior of method get_declared_classes() has changed
please visit https://www.php.net/manual/en/function.get-declared-classes.php
for details.

With this in mind, imagine that you want to extend a certain sniff and
extend a current one. For example the `ReferenceUsedNamesOnlySniff`
should be overwritten and extended with `ReferenceUsedNamesOnlyOverrideSniff`.
As PHP 7.4 does not guarantee the order of parent or child class anymore
reflected by get_declared_classes() it might happen, that the parent
class is used to load and to be registered in the runtime cache
`self::$loadedFiles[$name]`.

With this it is not possible to overwrite a sniff that extends
a certain one. Thus with this change it is simply checked whether the
current name is the same as the path name (only working with PSR-0 or
PSR-4) and if not, it continues to the next class, thus the parent
class is not registered and would set it as a "loaded" file.
Furthermore the overwritten class has to have a different name than
the parent class.

Thanks @NamelessCoder for your support.