### PR TITLE
Ignore tokens that belong to array element declaration

### DIFF
--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -620,7 +620,16 @@ class ArrayDeclarationSniff implements Sniff
 
                 $valuePointer = $value['value'];
 
-                $previous = $phpcsFile->findPrevious([T_WHITESPACE, T_COMMA], ($valuePointer - 1), ($arrayStart + 1), true);
+                $ignoreTokens = ([
+                    T_WHITESPACE => T_WHITESPACE,
+                    T_COMMA      => T_COMMA,
+                ] + Tokens::$castTokens);
+
+                if ($tokens[$valuePointer]['code'] === T_CLOSURE) {
+                    $ignoreTokens += [T_STATIC => T_STATIC];
+                }
+
+                $previous = $phpcsFile->findPrevious($ignoreTokens, ($valuePointer - 1), ($arrayStart + 1), true);
                 if ($previous === false) {
                     $previous = $stackPtr;
                 }

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -436,6 +436,19 @@ $c];
 ['a' => $a, 'b' => $b,
 'c' => $c];
 
+[
+ static function() {
+     return null;
+ },
+ (array) [],
+ (bool) [],
+ (double) [],
+ (int) [],
+ (object) [],
+ (string) [],
+ (unset) [],
+];
+
 // Intentional syntax error.
 $a = [
       'a' =>

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -470,6 +470,19 @@ $foo = [
  'c' => $c,
 ];
 
+[
+ static function() {
+     return null;
+ },
+ (array) [],
+ (bool) [],
+ (double) [],
+ (int) [],
+ (object) [],
+ (string) [],
+ (unset) [],
+];
+
 // Intentional syntax error.
 $a = [
       'a' =>


### PR DESCRIPTION
- [x] Ignore `T_*_CAST` to allow `(cast) ...` array elements. Fixes #3059.
- [x] Ignore `T_STATIC` before `T_CLOSURE` to allow `static function` array elements. Fixes #3060.