### PR TITLE
PHP 8.0 | "undo" namespaced names as single token

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -121,6 +121,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="StableCommentWhitespaceTest.php" role="test" />
       <file baseinstalldir="" name="StableCommentWhitespaceWinTest.inc" role="test" />
       <file baseinstalldir="" name="StableCommentWhitespaceWinTest.php" role="test" />
+      <file baseinstalldir="" name="UndoNamespacedNameSingleTokenTest.inc" role="test" />
+      <file baseinstalldir="" name="UndoNamespacedNameSingleTokenTest.php" role="test" />
      </dir>
      <file baseinstalldir="" name="AbstractMethodUnitTest.php" role="test" />
      <file baseinstalldir="" name="AllTests.php" role="test" />
@@ -1997,6 +1999,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php" name="tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc" name="tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
   </filelist>
@@ -2058,6 +2062,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" name="tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php" name="tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc" name="tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
    <ignore name="bin/phpcs.bat" />

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -129,6 +129,18 @@ if (defined('T_NULLSAFE_OBJECT_OPERATOR') === false) {
     define('T_NULLSAFE_OBJECT_OPERATOR', 'PHPCS_T_NULLSAFE_OBJECT_OPERATOR');
 }
 
+if (defined('T_NAME_QUALIFIED') === false) {
+    define('T_NAME_QUALIFIED', 'PHPCS_T_NAME_QUALIFIED');
+}
+
+if (defined('T_NAME_FULLY_QUALIFIED') === false) {
+    define('T_NAME_FULLY_QUALIFIED', 'PHPCS_T_NAME_FULLY_QUALIFIED');
+}
+
+if (defined('T_NAME_RELATIVE') === false) {
+    define('T_NAME_RELATIVE', 'PHPCS_T_NAME_RELATIVE');
+}
+
 // Tokens used for parsing doc blocks.
 define('T_DOC_COMMENT_STAR', 'PHPCS_T_DOC_COMMENT_STAR');
 define('T_DOC_COMMENT_WHITESPACE', 'PHPCS_T_DOC_COMMENT_WHITESPACE');

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.inc
@@ -1,0 +1,147 @@
+<?php
+
+/* testNamespaceDeclaration */
+namespace Package;
+
+/* testNamespaceDeclarationWithLevels */
+namespace Vendor\SubLevel\Domain;
+
+/* testUseStatement */
+use ClassName;
+
+/* testUseStatementWithLevels */
+use Vendor\Level\Domain;
+
+/* testFunctionUseStatement */
+use function function_name;
+
+/* testFunctionUseStatementWithLevels */
+use function Vendor\Level\function_in_ns;
+
+/* testConstantUseStatement */
+use const CONSTANT_NAME;
+
+/* testConstantUseStatementWithLevels */
+use const Vendor\Level\OTHER_CONSTANT;
+
+/* testMultiUseUnqualified */
+use UnqualifiedClassName,
+    /* testMultiUsePartiallyQualified */
+    Sublevel\PartiallyClassName;
+
+/* testGroupUseStatement */
+use Vendor\Level\{
+    AnotherDomain,
+    function function_grouped,
+    const CONSTANT_GROUPED,
+    Sub\YetAnotherDomain,
+    function SubLevelA\function_grouped_too,
+    const SubLevelB\CONSTANT_GROUPED_TOO,
+};
+
+/* testClassName */
+class MyClass
+    /* testExtendedFQN */
+    extends \Vendor\Level\FQN
+    /* testImplementsRelative */
+    implements namespace\Name,
+        /* testImplementsFQN */
+        \Fully\Qualified,
+        /* testImplementsUnqualified */
+        Unqualified,
+        /* testImplementsPartiallyQualified */
+        Sub\Level\Name
+{
+    /* testFunctionName */
+    public function function_name(
+        /* testTypeDeclarationRelative */
+        ?namespace\Name|object $paramA,
+
+        /* testTypeDeclarationFQN */
+        \Fully\Qualified\Name $paramB,
+
+        /* testTypeDeclarationUnqualified */
+        Unqualified|false $paramC,
+
+        /* testTypeDeclarationPartiallyQualified */
+        ?Sublevel\Name $paramD,
+
+    /* testReturnTypeFQN */
+    ) : ?\Name {
+
+        try {
+            /* testFunctionCallRelative */
+            echo NameSpace\function_name();
+
+            /* testFunctionCallFQN */
+            echo \Vendor\Package\function_name();
+
+            /* testFunctionCallUnqualified */
+            echo function_name();
+
+            /* testFunctionPartiallyQualified */
+            echo Level\function_name();
+
+        /* testCatchRelative */
+        } catch (namespace\SubLevel\Exception $e) {
+
+        /* testCatchFQN */
+        } catch (\Exception $e) {
+
+        /* testCatchUnqualified */
+        } catch (Exception $e) {
+
+        /* testCatchPartiallyQualified */
+        } catch (Level\Exception $e) {
+        }
+
+        /* testNewRelative */
+        $obj = new namespace\ClassName();
+
+        /* testNewFQN */
+        $obj = new \Vendor\ClassName();
+
+        /* testNewUnqualified */
+        $obj = new ClassName;
+
+        /* testNewPartiallyQualified */
+        $obj = new Level\ClassName;
+
+        /* testDoubleColonRelative */
+        $value = namespace\ClassName::property;
+
+        /* testDoubleColonFQN */
+        $value = \ClassName::static_function();
+
+        /* testDoubleColonUnqualified */
+        $value = ClassName::CONSTANT_NAME;
+
+        /* testDoubleColonPartiallyQualified */
+        $value = Level\ClassName::CONSTANT_NAME['key'];
+        
+        /* testInstanceOfRelative */
+        $is = $obj instanceof namespace\ClassName;
+
+        /* testInstanceOfFQN */
+        if ($obj instanceof \Full\ClassName) {}
+
+        /* testInstanceOfUnqualified */
+        if ($a === $b && $obj instanceof ClassName && true) {}
+
+        /* testInstanceOfPartiallyQualified */
+        $is = $obj instanceof Partially\ClassName;
+    }
+}
+
+/* testInvalidInPHP8Whitespace */
+namespace \ Sublevel
+          \ function_name();
+
+/* testInvalidInPHP8Comments */
+$value = \Fully
+    // phpcs:ignore Stnd.Cat.Sniff -- for reasons
+    \Qualified
+    /* comment */
+    \Name
+    // comment
+    :: function_name();

--- a/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
+++ b/tests/Core/Tokenizer/UndoNamespacedNameSingleTokenTest.php
@@ -1,0 +1,1297 @@
+<?php
+/**
+ * Tests the tokenization of identifier names.
+ *
+ * As of PHP 8, identifier names are tokenized differently, depending on them being
+ * either fully qualified, partially qualified or relative to the current namespace.
+ *
+ * This test file safeguards that in PHPCS 3.x this new form of tokenization is "undone"
+ * and the tokenization of these identifier names is the same in all PHP versions
+ * based on how these names were tokenized in PHP 5/7.
+ *
+ * {@link https://wiki.php.net/rfc/namespaced_names_as_token}
+ * {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/3041}
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class UndoNamespacedNameSingleTokenTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that identifier names are tokenized the same across PHP versions, based on the PHP 5/7 tokenization.
+     *
+     * @param string $testMarker     The comment prefacing the test.
+     * @param array  $expectedTokens The tokenization expected.
+     *
+     * @dataProvider dataIdentifierTokenization
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testIdentifierTokenization($testMarker, $expectedTokens)
+    {
+        $tokens     = self::$phpcsFile->getTokens();
+        $identifier = $this->getTargetToken($testMarker, constant($expectedTokens[0]['type']));
+
+        foreach ($expectedTokens as $key => $tokenInfo) {
+            $this->assertSame(constant($tokenInfo['type']), $tokens[$identifier]['code']);
+            $this->assertSame($tokenInfo['type'], $tokens[$identifier]['type']);
+            $this->assertSame($tokenInfo['content'], $tokens[$identifier]['content']);
+
+            ++$identifier;
+        }
+
+    }//end testIdentifierTokenization()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testIdentifierTokenization()
+     *
+     * @return array
+     */
+    public function dataIdentifierTokenization()
+    {
+        return [
+            [
+                '/* testNamespaceDeclaration */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Package',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testNamespaceDeclarationWithLevels */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'SubLevel',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Domain',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testUseStatement */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testUseStatementWithLevels */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Domain',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testFunctionUseStatement */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_name',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testFunctionUseStatementWithLevels */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_in_ns',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testConstantUseStatement */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'const',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'CONSTANT_NAME',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testConstantUseStatementWithLevels */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'const',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'OTHER_CONSTANT',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiUseUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'UnqualifiedClassName',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiUsePartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Sublevel',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'PartiallyClassName',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testGroupUseStatement */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_USE_GROUP',
+                        'content' => '{',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'AnotherDomain',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_grouped',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'const',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'CONSTANT_GROUPED',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Sub',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'YetAnotherDomain',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'SubLevelA',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_grouped_too',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'const',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'SubLevelB',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'CONSTANT_GROUPED_TOO',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_USE_GROUP',
+                        'content' => '}',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testClassName */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'MyClass',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testExtendedFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'FQN',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testImplementsRelative */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'namespace',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Name',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                ],
+            ],
+            [
+                '/* testImplementsFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Fully',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Qualified',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                ],
+            ],
+            [
+                '/* testImplementsUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Unqualified',
+                    ],
+                    [
+                        'type'    => 'T_COMMA',
+                        'content' => ',',
+                    ],
+                ],
+            ],
+            [
+                '/* testImplementsPartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Sub',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Name',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testFunctionName */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_name',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testTypeDeclarationRelative */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'namespace',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Name',
+                    ],
+                    // TODO: change this to T_TYPE_UNION when #3032 is merged.
+                    [
+                        'type'    => 'T_BITWISE_OR',
+                        'content' => '|',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'object',
+                    ],
+                ],
+            ],
+            [
+                '/* testTypeDeclarationFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Fully',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Qualified',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Name',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testTypeDeclarationUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Unqualified',
+                    ],
+                    // TODO: change this to T_TYPE_UNION when #3032 is merged.
+                    [
+                        'type'    => 'T_BITWISE_OR',
+                        'content' => '|',
+                    ],
+                    [
+                        'type'    => 'T_FALSE',
+                        'content' => 'false',
+                    ],
+                ],
+            ],
+            [
+                '/* testTypeDeclarationPartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_NULLABLE',
+                        'content' => '?',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Sublevel',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Name',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testReturnTypeFQN */',
+                [
+                    [
+                        'type'    => 'T_NULLABLE',
+                        'content' => '?',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Name',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testFunctionCallRelative */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'NameSpace',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_name',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testFunctionCallFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Package',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_name',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testFunctionCallUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_name',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testFunctionPartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_name',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testCatchRelative */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'namespace',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'SubLevel',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Exception',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testCatchFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Exception',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testCatchUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Exception',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testCatchPartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Exception',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testNewRelative */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'namespace',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testNewFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Vendor',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testNewUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testNewPartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testDoubleColonRelative */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'namespace',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_DOUBLE_COLON',
+                        'content' => '::',
+                    ],
+                ],
+            ],
+            [
+                '/* testDoubleColonFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_DOUBLE_COLON',
+                        'content' => '::',
+                    ],
+                ],
+            ],
+            [
+                '/* testDoubleColonUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_DOUBLE_COLON',
+                        'content' => '::',
+                    ],
+                ],
+            ],
+            [
+                '/* testDoubleColonPartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Level',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_DOUBLE_COLON',
+                        'content' => '::',
+                    ],
+                ],
+            ],
+            [
+                '/* testInstanceOfRelative */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'namespace',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testInstanceOfFQN */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Full',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_PARENTHESIS',
+                        'content' => ')',
+                    ],
+                ],
+            ],
+            [
+                '/* testInstanceOfUnqualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                ],
+            ],
+            [
+                '/* testInstanceOfPartiallyQualified */',
+                [
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Partially',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'ClassName',
+                    ],
+                    [
+                        'type'    => 'T_SEMICOLON',
+                        'content' => ';',
+                    ],
+                ],
+            ],
+            [
+                '/* testInvalidInPHP8Whitespace */',
+                [
+                    [
+                        'type'    => 'T_NAMESPACE',
+                        'content' => 'namespace',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Sublevel',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '          ',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => ' ',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'function_name',
+                    ],
+                    [
+                        'type'    => 'T_OPEN_PARENTHESIS',
+                        'content' => '(',
+                    ],
+                ],
+            ],
+            [
+                '/* testInvalidInPHP8Comments */',
+                [
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Fully',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_PHPCS_IGNORE',
+                        'content' => '// phpcs:ignore Stnd.Cat.Sniff -- for reasons
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Qualified',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '/* comment */',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_NS_SEPARATOR',
+                        'content' => '\\',
+                    ],
+                    [
+                        'type'    => 'T_STRING',
+                        'content' => 'Name',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+        ];
+
+    }//end dataIdentifierTokenization()
+
+
+}//end class


### PR DESCRIPTION
As per the proposal in #3041.

This effectively "undoes" the new PHP 8.0 tokenization of identifier names for PHPCS 3.x.

Includes extensive unit tests to ensure the correct re-tokenization as well as that the rest of the tokenization is not adversely affected by this change.

Includes preventing `function ...` within a group use statement from breaking the retokenization.

Includes fixing the nullable tokenization when combined with any of the new PHP 8 identifier name tokens.

Fixes #3041 for PHPCS 3.x