### PR TITLE
No support for namespace operator used in type declarations

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -114,6 +114,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="BackfillNumericSeparatorTest.php" role="test" />
       <file baseinstalldir="" name="NullsafeObjectOperatorTest.inc" role="test" />
       <file baseinstalldir="" name="NullsafeObjectOperatorTest.php" role="test" />
+      <file baseinstalldir="" name="ScopeSettingWithNamespaceOperatorTest.inc" role="test" />
+      <file baseinstalldir="" name="ScopeSettingWithNamespaceOperatorTest.php" role="test" />
       <file baseinstalldir="" name="ShortArrayTest.inc" role="test" />
       <file baseinstalldir="" name="ShortArrayTest.php" role="test" />
       <file baseinstalldir="" name="StableCommentWhitespaceTest.inc" role="test" />
@@ -1986,6 +1988,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.php" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.inc" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php" name="tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc" name="tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.php" name="tests/Core/Tokenizer/ShortArrayTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.inc" name="tests/Core/Tokenizer/ShortArrayTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.php" />
@@ -2047,6 +2051,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.php" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/NullsafeObjectOperatorTest.inc" name="tests/Core/Tokenizer/NullsafeObjectOperatorTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php" name="tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc" name="tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.php" name="tests/Core/Tokenizer/ShortArrayTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/ShortArrayTest.inc" name="tests/Core/Tokenizer/ShortArrayTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/StableCommentWhitespaceTest.php" name="tests/Core/Tokenizer/StableCommentWhitespaceTest.php" />

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1441,6 +1441,7 @@ class File
                     $typeHintEndToken = $i;
                 }
                 break;
+            case T_NAMESPACE:
             case T_NS_SEPARATOR:
                 // Part of a type hint or default value.
                 if ($defaultStart === null) {
@@ -1630,6 +1631,7 @@ class File
                 T_SELF         => T_SELF,
                 T_PARENT       => T_PARENT,
                 T_STATIC       => T_STATIC,
+                T_NAMESPACE    => T_NAMESPACE,
                 T_NS_SEPARATOR => T_NS_SEPARATOR,
             ];
 
@@ -1813,6 +1815,7 @@ class File
                 T_CALLABLE     => T_CALLABLE,
                 T_SELF         => T_SELF,
                 T_PARENT       => T_PARENT,
+                T_NAMESPACE    => T_NAMESPACE,
                 T_NS_SEPARATOR => T_NS_SEPARATOR,
             ];
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1898,6 +1898,7 @@ class PHP extends Tokenizer
                         T_STRING       => T_STRING,
                         T_ARRAY        => T_ARRAY,
                         T_COLON        => T_COLON,
+                        T_NAMESPACE    => T_NAMESPACE,
                         T_NS_SEPARATOR => T_NS_SEPARATOR,
                         T_NULLABLE     => T_NULLABLE,
                         T_CALLABLE     => T_CALLABLE,

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1149,6 +1149,7 @@ class PHP extends Tokenizer
 
                     if ($tokenType === T_STRING
                         || $tokenType === T_ARRAY
+                        || $tokenType === T_NAMESPACE
                         || $tokenType === T_NS_SEPARATOR
                     ) {
                         $lastRelevantNonEmpty = $tokenType;
@@ -1382,6 +1383,7 @@ class PHP extends Tokenizer
                             T_CALLABLE     => T_CALLABLE,
                             T_SELF         => T_SELF,
                             T_PARENT       => T_PARENT,
+                            T_NAMESPACE    => T_NAMESPACE,
                             T_NS_SEPARATOR => T_NS_SEPARATOR,
                         ];
 

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -1111,6 +1111,13 @@ abstract class Tokenizer
                         continue;
                     }
 
+                    if ($tokenType === T_NAMESPACE) {
+                        // PHP namespace keywords are special because they can be
+                        // used as blocks but also inline as operators.
+                        // So if we find them nested inside another opener, just skip them.
+                        continue;
+                    }
+
                     if ($tokenType === T_FUNCTION
                         && $this->tokens[$stackPtr]['code'] !== T_FUNCTION
                     ) {

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -188,3 +188,8 @@ class PHP8Mixed {
     // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
     private ?mixed $nullableMixed;
 }
+
+class NSOperatorInType {
+    /* testNamespaceOperatorTypeHint */
+    public ?namespace\Name $prop;
+}

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -479,6 +479,16 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'nullable_type'   => true,
                 ],
             ],
+            [
+                '/* testNamespaceOperatorTypeHint */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?namespace\Name',
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
 
     }//end dataGetMemberProperties()

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -38,3 +38,6 @@ function mixedTypeHint(mixed &...$var1) {}
 /* testPHP8MixedTypeHintNullable */
 // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
 function mixedTypeHintNullable(?Mixed $var1) {}
+
+/* testNamespaceOperatorTypeHint */
+function namespaceOperatorTypeHint(?namespace\Name $var1) {}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -319,6 +319,28 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of type declarations using the namespace operator.
+     *
+     * @return void
+     */
+    public function testNamespaceOperatorTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '?namespace\Name $var1',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '?namespace\Name',
+            'nullable_type'     => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testNamespaceOperatorTypeHint()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/tests/Core/File/GetMethodPropertiesTest.inc
+++ b/tests/Core/File/GetMethodPropertiesTest.inc
@@ -80,3 +80,6 @@ function mixedTypeHint() :mixed {}
 /* testPHP8MixedTypeHintNullable */
 // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
 function mixedTypeHintNullable(): ?mixed {}
+
+/* testNamespaceOperatorTypeHint */
+function namespaceOperatorTypeHint() : ?namespace\Name {}

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -453,6 +453,29 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test a function with return type using the namespace operator.
+     *
+     * @return void
+     */
+    public function testNamespaceOperatorTypeHint()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '?namespace\Name',
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testNamespaceOperatorTypeHint()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.inc
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.inc
@@ -63,6 +63,9 @@ $a = fn($x) => yield 'k' => $x;
 /* testNullableNamespace */
 $a = fn(?\DateTime $x) : ?\DateTime => $x;
 
+/* testNamespaceOperatorInTypes */
+$fn = fn(namespace\Foo $a) : ?namespace\Foo => $a;
+
 /* testSelfReturnType */
 fn(self $a) : self => $a;
 

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -466,6 +466,34 @@ class BackfillFnTokenTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test arrow functions that use the namespace operator in the return type.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testNamespaceOperatorInTypes()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token = $this->getTargetToken('/* testNamespaceOperatorInTypes */', T_FN);
+        $this->backfillHelper($token);
+
+        $this->assertSame($tokens[$token]['scope_opener'], ($token + 16), 'Scope opener is not the arrow token');
+        $this->assertSame($tokens[$token]['scope_closer'], ($token + 19), 'Scope closer is not the semicolon token');
+
+        $opener = $tokens[$token]['scope_opener'];
+        $this->assertSame($tokens[$opener]['scope_opener'], ($token + 16), 'Opener scope opener is not the arrow token');
+        $this->assertSame($tokens[$opener]['scope_closer'], ($token + 19), 'Opener scope closer is not the semicolon token');
+
+        $closer = $tokens[$token]['scope_closer'];
+        $this->assertSame($tokens[$closer]['scope_opener'], ($token + 16), 'Closer scope opener is not the arrow token');
+        $this->assertSame($tokens[$closer]['scope_closer'], ($token + 19), 'Closer scope closer is not the semicolon token');
+
+    }//end testNamespaceOperatorInTypes()
+
+
+    /**
      * Test arrow functions that use self/parent/callable/array/static return types.
      *
      * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional

--- a/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc
+++ b/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+/* testClassExtends */
+class Foo extends namespace\Bar {}
+
+/* testClassImplements */
+$anon = new class implements namespace\Foo {}
+
+/* testInterfaceExtends */
+interface FooBar extends namespace\BarFoo {}
+
+/* testFunctionReturnType */
+function foo() : namespace\Baz {}
+
+/* testClosureReturnType */
+$closure = function () : namespace\Baz {}
+
+/* testArrowFunctionReturnType */
+$fn = fn() : namespace\Baz => new namespace\Baz;

--- a/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
+++ b/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests the adding of the "bracket_opener/closer" keys to use group tokens.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class ScopeSettingWithNamespaceOperatorTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that the scope opener/closers are set correctly when the namespace keyword is encountered as an operator.
+     *
+     * @param string       $testMarker The comment which prefaces the target tokens in the test file.
+     * @param int|string[] $tokenTypes The token type to search for.
+     * @param int|string[] $open       Optional. The token type for the scope opener.
+     * @param int|string[] $close      Optional. The token type for the scope closer.
+     *
+     * @dataProvider dataScopeSetting
+     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
+     *
+     * @return void
+     */
+    public function testScopeSetting($testMarker, $tokenTypes, $open=T_OPEN_CURLY_BRACKET, $close=T_CLOSE_CURLY_BRACKET)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $target = $this->getTargetToken($testMarker, $tokenTypes);
+        $opener = $this->getTargetToken($testMarker, $open);
+        $closer = $this->getTargetToken($testMarker, $close);
+
+        $this->assertArrayHasKey('scope_opener', $tokens[$target], 'Scope opener missing');
+        $this->assertArrayHasKey('scope_closer', $tokens[$target], 'Scope closer missing');
+        $this->assertSame($opener, $tokens[$target]['scope_opener'], 'Scope opener not same');
+        $this->assertSame($closer, $tokens[$target]['scope_closer'], 'Scope closer not same');
+
+        $this->assertArrayHasKey('scope_opener', $tokens[$opener], 'Scope opener missing for open curly');
+        $this->assertArrayHasKey('scope_closer', $tokens[$opener], 'Scope closer missing for open curly');
+        $this->assertSame($opener, $tokens[$opener]['scope_opener'], 'Scope opener not same for open curly');
+        $this->assertSame($closer, $tokens[$opener]['scope_closer'], 'Scope closer not same for open curly');
+
+        $this->assertArrayHasKey('scope_opener', $tokens[$closer], 'Scope opener missing for close curly');
+        $this->assertArrayHasKey('scope_closer', $tokens[$closer], 'Scope closer missing for close curly');
+        $this->assertSame($opener, $tokens[$closer]['scope_opener'], 'Scope opener not same for close curly');
+        $this->assertSame($closer, $tokens[$closer]['scope_closer'], 'Scope closer not same for close curly');
+
+    }//end testScopeSetting()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testScopeSetting()
+     *
+     * @return array
+     */
+    public function dataScopeSetting()
+    {
+        return [
+            [
+                '/* testClassExtends */',
+                [T_CLASS],
+            ],
+            [
+                '/* testClassImplements */',
+                [T_ANON_CLASS],
+            ],
+            [
+                '/* testInterfaceExtends */',
+                [T_INTERFACE],
+            ],
+            [
+                '/* testFunctionReturnType */',
+                [T_FUNCTION],
+            ],
+            [
+                '/* testClosureReturnType */',
+                [T_CLOSURE],
+            ],
+            [
+                '/* testArrowFunctionReturnType */',
+                [T_FN],
+                [T_FN_ARROW],
+                [T_SEMICOLON],
+            ],
+        ];
+
+    }//end dataScopeSetting()
+
+
+}//end class


### PR DESCRIPTION
Follow up on https://github.com/squizlabs/PHP_CodeSniffer/pull/3063#issuecomment-683476495

The `namespace` keyword as an operator is perfectly valid to be used as part of a type declaration.
See: https://3v4l.org/hvjlL

This usage was so far not supported in the tokenizer for the determination whether a `?` is a nullable type token or a ternary, nor was it taken into account for skipping over the return type for an arrow function in the backfill.

Lastly, this usage was so far not supported in the `File::getMethodParameters()`, `File::getMethodProperties()` and the `File::getMemberProperties()` methods.

Fixed now.

Includes select unit tests covering the functionality.

--- 

[Edit]
I've added an additional commit fixing the `Tokenizer::recurseScopeMap()` method as when the namespace keyword used as an operator was encountered, the scope openers/closers would incorrectly not be set.

The namespace keyword as a scope opener can never be within another scope, so we can safely ignore it when encountered as it will always be the namespace keyword used as an operator in that case.

Includes dedicated unit tests.

