### PR TITLE
PHP 8.0 | PSR12/NullableTypeDeclaration: allow for static return type

### DIFF
--- a/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/NullableTypeDeclarationSniff.php
@@ -26,6 +26,7 @@ class NullableTypeDeclarationSniff implements Sniff
         T_CALLABLE     => true,
         T_SELF         => true,
         T_PARENT       => true,
+        T_STATIC       => true,
     ];
 
 

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc
@@ -82,3 +82,6 @@ class testInstanceOf() {
         $bal = $value instanceof static ? CONSTANT_NAME : $value;
     }
 }
+
+// PHP 8.0: static return type.
+function testStatic() : ? static {}

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.inc.fixed
@@ -80,3 +80,6 @@ class testInstanceOf() {
         $bal = $value instanceof static ? CONSTANT_NAME : $value;
     }
 }
+
+// PHP 8.0: static return type.
+function testStatic() : ?static {}

--- a/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/NullableTypeDeclarationUnitTest.php
@@ -40,6 +40,7 @@ class NullableTypeDeclarationUnitTest extends AbstractSniffUnitTest
             57 => 2,
             58 => 2,
             59 => 2,
+            87 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
PHP 8.0 introduces `static` as a valid return type. This PR adjusts the `PSR12.Functions.NullableTypeDeclaration` sniff to handle that return type as well.