### PR TITLE
PHP 8.0 | Stabilize comment tokenization for hash comments

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -567,12 +567,12 @@ class PHP extends Tokenizer
             }
 
             /*
-                PHP 8 tokenizes a new line after a slash comment to the next whitespace token.
+                PHP 8 tokenizes a new line after a slash and hash comment to the next whitespace token.
             */
 
             if (PHP_VERSION_ID >= 80000
                 && $tokenIsArray === true
-                && ($token[0] === T_COMMENT && strpos($token[1], '//') === 0)
+                && ($token[0] === T_COMMENT && (strpos($token[1], '//') === 0 || strpos($token[1], '#') === 0))
                 && isset($tokens[($stackPtr + 1)]) === true
                 && is_array($tokens[($stackPtr + 1)]) === true
                 && $tokens[($stackPtr + 1)][0] === T_WHITESPACE

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.inc
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.inc
@@ -111,8 +111,28 @@ $prop = 123; /** Comment */
  * @tag Comment
  */
 
+/* testSingleLineHashComment */
+# Comment
+
+/* testSingleLineHashCommentTrailing */
+echo 'a'; # Comment
+
+/* testMultiLineHashComment */
+# Comment1
+# Comment2
+# Comment3
+
+/* testMultiLineHashCommentWithIndent */
+    # Comment1
+    # Comment2
+    # Comment3
+
 /* testSingleLineSlashCommentNoNewLineAtEnd */
 // Slash ?>
+<?php
+
+/* testSingleLineHashCommentNoNewLineAtEnd */
+# Hash ?>
 <?php
 
 /* testCommentAtEndOfFile */

--- a/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceTest.php
@@ -924,11 +924,113 @@ class StableCommentWhitespaceTest extends AbstractMethodUnitTest
                 ],
             ],
             [
+                '/* testSingleLineHashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineHashCommentTrailing */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineHashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineHashCommentWithIndent */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
                 '/* testSingleLineSlashCommentNoNewLineAtEnd */',
                 [
                     [
                         'type'    => 'T_COMMENT',
                         'content' => '// Slash ',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_TAG',
+                        'content' => '?>
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineHashCommentNoNewLineAtEnd */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Hash ',
                     ],
                     [
                         'type'    => 'T_CLOSE_TAG',

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.inc
@@ -39,5 +39,25 @@ echo 'a'; // Comment
 // Slash ?>
 <?php
 
+/* testSingleLineHashComment */
+# Comment
+
+/* testSingleLineHashCommentTrailing */
+echo 'a'; # Comment
+
+/* testMultiLineHashComment */
+# Comment1
+# Comment2
+# Comment3
+
+/* testMultiLineHashCommentWithIndent */
+    # Comment1
+    # Comment2
+    # Comment3
+
+/* testSingleLineHashCommentNoNewLineAtEnd */
+# Hash ?>
+<?php
+
 /* testCommentAtEndOfFile */
 /* Comment

--- a/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
+++ b/tests/Core/Tokenizer/StableCommentWhitespaceWinTest.php
@@ -249,6 +249,108 @@ class StableCommentWhitespaceWinTest extends AbstractMethodUnitTest
                 ],
             ],
             [
+                '/* testSingleLineHashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineHashCommentTrailing */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineHashComment */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testMultiLineHashCommentWithIndent */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment1
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment2
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '    ',
+                    ],
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Comment3
+',
+                    ],
+                    [
+                        'type'    => 'T_WHITESPACE',
+                        'content' => '
+',
+                    ],
+                ],
+            ],
+            [
+                '/* testSingleLineHashCommentNoNewLineAtEnd */',
+                [
+                    [
+                        'type'    => 'T_COMMENT',
+                        'content' => '# Hash ',
+                    ],
+                    [
+                        'type'    => 'T_CLOSE_TAG',
+                        'content' => '?>
+',
+                    ],
+                ],
+            ],
+            [
                 '/* testCommentAtEndOfFile */',
                 [
                     [


### PR DESCRIPTION
Follow up on #3027 which handled this for slash-style comments.

Hash-style comments were not addressed in the earlier change. This oversight has now been fixed.

Includes additional unit tests.

Fixes #3069