### PR TITLE
Do not attempt to fix ArrayDeclaration.SpaceBeforeComma if there is a comment in between

### DIFF
--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -450,9 +450,14 @@ class ArrayDeclarationSniff implements Sniff
                             $error = 'Expected 0 spaces before comma; %s found';
                             $data  = [$spaceLength];
 
-                            $fix = $phpcsFile->addFixableError($error, $nextToken, 'SpaceBeforeComma', $data);
-                            if ($fix === true) {
-                                $phpcsFile->fixer->replaceToken(($nextToken - 1), '');
+                            // The error is only fixable if there is only whitespace between the tokens.
+                            if ($prev === $phpcsFile->findPrevious(T_WHITESPACE, ($nextToken - 1), null, true)) {
+                                $fix = $phpcsFile->addFixableError($error, $nextToken, 'SpaceBeforeComma', $data);
+                                if ($fix === true) {
+                                    $phpcsFile->fixer->replaceToken(($nextToken - 1), '');
+                                }
+                            } else {
+                                $phpcsFile->addError($error, $nextToken, 'SpaceBeforeComma', $data);
                             }
                         }
                     }//end if

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -436,6 +436,13 @@ $c];
 ['a' => $a, 'b' => $b,
 'c' => $c];
 
+[
+ 'foo',
+ 'bar'
+ // This is a non-fixable error.
+ ,
+];
+
 // Intentional syntax error.
 $a = [
       'a' =>

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -470,6 +470,13 @@ $foo = [
  'c' => $c,
 ];
 
+[
+ 'foo',
+ 'bar'
+ // This is a non-fixable error.
+ ,
+];
+
 // Intentional syntax error.
 $a = [
       'a' =>

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -204,6 +204,7 @@ class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 434 => 2,
                 436 => 2,
                 437 => 3,
+                443 => 1,
             ];
         default:
             return [];


### PR DESCRIPTION
Fixes #3065.