### PR TITLE
PHPCS 4.x | .gitignore: ignore the PHPUnit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/*
 /vendor/
 composer.lock
+/.phpunit.result.cache


### PR DESCRIPTION
As PHPCS 4.x now supports PHPUnit 8 and 9, which automatically enables caching of the test results, a `.phpunit.result.cache` file will be created.

This file should not be committed, so adding it to the `.gitignore` file.

---
Note: the build will fail because the 4.x build is failing anyway: https://travis-ci.org/github/squizlabs/PHP_CodeSniffer/builds/719778827 - that should be fixed once commit d33a6a99ae2f165f1f835ebf1645e471280cbcbd has been cherry-picked to the 4.x branch.