### PR TITLE
PHPCS 4.x | Fix inconsistent output

### DIFF
--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -45,9 +45,9 @@ class Code implements Report
         if (empty($tokens) === true) {
             if (PHP_CODESNIFFER_VERBOSITY === 1) {
                 $startTime = microtime(true);
-                echo 'CODE report is parsing '.basename($file).' ';
+                Util\Common::forcePrintStatusMessage('CODE report is parsing '.basename($file).' ', 0, true);
             } else if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                echo "CODE report is forcing parse of $file".PHP_EOL;
+                Util\Common::forcePrintStatusMessage("CODE report is forcing parse of $file", 0);
             }
 
             try {
@@ -61,13 +61,11 @@ class Code implements Report
                 $timeTaken = ((microtime(true) - $startTime) * 1000);
                 if ($timeTaken < 1000) {
                     $timeTaken = round($timeTaken);
-                    echo "DONE in {$timeTaken}ms";
+                    Util\Common::forcePrintStatusMessage("DONE in {$timeTaken}ms", 0);
                 } else {
                     $timeTaken = round(($timeTaken / 1000), 2);
-                    echo "DONE in $timeTaken secs";
+                    Util\Common::forcePrintStatusMessage("DONE in $timeTaken secs", 0);
                 }
-
-                echo PHP_EOL;
             }
 
             $tokens = $phpcsFile->getTokens();

--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -332,7 +332,7 @@ class ScopeIndentSniff implements Sniff
                         if ($this->debug === true) {
                             $line = $tokens[$first]['line'];
                             $type = $tokens[$first]['type'];
-                            echo "\t* first token on line $line is $first ($type) *".PHP_EOL;
+                            Common::printStatusMessage("* first token on line $line is $first ($type) *", 1);
                         }
 
                         $checkIndent = ($tokens[$first]['column'] - 1);

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -690,8 +690,7 @@ abstract class Tokenizer
             } else if ($this->tokens[$i]['code'] === T_ATTRIBUTE) {
                 $openers[] = $i;
                 if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                    echo str_repeat("\t", count($openers));
-                    echo "=> Found attribute opener at $i".PHP_EOL;
+                    Common::printStatusMessage("=> Found attribute opener at $i", count($openers));
                 }
 
                 $this->tokens[$i]['attribute_opener'] = $i;
@@ -704,8 +703,7 @@ abstract class Tokenizer
                         $this->tokens[$opener]['attribute_closer'] = $i;
 
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                            echo str_repeat("\t", (count($openers) + 1));
-                            echo "=> Found attribute closer at $i for $opener".PHP_EOL;
+                            Common::printStatusMessage("=> Found attribute closer at $i for $opener", (count($openers) + 1));
                         }
 
                         for ($x = ($opener + 1); $x <= $i; ++$x) {
@@ -717,8 +715,7 @@ abstract class Tokenizer
                             $this->tokens[$x]['attribute_closer'] = $i;
                         }
                     } else if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                        echo str_repeat("\t", (count($openers) + 1));
-                        echo "=> Found unowned attribute closer at $i for $opener".PHP_EOL;
+                        Common::printStatusMessage("=> Found unowned attribute closer at $i for $opener", (count($openers) + 1));
                     }
                 }//end if
             }//end if


### PR DESCRIPTION
Commit d4f33dbf45aa5bb78e077b0e73306746c8bd98cf changed the output from STDOUT to STDERR using `Common::printStatusMessage()` instead of plain `echo`'s.

In the mean time, some new `echo`'s have slipped in. This fixes those up.