### PR TITLE
PHP 8.0 | Generic/UpperCaseConstantName: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/UpperCaseConstantNameSniff.php
@@ -83,6 +83,7 @@ class UpperCaseConstantNameSniff implements Sniff
         $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if ($tokens[$prev]['code'] === T_OBJECT_OPERATOR
             || $tokens[$prev]['code'] === T_DOUBLE_COLON
+            || $tokens[$prev]['code'] === T_NULLSAFE_OBJECT_OPERATOR
         ) {
             return;
         }

--- a/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/UpperCaseConstantNameUnitTest.inc
@@ -29,3 +29,5 @@ class ClassConstBowOutTest {
     const // phpcs:ignore Standard.Category.Sniff
         some_constant = 2;
 }
+
+$foo->getBar()?->define('foo');


### PR DESCRIPTION
Includes unit test.