### PR TITLE
PHP 8.0 | Generic/ForbiddenFunctions: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -120,18 +120,19 @@ class ForbiddenFunctionsSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = [
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
-            T_PUBLIC          => true,
-            T_PRIVATE         => true,
-            T_PROTECTED       => true,
-            T_AS              => true,
-            T_NEW             => true,
-            T_INSTEADOF       => true,
-            T_NS_SEPARATOR    => true,
-            T_IMPLEMENTS      => true,
+            T_DOUBLE_COLON             => true,
+            T_OBJECT_OPERATOR          => true,
+            T_NULLSAFE_OBJECT_OPERATOR => true,
+            T_FUNCTION                 => true,
+            T_CONST                    => true,
+            T_PUBLIC                   => true,
+            T_PRIVATE                  => true,
+            T_PROTECTED                => true,
+            T_AS                       => true,
+            T_NEW                      => true,
+            T_INSTEADOF                => true,
+            T_NS_SEPARATOR             => true,
+            T_IMPLEMENTS               => true,
         ];
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);

--- a/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
@@ -54,4 +54,4 @@ class SizeOf implements Something {}
 function mymodule_form_callback(SizeOf $sizeof) {
 }
 
-?>
+$size = $class?->sizeof($array);


### PR DESCRIPTION
Includes unit test.