### PR TITLE
PHP 8.0 | Generic/SAPIUsage: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/SAPIUsageSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SAPIUsageSniff.php
@@ -42,10 +42,11 @@ class SAPIUsageSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = [
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            T_DOUBLE_COLON             => true,
+            T_OBJECT_OPERATOR          => true,
+            T_NULLSAFE_OBJECT_OPERATOR => true,
+            T_FUNCTION                 => true,
+            T_CONST                    => true,
         ];
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);

--- a/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/SAPIUsageUnitTest.inc
@@ -2,3 +2,4 @@
 if (php_sapi_name() !== 'cli') {}
 if (PHP_SAPI !== 'cli') {}
 if ($object->php_sapi_name() === true) {}
+if ($object?->php_sapi_name() === true) {}


### PR DESCRIPTION
Includes unit test.