### PR TITLE
PHP 8.0 | Generic/ScopeIndent: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -913,7 +913,8 @@ class ScopeIndentSniff implements Sniff
             // Don't perform strict checking on chained method calls since they
             // are often covered by custom rules.
             if ($checkToken !== null
-                && $tokens[$checkToken]['code'] === T_OBJECT_OPERATOR
+                && ($tokens[$checkToken]['code'] === T_OBJECT_OPERATOR
+                || $tokens[$checkToken]['code'] === T_NULLSAFE_OBJECT_OPERATOR)
                 && $exact === true
             ) {
                 $exact = false;

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc
@@ -1454,6 +1454,15 @@ return [
     ]),
 ];
 
+echo $string?->append('foo')
+            ?->outputUsing();
+
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact true
+echo $string?->append('foo')
+            ?->outputUsing();
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact false
+
+/* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 
      <?php if (true) : ?>

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.1.inc.fixed
@@ -1454,6 +1454,15 @@ return [
     ]),
 ];
 
+echo $string?->append('foo')
+            ?->outputUsing();
+
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact true
+echo $string?->append('foo')
+            ?->outputUsing();
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact false
+
+/* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 
      <?php if (true) : ?>

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc
@@ -1454,6 +1454,15 @@ return [
 	]),
 ];
 
+echo $string?->append('foo')
+			?->outputUsing();
+
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact true
+echo $string?->append('foo')
+			?->outputUsing();
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact false
+
+/* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 
 	 <?php if (true) : ?>

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.2.inc.fixed
@@ -1454,6 +1454,15 @@ return [
 	]),
 ];
 
+echo $string?->append('foo')
+			?->outputUsing();
+
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact true
+echo $string?->append('foo')
+			?->outputUsing();
+// phpcs:set Generic.WhiteSpace.ScopeIndent exact false
+
+/* ADD NEW TESTS ABOVE THIS LINE AND MAKE SURE THAT THE 1 (space-based) AND 2 (tab-based) FILES ARE IN SYNC! */
 ?>
 
 	 <?php if (true) : ?>

--- a/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/ScopeIndentUnitTest.php
@@ -178,10 +178,10 @@ class ScopeIndentUnitTest extends AbstractSniffUnitTest
             1340 => 1,
             1342 => 1,
             1345 => 1,
-            1464 => 1,
-            1465 => 1,
-            1466 => 1,
-            1467 => 1,
+            1473 => 1,
+            1474 => 1,
+            1475 => 1,
+            1476 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes unit test.