### PR TITLE
PHP 8.0 | PEAR/ObjectOperatorIndent: sniff for nullsafe object operator

### DIFF
--- a/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/src/Standards/PEAR/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -29,6 +29,16 @@ class ObjectOperatorIndentSniff implements Sniff
      */
     public $multilevel = false;
 
+    /**
+     * Tokens to listen for.
+     *
+     * @var array
+     */
+    private $targets = [
+        T_OBJECT_OPERATOR,
+        T_NULLSAFE_OBJECT_OPERATOR,
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -37,7 +47,7 @@ class ObjectOperatorIndentSniff implements Sniff
      */
     public function register()
     {
-        return [T_OBJECT_OPERATOR];
+        return $this->targets;
 
     }//end register()
 
@@ -57,14 +67,14 @@ class ObjectOperatorIndentSniff implements Sniff
 
         // Make sure this is the first object operator in a chain of them.
         $start = $phpcsFile->findStartOfStatement($stackPtr);
-        $prev  = $phpcsFile->findPrevious(T_OBJECT_OPERATOR, ($stackPtr - 1), $start);
+        $prev  = $phpcsFile->findPrevious($this->targets, ($stackPtr - 1), $start);
         if ($prev !== false) {
             return;
         }
 
         // Make sure this is a chained call.
         $end  = $phpcsFile->findEndOfStatement($stackPtr);
-        $next = $phpcsFile->findNext(T_OBJECT_OPERATOR, ($stackPtr + 1), $end);
+        $next = $phpcsFile->findNext($this->targets, ($stackPtr + 1), $end);
         if ($next === false) {
             // Not a chained call.
             return;
@@ -179,7 +189,7 @@ class ObjectOperatorIndentSniff implements Sniff
             }//end if
 
             $next = $phpcsFile->findNext(
-                T_OBJECT_OPERATOR,
+                $this->targets,
                 ($next + 1),
                 null,
                 false,

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
@@ -110,3 +110,27 @@ $rootNode
         ->five();
 
 // phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false
+
+$object
+    ?->setBar($foo)
+    ?->setFoo($bar);
+
+$someObject?->someFunction("some", "parameter")
+->someOtherFunc(23, 42)?->
+    someOtherFunc2($one, $two)
+
+->someOtherFunc3(23, 42)
+    ?->andAThirdFunction();
+
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel true
+$object
+    ?->setBar($foo)
+        ?->setFoo($bar);
+
+$someObject?->someFunction("some", "parameter")
+->someOtherFunc(23, 42)
+        ?->someOtherFunc2($one, $two)
+
+->someOtherFunc3(23, 42)
+    ?->andAThirdFunction();
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
@@ -110,3 +110,27 @@ $rootNode
         ->five();
 
 // phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false
+
+$object
+    ?->setBar($foo)
+    ?->setFoo($bar);
+
+$someObject?->someFunction("some", "parameter")
+    ->someOtherFunc(23, 42)
+    ?->someOtherFunc2($one, $two)
+
+    ->someOtherFunc3(23, 42)
+    ?->andAThirdFunction();
+
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel true
+$object
+    ?->setBar($foo)
+        ?->setFoo($bar);
+
+$someObject?->someFunction("some", "parameter")
+    ->someOtherFunc(23, 42)
+        ?->someOtherFunc2($one, $two)
+
+    ->someOtherFunc3(23, 42)
+    ?->andAThirdFunction();
+// phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -44,6 +44,10 @@ class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
             82  => 1,
             95  => 1,
             103 => 1,
+            119 => 2,
+            122 => 1,
+            131 => 1,
+            134 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This adds sniffing for the indentation of nullsafe object operators to the sniff.

Includes unit test.