### PR TITLE
PHP 8.0 | PSR1/SideEffects: allow for nullsafe object operator

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1005,6 +1005,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.10.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.11.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.12.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.13.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.14.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.15.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.16.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.php" role="test" />
        </dir>
        <dir name="Methods">

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -193,6 +193,7 @@ class SideEffectsSniff implements Sniff
             ) {
                 $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
                 if ($tokens[$prev]['code'] !== T_OBJECT_OPERATOR
+                    && $tokens[$prev]['code'] !== T_NULLSAFE_OBJECT_OPERATOR
                     && $tokens[$prev]['code'] !== T_DOUBLE_COLON
                     && $tokens[$prev]['code'] !== T_FUNCTION
                 ) {
@@ -216,11 +217,13 @@ class SideEffectsSniff implements Sniff
                 && strtolower($tokens[$i]['content']) === 'defined'
             ) {
                 $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
-                if ($tokens[$openBracket]['code'] === T_OPEN_PARENTHESIS
+                if ($openBracket !== false
+                    && $tokens[$openBracket]['code'] === T_OPEN_PARENTHESIS
                     && isset($tokens[$openBracket]['parenthesis_closer']) === true
                 ) {
                     $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
                     if ($tokens[$prev]['code'] !== T_OBJECT_OPERATOR
+                        && $tokens[$prev]['code'] !== T_NULLSAFE_OBJECT_OPERATOR
                         && $tokens[$prev]['code'] !== T_DOUBLE_COLON
                         && $tokens[$prev]['code'] !== T_FUNCTION
                     ) {

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.13.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.13.inc
@@ -1,0 +1,2 @@
+<?php
+defined('MINSIZE') === false OR $my->define("MAXSIZE", 100);

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.14.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.14.inc
@@ -1,0 +1,2 @@
+<?php
+defined('MINSIZE') === false OR $my?->define("MAXSIZE", 100);

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.15.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.15.inc
@@ -1,0 +1,2 @@
+<?php
+$my->defined('MINSIZE') or define("MAXSIZE", 100);

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.16.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.16.inc
@@ -1,0 +1,2 @@
+<?php
+$my?->defined('MINSIZE') or define("MAXSIZE", 100);

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.php
@@ -67,6 +67,8 @@ class SideEffectsUnitTest extends AbstractSniffUnitTest
         case 'SideEffectsUnitTest.5.inc':
         case 'SideEffectsUnitTest.10.inc':
         case 'SideEffectsUnitTest.12.inc':
+        case 'SideEffectsUnitTest.15.inc':
+        case 'SideEffectsUnitTest.16.inc':
             return [1 => 1];
         default:
             return [];


### PR DESCRIPTION
Includes unit tests.

Note: adding the token to the second condition (test 15/16) seems redundant and the original `T_OBJECT_OPERATOR` could be removed here too as, if an instantiated object is seen before the `defined()`, a side-effect would already have registered for the variable anyway.