### PR TITLE
PHP 8.0 | PSR12/ClassInstantiation: allow for nullsafe object operator

### DIFF
--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -44,14 +44,15 @@ class ClassInstantiationSniff implements Sniff
 
         // Find the class name.
         $allowed = [
-            T_STRING          => T_STRING,
-            T_NS_SEPARATOR    => T_NS_SEPARATOR,
-            T_SELF            => T_SELF,
-            T_STATIC          => T_STATIC,
-            T_VARIABLE        => T_VARIABLE,
-            T_DOLLAR          => T_DOLLAR,
-            T_OBJECT_OPERATOR => T_OBJECT_OPERATOR,
-            T_DOUBLE_COLON    => T_DOUBLE_COLON,
+            T_STRING                   => T_STRING,
+            T_NS_SEPARATOR             => T_NS_SEPARATOR,
+            T_SELF                     => T_SELF,
+            T_STATIC                   => T_STATIC,
+            T_VARIABLE                 => T_VARIABLE,
+            T_DOLLAR                   => T_DOLLAR,
+            T_OBJECT_OPERATOR          => T_OBJECT_OPERATOR,
+            T_NULLSAFE_OBJECT_OPERATOR => T_NULLSAFE_OBJECT_OPERATOR,
+            T_DOUBLE_COLON             => T_DOUBLE_COLON,
         ];
 
         $allowed += Tokens::$emptyTokens;

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
@@ -32,3 +32,7 @@ $foo = new $bar['a'] [$baz['a']/* comment */  ['b']]['b'];
 $a = new self::$transport[$cap_string];
 $renderer = new $this->inline_diff_renderer;
 $a = new ${$varHoldingClassName};
+
+$class = new $obj?->classname();
+$class = new $obj?->classname;
+$class = new ${$obj?->classname};

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
@@ -32,3 +32,7 @@ $foo = new $bar['a'] [$baz['a']/* comment */  ['b']]['b']();
 $a = new self::$transport[$cap_string]();
 $renderer = new $this->inline_diff_renderer();
 $a = new ${$varHoldingClassName}();
+
+$class = new $obj?->classname();
+$class = new $obj?->classname();
+$class = new ${$obj?->classname}();

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
@@ -41,6 +41,8 @@ class ClassInstantiationUnitTest extends AbstractSniffUnitTest
             32 => 1,
             33 => 1,
             34 => 1,
+            37 => 1,
+            38 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes unit tests.