### PR TITLE
PHP 8.0 | Squiz/ValidVariableName: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -38,7 +38,9 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         }
 
         $objOperator = $phpcsFile->findNext([T_WHITESPACE], ($stackPtr + 1), null, true);
-        if ($tokens[$objOperator]['code'] === T_OBJECT_OPERATOR) {
+        if ($tokens[$objOperator]['code'] === T_OBJECT_OPERATOR
+            || $tokens[$objOperator]['code'] === T_NULLSAFE_OBJECT_OPERATOR
+        ) {
             // Check to see if we are using a variable from an object.
             $var = $phpcsFile->findNext([T_WHITESPACE], ($objOperator + 1), null, true);
             if ($tokens[$var]['code'] === T_STRING) {

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -142,3 +142,7 @@ $anonClass = new class() {
     }
 };
 
+echo $obj?->varName;
+echo $obj?->var_name;
+echo $obj?->varname;
+echo $obj?->_varName;

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -60,6 +60,7 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest
             123 => 1,
             138 => 1,
             141 => 1,
+            146 => 1,
         ];
 
         return $errors;


### PR DESCRIPTION
Includes unit test.