### PR TITLE
PHP 8.0 | Squiz/IncrementDecrementUsage: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Operators/IncrementDecrementUsageSniff.php
@@ -74,7 +74,8 @@ class IncrementDecrementUsageSniff implements Sniff
         // start looking for other operators.
         if ($tokens[($stackPtr - 1)]['code'] === T_VARIABLE
             || ($tokens[($stackPtr - 1)]['code'] === T_STRING
-            && $tokens[($stackPtr - 2)]['code'] === T_OBJECT_OPERATOR)
+            && ($tokens[($stackPtr - 2)]['code'] === T_OBJECT_OPERATOR
+            || $tokens[($stackPtr - 2)]['code'] === T_NULLSAFE_OBJECT_OPERATOR))
         ) {
             $start = ($stackPtr + 1);
         } else {

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.inc
@@ -37,4 +37,6 @@ $var = (1 + $var);
 $expected[$i]['sort_order'] = ($i + 1);
 $expected[($i + 1)]['sort_order'] = ($i + 1);
 
-$id = $id.($this->i++).$id;
+$id = $id.($obj->i++).$id;
+$id = $obj?->i++.$id;
+$id = $obj?->i++*10;

--- a/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Operators/IncrementDecrementUsageUnitTest.php
@@ -35,6 +35,8 @@ class IncrementDecrementUsageUnitTest extends AbstractSniffUnitTest
             27 => 1,
             29 => 1,
             31 => 1,
+            41 => 1,
+            42 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes unit test.

Note: there is quite a lot more which can do with improvement in this sniff, as the sniff is not code style independent, nor does it take all allowed syntaxes into account, such as array in/decrementing `$a[0]++` or nested property in/decrementing `--$obj->prop->nested` and more along those lines, but that's outside the scope of this PR.