### PR TITLE
PHP 8.0 | Squiz/DisallowComparisonAssignment: remove redundant code

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
@@ -70,7 +70,6 @@ class DisallowComparisonAssignmentSniff implements Sniff
         $ignore = [
             T_STRING,
             T_WHITESPACE,
-            T_OBJECT_OPERATOR,
         ];
 
         $next = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true);


### PR DESCRIPTION
While looking to add the `T_NULLSAFE_OBJECT_OPERATOR`, I realized the `T_OBJECT_OPERATOR` here did not have a function.

Removing it still allows all the tests to pass.