### PR TITLE
PHP 8.0 | Squiz/DisallowSizeFunctionsInLoops: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowSizeFunctionsInLoopsSniff.php
@@ -95,7 +95,9 @@ class DisallowSizeFunctionsInLoopsSniff implements Sniff
                     $functionName = 'object.'.$functionName;
                 } else {
                     // Make sure it isn't a member var.
-                    if ($tokens[($i - 1)]['code'] === T_OBJECT_OPERATOR) {
+                    if ($tokens[($i - 1)]['code'] === T_OBJECT_OPERATOR
+                        || $tokens[($i - 1)]['code'] === T_NULLSAFE_OBJECT_OPERATOR
+                    ) {
                         continue;
                     }
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DisallowSizeFunctionsInLoopsUnitTest.inc
@@ -55,4 +55,4 @@ do {
 } while($a->count);
 
 for ($i = 0; $i < $a->count; $i++) {}
-?>
+for ($i = 0; $i < $a?->count; $i++) {}


### PR DESCRIPTION
Includes unit test.