### PR TITLE
PHP 8.0 | Squiz/LowercasePHPFunctions: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -133,7 +133,9 @@ class LowercasePHPFunctionsSniff implements Sniff
             return;
         }
 
-        if ($tokens[$prev]['code'] === T_OBJECT_OPERATOR) {
+        if ($tokens[$prev]['code'] === T_OBJECT_OPERATOR
+            || $tokens[$prev]['code'] === T_NULLSAFE_OBJECT_OPERATOR
+        ) {
             // Not an inbuilt function.
             return;
         }

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc
@@ -39,3 +39,5 @@ $callToNamespacedFunction = MyNamespace /* phpcs:ignore Standard */ \STR_REPEAT(
 $callToNamespacedFunction = namespace\STR_REPEAT($a, 2); // Could potentially be false negative.
 
 $filePath = new \File($path);
+
+$count = $object?->Count();

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc.fixed
@@ -39,3 +39,5 @@ $callToNamespacedFunction = MyNamespace /* phpcs:ignore Standard */ \STR_REPEAT(
 $callToNamespacedFunction = namespace\STR_REPEAT($a, 2); // Could potentially be false negative.
 
 $filePath = new \File($path);
+
+$count = $object?->Count();


### PR DESCRIPTION
Includes unit test.