### PR TITLE
PHP 8.0 | Squiz/ObjectOperatorSpacing: sniff for nullsafe object operator

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -33,6 +33,7 @@ class ObjectOperatorSpacingSniff implements Sniff
         return [
             T_OBJECT_OPERATOR,
             T_DOUBLE_COLON,
+            T_NULLSAFE_OBJECT_OPERATOR,
         ];
 
     }//end register()

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc
@@ -46,3 +46,7 @@ thisObject::
     testThis();
 
 // phpcs:set Squiz.WhiteSpace.ObjectOperatorSpacing ignoreNewlines false
+
+$this?->testThis();
+$this?-> testThis();
+$this    ?->  testThis();

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.inc.fixed
@@ -42,3 +42,7 @@ thisObject::
     testThis();
 
 // phpcs:set Squiz.WhiteSpace.ObjectOperatorSpacing ignoreNewlines false
+
+$this?->testThis();
+$this?->testThis();
+$this?->testThis();

--- a/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ObjectOperatorSpacingUnitTest.php
@@ -43,6 +43,8 @@ class ObjectOperatorSpacingUnitTest extends AbstractSniffUnitTest
             39 => 1,
             40 => 2,
             42 => 2,
+            51 => 1,
+            52 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This adds sniffing for the spacing around nullsafe object operators to the sniff.

Includes unit test.