### PR TITLE
PHP 8.0 | Zend/ValidVariableName: allow for nullsafe object operator

### DIFF
--- a/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/Standards/Zend/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -38,7 +38,9 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         }
 
         $objOperator = $phpcsFile->findNext([T_WHITESPACE], ($stackPtr + 1), null, true);
-        if ($tokens[$objOperator]['code'] === T_OBJECT_OPERATOR) {
+        if ($tokens[$objOperator]['code'] === T_OBJECT_OPERATOR
+            || $tokens[$objOperator]['code'] === T_NULLSAFE_OBJECT_OPERATOR
+        ) {
             // Check to see if we are using a variable from an object.
             $var = $phpcsFile->findNext([T_WHITESPACE], ($objOperator + 1), null, true);
             if ($tokens[$var]['code'] === T_STRING) {

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -116,3 +116,7 @@ $anonClass = new class() {
         $bar_foo = 3;
     }
 };
+
+echo $obj?->varName;
+echo $obj?->var_name;
+echo $obj?->varName;

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -53,6 +53,7 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest
             99  => 1,
             113 => 1,
             116 => 1,
+            121 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes unit test.