### PR TITLE
Travis: retry composer install on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ before_install:
   # PHPUnit 8.x is not (yet) supported, so prevent issues with Travis images using it.
   - |
     if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
-      composer install
+      travis_retry composer install
     elif [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
       // Allow installing "incompatible" PHPUnit version on PHP 8/nightly.
-      composer install --ignore-platform-reqs
+      travis_retry composer install --ignore-platform-reqs
     fi
 
 before_script:


### PR DESCRIPTION
The builds are failing a little too often for my taste on the below error.
```
[Composer\Downloader\TransportException]
Peer fingerprint did not match
```

I'm prefixing the `composer install` commands now with `travis_retry` in an attempt to get round this problem.

Ref:
* https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies