### PR TITLE
Tokenizer/PHP: add missing scope closers

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -283,8 +283,10 @@ class PHP extends Tokenizer
         T_ENDFOREACH          => T_ENDFOREACH,
         T_ENDWHILE            => T_ENDWHILE,
         T_ENDSWITCH           => T_ENDSWITCH,
+        T_ENDDECLARE          => T_ENDDECLARE,
         T_BREAK               => T_BREAK,
         T_END_HEREDOC         => T_END_HEREDOC,
+        T_END_NOWDOC          => T_END_NOWDOC,
     ];
 
     /**


### PR DESCRIPTION
Noticed (while working on something else) there were some typical scope closers missing from the array.