### PR TITLE
Ignore the previous element's T_COMMA when looking up the beginning of the previous expression

### DIFF
--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -62,6 +62,7 @@ class ArrayIndentSniff extends AbstractArraySniff
         // Determine how far indented the entire array declaration should be.
         $ignore     = Tokens::$emptyTokens;
         $ignore[]   = T_DOUBLE_ARROW;
+        $ignore[]   = T_COMMA;
         $prev       = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
         $start      = $phpcsFile->findStartOfStatement($prev);
         $first      = $phpcsFile->findFirstOnLine(T_WHITESPACE, $start, true);

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
@@ -77,3 +77,14 @@ $var = [
         2 => 'two',
     /* three */ 3 => 'three',
     ];
+
+// phpcs:set Generic.Arrays.ArrayIndent indent 4
+
+$foo = [
+    'foo'
+        . 'bar',
+    [
+            'baz',
+            'qux',
+        ],
+];

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
@@ -78,3 +78,14 @@ $var = [
   2 => 'two',
   /* three */ 3 => 'three',
 ];
+
+// phpcs:set Generic.Arrays.ArrayIndent indent 4
+
+$foo = [
+    'foo'
+        . 'bar',
+    [
+        'baz',
+        'qux',
+    ],
+];

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -40,6 +40,9 @@ class ArrayIndentUnitTest extends AbstractSniffUnitTest
             77 => 1,
             78 => 1,
             79 => 1,
+            87 => 1,
+            88 => 1,
+            89 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Fixes #3100.