### PR TITLE
PSR12.Squiz.OperatorSpacing false positive for default values of arrow functions

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -345,6 +345,7 @@ class OperatorSpacingSniff implements Sniff
                     $function = $tokens[$bracket]['parenthesis_owner'];
                     if ($tokens[$function]['code'] === T_FUNCTION
                         || $tokens[$function]['code'] === T_CLOSURE
+                        || $tokens[$function]['code'] === T_FN
                         || $tokens[$function]['code'] === T_DECLARE
                     ) {
                         return false;

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -465,5 +465,10 @@ $a = $a ? - $b : - $b;
 
 exit -1;
 
+$cl = function ($boo =-1) {};
+$cl = function ($boo =+1) {};
+$fn = fn ($boo =-1) => $boo;
+$fn = fn ($boo =+1) => $boo;
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -459,5 +459,10 @@ $a = $a ? - $b : - $b;
 
 exit -1;
 
+$cl = function ($boo =-1) {};
+$cl = function ($boo =+1) {};
+$fn = fn ($boo =-1) => $boo;
+$fn = fn ($boo =+1) => $boo;
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +


### PR DESCRIPTION
The plus/minus in a default value of a function parameter declaration is ignored for normal functions and closures, but wasn't ignored yet for arrow functions.

Fixed now.

Includes unit test + test for the same for closures, which so far wasn't tested yet.

This also, by extension, fixes the same issue in the `PSR12.Operators.OperatorSpacing` sniff.