### PR TITLE
File::isReference(): bug fix - arrow function params passed by reference

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1978,6 +1978,7 @@ class File
                 $owner = $this->tokens[$this->tokens[$lastBracket]['parenthesis_owner']];
                 if ($owner['code'] === T_FUNCTION
                     || $owner['code'] === T_CLOSURE
+                    || $owner['code'] === T_FN
                 ) {
                     $params = $this->getMethodParameters($this->tokens[$lastBracket]['parenthesis_owner']);
                     foreach ($params as $param) {

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
@@ -56,3 +56,6 @@ function name($a = -1) {}
 
 $a =& $ref;
 $a = [ 'a' => &$something ];
+
+$fn = fn(array &$one) => 1;
+$fn = fn(array & $one) => 1;

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
@@ -56,3 +56,6 @@ function name($a = -1) {}
 
 $a =& $ref;
 $a = [ 'a' => &$something ];
+
+$fn = fn(array &$one) => 1;
+$fn = fn(array & $one) => 1;

--- a/tests/Core/File/IsReferenceTest.inc
+++ b/tests/Core/File/IsReferenceTest.inc
@@ -140,5 +140,11 @@ $closure = function() use (&$var){};
 /* testArrowFunctionReturnByReference */
 fn&($x) => $x;
 
+/* testArrowFunctionPassByReferenceA */
+$fn = fn(array &$one) => 1;
+
+/* testArrowFunctionPassByReferenceB */
+$fn = fn($param, &...$moreParams) => 1;
+
 /* testClosureReturnByReference */
 $closure = function &($param) use ($value) {};

--- a/tests/Core/File/IsReferenceTest.php
+++ b/tests/Core/File/IsReferenceTest.php
@@ -229,6 +229,14 @@ class IsReferenceTest extends AbstractMethodUnitTest
                 true,
             ],
             [
+                '/* testArrowFunctionPassByReferenceA */',
+                true,
+            ],
+            [
+                '/* testArrowFunctionPassByReferenceB */',
+                true,
+            ],
+            [
                 '/* testClosureReturnByReference */',
                 true,
             ],


### PR DESCRIPTION
The `&` for parameters passed by reference in an arrow function declaration were incorrectly not recognized as references.

This is the root cause of issue #3049, which affected the `PSR12.Operators.OperatorSpacing` and the `Squiz.WhiteSpace.OperatorSpacing` sniffs (and possibly/probably more sniffs).

Includes unit test.

Fixes #3049