### PR TITLE
File::isReference(): simplify logic

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1981,19 +1981,7 @@ class File
                 ) {
                     $params = $this->getMethodParameters($this->tokens[$lastBracket]['parenthesis_owner']);
                     foreach ($params as $param) {
-                        $varToken = $tokenAfter;
-                        if ($param['variable_length'] === true) {
-                            $varToken = $this->findNext(
-                                (Util\Tokens::$emptyTokens + [T_ELLIPSIS]),
-                                ($stackPtr + 1),
-                                null,
-                                true
-                            );
-                        }
-
-                        if ($param['token'] === $varToken
-                            && $param['pass_by_reference'] === true
-                        ) {
+                        if ($param['reference_token'] === $stackPtr) {
                             // Function parameter declared to be passed by reference.
                             return true;
                         }


### PR DESCRIPTION
The `File::getMethodParameters()` returns a `reference_token` index, so no need to do any token walking.