### PR TITLE
Runner::printProgress(): fix alignment of file counts

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -874,7 +874,7 @@ class Runner
 
         $percent = round(($numProcessed / $numFiles) * 100);
         $padding = (strlen($numFiles) - strlen($numProcessed));
-        if ($numProcessed === $numFiles && $numFiles > $numPerLine) {
+        if ($numProcessed === $numFiles && $numFiles > $numPerLine && ($numProcessed % $numPerLine) !== 0) {
             $padding += ($numPerLine - ($numFiles - (floor($numFiles / $numPerLine) * $numPerLine)));
         }
 


### PR DESCRIPTION
... when the total number of files is exactly dividable by 60.

Fixes #3058

For a "before" screenshot see the original issue.

"After" screenshot tested with various file counts:

![image](https://user-images.githubusercontent.com/663378/92314320-59fcc900-efd6-11ea-8a82-7e279018ccff.png)

