### PR TITLE
Allow variables to be used in double quotes

### DIFF
--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -15,6 +15,12 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class DoubleQuoteUsageSniff implements Sniff
 {
 
+    /**
+     * Whether to allow variables in strings or not.
+     *
+     * @var bool
+     */
+    public $allowVariables = false;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -81,7 +87,7 @@ class DoubleQuoteUsageSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_DOUBLE_QUOTED_STRING) {
             $stringTokens = token_get_all('<?php '.$workingString);
             foreach ($stringTokens as $token) {
-                if (is_array($token) === true && $token[0] === T_VARIABLE) {
+                if (!$this->allowVariables && is_array($token) === true && $token[0] === T_VARIABLE) {
                     $error = 'Variable "%s" not allowed in double quoted string; use concatenation instead';
                     $data  = [$token[1]];
                     $phpcsFile->addError($error, $stackPtr, 'ContainsVar', $data);

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc
@@ -1,4 +1,14 @@
 <?php
+
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables true
+$string = "Hello $there";
+$string = 'Hello'."$there '".'hi';
+$string = "<div class='$class'>";
+$string = "Value: $var[test]";
+$x = "bar = '$z',
+baz = '" . $a . "'...$x";
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables false
+
 $string = "Hello\tThere";
 $string = "Hello There\r\n";
 $string = "Hello There";

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.inc.fixed
@@ -1,4 +1,14 @@
 <?php
+
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables true
+$string = "Hello $there";
+$string = 'Hello'."$there '".'hi';
+$string = "<div class='$class'>";
+$string = "Value: $var[test]";
+$x = "bar = '$z',
+baz = '" . $a . "'...$x";
+// phpcs:set Squiz.Strings.DoubleQuoteUsage allowVariables false
+
 $string = "Hello\tThere";
 $string = "Hello There\r\n";
 $string = 'Hello There';

--- a/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Strings/DoubleQuoteUsageUnitTest.php
@@ -26,19 +26,19 @@ class DoubleQuoteUsageUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            4  => 1,
-            5  => 1,
-            6  => 1,
-            8  => 2,
-            14 => 1,
-            15 => 1,
-            17 => 1,
-            19 => 1,
-            20 => 1,
-            22 => 1,
+            14  => 1,
+            15  => 1,
+            16  => 1,
+            18  => 2,
+            24 => 1,
+            25 => 1,
+            27 => 1,
             29 => 1,
             30 => 1,
             32 => 1,
+            39 => 1,
+            40 => 1,
+            42 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
We would like to replace/error on unnecessary use of double quotes, however if there is a variable then we don't want to enforce concatenation. This setting allows double quoted strings to be accepted if they contain variables. Which also means this sniff can run in a mode that only raises fixable errors