### PR TITLE
PHPCS 4.x | Travis: tweaks for cleaner output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,12 @@ language: php
 jobs:
   fast_finish: true
   include:
-    - php: 7.2
-      env: CUSTOM_INI=1 XMLLINT=1
-      addons:
-        apt:
-          packages:
-            - libxml2-utils
+    #############################################
+    # Builds using the default test script.
+    #############################################
     - php: 7.2
     - php: 7.3
     - php: 7.4
-    - php: 7.4
-      env: PHPSTAN=1
-      addons:
-        apt:
-          packages:
-            - libonig-dev
-      script:
-      - composer require --dev phpstan/phpstan
-      - php vendor/bin/phpstan analyse --configuration=phpstan.neon
-
     # Nightly is PHP 8.0 since Feb 2019.
     - php: nightly
       addons:
@@ -31,13 +18,65 @@ jobs:
           packages:
             - libonig-dev
 
+    #############################################
+    # Builds which don't use the default test script.
+    #############################################
+    # Builds running the basic tests with different PHP ini settings.
+    - php: 7.4
+      name: "PHP: 7.4 | Unit tests with custom PHP ini"
+      before_script:
+      - phpenv config-add testingConfig.ini
+      script:
+      - php bin/phpcs --config-set php_path php
+      - vendor/bin/phpunit tests/AllTests.php
+
+    # Build running just the XML file validation and code style check.
+    - php: 7.4
+      name: "PHP: 7.4 | XML validate"
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+      before_install:
+      - export XMLLINT_INDENT="    "
+      - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+      install:
+      - curl -O https://www.w3.org/2012/04/XMLSchema.xsd
+      script:
+      # Validate the xml ruleset files.
+      # @link http://xmlsoft.org/xmllint.html
+      - xmllint --noout --schema phpcs.xsd ./src/Standards/*/ruleset.xml
+      - xmllint --noout --schema ./XMLSchema.xsd ./phpcs.xsd
+      # Check the code-style consistency of the xml files.
+      - diff -B ./phpcs.xml.dist <(xmllint --format "./phpcs.xml.dist")
+      - diff -B ./src/Standards/Generic/ruleset.xml <(xmllint --format "./src/Standards/Generic/ruleset.xml")
+      - diff -B ./src/Standards/PEAR/ruleset.xml <(xmllint --format "./src/Standards/PEAR/ruleset.xml")
+      - diff -B ./src/Standards/PSR1/ruleset.xml <(xmllint --format "./src/Standards/PSR1/ruleset.xml")
+      - diff -B ./src/Standards/PSR2/ruleset.xml <(xmllint --format "./src/Standards/PSR2/ruleset.xml")
+      - diff -B ./src/Standards/PSR12/ruleset.xml <(xmllint --format "./src/Standards/PSR12/ruleset.xml")
+      - diff -B ./src/Standards/Squiz/ruleset.xml <(xmllint --format "./src/Standards/Squiz/ruleset.xml")
+      - diff -B ./src/Standards/Zend/ruleset.xml <(xmllint --format "./src/Standards/Zend/ruleset.xml")
+
+    # Build running just and only PHPStan.
+    - php: 7.4
+      name: "PHP: 7.4 | PHPStan"
+      env: PHPSTAN=1
+      addons:
+        apt:
+          packages:
+            - libonig-dev
+      before_install:
+      - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+      script:
+      - composer require --dev phpstan/phpstan
+      - php vendor/bin/phpstan analyse --configuration=phpstan.neon
+
   allow_failures:
     - php: 7.4
       env: PHPSTAN=1
     - php: nightly
 
 before_install:
-  - export XMLLINT_INDENT="    "
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   - |
@@ -48,27 +87,10 @@ before_install:
       travis_retry composer install --ignore-platform-reqs
     fi
 
-before_script:
-  - if [[ $CUSTOM_INI == "1" ]]; then phpenv config-add testingConfig.ini; fi
-
 script:
   - php bin/phpcs --config-set php_path php
   - vendor/bin/phpunit tests/AllTests.php
-  - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
-  - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
-  - if [[ $CUSTOM_INI != "1" ]]; then php scripts/build-phar.php; fi
-  - if [[ $CUSTOM_INI != "1" ]]; then php phpcs.phar; fi
-  # Validate the xml ruleset files.
-  # @link http://xmlsoft.org/xmllint.html
-  - if [[ $XMLLINT == "1" ]]; then xmllint --noout --schema phpcs.xsd ./src/Standards/*/ruleset.xml; fi
-  - if [[ $XMLLINT == "1" ]]; then curl -O https://www.w3.org/2012/04/XMLSchema.xsd; fi
-  - if [[ $XMLLINT == "1" ]]; then xmllint --noout --schema ./XMLSchema.xsd ./phpcs.xsd; fi
-  # Check the code-style consistency of the xml files.
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./phpcs.xml.dist <(xmllint --format "./phpcs.xml.dist"); fi
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/Generic/ruleset.xml <(xmllint --format "./src/Standards/Generic/ruleset.xml"); fi
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PEAR/ruleset.xml <(xmllint --format "./src/Standards/PEAR/ruleset.xml"); fi
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PSR1/ruleset.xml <(xmllint --format "./src/Standards/PSR1/ruleset.xml"); fi
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PSR2/ruleset.xml <(xmllint --format "./src/Standards/PSR2/ruleset.xml"); fi
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/PSR12/ruleset.xml <(xmllint --format "./src/Standards/PSR12/ruleset.xml"); fi
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/Squiz/ruleset.xml <(xmllint --format "./src/Standards/Squiz/ruleset.xml"); fi
-  - if [[ $XMLLINT == "1" ]]; then diff -B ./src/Standards/Zend/ruleset.xml <(xmllint --format "./src/Standards/Zend/ruleset.xml"); fi
+  - php bin/phpcs --no-cache --parallel=1
+  - composer validate --no-check-all --strict
+  - php scripts/build-phar.php
+  - php phpcs.phar


### PR DESCRIPTION
Sister-PR to PRs #3067 and #3073 for the PHPCS 4.x branch.

Basically does the same thing:
1. Skip the "normal" build checks for the PHPStan build and just and only run PHPStan.
2. Add a new build against PHP 7.4 which runs just and only the XML related checks.
    That build doesn't need to do a `composer install` and, as it has it's own script, will show just the output of those checks.
3. Add a separate `script` section to the build being run with custom a PHP `ini` file (and moves those down in the matrix).

For the "custom builds", the Travis script now has a separate "name" for these, so they can still be easily identified for what they are, without the environment variables (which is what used to show).