### PR TITLE
PHPCS 4.x: let `T_STATIC` be `T_STATIC`

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -55,6 +55,7 @@ class ScopeKeywordSpacingSniff implements Sniff
         if ($tokens[$stackPtr]['code'] === T_STATIC) {
             if (($nextToken === false || $tokens[$nextToken]['code'] === T_DOUBLE_COLON)
                 || $tokens[$prevToken]['code'] === T_NEW
+                || $tokens[$prevToken]['code'] === T_INSTANCEOF
             ) {
                 // Late static binding, e.g., static:: OR new static() usage or live coding.
                 return;

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2800,24 +2800,6 @@ class PHP extends Tokenizer
                 }
 
                 continue;
-            } else if ($this->tokens[$i]['code'] === T_STATIC) {
-                for ($x = ($i - 1); $x > 0; $x--) {
-                    if (isset(Tokens::$emptyTokens[$this->tokens[$x]['code']]) === false) {
-                        break;
-                    }
-                }
-
-                if ($this->tokens[$x]['code'] === T_INSTANCEOF) {
-                    $this->tokens[$i]['code'] = T_STRING;
-                    $this->tokens[$i]['type'] = 'T_STRING';
-
-                    if (PHP_CODESNIFFER_VERBOSITY > 1) {
-                        $line = $this->tokens[$i]['line'];
-                        Common::printStatusMessage("* token $i on line $line changed from T_STATIC to T_STRING", 1);
-                    }
-                }
-
-                continue;
             } else if ($this->tokens[$i]['code'] === T_TRUE
                 || $this->tokens[$i]['code'] === T_FALSE
                 || $this->tokens[$i]['code'] === T_NULL


### PR DESCRIPTION
Implementation of the proposal outlined in issue #3115.

1. Removes the Tokenizer/PHP code which made an exception for `instanceof static`.
2. Adds an exception for `instanceof static` to the `Squiz.WhiteSpace.ScopeKeywordSpacing` sniff for which the tokenizer code was originally put in place.

The tests for all other sniffs still pass.

I've had a quick look through the other sniffs which refer to the `T_STATIC` token, but didn't see any which should be impacted by this change (and didn't have unit tests with `instanceof static`).

Fixes #3115