### PR TITLE
PHPCS 4.x | Tests: fix incomplete test suite runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
 
 script:
   - php bin/phpcs --config-set php_path php
-  - vendor/bin/phpunit tests/AllTests.php
+  - vendor/bin/phpunit
   - if [[ $CUSTOM_INI != "1" ]]; then php bin/phpcs --no-cache --parallel=1; fi
   - if [[ $CUSTOM_INI != "1" ]]; then composer validate --no-check-all --strict; fi
   - if [[ $CUSTOM_INI != "1" ]]; then php scripts/build-phar.php; fi


### PR DESCRIPTION
Ok, don't ask me why as I'm not 100% sure myself, but removing the file name from the PHPUnit command fixes the issue.

The `phpunit.xml.dist` configuration already has the file set up as the one to be scanned for tests anyway.

Tested and found working on PHPUnit `8.1.5`, `8.4.2`, `8.5.8`, `9.0.2`, `9.1.2`, `9.1.5`, `9.2.6, `9.3.10` (versions I had around on my system anyway).

Also verified the Travis builds for my branch build and all builds now show 567 tests.

Fixes #3120