### PR TITLE
Squiz/PSR12/OperatorSpacing: bug fix - unary plus/minus in arrow function return

### DIFF
--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
@@ -59,3 +59,5 @@ $a = [ 'a' => &$something ];
 
 $fn = fn(array &$one) => 1;
 $fn = fn(array & $one) => 1;
+
+$fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
@@ -59,3 +59,5 @@ $a = [ 'a' => &$something ];
 
 $fn = fn(array &$one) => 1;
 $fn = fn(array & $one) => 1;
+
+$fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -77,11 +77,12 @@ class OperatorSpacingSniff implements Sniff
 
         // Returning/printing a negative value; eg. (return -1).
         $this->nonOperandTokens += [
-            T_RETURN => T_RETURN,
-            T_ECHO   => T_ECHO,
-            T_EXIT   => T_EXIT,
-            T_PRINT  => T_PRINT,
-            T_YIELD  => T_YIELD,
+            T_RETURN   => T_RETURN,
+            T_ECHO     => T_ECHO,
+            T_EXIT     => T_EXIT,
+            T_PRINT    => T_PRINT,
+            T_YIELD    => T_YIELD,
+            T_FN_ARROW => T_FN_ARROW,
         ];
 
         // Trying to use a negative value; eg. myFunction($var, -2).
@@ -90,7 +91,6 @@ class OperatorSpacingSniff implements Sniff
             T_OPEN_PARENTHESIS    => T_OPEN_PARENTHESIS,
             T_OPEN_SQUARE_BRACKET => T_OPEN_SQUARE_BRACKET,
             T_OPEN_SHORT_ARRAY    => T_OPEN_SHORT_ARRAY,
-            T_DOUBLE_ARROW        => T_DOUBLE_ARROW,
             T_COLON               => T_COLON,
             T_INLINE_THEN         => T_INLINE_THEN,
             T_INLINE_ELSE         => T_INLINE_ELSE,
@@ -99,15 +99,7 @@ class OperatorSpacingSniff implements Sniff
         ];
 
         // Casting a negative value; eg. (array) -$a.
-        $this->nonOperandTokens += [
-            T_ARRAY_CAST  => T_ARRAY_CAST,
-            T_BOOL_CAST   => T_BOOL_CAST,
-            T_DOUBLE_CAST => T_DOUBLE_CAST,
-            T_INT_CAST    => T_INT_CAST,
-            T_OBJECT_CAST => T_OBJECT_CAST,
-            T_STRING_CAST => T_STRING_CAST,
-            T_UNSET_CAST  => T_UNSET_CAST,
-        ];
+        $this->nonOperandTokens += Tokens::$castTokens;
 
         /*
             These are the tokens the sniff is looking for.

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -470,5 +470,7 @@ $cl = function ($boo =+1) {};
 $fn = fn ($boo =-1) => $boo;
 $fn = fn ($boo =+1) => $boo;
 
+$fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +

--- a/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/OperatorSpacingUnitTest.inc.fixed
@@ -464,5 +464,7 @@ $cl = function ($boo =+1) {};
 $fn = fn ($boo =-1) => $boo;
 $fn = fn ($boo =+1) => $boo;
 
+$fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
+
 /* Intentional parse error. This has to be the last test in the file. */
 $a = 10 +


### PR DESCRIPTION
A plus/minus directly after the arrow of an arrow function, will always be a unary plus/minus and should therefore be ignored by these sniffs.

Includes unit tests.

Includes two additional simplifications:
* `T_DOUBLE_ARROW` is already part of the `Tokens::$assignmentTokens` array, so doesn't need to be added separately.
* The cast tokens array was incomplete (missing `T_BINARY_CAST`) and can be replaced by the more complete `Tokens::$castTokens` array anyhow.

Fixes #3043