### PR TITLE
Fix PHP 7.4 regression, changed behavior of get_declared_classes()

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -168,6 +168,19 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
 
             $className  = null;
             $newClasses = array_reverse(array_diff(get_declared_classes(), $classes));
+            // Since PHP 7.4 get_declared_classes() does not guarantee any order. That
+            // implies that parent classes aren't the first any more, rendering the
+            // array_reverse() technique futile for the loop & break code that follows.
+            // So, additionally, let's try to reduce the list of candidates by removing all
+            // the classes known to be "parents". That way, at the end, only the "main"
+            // class just included with remain.
+            $newClasses = array_reduce(
+                $newClasses,
+                function ($remaining, $current) {
+                    return array_diff($remaining, class_parents($current));
+                },
+                $newClasses
+            );
             foreach ($newClasses as $name) {
                 if (isset(self::$loadedFiles[$name]) === false) {
                     $className = $name;


### PR DESCRIPTION
Since PHP 7.4 get_declared_classes() does not guarantee any order. That
implies that parent classes aren't the first any more, rendering the
array_reverse() technique futile for the loop & break code that follows.
So, additionally, let's try to reduce the list of candidates by removing all
the classes known to be "parents". That way, at the end, only the "main"
class just included with remain.

Source:
  https://raw.githubusercontent.com/php/php-src/PHP-7.4/UPGRADING

Text:
  Previously get_declared_classes() always returned parent classes before
  child classes. This is no longer the case. No particular order is guaranteed
  for the get_declared_classes() return value.

----

Part of the move to phpcs3 we were getting some [strange errors with phpunit, only reproducible with php74](https://travis-ci.com/github/stronk7/moodle-local_codechecker/jobs/392240848), with error:

```
PHP_CodeSniffer\Exceptions\RuntimeException: No sniffs were registered
```

Tracing down the problem to the autoloader, we were getting these classes with php73 (with the "main" one returned the 1st, that is a requirement for the loop in code to work):

```
Moodle 4.0dev (Build: 20200924), f09429e7f727a4f3ff5bc8da0029781a6fd194a4
Php: 7.3.22, pgsql: 9.6.19, OS: Darwin 19.6.0 x86_64
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Array
(
    [0] => PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff
    [1] => PHPCompatibility\AbstractRemovedFeatureSniff
    [2] => PHPCompatibility\AbstractComplexVersionSniff
    [3] => PHPCompatibility\Sniff
)
```

And these classes with php74:

```
Moodle 4.0dev (Build: 20200924), f09429e7f727a4f3ff5bc8da0029781a6fd194a4
Php: 7.4.10, pgsql: 9.6.19, OS: Darwin 19.6.0 x86_64
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Array
(
    [0] => PHPCompatibility\Sniff
    [1] => PHPCompatibility\AbstractComplexVersionSniff
    [2] => PHPCompatibility\AbstractRemovedFeatureSniff
    [3] => PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff
```

That obviously, doesn't work because the first element in the array is not the just included class.

With the patch applied, and being able to reduce the candidates to all the classes not being parents in the hierarchy... everything is working as expected:

````
Moodle 4.0dev (Build: 20200924), f09429e7f727a4f3ff5bc8da0029781a6fd194a4
Php: 7.4.10, pgsql: 9.6.19, OS: Darwin 19.6.0 x86_64
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Array
(
    [3] => PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff
)
````

I've looked for more occurrences of `get_declared_classes()` in codebase and haven't found any.

And that's the story, so far. For your consideration, ciao :-)