### PR TITLE
Ignore annotations are broken on PHP 8.0

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -424,10 +424,10 @@ abstract class Tokenizer
                         $disabledSniffs = [];
 
                         $additionalText = substr($commentText, 14);
-                        if ($additionalText === false) {
+                        if (empty($additionalText) === true) {
                             $ignoring = ['.all' => true];
                         } else {
-                            $parts = explode(',', substr($commentText, 13));
+                            $parts = explode(',', $additionalText);
                             foreach ($parts as $sniffCode) {
                                 $sniffCode = trim($sniffCode);
                                 $disabledSniffs[$sniffCode] = true;
@@ -459,10 +459,10 @@ abstract class Tokenizer
                             $enabledSniffs = [];
 
                             $additionalText = substr($commentText, 13);
-                            if ($additionalText === false) {
+                            if (empty($additionalText) === true) {
                                 $ignoring = null;
                             } else {
-                                $parts = explode(',', substr($commentText, 13));
+                                $parts = explode(',', $additionalText);
                                 foreach ($parts as $sniffCode) {
                                     $sniffCode = trim($sniffCode);
                                     $enabledSniffs[$sniffCode] = true;
@@ -520,10 +520,10 @@ abstract class Tokenizer
                         $ignoreRules = [];
 
                         $additionalText = substr($commentText, 13);
-                        if ($additionalText === false) {
+                        if (empty($additionalText) === true) {
                             $ignoreRules = ['.all' => true];
                         } else {
-                            $parts = explode(',', substr($commentText, 13));
+                            $parts = explode(',', $additionalText);
                             foreach ($parts as $sniffCode) {
                                 $ignoreRules[trim($sniffCode)] = true;
                             }


### PR DESCRIPTION
A very recent change in PHP 8.0 changes the possible return values of the `substr()` function from:

> Pre-PHP 8:
> Returns the extracted part of string; or FALSE on failure, or an empty string.

> PHP 8-RC1:
> Returns the extracted part of string; or an empty string.

This is an insidious change as basically all code (strict) checking the return value of `substr()` against `false` will now be broken.

Checking the return value with `empty()` will fix this in a cross-version compatible manner as it allows for both `false` as well as an empty string being returned.

This change broke the ignore annotations as implemented in PHPCS.

The existing unit tests for the ignore annotations cover this change.

Includes removing some unnecessary, duplicate function calls to `substr()`.

Ref: https://github.com/php/php-src/pull/6182