### PR TITLE
Add support to use short forms of type keywords

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -24,6 +24,13 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
      */
     private $phpVersion = null;
 
+    /**
+     * Whether to use short forms of type keywords.
+     *
+     * @var boolean
+     */
+    public $useShortTypes = false;
+
 
     /**
      * Process the return comment of this function comment.
@@ -77,7 +84,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 $typeNames      = explode('|', $returnType);
                 $suggestedNames = [];
                 foreach ($typeNames as $i => $typeName) {
-                    $suggestedName = Common::suggestType($typeName);
+                    $suggestedName = Common::suggestType($typeName, $this->useShortTypes);
                     if (in_array($suggestedName, $suggestedNames, true) === false) {
                         $suggestedNames[] = $suggestedName;
                     }
@@ -382,7 +389,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                     $typeName = substr($typeName, 1);
                 }
 
-                $suggestedName        = Common::suggestType($typeName);
+                $suggestedName        = Common::suggestType($typeName, $this->useShortTypes);
                 $suggestedTypeNames[] = $suggestedName;
 
                 if (count($typeNames) > 1) {

--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -16,6 +16,13 @@ use PHP_CodeSniffer\Util\Common;
 class VariableCommentSniff extends AbstractVariableSniff
 {
 
+    /**
+     * Whether to use short forms of type keywords.
+     *
+     * @var boolean
+     */
+    public $useShortTypes = false;
+
 
     /**
      * Called to process class member vars.
@@ -113,7 +120,7 @@ class VariableCommentSniff extends AbstractVariableSniff
         $typeNames      = explode('|', $varType);
         $suggestedNames = [];
         foreach ($typeNames as $i => $typeName) {
-            $suggestedName = Common::suggestType($typeName);
+            $suggestedName = Common::suggestType($typeName, $this->useShortTypes);
             if (in_array($suggestedName, $suggestedNames, true) === false) {
                 $suggestedNames[] = $suggestedName;
             }

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -29,6 +29,23 @@ class Common
         'callable',
     ];
 
+    /**
+     * An array of short variable types for param/var we will check.
+     *
+     * @var string[]
+     */
+    public static $allowedShortTypes = [
+        'array',
+        'bool',
+        'float',
+        'int',
+        'mixed',
+        'object',
+        'string',
+        'resource',
+        'callable',
+    ];
+
 
     /**
      * Return TRUE if the path is a PHAR file.
@@ -389,31 +406,48 @@ class Common
      * If type is not one of the standard types, it must be a custom type.
      * Returns the correct type name suggestion if type name is invalid.
      *
-     * @param string $varType The variable type to process.
+     * @param string  $varType       The variable type to process.
+     * @param boolean $useShortTypes Whether to use short forms of type keywords.
      *
      * @return string
      */
-    public static function suggestType($varType)
+    public static function suggestType($varType, $useShortTypes=false)
     {
         if ($varType === '') {
             return '';
         }
 
-        if (in_array($varType, self::$allowedTypes, true) === true) {
+        if ($useShortTypes === true) {
+            $allowedTypes = self::$allowedShortTypes;
+        } else {
+            $allowedTypes = self::$allowedTypes;
+        }
+
+        if (in_array($varType, $allowedTypes, true) === true) {
             return $varType;
         } else {
             $lowerVarType = strtolower($varType);
             switch ($lowerVarType) {
             case 'bool':
             case 'boolean':
-                return 'boolean';
+                if ($useShortTypes === true) {
+                    return 'bool';
+                } else {
+                    return 'boolean';
+                }
+
             case 'double':
             case 'real':
             case 'float':
                 return 'float';
             case 'int':
             case 'integer':
-                return 'integer';
+                if ($useShortTypes === true) {
+                    return 'int';
+                } else {
+                    return 'integer';
+                }
+
             case 'array()':
             case 'array':
                 return 'array';
@@ -435,8 +469,8 @@ class Common
                         $type2 = $matches[3];
                     }
 
-                    $type1 = self::suggestType($type1);
-                    $type2 = self::suggestType($type2);
+                    $type1 = self::suggestType($type1, $useShortTypes);
+                    $type2 = self::suggestType($type2, $useShortTypes);
                     if ($type2 !== '') {
                         $type2 = ' => '.$type2;
                     }
@@ -445,7 +479,7 @@ class Common
                 } else {
                     return 'array';
                 }//end if
-            } else if (in_array($lowerVarType, self::$allowedTypes, true) === true) {
+            } else if (in_array($lowerVarType, $allowedTypes, true) === true) {
                 // A valid type, but not lower cased.
                 return $lowerVarType;
             } else {


### PR DESCRIPTION
This adds support to use short forms of type keywords in comments for function parameters and returns and variable types. It fixes #1864 and fixes #1434.

It adds `useShortTypes` property, which is by default `false`, to `Squiz.Commenting.FunctionComment` and `Squiz.Commenting.VariableComment` to allow users to use short type checks. If it is enabled, it will force short types in comments and suggest them when long ones are used.

P.S. I would appreciate if you add `hacktoberfest-accepted` label to this PR, so it will count for this year's Hacktoberfest.