### PR TITLE
Keep correct indent when moving brace to a new line

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -121,6 +121,9 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($openingBrace - 1), '');
                     }
 
+	                $indentSize = $tokens[$phpcsFile->findPrevious([T_IF, T_ELSEIF, T_ELSE], $stackPtr)]['column'];
+	                $phpcsFile->fixer->replaceToken($openingBrace, str_repeat(' ', $indentSize) . '{');
+
                     $phpcsFile->fixer->addNewlineBefore($openingBrace);
                 } else {
                     $phpcsFile->fixer->replaceToken($openingBrace, '');

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -121,9 +121,6 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($openingBrace - 1), '');
                     }
 
-	                $indentSize = $tokens[$phpcsFile->findPrevious([T_IF, T_ELSEIF, T_ELSE], $stackPtr)]['column'];
-	                $phpcsFile->fixer->replaceToken($openingBrace, str_repeat(' ', $indentSize) . '{');
-
                     $phpcsFile->fixer->addNewlineBefore($openingBrace);
                 } else {
                     $phpcsFile->fixer->replaceToken($openingBrace, '');

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -30,6 +30,13 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
      */
     public $checkClosures = false;
 
+	/**
+	 * Should this sniff use tabs instead of spaces ?
+	 *
+	 * @var boolean
+	 */
+	public $tabIndent = false;
+
 
     /**
      * Registers the tokens that this sniff wants to listen for.
@@ -196,7 +203,7 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
 
             $fix = $phpcsFile->addFixableError($error, $openingBrace, 'BraceIndent', $data);
             if ($fix === true) {
-                $indent = str_repeat(' ', $expected);
+                $indent = str_repeat($this->tabIndent ? '	' : ' ', $expected);
                 if ($found === 0) {
                     $phpcsFile->fixer->addContentBefore($openingBrace, $indent);
                 } else {


### PR DESCRIPTION
When using this rule, brace is moved at the beginning of a new line.
Example:
```
    public function foo()
{
        // stuff
    }
```

With this fix, correct indent is used:
```
    public function foo()
    {
        // stuff
    }
```