### PR TITLE
PHP 8.0 | File::getMethodParameters(): add support for PHP 8 constructor property promotion

### DIFF
--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -85,3 +85,35 @@ function pseudoTypeIterableAndArray(iterable|array|Traversable $var) {}
 /* testPHP8DuplicateTypeInUnionWhitespaceAndComment */
 // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
 function duplicateTypeInUnion( int | string /*comment*/ | INT $var) {}
+
+class ConstructorPropertyPromotionNoTypes {
+    /* testPHP8ConstructorPropertyPromotionNoTypes */
+    public function __construct(
+        public $x = 0.0,
+        protected $y = '',
+        private $z = null,
+    ) {}
+}
+
+class ConstructorPropertyPromotionWithTypes {
+    /* testPHP8ConstructorPropertyPromotionWithTypes */
+    public function __construct(protected float|int $x, public ?string &$y = 'test', private mixed $z) {}
+}
+
+class ConstructorPropertyPromotionAndNormalParams {
+    /* testPHP8ConstructorPropertyPromotionAndNormalParam */
+    public function __construct(public int $promotedProp, ?int $normalArg) {}
+}
+
+/* testPHP8ConstructorPropertyPromotionGlobalFunction */
+// Intentional fatal error. Property promotion not allowed in non-constructor, but that's not the concern of this method.
+function globalFunction(private $x) {}
+
+abstract class ConstructorPropertyPromotionAbstractMethod {
+    /* testPHP8ConstructorPropertyPromotionAbstractMethod */
+    // Intentional fatal error.
+    // 1. Property promotion not allowed in abstract method, but that's not the concern of this method.
+    // 2. Variadic arguments not allowed in property promotion, but that's not the concern of this method.
+    // 3. The callable type is not supported for properties, but that's not the concern of this method.
+    abstract public function __construct(public callable $y, private ...$x);
+}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -617,6 +617,178 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of PHP8 constructor property promotion without type declaration, with defaults.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionNoTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'                => '$x',
+            'content'             => 'public $x = 0.0',
+            'default'             => '0.0',
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => '',
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+        ];
+        $expected[1] = [
+            'name'                => '$y',
+            'content'             => 'protected $y = \'\'',
+            'default'             => "''",
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => '',
+            'nullable_type'       => false,
+            'property_visibility' => 'protected',
+        ];
+        $expected[2] = [
+            'name'                => '$z',
+            'content'             => 'private $z = null',
+            'default'             => 'null',
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => '',
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8ConstructorPropertyPromotionNoTypes()
+
+
+    /**
+     * Verify recognition of PHP8 constructor property promotion with type declarations.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionWithTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'                => '$x',
+            'content'             => 'protected float|int $x',
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => 'float|int',
+            'nullable_type'       => false,
+            'property_visibility' => 'protected',
+        ];
+        $expected[1] = [
+            'name'                => '$y',
+            'content'             => 'public ?string &$y = \'test\'',
+            'default'             => "'test'",
+            'pass_by_reference'   => true,
+            'variable_length'     => false,
+            'type_hint'           => '?string',
+            'nullable_type'       => true,
+            'property_visibility' => 'public',
+        ];
+        $expected[2] = [
+            'name'                => '$z',
+            'content'             => 'private mixed $z',
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => 'mixed',
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8ConstructorPropertyPromotionWithTypes()
+
+
+    /**
+     * Verify recognition of PHP8 constructor with both property promotion as well as normal parameters.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionAndNormalParam()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'                => '$promotedProp',
+            'content'             => 'public int $promotedProp',
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => 'int',
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+        ];
+        $expected[1] = [
+            'name'              => '$normalArg',
+            'content'           => '?int $normalArg',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '?int',
+            'nullable_type'     => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8ConstructorPropertyPromotionAndNormalParam()
+
+
+    /**
+     * Verify behaviour when a non-constructor function uses PHP 8 property promotion syntax.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionGlobalFunction()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'                => '$x',
+            'content'             => 'private $x',
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => '',
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8ConstructorPropertyPromotionGlobalFunction()
+
+
+    /**
+     * Verify behaviour when an abstract constructor uses PHP 8 property promotion syntax.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionAbstractMethod()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'                => '$y',
+            'content'             => 'public callable $y',
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => 'callable',
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+        ];
+        $expected[1] = [
+            'name'                => '$x',
+            'content'             => 'private ...$x',
+            'pass_by_reference'   => false,
+            'variable_length'     => true,
+            'type_hint'           => '',
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8ConstructorPropertyPromotionAbstractMethod()
+
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.


### PR DESCRIPTION
PHP 8 introduces constructor property promotion.

This commit adds support for constructor property promotion to the `File::getMethodParameters()` method.

This change introduces two new keys - `property_visibility` and `visibility_token` - to the return array which will only be included if constructor property promotion is detected.

The method does not check whether property promotion is _valid_ in the function/method in which it is used. That is not the concern of this method.

Includes unit tests.

Ref: https://wiki.php.net/rfc/constructor_promotion

Implementation as discussed in #2968. Partially fixes #2968.