### PR TITLE
PHP 7.4/8.0 | Generic/LowerCaseType: add support for union types and typed properties

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1538,17 +1538,19 @@ class File
      * The format of the return value is:
      * <code>
      *   array(
-     *    'scope'                => 'public', // Public, private, or protected
-     *    'scope_specified'      => true,     // TRUE if the scope keyword was found.
-     *    'return_type'          => '',       // The return type of the method.
-     *    'return_type_token'    => integer,  // The stack pointer to the start of the return type
-     *                                        // or FALSE if there is no return type.
-     *    'nullable_return_type' => false,    // TRUE if the return type is preceded by the
-     *                                        // nullability operator.
-     *    'is_abstract'          => false,    // TRUE if the abstract keyword was found.
-     *    'is_final'             => false,    // TRUE if the final keyword was found.
-     *    'is_static'            => false,    // TRUE if the static keyword was found.
-     *    'has_body'             => false,    // TRUE if the method has a body
+     *    'scope'                 => 'public', // Public, private, or protected
+     *    'scope_specified'       => true,     // TRUE if the scope keyword was found.
+     *    'return_type'           => '',       // The return type of the method.
+     *    'return_type_token'     => integer,  // The stack pointer to the start of the return type
+     *                                         // or FALSE if there is no return type.
+     *    'return_type_end_token' => integer,  // The stack pointer to the end of the return type
+     *                                         // or FALSE if there is no return type.
+     *    'nullable_return_type'  => false,    // TRUE if the return type is preceded by the
+     *                                         // nullability operator.
+     *    'is_abstract'           => false,    // TRUE if the abstract keyword was found.
+     *    'is_final'              => false,    // TRUE if the final keyword was found.
+     *    'is_static'             => false,    // TRUE if the static keyword was found.
+     *    'has_body'              => false,    // TRUE if the method has a body
      *   );
      * </code>
      *
@@ -1627,6 +1629,7 @@ class File
 
         $returnType         = '';
         $returnTypeToken    = false;
+        $returnTypeEndToken = false;
         $nullableReturnType = false;
         $hasBody            = true;
 
@@ -1666,9 +1669,10 @@ class File
                         $returnTypeToken = $i;
                     }
 
-                    $returnType .= $this->tokens[$i]['content'];
+                    $returnType        .= $this->tokens[$i]['content'];
+                    $returnTypeEndToken = $i;
                 }
-            }
+            }//end for
 
             if ($this->tokens[$stackPtr]['code'] === T_FN) {
                 $bodyToken = T_FN_ARROW;
@@ -1685,15 +1689,16 @@ class File
         }
 
         return [
-            'scope'                => $scope,
-            'scope_specified'      => $scopeSpecified,
-            'return_type'          => $returnType,
-            'return_type_token'    => $returnTypeToken,
-            'nullable_return_type' => $nullableReturnType,
-            'is_abstract'          => $isAbstract,
-            'is_final'             => $isFinal,
-            'is_static'            => $isStatic,
-            'has_body'             => $hasBody,
+            'scope'                 => $scope,
+            'scope_specified'       => $scopeSpecified,
+            'return_type'           => $returnType,
+            'return_type_token'     => $returnTypeToken,
+            'return_type_end_token' => $returnTypeEndToken,
+            'nullable_return_type'  => $nullableReturnType,
+            'is_abstract'           => $isAbstract,
+            'is_final'              => $isFinal,
+            'is_static'             => $isStatic,
+            'has_body'              => $hasBody,
         ];
 
     }//end getMethodProperties()

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -16,6 +16,29 @@ use PHP_CodeSniffer\Util\Tokens;
 class LowerCaseTypeSniff implements Sniff
 {
 
+    /**
+     * Native types supported by PHP.
+     *
+     * @var array
+     */
+    private $phpTypes = [
+        'self'     => true,
+        'parent'   => true,
+        'array'    => true,
+        'callable' => true,
+        'bool'     => true,
+        'float'    => true,
+        'int'      => true,
+        'string'   => true,
+        'iterable' => true,
+        'void'     => true,
+        'object'   => true,
+        'mixed'    => true,
+        'static'   => true,
+        'false'    => true,
+        'null'     => true,
+    ];
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -71,20 +94,6 @@ class LowerCaseTypeSniff implements Sniff
             return;
         }//end if
 
-        $phpTypes = [
-            'self'     => true,
-            'parent'   => true,
-            'array'    => true,
-            'callable' => true,
-            'bool'     => true,
-            'float'    => true,
-            'int'      => true,
-            'string'   => true,
-            'iterable' => true,
-            'void'     => true,
-            'object'   => true,
-        ];
-
         $props = $phpcsFile->getMethodProperties($stackPtr);
 
         // Strip off potential nullable indication.
@@ -92,7 +101,7 @@ class LowerCaseTypeSniff implements Sniff
         $returnTypeLower = strtolower($returnType);
 
         if ($returnType !== ''
-            && isset($phpTypes[$returnTypeLower]) === true
+            && isset($this->phpTypes[$returnTypeLower]) === true
         ) {
             // A function return type.
             if ($returnTypeLower !== $returnType) {
@@ -129,7 +138,7 @@ class LowerCaseTypeSniff implements Sniff
             $typeHintLower = strtolower($typeHint);
 
             if ($typeHint !== ''
-                && isset($phpTypes[$typeHintLower]) === true
+                && isset($this->phpTypes[$typeHintLower]) === true
             ) {
                 // A function return type.
                 if ($typeHintLower !== $typeHint) {

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -45,3 +45,11 @@ $foo = function (?Int $a, ?    Callable $b)
 
 $var = (BInARY) $string;
 $var = (binary)$string;
+
+function unionParamTypesA (bool|array| /* nullability operator not allowed in union */ NULL $var) {}
+
+function unionParamTypesB (\Package\ClassName | Int | \Package\Other_Class | FALSE $var) {}
+
+function unionReturnTypesA ($var): bool|array| /* nullability operator not allowed in union */ NULL {}
+
+function unionReturnTypesB ($var): \Package\ClassName | Int | \Package\Other_Class | FALSE {}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -15,7 +15,7 @@ $foo = (Int) $bar;
 $foo = (INTEGER) $bar;
 $foo = (BOOL) $bar;
 $foo = (String) $bar;
-$foo = (Array) $bar;
+$foo = ( Array ) $bar;
 
 function foo(int $a, string $b, bool $c, array $d, Foo\Bar $e) : int {}
 function foo(Int $a, String $b, BOOL $c, Array $d, Foo\Bar $e) : Foo\Bar {}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -53,3 +53,23 @@ function unionParamTypesB (\Package\ClassName | Int | \Package\Other_Class | FAL
 function unionReturnTypesA ($var): bool|array| /* nullability operator not allowed in union */ NULL {}
 
 function unionReturnTypesB ($var): \Package\ClassName | Int | \Package\Other_Class | FALSE {}
+
+class TypedProperties
+{
+    protected ClassName $class;
+    public Int $int;
+    private ?BOOL $bool;
+    public Self $self;
+    protected PaRenT $parent;
+    private ARRAY $array;
+    public Float $float;
+    protected ?STRING $string;
+    private IterablE $iterable;
+    public Object $object;
+    protected Mixed $mixed;
+
+    public Iterable|FALSE|NULL $unionTypeA;
+    protected SELF|Parent /* comment */ |\Fully\Qualified\ClassName|UnQualifiedClass $unionTypeB;
+    private ClassName|/*comment*/Float|STRING|False $unionTypeC;
+    public sTRing | aRRaY | FaLSe $unionTypeD;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -45,3 +45,11 @@ $foo = function (?int $a, ?    callable $b)
 
 $var = (binary) $string;
 $var = (binary)$string;
+
+function unionParamTypesA (bool|array| /* nullability operator not allowed in union */ null $var) {}
+
+function unionParamTypesB (\Package\ClassName | int | \Package\Other_Class | false $var) {}
+
+function unionReturnTypesA ($var): bool|array| /* nullability operator not allowed in union */ null {}
+
+function unionReturnTypesB ($var): \Package\ClassName | int | \Package\Other_Class | false {}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -15,7 +15,7 @@ $foo = (int) $bar;
 $foo = (integer) $bar;
 $foo = (bool) $bar;
 $foo = (string) $bar;
-$foo = (array) $bar;
+$foo = ( array ) $bar;
 
 function foo(int $a, string $b, bool $c, array $d, Foo\Bar $e) : int {}
 function foo(int $a, string $b, bool $c, array $d, Foo\Bar $e) : Foo\Bar {}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -53,3 +53,23 @@ function unionParamTypesB (\Package\ClassName | int | \Package\Other_Class | fal
 function unionReturnTypesA ($var): bool|array| /* nullability operator not allowed in union */ null {}
 
 function unionReturnTypesB ($var): \Package\ClassName | int | \Package\Other_Class | false {}
+
+class TypedProperties
+{
+    protected ClassName $class;
+    public int $int;
+    private ?bool $bool;
+    public self $self;
+    protected parent $parent;
+    private array $array;
+    public float $float;
+    protected ?string $string;
+    private iterable $iterable;
+    public object $object;
+    protected mixed $mixed;
+
+    public iterable|false|null $unionTypeA;
+    protected self|parent /* comment */ |\Fully\Qualified\ClassName|UnQualifiedClass $unionTypeB;
+    private ClassName|/*comment*/float|string|false $unionTypeC;
+    public string | array | false $unionTypeD;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -45,6 +45,10 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             43 => 2,
             44 => 1,
             46 => 1,
+            49 => 1,
+            51 => 2,
+            53 => 1,
+            55 => 2,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -49,6 +49,20 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             51 => 2,
             53 => 1,
             55 => 2,
+            60 => 1,
+            61 => 1,
+            62 => 1,
+            63 => 1,
+            64 => 1,
+            65 => 1,
+            66 => 1,
+            67 => 1,
+            68 => 1,
+            69 => 1,
+            71 => 3,
+            72 => 2,
+            73 => 3,
+            74 => 3,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## File::getMethodProperties(): add new `return_type_end_token` index to return value

With union types, even non-class return types may consist of multiple tokens, so having access to the stackPtr for the exact end of the return type becomes relevant for sniffs which include fixers.

This commit adds a `return_type_end_token` index key to the array return value of the `File::getMethodProperties()` method.

## Generic/LowerCaseType: minor tweak to a unit test

... to verify and safeguard that spacing within a type cast is not touched by the sniff.

## Generic/LowerCaseType: refactor [1] - move array to property

Move the `$phpTypes` array to a property and add the new types introduced in PHP 8.0 to it.

## Generic/LowerCaseType: refactor [2] - remove duplicate code

Extract duplicate code out to a separate method and call the method instead.

## PHP 8.0 | Generic/LowerCaseType: refactor [3] - allow for union types

Allow for union types, as introduced in PHP 8.0, in return and parameter type declarations.

Includes unit tests.

## PHP 7.4 | Generic/LowerCaseType: add support for typed properties

PHP 7.4 introduced typed properties, but this sniff did not examine those yet.

Includes unit tests.

Partially fixes #2968.