### PR TITLE
PHPCS 4.x | .gitattributes: minor tweak

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 phpcs.xml.dist export-ignore
 phpstan.neon export-ignore
 phpunit.xml.dist export-ignore
+testingConfig.ini  export-ignore
 
 # Declare files that should always have CRLF line endings on checkout.
 *WinTest.inc text eol=crlf


### PR DESCRIPTION
Commit 5c40919e9cbc32db69e7e31843c2d19a038acd65 removed a little too much when ported to the 4.x branch, as there is still a committed `testingConfig.ini` file which is used by the test runs and is not needed for end-users.