### PR TITLE
Undefined index error with pre-commit hook using husky on PHP 7.4

### DIFF
--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -184,7 +184,7 @@ class FileList implements \Iterator, \Countable
     public function current()
     {
         $path = key($this->files);
-        if ($this->files[$path] === null) {
+        if (isset($this->files[$path]) === false || $this->files[$path] === null) {
             $this->files[$path] = new LocalFile($path, $this->ruleset, $this->config);
         }
 


### PR DESCRIPTION
For some unknown reason, doing git pre-commit hook with [husky](https://github.com/typicode/husky) and PHP 7.4, FileList method `current` tries to access undefined array index and throws RuntimeException.

    ✖ vendor/bin/phpcs --standard=phpcs.xml web/app/ config/ found some errors. Please fix them and try committing again.
    .....
    Fatal error: Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Undefined index:  in vendor/squizlabs/php_codesniffer/src/Files/FileList.php on line 187 in vendor/squizlabs/php_codesniffer/src/Runner.php:606
    Stack trace:
    #0 vendor/squizlabs/php_codesniffer/src/Files/FileList.php(187): PHP_CodeSniffer\Runner→handleErrors(8, 'Undefined index...', '/Users/ivuorine...', 187, Array)
    #1 vendor/squizlabs/php_codesniffer/src/Runner.php(487): PHP_CodeSniffer\Files\FileList→current()
    #2 vendor/squizlabs/php_codesniffer/src/Runner.php(114): PHP_CodeSniffer\Runner→run()
    #3 vendor/squizlabs/php_codesniffer/bin/phpcs(18): PHP_CodeSniffer\Runner→runPHPCS()
    #4 {main}
    thrown in vendor/squizlabs/php_codesniffer/src/Runner.php on line 606
    .......[33mW[0m......[33mW[0m...[33mW[0m.[33mW[0m....[33mW[0m...[31mE[0m. 36 / 36 (100%)


After adding the `isset($this->files[$path]) === false` check, linting works as expected.

    ✖ vendor/bin/phpcs --standard=phpcs.xml web/app/ config/ found some errors. Please fix them and try committing again.
    [33mW[0m...............[33mW[0m.......[33mW[0m....[33mW[0m.[31mE[0m[33mW[0m... 36 / 36 (100%)
