### PR TITLE
Squiz.WhiteSpace.OperatorSpacing false positive when using negation with string concat

### DIFF
--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
@@ -49,8 +49,10 @@ try {
 
 if (strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"') {}
 
-$oldConstructorPos = +1;
-return -$content;
+$oldConstructorPos = + 1;
+return - $content;
+return - PHP_INT_MAX;
+return 'min int is ' . - PHP_INT_MAX;
 
 function name($a = -1) {}
 

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
@@ -51,6 +51,8 @@ if (strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"') {}
 
 $oldConstructorPos = +1;
 return -$content;
+return -PHP_INT_MAX;
+return 'min int is ' . -PHP_INT_MAX;
 
 function name($a = -1) {}
 


### PR DESCRIPTION
~I don't know how to fix but OperatorSpacing sniff wrongly requires space when negating var/constant in string concatenation~

Ok, I don't understand how this test was meant. My point I was trying to make is that

```php
private const A = -PHP_INT_MAX; // is valid
private const B = 'a ' . -PHP_INT_MAX; // is not valid
private const C = 'a ' . - PHP_INT_MAX; // is valid
```

I cannot negate a constant when used within string concatenation without having a space after negation.
