### PR TITLE
PHP 8.0 | Tokenizer/PHP: support dereferencing of text strings with interpolated variables

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2147,6 +2147,7 @@ class PHP extends Tokenizer
                     T_NULLSAFE_OBJECT_OPERATOR => T_NULLSAFE_OBJECT_OPERATOR,
                     T_STRING                   => T_STRING,
                     T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+                    T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
                 ];
                 $allowed     += Util\Tokens::$magicConstants;
 

--- a/tests/Core/Tokenizer/ShortArrayTest.inc
+++ b/tests/Core/Tokenizer/ShortArrayTest.inc
@@ -65,6 +65,9 @@ echo (clone $iterable)[20];
 /* testNullsafeMethodCallDereferencing */
 $var = $obj?->function_call()[$x];
 
+/* testInterpolatedStringDereferencing */
+$var = "PHP{$rocks}"[1];
+
 /*
  * Short array brackets.
  */

--- a/tests/Core/Tokenizer/ShortArrayTest.php
+++ b/tests/Core/Tokenizer/ShortArrayTest.php
@@ -73,6 +73,7 @@ class ShortArrayTest extends AbstractMethodUnitTest
             ['/* testClassMemberDereferencingOnInstantiation2 */'],
             ['/* testClassMemberDereferencingOnClone */'],
             ['/* testNullsafeMethodCallDereferencing */'],
+            ['/* testInterpolatedStringDereferencing */'],
             ['/* testLiveCoding */'],
         ];
 


### PR DESCRIPTION
As of PHP 8, interpolated text strings can be dereferenced, however, the square brackets are incorrectly tokenized as _short array_ brackets instead of as "normal" square brackets.

Fixed by adding the `T_DOUBLE_QUOTED_STRING` token to the allowed tokens for leaving the brackets alone in the PHP Tokenizer class.

Includes unit test.

Ref: https://wiki.php.net/rfc/variable_syntax_tweaks#interpolated_and_non-interpolated_strings