### PR TITLE
Travis: add build against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ jobs:
     - php: 7.2
     - php: 7.3
     - php: 7.4
-    # Nightly is PHP 8.0 since Feb 2019.
+    - php: 8.0
+    # Nightly is PHP 8.1 since Oct 2020.
     - php: nightly
       addons:
         apt:
@@ -97,13 +98,12 @@ jobs:
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-  # PHPUnit 8.x is not (yet) supported, so prevent issues with Travis images using it.
   - |
-    if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
-      travis_retry composer install
-    elif [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    if [[ $TRAVIS_PHP_VERSION == "nightly" || $TRAVIS_PHP_VERSION == "8.0" ]]; then
       // Allow installing "incompatible" PHPUnit version on PHP 8/nightly.
       travis_retry composer install --ignore-platform-reqs
+    else
+      travis_retry composer install
     fi
 
 script:


### PR DESCRIPTION
PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds a new build against PHP 8.0 to the matrix and, as PHP 8.0 has been released, that build is not allowed to fail.