### PR TITLE
PSR2.Namespace.NamespaceDeclaration false positive on namespace operator

### DIFF
--- a/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class NamespaceDeclarationSniff implements Sniff
 {
@@ -40,6 +41,12 @@ class NamespaceDeclarationSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($tokens[$nextNonEmpty]['code'] === T_NS_SEPARATOR) {
+            // Namespace keyword as operator. Not a declaration.
+            return;
+        }
 
         $end = $phpcsFile->findEndOfStatement($stackPtr);
         for ($i = ($end + 1); $i < ($phpcsFile->numTokens - 1); $i++) {

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc
@@ -20,3 +20,7 @@ namespace Vendor\
 
 Package;
 namespace Vendor\Package;
+
+$call = namespace\function_name();
+echo namespace\CONSTANT_NAME;
+// Something which is not a blank line.

--- a/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Namespaces/NamespaceDeclarationUnitTest.inc.fixed
@@ -22,3 +22,7 @@ namespace Vendor\
 Package;
 
 namespace Vendor\Package;
+
+$call = namespace\function_name();
+echo namespace\CONSTANT_NAME;
+// Something which is not a blank line.


### PR DESCRIPTION
When the `namespace` keyword was used as an operator, the sniff would incorrectly throw an error too.

Fixed now.

Includes unit test.