### PR TITLE
PHP 8.0 | Squiz/ScopeKeywordSpacing: fix false positive on static as return type

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
@@ -25,7 +25,7 @@ class MyClass
 
     public static$var = null;
 
-    public  
+    public
     static
     $var = null;
 }
@@ -82,3 +82,17 @@ class MyOtherClass
         $varS,
         $varT
 }
+
+// Issue #3188 - static as return type.
+public static function fCreate($attributes = []): static
+{
+    return static::factory()->create($attributes);
+}
+
+// Also account for static used within union types.
+public function fCreate($attributes = []): object|static
+{
+}
+
+// Ensure that static as a scope keyword when preceeded by a colon which is not for a type dclaration is still handled.
+$callback = $cond ? get_fn_name() : static  function ($a) { return $a * 10; };

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
@@ -77,3 +77,17 @@ class MyOtherClass
         $varS,
         $varT
 }
+
+// Issue #3188 - static as return type.
+public static function fCreate($attributes = []): static
+{
+    return static::factory()->create($attributes);
+}
+
+// Also account for static used within union types.
+public function fCreate($attributes = []): object|static
+{
+}
+
+// Ensure that static as a scope keyword when preceeded by a colon which is not for a type dclaration is still handled.
+$callback = $cond ? get_fn_name() : static function ($a) { return $a * 10; };

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -38,6 +38,7 @@ class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
             64 => 1,
             67 => 1,
             71 => 1,
+            98 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This adds some additional safeguards to the sniff to prevent it from triggering when `static` is used in a return type declaration, as allowed since PHP 8.0.

Includes unit tests.

Fixes #3188