### PR TITLE
Tokenizer: add support for PHP8 attributes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -226,6 +226,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
      <dir name="Tokenizer">
       <file baseinstalldir="" name="AnonClassParenthesisOwnerTest.inc" role="test" />
       <file baseinstalldir="" name="AnonClassParenthesisOwnerTest.php" role="test" />
+      <file baseinstalldir="" name="AttributesTest.inc" role="test" />
+      <file baseinstalldir="" name="AttributesTest.php" role="test" />
       <file baseinstalldir="" name="BackfillFnTokenTest.inc" role="test" />
       <file baseinstalldir="" name="BackfillFnTokenTest.php" role="test" />
       <file baseinstalldir="" name="BackfillMatchTokenTest.inc" role="test" />
@@ -2138,6 +2140,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTestable.php" name="tests/Core/Sniffs/AbstractArraySniffTestable.php" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/AttributesTest.php" name="tests/Core/Tokenizer/AttributesTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/AttributesTest.inc" name="tests/Core/Tokenizer/AttributesTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.php" name="tests/Core/Tokenizer/BackfillFnTokenTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.inc" name="tests/Core/Tokenizer/BackfillFnTokenTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillMatchTokenTest.php" name="tests/Core/Tokenizer/BackfillMatchTokenTest.php" />
@@ -2222,6 +2226,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTestable.php" name="tests/Core/Sniffs/AbstractArraySniffTestable.php" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/AttributesTest.php" name="tests/Core/Tokenizer/AttributesTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/AttributesTest.inc" name="tests/Core/Tokenizer/AttributesTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.php" name="tests/Core/Tokenizer/BackfillFnTokenTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.inc" name="tests/Core/Tokenizer/BackfillFnTokenTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillMatchTokenTest.php" name="tests/Core/Tokenizer/BackfillMatchTokenTest.php" />

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1813,6 +1813,7 @@ class File
                 T_SEMICOLON,
                 T_OPEN_CURLY_BRACKET,
                 T_CLOSE_CURLY_BRACKET,
+                T_ATTRIBUTE_END,
             ],
             ($stackPtr - 1)
         );

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -3181,7 +3181,7 @@ class PHP extends Tokenizer
                 return null;
             }
 
-            array_splice($subTokens, count($subTokens), 0, array_slice($tokens, ($stackPtr + 1), ($bracketCloser - $stackPtr)));
+            $subTokens = array_merge($subTokens, array_slice($tokens, ($stackPtr + 1), ($bracketCloser - $stackPtr)));
             array_splice($tokens, ($stackPtr + 1), ($bracketCloser - $stackPtr));
         }
 

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2147,6 +2147,8 @@ class PHP extends Tokenizer
             echo "\t*** START ADDITIONAL PHP PROCESSING ***".PHP_EOL;
         }
 
+        $this->createAttributesNestingMap();
+
         $numTokens = count($this->tokens);
         for ($i = ($numTokens - 1); $i >= 0; $i--) {
             // Check for any unset scope conditions due to alternate IF/ENDIF syntax.
@@ -3207,6 +3209,43 @@ class PHP extends Tokenizer
         return $subTokens;
 
     }//end parsePhpAttribute()
+
+
+    /**
+     * Creates a map for the attributes tokens that surround other tokens.
+     *
+     * @return void
+     */
+    private function createAttributesNestingMap()
+    {
+        $map = [];
+        for ($i = 0; $i < $this->numTokens; $i++) {
+            if (isset($this->tokens[$i]['attribute_opener']) === true
+                && $i === $this->tokens[$i]['attribute_opener']
+            ) {
+                if (empty($map) === false) {
+                    $this->tokens[$i]['nested_attributes'] = $map;
+                }
+
+                if (isset($this->tokens[$i]['attribute_closer']) === true) {
+                    $map[$this->tokens[$i]['attribute_opener']]
+                        = $this->tokens[$i]['attribute_closer'];
+                }
+            } else if (isset($this->tokens[$i]['attribute_closer']) === true
+                && $i === $this->tokens[$i]['attribute_closer']
+            ) {
+                array_pop($map);
+                if (empty($map) === false) {
+                    $this->tokens[$i]['nested_attributes'] = $map;
+                }
+            } else {
+                if (empty($map) === false) {
+                    $this->tokens[$i]['nested_attributes'] = $map;
+                }
+            }//end if
+        }//end for
+
+    }//end createAttributesNestingMap()
 
 
 }//end class

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -741,24 +741,39 @@ abstract class Tokenizer
                     $this->tokens[$opener]['parenthesis_closer'] = $i;
                 }//end if
             } else if ($this->tokens[$i]['code'] === T_ATTRIBUTE) {
-                $found     = null;
-                $numTokens = count($this->tokens);
-                for ($x = ($i + 1); $x < $numTokens; $x++) {
-                    if ($this->tokens[$x]['code'] === T_ATTRIBUTE_END) {
-                        $found = $x;
-                        break;
-                    }
+                $openers[] = $i;
+                if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                    echo str_repeat("\t", count($openers));
+                    echo "=> Found attribute opener at $i".PHP_EOL;
                 }
 
                 $this->tokens[$i]['attribute_opener'] = $i;
-                $this->tokens[$i]['attribute_closer'] = $found;
+                $this->tokens[$i]['attribute_closer'] = null;
+            } else if ($this->tokens[$i]['code'] === T_ATTRIBUTE_END) {
+                $numOpeners = count($openers);
+                if ($numOpeners !== 0) {
+                    $opener = array_pop($openers);
+                    if (isset($this->tokens[$opener]['attribute_opener']) === true) {
+                        $this->tokens[$opener]['attribute_closer'] = $i;
 
-                if ($found !== null) {
-                    for ($x = ($i + 1); $x <= $found; ++$x) {
-                        $this->tokens[$x]['attribute_opener'] = $i;
-                        $this->tokens[$x]['attribute_closer'] = $found;
+                        if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                            echo str_repeat("\t", (count($openers) + 1));
+                            echo "=> Found attribute closer at $i for $opener".PHP_EOL;
+                        }
+
+                        for ($x = ($opener + 1); $x <= $i; ++$x) {
+                            if (isset($this->tokens[$x]['attribute_closer']) === true) {
+                                continue;
+                            }
+
+                            $this->tokens[$x]['attribute_opener'] = $opener;
+                            $this->tokens[$x]['attribute_closer'] = $i;
+                        }
+                    } else if (PHP_CODESNIFFER_VERBOSITY > 1) {
+                        echo str_repeat("\t", (count($openers) + 1));
+                        echo "=> Found unowned attribute closer at $i for $opener".PHP_EOL;
                     }
-                }
+                }//end if
             }//end if
 
             /*

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -740,6 +740,23 @@ abstract class Tokenizer
                     $this->tokens[$i]['parenthesis_closer']      = $i;
                     $this->tokens[$opener]['parenthesis_closer'] = $i;
                 }//end if
+            } else if ($this->tokens[$i]['code'] === T_ATTRIBUTE) {
+                $found     = null;
+                $numTokens = count($this->tokens);
+                for ($x = ($i + 1); $x < $numTokens; $x++) {
+                    if ($this->tokens[$x]['code'] === T_ATTRIBUTE_END) {
+                        $found = $x;
+                        break;
+                    }
+                }
+
+                $this->tokens[$i]['attribute_opener'] = $i;
+                $this->tokens[$i]['attribute_closer'] = $found;
+
+                if ($found !== null) {
+                    $this->tokens[$found]['attribute_opener'] = $i;
+                    $this->tokens[$found]['attribute_closer'] = $found;
+                }
             }//end if
 
             /*

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -754,8 +754,10 @@ abstract class Tokenizer
                 $this->tokens[$i]['attribute_closer'] = $found;
 
                 if ($found !== null) {
-                    $this->tokens[$found]['attribute_opener'] = $i;
-                    $this->tokens[$found]['attribute_closer'] = $found;
+                    for ($x = ($i + 1); $x <= $found; ++$x) {
+                        $this->tokens[$x]['attribute_opener'] = $i;
+                        $this->tokens[$x]['attribute_closer'] = $found;
+                    }
                 }
             }//end if
 

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -79,6 +79,7 @@ define('T_TYPE_UNION', 'PHPCS_T_TYPE_UNION');
 define('T_PARAM_NAME', 'PHPCS_T_PARAM_NAME');
 define('T_MATCH_ARROW', 'PHPCS_T_MATCH_ARROW');
 define('T_MATCH_DEFAULT', 'PHPCS_T_MATCH_DEFAULT');
+define('T_ATTRIBUTE_END', 'PHPCS_T_ATTRIBUTE_END');
 
 // Some PHP 5.5 tokens, replicated for lower versions.
 if (defined('T_FINALLY') === false) {
@@ -147,6 +148,10 @@ if (defined('T_NAME_RELATIVE') === false) {
 
 if (defined('T_MATCH') === false) {
     define('T_MATCH', 'PHPCS_T_MATCH');
+}
+
+if (defined('T_ATTRIBUTE') === false) {
+    define('T_ATTRIBUTE', 'PHPCS_T_ATTRIBUTE');
 }
 
 // Tokens used for parsing doc blocks.

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -240,3 +240,19 @@ $anon = class() {
     // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
     public int |string| /*comment*/ INT $duplicateTypeInUnion;
 };
+
+$anon = class {
+    /* testPHP8PropertySingleAttribute */
+    #[PropertyWithAttribute]
+    public string $foo;
+
+    /* testPHP8PropertyMultipleAttributes */
+    #[PropertyWithAttribute(foo: 'bar'), MyAttribute]
+    protected ?int|float $bar;
+
+    /* testPHP8PropertyMultilineAttribute */
+    #[
+        PropertyWithAttribute(/* comment */ 'baz')
+    ]
+    private mixed $baz;
+};

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -610,6 +610,36 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'nullable_type'   => false,
                 ],
             ],
+            [
+                '/* testPHP8PropertySingleAttribute */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'string',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPHP8PropertyMultipleAttributes */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?int|float',
+                    'nullable_type'   => true,
+                ],
+            ],
+            [
+                '/* testPHP8PropertyMultilineAttribute */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'mixed',
+                    'nullable_type'   => false,
+                ],
+            ],
         ];
 
     }//end dataGetMemberProperties()

--- a/tests/Core/Tokenizer/AttributesTest.inc
+++ b/tests/Core/Tokenizer/AttributesTest.inc
@@ -1,0 +1,69 @@
+<?php
+
+/* testAttribute */
+#[Attribute]
+class CustomAttribute {}
+
+/* testAttributeWithParams */
+#[Attribute(Attribute::TARGET_CLASS)]
+class SecondCustomAttribute {}
+
+/* testAttributeWithNamedParam */
+#[Attribute(flags: Attribute::TARGET_ALL)]
+class AttributeWithParams {
+    public function __construct($foo, array $bar) {}
+}
+
+/* testAttributeOnFunction */
+#[CustomAttribute]
+function attribute_on_function_test() {}
+
+/* testAttributeOnFunctionWithParams */
+#[AttributeWithParams('foo', bar: ['bar' => 'foobar'])]
+function attribute_with_params_on_function_test() {}
+
+/* testTwoAttributeOnTheSameLine */
+#[CustomAttribute] #[AttributeWithParams('foo')]
+function two_attribute_on_same_line_test() {}
+
+/* testAttributeAndCommentOnTheSameLine */
+#[CustomAttribute] // This is a comment
+function attribute_and_line_comment_on_same_line_test() {}
+
+/* testAttributeGrouping */
+#[CustomAttribute, AttributeWithParams('foo'), AttributeWithParams('foo', bar: ['bar' => 'foobar'])]
+function attribute_grouping_test() {}
+
+/* testAttributeMultiline */
+#[
+    CustomAttribute,
+    AttributeWithParams('foo'),
+    AttributeWithParams('foo', bar: ['bar' => 'foobar'])
+]
+function attribute_multiline_test() {}
+
+/* testAttributeMultilineWithComment */
+#[
+    CustomAttribute,                // comment
+    AttributeWithParams(/* another comment */ 'foo'),
+    AttributeWithParams('foo', bar: ['bar' => 'foobar'])
+]
+function attribute_multiline_with_comment_test() {}
+
+/* testSingleAttributeOnParameter */
+function single_attribute_on_parameter_test(#[ParamAttribute] int $param) {}
+
+/* testMultipleAttributesOnParameter */
+function multiple_attributes_on_parameter_test(#[ParamAttribute, AttributeWithParams(/* another comment */ 'foo')] int $param) {}
+
+/* testMultilineAttributesOnParameter */
+function multiline_attributes_on_parameter_test(#[
+    AttributeWithParams(
+        'foo'
+    )
+                                                ] int $param) {}
+
+/* testInvalidAttribute */
+#[ThisIsNotAnAttribute
+function invalid_attribute_test() {}
+

--- a/tests/Core/Tokenizer/AttributesTest.inc
+++ b/tests/Core/Tokenizer/AttributesTest.inc
@@ -22,6 +22,10 @@ function attribute_on_function_test() {}
 #[AttributeWithParams('foo', bar: ['bar' => 'foobar'])]
 function attribute_with_params_on_function_test() {}
 
+/* testAttributeWithShortClosureParameter */
+#[AttributeWithParams(static fn ($value) => ! $value)]
+function attribute_with_short_closure_param_test() {}
+
 /* testTwoAttributeOnTheSameLine */
 #[CustomAttribute] #[AttributeWithParams('foo')]
 function two_attribute_on_same_line_test() {}

--- a/tests/Core/Tokenizer/AttributesTest.inc
+++ b/tests/Core/Tokenizer/AttributesTest.inc
@@ -64,6 +64,10 @@ function multiple_attributes_on_parameter_test(#[ParamAttribute, AttributeWithPa
 #[Boo\QualifiedName, \Foo\FullyQualifiedName('foo')]
 function fqcn_attrebute_test() {}
 
+/* testNestedAttributes */
+#[Boo\QualifiedName(fn (#[AttributeOne('boo')] $value) => (string) $value)]
+function nested_attributes_test() {}
+
 /* testMultilineAttributesOnParameter */
 function multiline_attributes_on_parameter_test(#[
     AttributeWithParams(

--- a/tests/Core/Tokenizer/AttributesTest.inc
+++ b/tests/Core/Tokenizer/AttributesTest.inc
@@ -60,6 +60,10 @@ function single_attribute_on_parameter_test(#[ParamAttribute] int $param) {}
 /* testMultipleAttributesOnParameter */
 function multiple_attributes_on_parameter_test(#[ParamAttribute, AttributeWithParams(/* another comment */ 'foo')] int $param) {}
 
+/* testFqcnAttribute */
+#[Boo\QualifiedName, \Foo\FullyQualifiedName('foo')]
+function fqcn_attrebute_test() {}
+
 /* testMultilineAttributesOnParameter */
 function multiline_attributes_on_parameter_test(#[
     AttributeWithParams(

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -10,7 +10,6 @@
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
-use PHP_CodeSniffer\Util\Tokens;
 
 class AttributesTest extends AbstractMethodUnitTest
 {
@@ -46,7 +45,10 @@ class AttributesTest extends AbstractMethodUnitTest
         $this->assertSame($tokens[$attribute]['attribute_closer'], $tokens[$closer]['attribute_closer']);
 
         $map = array_map(
-            static function ($token) {
+            function ($token) use ($attribute, $length) {
+                $this->assertArrayHasKey('attribute_closer', $token);
+                $this->assertSame(($attribute + $length), $token['attribute_closer']);
+
                 return $token['code'];
             },
             array_slice($tokens, ($attribute + 1), ($length - 1))

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -129,6 +129,28 @@ class AttributesTest extends AbstractMethodUnitTest
                 ],
             ],
             [
+                '/* testAttributeWithShortClosureParameter */',
+                17,
+                [
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_STATIC,
+                    T_WHITESPACE,
+                    T_FN,
+                    T_WHITESPACE,
+                    T_OPEN_PARENTHESIS,
+                    T_VARIABLE,
+                    T_CLOSE_PARENTHESIS,
+                    T_WHITESPACE,
+                    T_FN_ARROW,
+                    T_WHITESPACE,
+                    T_BOOLEAN_NOT,
+                    T_WHITESPACE,
+                    T_VARIABLE,
+                    T_CLOSE_PARENTHESIS,
+                ],
+            ],
+            [
                 '/* testAttributeGrouping */',
                 26,
                 [

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * Tests the support of PHP 8 attributes
+ *
+ * @author    Alessandro Chitolina <alekitto@gmail.com>
+ * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
+
+class AttributesTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that attributes are parsed correctly.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param int    $length     The number of tokens between opener and closer.
+     * @param array  $tokenCodes The codes of tokens inside the attributes.
+     *
+     * @dataProvider dataAttribute
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::findCloser
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
+     *
+     * @return void
+     */
+    public function testAttribute($testMarker, $length, $tokenCodes)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $attribute = $this->getTargetToken($testMarker, T_ATTRIBUTE);
+        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
+
+        $closer = $tokens[$attribute]['attribute_closer'];
+        $this->assertSame(($attribute + $length), $closer);
+
+        $this->assertSame(T_ATTRIBUTE_END, $tokens[$closer]['code']);
+
+        $this->assertSame($tokens[$attribute]['attribute_opener'], $tokens[$closer]['attribute_opener']);
+        $this->assertSame($tokens[$attribute]['attribute_closer'], $tokens[$closer]['attribute_closer']);
+
+        $map = array_map(
+            static function ($token) {
+                return $token['code'];
+            },
+            array_slice($tokens, ($attribute + 1), ($length - 1))
+        );
+
+        $this->assertSame($tokenCodes, $map);
+
+    }//end testAttribute()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testAttribute()
+     *
+     * @return array
+     */
+    public function dataAttribute()
+    {
+        return [
+            [
+                '/* testAttribute */',
+                2,
+                [ T_STRING ],
+            ],
+            [
+                '/* testAttributeWithParams */',
+                7,
+                [
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_STRING,
+                    T_DOUBLE_COLON,
+                    T_STRING,
+                    T_CLOSE_PARENTHESIS,
+                ],
+            ],
+            [
+                '/* testAttributeWithNamedParam */',
+                10,
+                [
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_PARAM_NAME,
+                    T_COLON,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_DOUBLE_COLON,
+                    T_STRING,
+                    T_CLOSE_PARENTHESIS,
+                ],
+            ],
+            [
+                '/* testAttributeOnFunction */',
+                2,
+                [ T_STRING ],
+            ],
+            [
+                '/* testAttributeOnFunctionWithParams */',
+                17,
+                [
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_PARAM_NAME,
+                    T_COLON,
+                    T_WHITESPACE,
+                    T_OPEN_SHORT_ARRAY,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_WHITESPACE,
+                    T_DOUBLE_ARROW,
+                    T_WHITESPACE,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_SHORT_ARRAY,
+                    T_CLOSE_PARENTHESIS,
+                ],
+            ],
+            [
+                '/* testAttributeGrouping */',
+                26,
+                [
+                    T_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_PARENTHESIS,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_PARAM_NAME,
+                    T_COLON,
+                    T_WHITESPACE,
+                    T_OPEN_SHORT_ARRAY,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_WHITESPACE,
+                    T_DOUBLE_ARROW,
+                    T_WHITESPACE,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_SHORT_ARRAY,
+                    T_CLOSE_PARENTHESIS,
+                ],
+            ],
+            [
+                '/* testAttributeMultiline */',
+                31,
+                [
+                    T_WHITESPACE,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_PARENTHESIS,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_WHITESPACE,
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_PARAM_NAME,
+                    T_COLON,
+                    T_WHITESPACE,
+                    T_OPEN_SHORT_ARRAY,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_WHITESPACE,
+                    T_DOUBLE_ARROW,
+                    T_WHITESPACE,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_SHORT_ARRAY,
+                    T_CLOSE_PARENTHESIS,
+                    T_WHITESPACE,
+                ],
+            ],
+        ];
+
+    }//end dataAttribute()
+
+
+    /**
+     * Test that multiple attributes on the same line are parsed correctly.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::findCloser
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
+     *
+     * @return void
+     */
+    public function testTwoAttributesOnTheSameLine()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $attribute = $this->getTargetToken('/* testTwoAttributeOnTheSameLine */', T_ATTRIBUTE);
+        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
+
+        $closer = $tokens[$attribute]['attribute_closer'];
+        $this->assertSame(T_WHITESPACE, $tokens[($closer + 1)]['code']);
+        $this->assertSame(T_ATTRIBUTE, $tokens[($closer + 2)]['code']);
+        $this->assertArrayHasKey('attribute_closer', $tokens[($closer + 2)]);
+
+    }//end testTwoAttributesOnTheSameLine()
+
+
+    /**
+     * Test that attribute followed by a line comment is parsed correctly.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::findCloser
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
+     *
+     * @return void
+     */
+    public function testAttributeAndLineComment()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $attribute = $this->getTargetToken('/* testAttributeAndCommentOnTheSameLine */', T_ATTRIBUTE);
+        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
+
+        $closer = $tokens[$attribute]['attribute_closer'];
+        $this->assertSame(T_WHITESPACE, $tokens[($closer + 1)]['code']);
+        $this->assertSame(T_COMMENT, $tokens[($closer + 2)]['code']);
+
+    }//end testAttributeAndLineComment()
+
+
+    /**
+     * Test that attribute followed by a line comment is parsed correctly.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param int    $position   The token position (starting from T_FUNCTION) of T_ATTRIBUTE token.
+     * @param int    $length     The number of tokens between opener and closer.
+     *
+     * @dataProvider dataAttributeOnParameters
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::findCloser
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
+     *
+     * @return void
+     */
+    public function testAttributeOnParameters($testMarker, $position, $length)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $function  = $this->getTargetToken($testMarker, T_FUNCTION);
+        $attribute = ($function + $position);
+
+        $this->assertSame(T_ATTRIBUTE, $tokens[$attribute]['code']);
+        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
+        $this->assertSame(($attribute + $length), $tokens[$attribute]['attribute_closer']);
+
+        $closer = $tokens[$attribute]['attribute_closer'];
+        $this->assertSame(T_WHITESPACE, $tokens[($closer + 1)]['code']);
+        $this->assertSame(T_STRING, $tokens[($closer + 2)]['code']);
+        $this->assertSame('int', $tokens[($closer + 2)]['content']);
+
+        $this->assertSame(T_VARIABLE, $tokens[($closer + 4)]['code']);
+        $this->assertSame('$param', $tokens[($closer + 4)]['content']);
+
+    }//end testAttributeOnParameters()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testAttributeOnParameters()
+     *
+     * @return array
+     */
+    public function dataAttributeOnParameters()
+    {
+        return [
+            [
+                '/* testSingleAttributeOnParameter */',
+                4,
+                2,
+            ],
+            [
+                '/* testMultipleAttributesOnParameter */',
+                4,
+                10,
+            ],
+            [
+                '/* testMultilineAttributesOnParameter */',
+                4,
+                13,
+            ],
+        ];
+
+    }//end dataAttributeOnParameters()
+
+
+    /**
+     * Test that invalid attribute (or comment starting with #[ and without ]) are parsed correctly.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::findCloser
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::parsePhpAttribute
+     *
+     * @return void
+     */
+    public function testInvalidAttribute()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $attribute = $this->getTargetToken('/* testInvalidAttribute */', T_ATTRIBUTE);
+
+        $this->assertArrayHasKey('attribute_closer', $tokens[$attribute]);
+        $this->assertNull($tokens[$attribute]['attribute_closer']);
+
+    }//end testInvalidAttribute()
+
+
+}//end class

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -465,19 +465,33 @@ class AttributesTest extends AbstractMethodUnitTest
         $this->assertSame($tokens[$attribute]['attribute_opener'], $tokens[$closer]['attribute_opener']);
         $this->assertSame($tokens[$attribute]['attribute_closer'], $tokens[$closer]['attribute_closer']);
 
-        $test = function (array $tokens, $length) use ($attribute) {
+        $this->assertArrayNotHasKey('nested_attributes', $tokens[$attribute]);
+        $this->assertArrayHasKey('nested_attributes', $tokens[($attribute + 8)]);
+        $this->assertSame([$attribute => ($attribute + 24)], $tokens[($attribute + 8)]['nested_attributes']);
+
+        $test = function (array $tokens, $length, $nestedMap) use ($attribute) {
             foreach ($tokens as $token) {
                 $this->assertArrayHasKey('attribute_closer', $token);
                 $this->assertSame(($attribute + $length), $token['attribute_closer']);
+                $this->assertSame($nestedMap, $token['nested_attributes']);
             }
         };
 
-        $test(array_slice($tokens, ($attribute + 1), 7), 24);
+        $test(array_slice($tokens, ($attribute + 1), 7), 24, [$attribute => $attribute + 24]);
+        $test(array_slice($tokens, ($attribute + 8), 1), 8 + 5, [$attribute => $attribute + 24]);
 
         // Length here is 8 (nested attribute offset) + 5 (real length).
-        $test(array_slice($tokens, ($attribute + 8), 6), 8 + 5);
+        $test(
+            array_slice($tokens, ($attribute + 9), 4),
+            8 + 5,
+            [
+                $attribute     => $attribute + 24,
+                $attribute + 8 => $attribute + 13,
+            ]
+        );
 
-        $test(array_slice($tokens, ($attribute + 14), 11), 24);
+        $test(array_slice($tokens, ($attribute + 13), 1), 8 + 5, [$attribute => $attribute + 24]);
+        $test(array_slice($tokens, ($attribute + 14), 10), 24, [$attribute => $attribute + 24]);
 
         $map = array_map(
             static function ($token) {

--- a/tests/Core/Tokenizer/AttributesTest.php
+++ b/tests/Core/Tokenizer/AttributesTest.php
@@ -10,6 +10,7 @@
 namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
 
 use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
 
 class AttributesTest extends AbstractMethodUnitTest
 {
@@ -215,6 +216,24 @@ class AttributesTest extends AbstractMethodUnitTest
                     T_CLOSE_SHORT_ARRAY,
                     T_CLOSE_PARENTHESIS,
                     T_WHITESPACE,
+                ],
+            ],
+            [
+                '/* testFqcnAttribute */',
+                13,
+                [
+                    T_STRING,
+                    T_NS_SEPARATOR,
+                    T_STRING,
+                    T_COMMA,
+                    T_WHITESPACE,
+                    T_NS_SEPARATOR,
+                    T_STRING,
+                    T_NS_SEPARATOR,
+                    T_STRING,
+                    T_OPEN_PARENTHESIS,
+                    T_CONSTANT_ENCAPSED_STRING,
+                    T_CLOSE_PARENTHESIS,
                 ],
             ],
         ];


### PR DESCRIPTION
I tried to add PHP8 attributes parsing functionalities in PHP tokenizer.
Hope this could help completing PHP8 support on this great project.

PS: Since its my first PR here, please indicate me if there's something wrong with it. Thanks