### PR TITLE
Ignore files when exporting package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,15 @@
+.github/ export-ignore
+scripts/ export-ignore
+src/Standards/**/Tests/ export-ignore
+tests/ export-ignore
 .cspell.json export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+CONTRIBUTING.md export-ignore
 phpcs.xml.dist export-ignore
 phpstan.neon export-ignore
 package.xml export-ignore
 phpunit.xml.dist export-ignore
-scripts/ export-ignore
 
 # Declare files that should always have CRLF line endings on checkout.
 *WinTest.inc text eol=crlf


### PR DESCRIPTION
This commit is part of a campaign to reduce the amount of data transferred to save global bandwidth and reduce the amount of CO2. See https://github.com/Codeception/Codeception/pull/5527 for more info.