### PR TITLE
JSLint: bug fix

### DIFF
--- a/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
@@ -48,7 +48,7 @@ class JSLintSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $rhinoPath  = Config::getExecutablePath('jslint');
+        $rhinoPath  = Config::getExecutablePath('rhino');
         $jslintPath = Config::getExecutablePath('jslint');
         if ($rhinoPath === null || $jslintPath === null) {
             return;


### PR DESCRIPTION
The `$name` passed to `Config::getExecutablePath()` appears to be incorrect which would result in a duplicate `jslint jslint` command.