### PR TITLE
Generic/FunctionCallArgumentSpacing: add test with named function call args

### DIFF
--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
@@ -149,3 +149,7 @@ $foobar = functionCallAnonClassParam(
 	},
 	$args=array(),
 );
+
+$result = myFunction(param1: $arg1, param2: $arg2);
+$result = myFunction(param1: $arg1 ,  param2:$arg2);
+$result = myFunction(param1: $arg1, param2:$arg2, param3: $arg3,param4:$arg4, param5:$arg5);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
@@ -149,3 +149,7 @@ $foobar = functionCallAnonClassParam(
 	},
 	$args=array(),
 );
+
+$result = myFunction(param1: $arg1, param2: $arg2);
+$result = myFunction(param1: $arg1, param2:$arg2);
+$result = myFunction(param1: $arg1, param2:$arg2, param3: $arg3, param4:$arg4, param5:$arg5);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -52,6 +52,8 @@ class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
             132 => 2,
             133 => 2,
             134 => 1,
+            154 => 2,
+            155 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This verifies that named function call arguments do not affect the functioning of the sniff as-is.