### PR TITLE
Tokens: fix up some PHPCS native token values

### DIFF
--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -74,9 +74,9 @@ define('T_OPEN_USE_GROUP', 'PHPCS_T_OPEN_USE_GROUP');
 define('T_CLOSE_USE_GROUP', 'PHPCS_T_CLOSE_USE_GROUP');
 define('T_ZSR', 'PHPCS_T_ZSR');
 define('T_ZSR_EQUAL', 'PHPCS_T_ZSR_EQUAL');
-define('T_FN_ARROW', 'T_FN_ARROW');
-define('T_TYPE_UNION', 'T_TYPE_UNION');
-define('T_PARAM_NAME', 'T_PARAM_NAME');
+define('T_FN_ARROW', 'PHPCS_T_FN_ARROW');
+define('T_TYPE_UNION', 'PHPCS_T_TYPE_UNION');
+define('T_PARAM_NAME', 'PHPCS_T_PARAM_NAME');
 
 // Some PHP 5.5 tokens, replicated for lower versions.
 if (defined('T_FINALLY') === false) {


### PR DESCRIPTION
The values of the PHPCS native token types are normally prefixed with `PHPCS_`. This wasn't the case for the three most recent additions, `T_FN_ARROW` as introduced in PHPCS 3.5.3, `T_TYPE_UNION` and `T_PARAM_NAME` as will be introduced in PHPCS 3.6.0 (not yet released).

While the change to the value for `T_FN_ARROW` could be considered a breaking change, it is exceedingly rare for a sniff to use the _value_ of a token constant, so IMO opinion, this is a safe change to make.

As for the other two tokens, as they have not been in a release yet, they can be safely updated no matter what.