### PR TITLE
PHP 8 | Tokenizer/PHP: add support for match expressions

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -202,6 +202,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="BackfillNumericSeparatorTest.php" role="test" />
       <file baseinstalldir="" name="BitwiseOrTest.inc" role="test" />
       <file baseinstalldir="" name="BitwiseOrTest.php" role="test" />
+      <file baseinstalldir="" name="DefaultKeywordTest.inc" role="test" />
+      <file baseinstalldir="" name="DefaultKeywordTest.php" role="test" />
       <file baseinstalldir="" name="GotoLabelTest.inc" role="test" />
       <file baseinstalldir="" name="GotoLabelTest.php" role="test" />
       <file baseinstalldir="" name="NamedFunctionCallArgumentsTest.inc" role="test" />
@@ -2108,6 +2110,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.php" name="tests/Core/Tokenizer/BitwiseOrTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.inc" name="tests/Core/Tokenizer/BitwiseOrTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.php" name="tests/Core/Tokenizer/DefaultKeywordTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.php" name="tests/Core/Tokenizer/GotoLabelTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.inc" name="tests/Core/Tokenizer/GotoLabelTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" name="tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" />
@@ -2186,6 +2190,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.php" name="tests/Core/Tokenizer/BitwiseOrTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.inc" name="tests/Core/Tokenizer/BitwiseOrTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.php" name="tests/Core/Tokenizer/DefaultKeywordTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.php" name="tests/Core/Tokenizer/GotoLabelTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.inc" name="tests/Core/Tokenizer/GotoLabelTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" name="tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" />

--- a/package.xml
+++ b/package.xml
@@ -204,6 +204,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="BitwiseOrTest.php" role="test" />
       <file baseinstalldir="" name="DefaultKeywordTest.inc" role="test" />
       <file baseinstalldir="" name="DefaultKeywordTest.php" role="test" />
+      <file baseinstalldir="" name="DoubleArrowTest.inc" role="test" />
+      <file baseinstalldir="" name="DoubleArrowTest.php" role="test" />
       <file baseinstalldir="" name="GotoLabelTest.inc" role="test" />
       <file baseinstalldir="" name="GotoLabelTest.php" role="test" />
       <file baseinstalldir="" name="NamedFunctionCallArgumentsTest.inc" role="test" />
@@ -2112,6 +2114,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.inc" name="tests/Core/Tokenizer/BitwiseOrTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.php" name="tests/Core/Tokenizer/DefaultKeywordTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.php" name="tests/Core/Tokenizer/DoubleArrowTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.inc" name="tests/Core/Tokenizer/DoubleArrowTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.php" name="tests/Core/Tokenizer/GotoLabelTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.inc" name="tests/Core/Tokenizer/GotoLabelTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" name="tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" />
@@ -2192,6 +2196,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.inc" name="tests/Core/Tokenizer/BitwiseOrTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.php" name="tests/Core/Tokenizer/DefaultKeywordTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.php" name="tests/Core/Tokenizer/DoubleArrowTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.inc" name="tests/Core/Tokenizer/DoubleArrowTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.php" name="tests/Core/Tokenizer/GotoLabelTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.inc" name="tests/Core/Tokenizer/GotoLabelTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" name="tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" />

--- a/package.xml
+++ b/package.xml
@@ -196,6 +196,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="AnonClassParenthesisOwnerTest.php" role="test" />
       <file baseinstalldir="" name="BackfillFnTokenTest.inc" role="test" />
       <file baseinstalldir="" name="BackfillFnTokenTest.php" role="test" />
+      <file baseinstalldir="" name="BackfillMatchTokenTest.inc" role="test" />
+      <file baseinstalldir="" name="BackfillMatchTokenTest.php" role="test" />
       <file baseinstalldir="" name="BackfillNumericSeparatorTest.inc" role="test" />
       <file baseinstalldir="" name="BackfillNumericSeparatorTest.php" role="test" />
       <file baseinstalldir="" name="BitwiseOrTest.inc" role="test" />
@@ -2100,6 +2102,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.php" name="tests/Core/Tokenizer/BackfillFnTokenTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.inc" name="tests/Core/Tokenizer/BackfillFnTokenTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/BackfillMatchTokenTest.php" name="tests/Core/Tokenizer/BackfillMatchTokenTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/BackfillMatchTokenTest.inc" name="tests/Core/Tokenizer/BackfillMatchTokenTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.php" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.php" name="tests/Core/Tokenizer/BitwiseOrTest.php" />
@@ -2176,6 +2180,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" name="tests/Core/Tokenizer/AnonClassParenthesisOwnerTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.php" name="tests/Core/Tokenizer/BackfillFnTokenTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillFnTokenTest.inc" name="tests/Core/Tokenizer/BackfillFnTokenTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/BackfillMatchTokenTest.php" name="tests/Core/Tokenizer/BackfillMatchTokenTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/BackfillMatchTokenTest.inc" name="tests/Core/Tokenizer/BackfillMatchTokenTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.php" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/BackfillNumericSeparatorTest.inc" name="tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/BitwiseOrTest.php" name="tests/Core/Tokenizer/BitwiseOrTest.php" />

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -386,6 +386,7 @@ final class Tokens
         T_ELSEIF     => T_ELSEIF,
         T_CATCH      => T_CATCH,
         T_DECLARE    => T_DECLARE,
+        T_MATCH      => T_MATCH,
     ];
 
     /**
@@ -418,6 +419,7 @@ final class Tokens
         T_PROPERTY   => T_PROPERTY,
         T_OBJECT     => T_OBJECT,
         T_USE        => T_USE,
+        T_MATCH      => T_MATCH,
     ];
 
     /**

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -143,6 +143,10 @@ if (defined('T_NAME_RELATIVE') === false) {
     define('T_NAME_RELATIVE', 'PHPCS_T_NAME_RELATIVE');
 }
 
+if (defined('T_MATCH') === false) {
+    define('T_MATCH', 'PHPCS_T_MATCH');
+}
+
 // Tokens used for parsing doc blocks.
 define('T_DOC_COMMENT_STAR', 'PHPCS_T_DOC_COMMENT_STAR');
 define('T_DOC_COMMENT_WHITESPACE', 'PHPCS_T_DOC_COMMENT_WHITESPACE');
@@ -189,6 +193,7 @@ final class Tokens
         T_CATCH               => 50,
         T_FINALLY             => 50,
         T_SWITCH              => 50,
+        T_MATCH               => 50,
 
         T_SELF                => 25,
         T_PARENT              => 25,

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -77,6 +77,7 @@ define('T_ZSR_EQUAL', 'PHPCS_T_ZSR_EQUAL');
 define('T_FN_ARROW', 'PHPCS_T_FN_ARROW');
 define('T_TYPE_UNION', 'PHPCS_T_TYPE_UNION');
 define('T_PARAM_NAME', 'PHPCS_T_PARAM_NAME');
+define('T_MATCH_ARROW', 'PHPCS_T_MATCH_ARROW');
 define('T_MATCH_DEFAULT', 'PHPCS_T_MATCH_DEFAULT');
 
 // Some PHP 5.5 tokens, replicated for lower versions.

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -77,6 +77,7 @@ define('T_ZSR_EQUAL', 'PHPCS_T_ZSR_EQUAL');
 define('T_FN_ARROW', 'PHPCS_T_FN_ARROW');
 define('T_TYPE_UNION', 'PHPCS_T_TYPE_UNION');
 define('T_PARAM_NAME', 'PHPCS_T_PARAM_NAME');
+define('T_MATCH_DEFAULT', 'PHPCS_T_MATCH_DEFAULT');
 
 // Some PHP 5.5 tokens, replicated for lower versions.
 if (defined('T_FINALLY') === false) {

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.inc
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.inc
@@ -90,6 +90,46 @@ $arrowWithUnionReturn = fn($param) : int|float => $param | 10;
 /* testTernary */
 $fn = fn($a) => $a ? /* testTernaryThen */ fn() : string => 'a' : /* testTernaryElse */ fn() : string => 'b';
 
+function matchInArrow($x) {
+    /* testWithMatchValue */
+    $fn = fn($x) => match(true) {
+        1, 2, 3, 4, 5 => 'foo',
+        default => 'bar',
+    };
+}
+
+function matchInArrowAndMore($x) {
+    /* testWithMatchValueAndMore */
+    $fn = fn($x) => match(true) {
+        1, 2, 3, 4, 5 => 'foo',
+        default => 'bar',
+    } . 'suffix';
+}
+
+function arrowFunctionInMatchWithTrailingComma($x) {
+    return match ($x) {
+        /* testInMatchNotLastValue */
+        1 => fn($y) => callMe($y),
+        /* testInMatchLastValueWithTrailingComma */
+        default => fn($y) => callThem($y),
+    };
+}
+
+function arrowFunctionInMatchNoTrailingComma1($x) {
+    return match ($x) {
+        1 => fn($y) => callMe($y),
+        /* testInMatchLastValueNoTrailingComma1 */
+        default => fn($y) => callThem($y)
+    };
+}
+
+function arrowFunctionInMatchNoTrailingComma2($x) {
+    return match ($x) {
+        /* testInMatchLastValueNoTrailingComma2 */
+        default => fn($y) => 5 * $y
+    };
+}
+
 /* testConstantDeclaration */
 const FN = 'a';
 

--- a/tests/Core/Tokenizer/BackfillFnTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillFnTokenTest.php
@@ -466,6 +466,109 @@ class BackfillFnTokenTest extends AbstractMethodUnitTest
 
 
     /**
+     * Test arrow function returning a match control structure.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testWithMatchValue()
+    {
+        $token = $this->getTargetToken('/* testWithMatchValue */', T_FN);
+        $this->backfillHelper($token);
+        $this->scopePositionTestHelper($token, 5, 44);
+
+    }//end testWithMatchValue()
+
+
+    /**
+     * Test arrow function returning a match control structure with something behind it.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testWithMatchValueAndMore()
+    {
+        $token = $this->getTargetToken('/* testWithMatchValueAndMore */', T_FN);
+        $this->backfillHelper($token);
+        $this->scopePositionTestHelper($token, 5, 48);
+
+    }//end testWithMatchValueAndMore()
+
+
+    /**
+     * Test match control structure returning arrow functions.
+     *
+     * @param string $testMarker                 The comment prefacing the target token.
+     * @param int    $openerOffset               The expected offset of the scope opener in relation to the testMarker.
+     * @param int    $closerOffset               The expected offset of the scope closer in relation to the testMarker.
+     * @param string $expectedCloserType         The type of token expected for the scope closer.
+     * @param string $expectedCloserFriendlyName A friendly name for the type of token expected for the scope closer
+     *                                           to be used in the error message for failing tests.
+     *
+     * @dataProvider dataInMatchValue
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testInMatchValue($testMarker, $openerOffset, $closerOffset, $expectedCloserType, $expectedCloserFriendlyName)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token = $this->getTargetToken($testMarker, T_FN);
+        $this->backfillHelper($token);
+        $this->scopePositionTestHelper($token, $openerOffset, $closerOffset, $expectedCloserFriendlyName);
+
+        $this->assertSame($expectedCloserType, $tokens[($token + $closerOffset)]['type'], 'Mismatched scope closer type');
+
+    }//end testInMatchValue()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testInMatchValue()
+     *
+     * @return array
+     */
+    public function dataInMatchValue()
+    {
+        return [
+            'not_last_value'                      => [
+                '/* testInMatchNotLastValue */',
+                5,
+                11,
+                'T_COMMA',
+                'comma',
+            ],
+            'last_value_with_trailing_comma'      => [
+                '/* testInMatchLastValueWithTrailingComma */',
+                5,
+                11,
+                'T_COMMA',
+                'comma',
+            ],
+            'last_value_without_trailing_comma_1' => [
+                '/* testInMatchLastValueNoTrailingComma1 */',
+                5,
+                10,
+                'T_CLOSE_PARENTHESIS',
+                'close parenthesis',
+            ],
+            'last_value_without_trailing_comma_2' => [
+                '/* testInMatchLastValueNoTrailingComma2 */',
+                5,
+                11,
+                'T_VARIABLE',
+                '$y variable',
+            ],
+        ];
+
+    }//end dataInMatchValue()
+
+
+    /**
      * Test arrow function nested within a method declaration.
      *
      * @covers PHP_CodeSniffer\Tokenizers\PHP::processAdditional

--- a/tests/Core/Tokenizer/BackfillMatchTokenTest.inc
+++ b/tests/Core/Tokenizer/BackfillMatchTokenTest.inc
@@ -1,0 +1,307 @@
+<?php
+
+function simpleMatch($x) {
+    /* testMatchSimple */
+    return match ($x) {
+        0 => 'Zero',
+        1 => 'One',
+        2 => 'Two',
+    };
+}
+
+function matchNoTrailingComma($bool) {
+    /* testMatchNoTrailingComma */
+    echo match ($bool) {
+        true => "true\n",
+        false => "false\n"
+    };
+}
+
+function matchWithDefault($i) {
+    /* testMatchWithDefault */
+    return match ($i) {
+        1 => 1,
+        2 => 2,
+        default => 'default',
+    };
+}
+
+function matchExpressionInCondition($i) {
+    /* testMatchExpressionInCondition */
+    return match (true) {
+        $i >= 50 => '50+',
+        $i >= 40 => '40-50',
+        $i >= 30 => '30-40',
+        $i >= 20 => '20-30',
+        $i >= 10 => '10-20',
+        default => '0-10',
+    };
+}
+
+function matchMultiCase($day) {
+    /* testMatchMultiCase */
+    return match ($day) {
+        1, 7 => false,
+        2, 3, 4, 5, 6 => true,
+    };
+}
+
+function matchMultiCaseTrailingCommaInCase($bool) {
+    /* testMatchMultiCaseTrailingCommaInCase */
+    echo match ($bool) {
+        false,
+        0,
+            => "false\n",
+        true,
+        1,
+            => "true\n",
+        default,
+            => "not bool\n",
+    };
+}
+
+assert((function () {
+    /* testMatchInClosureNotLowercase */
+    Match ('foo') {
+        'foo', 'bar' => false,
+        'baz' => 'a',
+        default => 'b',
+    };
+})());
+
+function matchInArrowFunction($x) {
+    /* testMatchInArrowFunction */
+    $fn = fn($x) => match(true) {
+        1, 2, 3, 4, 5 => 'foo',
+        default => 'bar',
+    };
+}
+
+function arrowFunctionInMatchNoTrailingComma($x) {
+    /* testArrowFunctionInMatchNoTrailingComma */
+    return match ($x) {
+        1 => fn($y) => callMe($y),
+        default => fn($y) => callThem($y)
+    };
+}
+
+/* testMatchInFunctionCallParamNotLowercase */
+var_dump(MATCH ( 'foo' ) {
+    'foo' => dump_and_return('foo'),
+    'bar' => dump_and_return('bar'),
+});
+
+/* testMatchInMethodCallParam */
+Test::usesValue(match(true) { true => $i });
+
+/* testMatchDiscardResult */
+match (1) {
+    1 => print "Executed\n",
+};
+
+/* testMatchWithDuplicateConditionsWithComments */
+echo match /*comment*/ ( $value /*comment*/ ) {
+    // Comment.
+    2, 1 => '2, 1',
+    1 => 1,
+    3 => 3,
+    4 => 4,
+    5 => 5,
+};
+
+/* testNestedMatchOuter */
+$x = match ($y) {
+    /* testNestedMatchInner */
+    default => match ($z) { 1 => 1 },
+};
+
+/* testMatchInTernaryCondition */
+$x = match ($test) { 1 => 'a', 2 => 'b' } ?
+    /* testMatchInTernaryThen */ match ($test) { 1 => 'a', 2 => 'b' } :
+    /* testMatchInTernaryElse */ match ($notTest) { 3 => 'a', 4 => 'b' };
+
+/* testMatchInArrayValue */
+$array = array(
+    match ($test) { 1 => 'a', 2 => 'b' },
+);
+
+/* testMatchInArrayKey */
+$array = [
+    match ($test) { 1 => 'a', 2 => 'b' } => 'dynamic keys, woho!',
+];
+
+/* testMatchreturningArray */
+$matcher = match ($x) {
+    0 => array( 0 => 1, 'a' => 2, 'b' => 3 ),
+    1 => [1, 2, 3],
+    2 => array( 1, [1, 2, 3], 2, 3),
+    3 => [ 0 => 1, 'a' => array(1, 2, 3), 'b' => 2, 3],
+};
+
+/* testSwitchContainingMatch */
+switch ($something) {
+    /* testMatchWithDefaultNestedInSwitchCase1 */
+    case 'foo':
+        $var = [1, 2, 3];
+        $var = match ($i) {
+            1 => 1,
+            default => 'default',
+        };
+        continue 2;
+
+    /* testMatchWithDefaultNestedInSwitchCase2 */
+    case 'bar' ;
+        $i = callMe($a, $b);
+        return match ($i) {
+            1 => 1,
+            default => 'default',
+        };
+
+    /* testMatchWithDefaultNestedInSwitchDefault */
+    default:
+        echo 'something', match ($i) {
+            1 => 1,
+            default => 'default',
+        };
+        break;
+}
+
+/* testMatchContainingSwitch */
+$x = match ($y) {
+    5, 8 => function($z) {
+        /* testSwitchNestedInMatch1 */
+        switch($z) {
+            case 'a':
+                $var = [1, 2, 3];
+                return 'a';
+            /* testSwitchDefaultNestedInMatchCase */
+            default:
+                $i = callMe($a, $b);
+                return 'default1';
+        }
+    },
+    default => function($z) {
+        /* testSwitchNestedInMatch2 */
+        switch($z) {
+            case 'a';
+                $i = callMe($a, $b);
+                return 'b';
+            /* testSwitchDefaultNestedInMatchDefault */
+            default;
+                $var = [1, 2, 3];
+                return 'default2';
+        }
+    }
+};
+
+/* testMatchNoCases */
+// Intentional fatal error.
+$x = match (true) {};
+
+/* testMatchMultiDefault */
+// Intentional fatal error.
+echo match (1) {
+    default => 'foo',
+    1 => 'bar',
+    2 => 'baz',
+    default => 'qux',
+};
+
+/* testNoMatchStaticMethodCall */
+$a = Foo::match($param);
+
+/* testNoMatchClassConstantAccess */
+$a = MyClass::MATCH;
+
+/* testNoMatchClassConstantArrayAccessMixedCase */
+$a = MyClass::Match[$a];
+
+/* testNoMatchMethodCall */
+$a = $obj->match($param);
+
+/* testNoMatchMethodCallUpper */
+$a = $obj->MATCH()->chain($param);
+
+/* testNoMatchPropertyAccess */
+$a = $obj->match;
+
+/* testNoMatchNamespacedFunctionCall */
+// Intentional fatal error.
+$a = MyNS\Sub\match($param);
+
+/* testNoMatchNamespaceOperatorFunctionCall */
+// Intentional fatal error.
+$a = namespace\match($param);
+
+interface MatchInterface {
+    /* testNoMatchInterfaceMethodDeclaration */
+    public static function match($param);
+}
+
+class MatchClass {
+    /* testNoMatchClassConstantDeclarationLower */
+    const match = 'a';
+
+    /* testNoMatchClassMethodDeclaration */
+    public static function match($param) {
+        /* testNoMatchPropertyAssignment */
+        $this->match = 'a';
+    }
+}
+
+/* testNoMatchClassInstantiation */
+$obj = new Match();
+
+$anon = new class() {
+    /* testNoMatchAnonClassMethodDeclaration */
+    protected function maTCH($param) {
+    }
+};
+
+/* testNoMatchClassDeclaration */
+// Intentional fatal error. Match is now a reserved keyword.
+class Match {}
+
+/* testNoMatchInterfaceDeclaration */
+// Intentional fatal error. Match is now a reserved keyword.
+interface Match {}
+
+/* testNoMatchTraitDeclaration */
+// Intentional fatal error. Match is now a reserved keyword.
+trait Match {}
+
+/* testNoMatchConstantDeclaration */
+// Intentional fatal error. Match is now a reserved keyword.
+const MATCH = '1';
+
+/* testNoMatchFunctionDeclaration */
+// Intentional fatal error. Match is now a reserved keyword.
+function match() {}
+
+/* testNoMatchNamespaceDeclaration */
+// Intentional fatal error. Match is now a reserved keyword.
+namespace Match {}
+
+function brokenMatchNoCurlies($x) {
+    /* testNoMatchMissingCurlies */
+    // Intentional fatal error. New control structure is not supported without curly braces.
+    return match ($x)
+        0 => 'Zero',
+        1 => 'One',
+        2 => 'Two',
+    ;
+}
+
+function brokenMatchAlternativeSyntax($x) {
+    /* testNoMatchAlternativeSyntax */
+    // Intentional fatal error. Alternative syntax is not supported.
+    return match ($x) :
+        0 => 'Zero',
+        1 => 'One',
+        2 => 'Two',
+    endmatch;
+}
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+echo match

--- a/tests/Core/Tokenizer/BackfillMatchTokenTest.php
+++ b/tests/Core/Tokenizer/BackfillMatchTokenTest.php
@@ -1,0 +1,517 @@
+<?php
+/**
+ * Tests the backfilling of the T_MATCH token to PHP < 8.0, as well as the
+ * setting of parenthesis/scopes for match control structures across PHP versions.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020-2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHP_CodeSniffer\Util\Tokens;
+
+class BackfillMatchTokenTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test tokenization of match expressions.
+     *
+     * @param string $testMarker   The comment prefacing the target token.
+     * @param int    $openerOffset The expected offset of the scope opener in relation to the testMarker.
+     * @param int    $closerOffset The expected offset of the scope closer in relation to the testMarker.
+     * @param string $testContent  The token content to look for.
+     *
+     * @dataProvider dataMatchExpression
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testMatchExpression($testMarker, $openerOffset, $closerOffset, $testContent='match')
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken($testMarker, [T_STRING, T_MATCH], $testContent);
+        $tokenArray = $tokens[$token];
+
+        $this->assertSame(T_MATCH, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_MATCH (code)');
+        $this->assertSame('T_MATCH', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_MATCH (type)');
+
+        $this->scopeTestHelper($token, $openerOffset, $closerOffset);
+        $this->parenthesisTestHelper($token);
+
+    }//end testMatchExpression()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testMatchExpression()
+     *
+     * @return array
+     */
+    public function dataMatchExpression()
+    {
+        return [
+            'simple_match'                              => [
+                '/* testMatchSimple */',
+                6,
+                33,
+            ],
+            'no_trailing_comma'                         => [
+                '/* testMatchNoTrailingComma */',
+                6,
+                24,
+            ],
+            'with_default_case'                         => [
+                '/* testMatchWithDefault */',
+                6,
+                33,
+            ],
+            'expression_in_condition'                   => [
+                '/* testMatchExpressionInCondition */',
+                6,
+                77,
+            ],
+            'multicase'                                 => [
+                '/* testMatchMultiCase */',
+                6,
+                40,
+            ],
+            'multicase_trailing_comma_in_case'          => [
+                '/* testMatchMultiCaseTrailingCommaInCase */',
+                6,
+                47,
+            ],
+            'in_closure_not_lowercase'                  => [
+                '/* testMatchInClosureNotLowercase */',
+                6,
+                36,
+                'Match',
+            ],
+            'in_arrow_function'                         => [
+                '/* testMatchInArrowFunction */',
+                5,
+                36,
+            ],
+            'arrow_function_in_match_no_trailing_comma' => [
+                '/* testArrowFunctionInMatchNoTrailingComma */',
+                6,
+                44,
+            ],
+            'in_function_call_param_not_lowercase'      => [
+                '/* testMatchInFunctionCallParamNotLowercase */',
+                8,
+                32,
+                'MATCH',
+            ],
+            'in_method_call_param'                      => [
+                '/* testMatchInMethodCallParam */',
+                5,
+                13,
+            ],
+            'discard_result'                            => [
+                '/* testMatchDiscardResult */',
+                6,
+                18,
+            ],
+            'duplicate_conditions_and_comments'         => [
+                '/* testMatchWithDuplicateConditionsWithComments */',
+                12,
+                59,
+            ],
+            'nested_match_outer'                        => [
+                '/* testNestedMatchOuter */',
+                6,
+                33,
+            ],
+            'nested_match_inner'                        => [
+                '/* testNestedMatchInner */',
+                6,
+                14,
+            ],
+            'ternary_condition'                         => [
+                '/* testMatchInTernaryCondition */',
+                6,
+                21,
+            ],
+            'ternary_then'                              => [
+                '/* testMatchInTernaryThen */',
+                6,
+                21,
+            ],
+            'ternary_else'                              => [
+                '/* testMatchInTernaryElse */',
+                6,
+                21,
+            ],
+            'array_value'                               => [
+                '/* testMatchInArrayValue */',
+                6,
+                21,
+            ],
+            'array_key'                                 => [
+                '/* testMatchInArrayKey */',
+                6,
+                21,
+            ],
+            'returning_array'                           => [
+                '/* testMatchreturningArray */',
+                6,
+                125,
+            ],
+            'nested_in_switch_case_1'                   => [
+                '/* testMatchWithDefaultNestedInSwitchCase1 */',
+                6,
+                25,
+            ],
+            'nested_in_switch_case_2'                   => [
+                '/* testMatchWithDefaultNestedInSwitchCase2 */',
+                6,
+                25,
+            ],
+            'nested_in_switch_default'                  => [
+                '/* testMatchWithDefaultNestedInSwitchDefault */',
+                6,
+                25,
+            ],
+            'match_with_nested_switch'                  => [
+                '/* testMatchContainingSwitch */',
+                6,
+                180,
+            ],
+            'no_cases'                                  => [
+                '/* testMatchNoCases */',
+                6,
+                7,
+            ],
+            'multi_default'                             => [
+                '/* testMatchMultiDefault */',
+                6,
+                40,
+            ],
+        ];
+
+    }//end dataMatchExpression()
+
+
+    /**
+     * Verify that "match" keywords which are not match control structures get tokenized as T_STRING
+     * and don't have the extra token array indexes.
+     *
+     * @param string $testMarker  The comment prefacing the target token.
+     * @param string $testContent The token content to look for.
+     *
+     * @dataProvider dataNotAMatchStructure
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testNotAMatchStructure($testMarker, $testContent='match')
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken($testMarker, [T_STRING, T_MATCH], $testContent);
+        $tokenArray = $tokens[$token];
+
+        $this->assertSame(T_STRING, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (code)');
+        $this->assertSame('T_STRING', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_STRING (type)');
+
+        $this->assertArrayNotHasKey('scope_condition', $tokenArray, 'Scope condition is set');
+        $this->assertArrayNotHasKey('scope_opener', $tokenArray, 'Scope opener is set');
+        $this->assertArrayNotHasKey('scope_closer', $tokenArray, 'Scope closer is set');
+        $this->assertArrayNotHasKey('parenthesis_owner', $tokenArray, 'Parenthesis owner is set');
+        $this->assertArrayNotHasKey('parenthesis_opener', $tokenArray, 'Parenthesis opener is set');
+        $this->assertArrayNotHasKey('parenthesis_closer', $tokenArray, 'Parenthesis closer is set');
+
+        $next = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($token + 1), null, true);
+        if ($next !== false && $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
+            $this->assertArrayNotHasKey('parenthesis_owner', $tokenArray, 'Parenthesis owner is set for opener after');
+        }
+
+    }//end testNotAMatchStructure()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testNotAMatchStructure()
+     *
+     * @return array
+     */
+    public function dataNotAMatchStructure()
+    {
+        return [
+            'static_method_call'                   => ['/* testNoMatchStaticMethodCall */'],
+            'class_constant_access'                => [
+                '/* testNoMatchClassConstantAccess */',
+                'MATCH',
+            ],
+            'class_constant_array_access'          => [
+                '/* testNoMatchClassConstantArrayAccessMixedCase */',
+                'Match',
+            ],
+            'method_call'                          => ['/* testNoMatchMethodCall */'],
+            'method_call_uppercase'                => [
+                '/* testNoMatchMethodCallUpper */',
+                'MATCH',
+            ],
+            'property_access'                      => ['/* testNoMatchPropertyAccess */'],
+            'namespaced_function_call'             => ['/* testNoMatchNamespacedFunctionCall */'],
+            'namespace_operator_function_call'     => ['/* testNoMatchNamespaceOperatorFunctionCall */'],
+            'interface_method_declaration'         => ['/* testNoMatchInterfaceMethodDeclaration */'],
+            'class_constant_declaration'           => ['/* testNoMatchClassConstantDeclarationLower */'],
+            'class_method_declaration'             => ['/* testNoMatchClassMethodDeclaration */'],
+            'property_assigment'                   => ['/* testNoMatchPropertyAssignment */'],
+            'class_instantiation'                  => [
+                '/* testNoMatchClassInstantiation */',
+                'Match',
+            ],
+            'anon_class_method_declaration'        => [
+                '/* testNoMatchAnonClassMethodDeclaration */',
+                'maTCH',
+            ],
+            'class_declaration'                    => [
+                '/* testNoMatchClassDeclaration */',
+                'Match',
+            ],
+            'interface_declaration'                => [
+                '/* testNoMatchInterfaceDeclaration */',
+                'Match',
+            ],
+            'trait_declaration'                    => [
+                '/* testNoMatchTraitDeclaration */',
+                'Match',
+            ],
+            'constant_declaration'                 => [
+                '/* testNoMatchConstantDeclaration */',
+                'MATCH',
+            ],
+            'function_declaration'                 => ['/* testNoMatchFunctionDeclaration */'],
+            'namespace_declaration'                => [
+                '/* testNoMatchNamespaceDeclaration */',
+                'Match',
+            ],
+            'unsupported_inline_control_structure' => ['/* testNoMatchMissingCurlies */'],
+            'unsupported_alternative_syntax'       => ['/* testNoMatchAlternativeSyntax */'],
+            'live_coding'                          => ['/* testLiveCoding */'],
+        ];
+
+    }//end dataNotAMatchStructure()
+
+
+    /**
+     * Verify that the tokenization of switch structures is not affected by the backfill.
+     *
+     * @param string $testMarker   The comment prefacing the target token.
+     * @param int    $openerOffset The expected offset of the scope opener in relation to the testMarker.
+     * @param int    $closerOffset The expected offset of the scope closer in relation to the testMarker.
+     *
+     * @dataProvider dataSwitchExpression
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testSwitchExpression($testMarker, $openerOffset, $closerOffset)
+    {
+        $token = $this->getTargetToken($testMarker, T_SWITCH);
+
+        $this->scopeTestHelper($token, $openerOffset, $closerOffset);
+        $this->parenthesisTestHelper($token);
+
+    }//end testSwitchExpression()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testSwitchExpression()
+     *
+     * @return array
+     */
+    public function dataSwitchExpression()
+    {
+        return [
+            'switch_containing_match'   => [
+                '/* testSwitchContainingMatch */',
+                6,
+                174,
+            ],
+            'match_containing_switch_1' => [
+                '/* testSwitchNestedInMatch1 */',
+                5,
+                63,
+            ],
+            'match_containing_switch_2' => [
+                '/* testSwitchNestedInMatch2 */',
+                5,
+                63,
+            ],
+        ];
+
+    }//end dataSwitchExpression()
+
+
+    /**
+     * Verify that the tokenization of a switch case/default structure containing a match structure
+     * or contained *in* a match structure is not affected by the backfill.
+     *
+     * @param string $testMarker   The comment prefacing the target token.
+     * @param int    $openerOffset The expected offset of the scope opener in relation to the testMarker.
+     * @param int    $closerOffset The expected offset of the scope closer in relation to the testMarker.
+     *
+     * @dataProvider dataSwitchCaseVersusMatch
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testSwitchCaseVersusMatch($testMarker, $openerOffset, $closerOffset)
+    {
+        $token = $this->getTargetToken($testMarker, [T_CASE, T_DEFAULT]);
+
+        $this->scopeTestHelper($token, $openerOffset, $closerOffset);
+
+    }//end testSwitchCaseVersusMatch()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testSwitchCaseVersusMatch()
+     *
+     * @return array
+     */
+    public function dataSwitchCaseVersusMatch()
+    {
+        return [
+            'switch_with_nested_match_case_1'       => [
+                '/* testMatchWithDefaultNestedInSwitchCase1 */',
+                3,
+                55,
+            ],
+            'switch_with_nested_match_case_2'       => [
+                '/* testMatchWithDefaultNestedInSwitchCase2 */',
+                4,
+                21,
+            ],
+            'switch_with_nested_match_default_case' => [
+                '/* testMatchWithDefaultNestedInSwitchDefault */',
+                1,
+                38,
+            ],
+            'match_with_nested_switch_case'         => [
+                '/* testSwitchDefaultNestedInMatchCase */',
+                1,
+                18,
+            ],
+            'match_with_nested_switch_default_case' => [
+                '/* testSwitchDefaultNestedInMatchDefault */',
+                1,
+                20,
+            ],
+        ];
+
+    }//end dataSwitchCaseVersusMatch()
+
+
+    /**
+     * Helper function to verify that all scope related array indexes for a control structure
+     * are set correctly.
+     *
+     * @param string $token                The control structure token to check.
+     * @param int    $openerOffset         The expected offset of the scope opener in relation to
+     *                                     the control structure token.
+     * @param int    $closerOffset         The expected offset of the scope closer in relation to
+     *                                     the control structure token.
+     * @param bool   $skipScopeCloserCheck Whether to skip the scope closer check.
+     *                                     This should be set to "true" when testing nested arrow functions,
+     *                                     where the "inner" arrow function shares a scope closer with the
+     *                                     "outer" arrow function, as the 'scope_condition' for the scope closer
+     *                                     of the "inner" arrow function will point to the "outer" arrow function.
+     *
+     * @return void
+     */
+    private function scopeTestHelper($token, $openerOffset, $closerOffset, $skipScopeCloserCheck=false)
+    {
+        $tokens     = self::$phpcsFile->getTokens();
+        $tokenArray = $tokens[$token];
+        $tokenType  = $tokenArray['type'];
+        $expectedScopeOpener = ($token + $openerOffset);
+        $expectedScopeCloser = ($token + $closerOffset);
+
+        $this->assertArrayHasKey('scope_condition', $tokenArray, 'Scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokenArray, 'Scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokenArray, 'Scope closer is not set');
+        $this->assertSame($token, $tokenArray['scope_condition'], 'Scope condition is not the '.$tokenType.' token');
+        $this->assertSame($expectedScopeOpener, $tokenArray['scope_opener'], 'Scope opener of the '.$tokenType.' token incorrect');
+        $this->assertSame($expectedScopeCloser, $tokenArray['scope_closer'], 'Scope closer of the '.$tokenType.' token incorrect');
+
+        $opener = $tokenArray['scope_opener'];
+        $this->assertArrayHasKey('scope_condition', $tokens[$opener], 'Opener scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokens[$opener], 'Opener scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokens[$opener], 'Opener scope closer is not set');
+        $this->assertSame($token, $tokens[$opener]['scope_condition'], 'Opener scope condition is not the '.$tokenType.' token');
+        $this->assertSame($expectedScopeOpener, $tokens[$opener]['scope_opener'], $tokenType.' opener scope opener token incorrect');
+        $this->assertSame($expectedScopeCloser, $tokens[$opener]['scope_closer'], $tokenType.' opener scope closer token incorrect');
+
+        $closer = $tokenArray['scope_closer'];
+        $this->assertArrayHasKey('scope_condition', $tokens[$closer], 'Closer scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokens[$closer], 'Closer scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokens[$closer], 'Closer scope closer is not set');
+        if ($skipScopeCloserCheck === false) {
+            $this->assertSame($token, $tokens[$closer]['scope_condition'], 'Closer scope condition is not the '.$tokenType.' token');
+        }
+
+        $this->assertSame($expectedScopeOpener, $tokens[$closer]['scope_opener'], $tokenType.' closer scope opener token incorrect');
+        $this->assertSame($expectedScopeCloser, $tokens[$closer]['scope_closer'], $tokenType.' closer scope closer token incorrect');
+
+        if (($opener + 1) !== $closer) {
+            for ($i = ($opener + 1); $i < $closer; $i++) {
+                $this->assertArrayHasKey(
+                    $token,
+                    $tokens[$i]['conditions'],
+                    $tokenType.' condition not added for token belonging to the '.$tokenType.' structure'
+                );
+            }
+        }
+
+    }//end scopeTestHelper()
+
+
+    /**
+     * Helper function to verify that all parenthesis related array indexes for a control structure
+     * token are set correctly.
+     *
+     * @param int $token The position of the control structure token.
+     *
+     * @return void
+     */
+    private function parenthesisTestHelper($token)
+    {
+        $tokens     = self::$phpcsFile->getTokens();
+        $tokenArray = $tokens[$token];
+        $tokenType  = $tokenArray['type'];
+
+        $this->assertArrayHasKey('parenthesis_owner', $tokenArray, 'Parenthesis owner is not set');
+        $this->assertArrayHasKey('parenthesis_opener', $tokenArray, 'Parenthesis opener is not set');
+        $this->assertArrayHasKey('parenthesis_closer', $tokenArray, 'Parenthesis closer is not set');
+        $this->assertSame($token, $tokenArray['parenthesis_owner'], 'Parenthesis owner is not the '.$tokenType.' token');
+
+        $opener = $tokenArray['parenthesis_opener'];
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$opener], 'Opening parenthesis owner is not set');
+        $this->assertSame($token, $tokens[$opener]['parenthesis_owner'], 'Opening parenthesis owner is not the '.$tokenType.' token');
+
+        $closer = $tokenArray['parenthesis_closer'];
+        $this->assertArrayHasKey('parenthesis_owner', $tokens[$closer], 'Closing parenthesis owner is not set');
+        $this->assertSame($token, $tokens[$closer]['parenthesis_owner'], 'Closing parenthesis owner is not the '.$tokenType.' token');
+
+    }//end parenthesisTestHelper()
+
+
+}//end class

--- a/tests/Core/Tokenizer/DefaultKeywordTest.inc
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.inc
@@ -1,0 +1,93 @@
+<?php
+
+function matchWithDefault($i) {
+    return match ($i) {
+        1 => 1,
+        2 => 2,
+        /* testSimpleMatchDefault */
+        default => 'default',
+    };
+}
+
+function switchWithDefault($i) {
+    switch ($i) {
+        case 1:
+            return 1;
+        case 2:
+            return 2;
+        /* testSimpleSwitchDefault */
+        default:
+            return 'default';
+    }
+}
+
+function switchWithDefaultAndCurlies($i) {
+    switch ($i) {
+        case 1:
+            return 1;
+        case 2:
+            return 2;
+        /* testSimpleSwitchDefaultWithCurlies */
+        default: {
+            return 'default';
+        }
+    }
+}
+
+function matchWithDefaultInSwitch() {
+    switch ($something) {
+        case 'foo':
+            $var = [1, 2, 3];
+            $var = match ($i) {
+                1 => 1,
+                /* testMatchDefaultNestedInSwitchCase1 */
+                default => 'default',
+            };
+            continue;
+
+        case 'bar' :
+            $i = callMe($a, $b);
+            return match ($i) {
+                1 => 1,
+                /* testMatchDefaultNestedInSwitchCase2 */
+                default => 'default',
+            };
+
+        /* testSwitchDefault */
+        default;
+            echo 'something', match ($i) {
+                1, => 1,
+                /* testMatchDefaultNestedInSwitchDefault */
+                default, => 'default',
+            };
+            break;
+    }
+}
+
+function switchWithDefaultInMatch() {
+    $x = match ($y) {
+        5, 8 => function($z) {
+            switch($z) {
+                case 'a';
+                    $var = [1, 2, 3];
+                    return 'a';
+                /* testSwitchDefaultNestedInMatchCase */
+                default:
+                    $var = [1, 2, 3];
+                    return 'default1';
+            }
+        },
+        /* testMatchDefault */
+        default => function($z) {
+            switch($z) {
+                case 'a':
+                    $i = callMe($a, $b);
+                    return 'b';
+                /* testSwitchDefaultNestedInMatchDefault */
+                default:
+                    $i = callMe($a, $b);
+                    return 'default2';
+            }
+        }
+    };
+}

--- a/tests/Core/Tokenizer/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Tests the retokenization of the `default` keyword to T_MATCH_DEFAULT for PHP 8.0 match structures
+ * and makes sure that the tokenization of switch `T_DEFAULT` structures is not aversely affected.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020-2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class DefaultKeywordTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test the retokenization of the `default` keyword for match structure to `T_MATCH_DEFAULT`.
+     *
+     * Note: Cases and default structures within a match structure do *NOT* get case/default scope
+     * conditions, in contrast to case and default structures in switch control structures.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider dataMatchDefault
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
+     *
+     * @return void
+     */
+    public function testMatchDefault($testMarker)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken($testMarker, [T_MATCH_DEFAULT, T_DEFAULT]);
+        $tokenArray = $tokens[$token];
+
+        $this->assertSame(T_MATCH_DEFAULT, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_MATCH_DEFAULT (code)');
+        $this->assertSame('T_MATCH_DEFAULT', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_MATCH_DEFAULT (type)');
+
+        $this->assertArrayNotHasKey('scope_condition', $tokenArray, 'Scope condition is set');
+        $this->assertArrayNotHasKey('scope_opener', $tokenArray, 'Scope opener is set');
+        $this->assertArrayNotHasKey('scope_closer', $tokenArray, 'Scope closer is set');
+
+    }//end testMatchDefault()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testMatchDefault()
+     *
+     * @return array
+     */
+    public function dataMatchDefault()
+    {
+        return [
+            'simple_match_default'            => ['/* testSimpleMatchDefault */'],
+            'match_default_in_switch_case_1'  => ['/* testMatchDefaultNestedInSwitchCase1 */'],
+            'match_default_in_switch_case_2'  => ['/* testMatchDefaultNestedInSwitchCase2 */'],
+            'match_default_in_switch_default' => ['/* testMatchDefaultNestedInSwitchDefault */'],
+            'match_default_containing_switch' => ['/* testMatchDefault */'],
+        ];
+
+    }//end dataMatchDefault()
+
+
+    /**
+     * Verify that the retokenization of `T_DEFAULT` tokens in match constructs, doesn't negatively
+     * impact the tokenization of `T_DEFAULT` tokens in switch control structures.
+     *
+     * Note: Cases and default structures within a switch control structure *do* get case/default scope
+     * conditions.
+     *
+     * @param string   $testMarker    The comment prefacing the target token.
+     * @param int      $openerOffset  The expected offset of the scope opener in relation to the testMarker.
+     * @param int      $closerOffset  The expected offset of the scope closer in relation to the testMarker.
+     * @param int|null $conditionStop The expected offset at which tokens stop having T_DEFAULT as a scope condition.
+     *
+     * @dataProvider dataSwitchDefault
+     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::recurseScopeMap
+     *
+     * @return void
+     */
+    public function testSwitchDefault($testMarker, $openerOffset, $closerOffset, $conditionStop=null)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken($testMarker, [T_MATCH_DEFAULT, T_DEFAULT]);
+        $tokenArray = $tokens[$token];
+        $expectedScopeOpener = ($token + $openerOffset);
+        $expectedScopeCloser = ($token + $closerOffset);
+
+        $this->assertSame(T_DEFAULT, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_DEFAULT (code)');
+        $this->assertSame('T_DEFAULT', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_DEFAULT (type)');
+
+        $this->assertArrayHasKey('scope_condition', $tokenArray, 'Scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokenArray, 'Scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokenArray, 'Scope closer is not set');
+        $this->assertSame($token, $tokenArray['scope_condition'], 'Scope condition is not the T_DEFAULT token');
+        $this->assertSame($expectedScopeOpener, $tokenArray['scope_opener'], 'Scope opener of the T_DEFAULT token incorrect');
+        $this->assertSame($expectedScopeCloser, $tokenArray['scope_closer'], 'Scope closer of the T_DEFAULT token incorrect');
+
+        $opener = $tokenArray['scope_opener'];
+        $this->assertArrayHasKey('scope_condition', $tokens[$opener], 'Opener scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokens[$opener], 'Opener scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokens[$opener], 'Opener scope closer is not set');
+        $this->assertSame($token, $tokens[$opener]['scope_condition'], 'Opener scope condition is not the T_DEFAULT token');
+        $this->assertSame($expectedScopeOpener, $tokens[$opener]['scope_opener'], 'T_DEFAULT opener scope opener token incorrect');
+        $this->assertSame($expectedScopeCloser, $tokens[$opener]['scope_closer'], 'T_DEFAULT opener scope closer token incorrect');
+
+        $closer = $tokenArray['scope_closer'];
+        $this->assertArrayHasKey('scope_condition', $tokens[$closer], 'Closer scope condition is not set');
+        $this->assertArrayHasKey('scope_opener', $tokens[$closer], 'Closer scope opener is not set');
+        $this->assertArrayHasKey('scope_closer', $tokens[$closer], 'Closer scope closer is not set');
+        $this->assertSame($token, $tokens[$closer]['scope_condition'], 'Closer scope condition is not the T_DEFAULT token');
+        $this->assertSame($expectedScopeOpener, $tokens[$closer]['scope_opener'], 'T_DEFAULT closer scope opener token incorrect');
+        $this->assertSame($expectedScopeCloser, $tokens[$closer]['scope_closer'], 'T_DEFAULT closer scope closer token incorrect');
+
+        if (($opener + 1) !== $closer) {
+            $end = $closer;
+            if (isset($conditionStop) === true) {
+                $end = $conditionStop;
+            }
+
+            for ($i = ($opener + 1); $i < $end; $i++) {
+                $this->assertArrayHasKey(
+                    $token,
+                    $tokens[$i]['conditions'],
+                    'T_DEFAULT condition not added for token belonging to the T_DEFAULT structure'
+                );
+            }
+        }
+
+    }//end testSwitchDefault()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testSwitchDefault()
+     *
+     * @return array
+     */
+    public function dataSwitchDefault()
+    {
+        return [
+            'simple_switch_default'                  => [
+                '/* testSimpleSwitchDefault */',
+                1,
+                4,
+            ],
+            'simple_switch_default_with_curlies'     => [
+                // For a default structure with curly braces, the scope opener
+                // will be the open curly and the closer the close curly.
+                // However, scope conditions will not be set for open to close,
+                // but only for the open token up to the "break/return/continue" etc.
+                '/* testSimpleSwitchDefaultWithCurlies */',
+                3,
+                12,
+                6,
+            ],
+            'switch_default_toplevel'                => [
+                '/* testSwitchDefault */',
+                1,
+                43,
+            ],
+            'switch_default_nested_in_match_case'    => [
+                '/* testSwitchDefaultNestedInMatchCase */',
+                1,
+                20,
+            ],
+            'switch_default_nested_in_match_default' => [
+                '/* testSwitchDefaultNestedInMatchDefault */',
+                1,
+                18,
+            ],
+        ];
+
+    }//end dataSwitchDefault()
+
+
+}//end class

--- a/tests/Core/Tokenizer/DoubleArrowTest.inc
+++ b/tests/Core/Tokenizer/DoubleArrowTest.inc
@@ -1,0 +1,221 @@
+<?php
+
+function simpleLongArray($x) {
+    return array(
+        /* testLongArrayArrowSimple */
+        0 => 'Zero',
+    );
+}
+
+function simpleShortArray($x) {
+    return [
+        /* testShortArrayArrowSimple */
+        0 => 'Zero',
+    ];
+}
+
+function simpleLongList($x) {
+    list(
+        /* testLongListArrowSimple */
+        0 => $a,
+    ) = $x;
+}
+
+function simpleShortList($x) {
+    [
+        /* testShortListArrowSimple */
+        0 => $a,
+    ] = $x;
+}
+
+function simpleYield($x) {
+    $i = 0;
+    foreach (explode("\n", $x) as $line) {
+        /* testYieldArrowSimple */
+        yield ++$i => $line;
+    }
+}
+
+function simpleForeach($x) {
+    /* testForeachArrowSimple */
+    foreach ($x as $k => $value) {}
+}
+
+function simpleMatch($x) {
+    return match ($x) {
+        /* testMatchArrowSimpleSingleCase */
+        0 => 'Zero',
+        /* testMatchArrowSimpleMultiCase */
+        2, 4, 6 => 'Zero',
+        /* testMatchArrowSimpleSingleCaseWithTrailingComma */
+        1, => 'Zero',
+        /* testMatchArrowSimpleMultiCaseWithTrailingComma */
+        3, 5, => 'Zero',
+    };
+}
+
+function simpleArrowFunction($y) {
+    /* testFnArrowSimple */
+    return fn ($y) => callMe($y);
+}
+
+function matchNestedInMatch() {
+    $x = match ($y) {
+        /* testMatchArrowNestedMatchOuter */
+        default, => match ($z) {
+            /* testMatchArrowNestedMatchInner */
+            1 => 1
+        },
+    };
+}
+
+function matchNestedInLongArrayValue() {
+    $array = array(
+        /* testLongArrayArrowWithNestedMatchValue1 */
+        'a' => match ($test) {
+            /* testMatchArrowInLongArrayValue1 */
+            1 => 'a',
+            /* testMatchArrowInLongArrayValue2 */
+            2 => 'b'
+        },
+        /* testLongArrayArrowWithNestedMatchValue2 */
+        $i => match ($test) {
+            /* testMatchArrowInLongArrayValue3 */
+            1 => 'a',
+        },
+    );
+}
+
+function matchNestedInShortArrayValue() {
+    $array = [
+        /* testShortArrayArrowWithNestedMatchValue1 */
+        'a' => match ($test) {
+            /* testMatchArrowInShortArrayValue1 */
+            1 => 'a',
+            /* testMatchArrowInShortArrayValue2 */
+            2 => 'b'
+        },
+        /* testShortArrayArrowWithNestedMatchValue2 */
+        $i => match ($test) {
+            /* testMatchArrowInShortArrayValue3 */
+            1 => 'a',
+        },
+    ];
+}
+
+function matchNestedInLongArrayKey() {
+    $array = array(
+        match ($test) { /* testMatchArrowInLongArrayKey1 */ 1 => 'a', /* testMatchArrowInLongArrayKey2 */ 2 => 'b' }
+            /* testLongArrayArrowWithMatchKey */
+            => 'dynamic keys, woho!',
+    );
+}
+
+function matchNestedInShortArrayKey() {
+    $array = [
+        match ($test) { /* testMatchArrowInShortArrayKey1 */ 1 => 'a', /* testMatchArrowInShortArrayKey2 */ 2 => 'b' }
+            /* testShortArrayArrowWithMatchKey */
+            => 'dynamic keys, woho!',
+    ];
+}
+
+function arraysNestedInMatch() {
+    $matcher = match ($x) {
+        /* testMatchArrowWithLongArrayBodyWithKeys */
+        0 => array(
+            /* testLongArrayArrowInMatchBody1 */
+            0 => 1,
+            /* testLongArrayArrowInMatchBody2 */
+            'a' => 2,
+            /* testLongArrayArrowInMatchBody3 */
+            'b' => 3
+        ),
+        /* testMatchArrowWithShortArrayBodyWithoutKeys */
+        1 => [1, 2, 3],
+        /* testMatchArrowWithLongArrayBodyWithoutKeys */
+        2 => array( 1, [1, 2, 3], 2, 3),
+        /* testMatchArrowWithShortArrayBodyWithKeys */
+        3 => [
+            /* testShortArrayArrowInMatchBody1 */
+            0 => 1,
+            /* testShortArrayArrowInMatchBody2 */
+            'a' => array(1, 2, 3),
+            /* testShortArrayArrowInMatchBody3 */
+            'b' => 2,
+            3
+        ],
+        /* testShortArrayArrowinMatchCase1 */
+        [4 => 'a', /* testShortArrayArrowinMatchCase2 */ 5 => 6]
+            /* testMatchArrowWithShortArrayWithKeysAsCase */
+            => 'match with array as case value',
+        /* testShortArrayArrowinMatchCase3 */
+        [4 => 'a'], /* testLongArrayArrowinMatchCase4 */ array(5 => 6),
+            /* testMatchArrowWithMultipleArraysWithKeysAsCase */
+            => 'match with multiple arrays as case value',
+    };
+}
+
+function matchNestedInArrowFunction($x) {
+    /* testFnArrowWithMatchInValue */
+    $fn = fn($x) => match(true) {
+        /* testMatchArrowInFnBody1 */
+        1, 2, 3, 4, 5 => 'foo',
+        /* testMatchArrowInFnBody2 */
+        default => 'bar',
+    };
+}
+
+function arrowFunctionsNestedInMatch($x) {
+    return match ($x) {
+        /* testMatchArrowWithFnBody1 */
+        1 => /* testFnArrowInMatchBody1 */ fn($y) => callMe($y),
+        /* testMatchArrowWithFnBody2 */
+        default => /* testFnArrowInMatchBody2 */ fn($y) => callThem($y)
+    };
+}
+
+function matchShortArrayMismash() {
+    $array = [
+        match ($test) {
+            /* testMatchArrowInComplexShortArrayKey1 */
+            1 => [ /* testShortArrayArrowInComplexMatchValueinShortArrayKey */ 1 => 'a'],
+            /* testMatchArrowInComplexShortArrayKey2 */
+            2 => 'b'
+        /* testShortArrayArrowInComplexMatchArrayMismash */
+        } => match ($test) {
+            /* testMatchArrowInComplexShortArrayValue1 */
+            1 => [ /* testShortArrayArrowInComplexMatchValueinShortArrayValue */ 1 => 'a'],
+            /* testMatchArrowInComplexShortArrayValue1 */
+            2 => /* testFnArrowInComplexMatchValueInShortArrayValue */ fn($y) => callMe($y)
+        },
+    ];
+}
+
+
+function longListInMatch($x, $y) {
+    return match($x) {
+        /* testMatchArrowWithLongListBody */
+        1 => list('a' => $a, /* testLongListArrowInMatchBody */ 'b' => $b, 'c' => list('d' => $c)) = $y,
+        /* testLongListArrowInMatchCase */
+        list('a' => $a, 'b' => $b) = $y /* testMatchArrowWithLongListInCase */ => 'something'
+    };
+}
+
+function shortListInMatch($x, $y) {
+    return match($x) {
+        /* testMatchArrowWithShortListBody */
+        1 => ['a' => $a, 'b' => $b, 'c' => /* testShortListArrowInMatchBody */  ['d' => $c]] = $y,
+        /* testShortListArrowInMatchCase */
+        ['a' => $a, 'b' => $b] = $y /* testMatchArrowWithShortListInCase */ => 'something'
+    };
+}
+
+function matchInLongList() {
+    /* testMatchArrowInLongListKey */
+    list(match($x) {1 => 1, 2 => 2} /* testLongListArrowWithMatchInKey */ => $a) = $array;
+}
+
+function matchInShortList() {
+    /* testMatchArrowInShortListKey */
+    [match($x) {1 => 1, 2 => 2} /* testShortListArrowWithMatchInKey */ => $a] = $array;
+}

--- a/tests/Core/Tokenizer/DoubleArrowTest.php
+++ b/tests/Core/Tokenizer/DoubleArrowTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Tests the retokenization of the double arrow to T_MATCH_ARROW for PHP 8.0 match structures
+ * and makes sure that the tokenization of other double arrows (array, arrow function, yield)
+ * is not aversely affected.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2020-2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class DoubleArrowTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that "normal" double arrows are correctly tokenized as `T_DOUBLE_ARROW`.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider  dataDoubleArrow
+     * @coversNothing
+     *
+     * @return void
+     */
+    public function testDoubleArrow($testMarker)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken($testMarker, [T_DOUBLE_ARROW, T_MATCH_ARROW, T_FN_ARROW]);
+        $tokenArray = $tokens[$token];
+
+        $this->assertSame(T_DOUBLE_ARROW, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_DOUBLE_ARROW (code)');
+        $this->assertSame('T_DOUBLE_ARROW', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_DOUBLE_ARROW (type)');
+
+    }//end testDoubleArrow()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDoubleArrow()
+     *
+     * @return array
+     */
+    public function dataDoubleArrow()
+    {
+        return [
+            'simple_long_array'                        => ['/* testLongArrayArrowSimple */'],
+            'simple_short_array'                       => ['/* testShortArrayArrowSimple */'],
+            'simple_long_list'                         => ['/* testLongListArrowSimple */'],
+            'simple_short_list'                        => ['/* testShortListArrowSimple */'],
+            'simple_yield'                             => ['/* testYieldArrowSimple */'],
+            'simple_foreach'                           => ['/* testForeachArrowSimple */'],
+
+            'long_array_with_match_value_1'            => ['/* testLongArrayArrowWithNestedMatchValue1 */'],
+            'long_array_with_match_value_2'            => ['/* testLongArrayArrowWithNestedMatchValue2 */'],
+            'short_array_with_match_value_1'           => ['/* testShortArrayArrowWithNestedMatchValue1 */'],
+            'short_array_with_match_value_2'           => ['/* testShortArrayArrowWithNestedMatchValue2 */'],
+
+            'long_array_with_match_key'                => ['/* testLongArrayArrowWithMatchKey */'],
+            'short_array_with_match_key'               => ['/* testShortArrayArrowWithMatchKey */'],
+
+            'long_array_in_match_body_1'               => ['/* testLongArrayArrowInMatchBody1 */'],
+            'long_array_in_match_body_2'               => ['/* testLongArrayArrowInMatchBody2 */'],
+            'long_array_in_match_body_2'               => ['/* testLongArrayArrowInMatchBody3 */'],
+            'short_array_in_match_body_1'              => ['/* testShortArrayArrowInMatchBody1 */'],
+            'short_array_in_match_body_2'              => ['/* testShortArrayArrowInMatchBody2 */'],
+            'short_array_in_match_body_2'              => ['/* testShortArrayArrowInMatchBody3 */'],
+
+            'short_array_in_match_case_1'              => ['/* testShortArrayArrowinMatchCase1 */'],
+            'short_array_in_match_case_2'              => ['/* testShortArrayArrowinMatchCase2 */'],
+            'short_array_in_match_case_3'              => ['/* testShortArrayArrowinMatchCase3 */'],
+            'long_array_in_match_case_4'               => ['/* testLongArrayArrowinMatchCase4 */'],
+
+            'in_complex_short_array_key_match_value'   => ['/* testShortArrayArrowInComplexMatchValueinShortArrayKey */'],
+            'in_complex_short_array_toplevel'          => ['/* testShortArrayArrowInComplexMatchArrayMismash */'],
+            'in_complex_short_array_value_match_value' => ['/* testShortArrayArrowInComplexMatchValueinShortArrayValue */'],
+
+            'long_list_in_match_body'                  => ['/* testLongListArrowInMatchBody */'],
+            'long_list_in_match_case'                  => ['/* testLongListArrowInMatchCase */'],
+            'short_list_in_match_body'                 => ['/* testShortListArrowInMatchBody */'],
+            'short_list_in_match_case'                 => ['/* testShortListArrowInMatchCase */'],
+            'long_list_with_match_in_key'              => ['/* testLongListArrowWithMatchInKey */'],
+            'short_list_with_match_in_key'             => ['/* testShortListArrowWithMatchInKey */'],
+        ];
+
+    }//end dataDoubleArrow()
+
+
+    /**
+     * Test that double arrows in match expressions which are the demarkation between a case and the return value
+     * are correctly tokenized as `T_MATCH_ARROW`.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider dataMatchArrow
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testMatchArrow($testMarker)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken($testMarker, [T_DOUBLE_ARROW, T_MATCH_ARROW, T_FN_ARROW]);
+        $tokenArray = $tokens[$token];
+
+        $this->assertSame(T_MATCH_ARROW, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_MATCH_ARROW (code)');
+        $this->assertSame('T_MATCH_ARROW', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_MATCH_ARROW (type)');
+
+    }//end testMatchArrow()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testMatchArrow()
+     *
+     * @return array
+     */
+    public function dataMatchArrow()
+    {
+        return [
+            'single_case'                            => ['/* testMatchArrowSimpleSingleCase */'],
+            'multi_case'                             => ['/* testMatchArrowSimpleMultiCase */'],
+            'single_case_with_trailing_comma'        => ['/* testMatchArrowSimpleSingleCaseWithTrailingComma */'],
+            'multi_case_with_trailing_comma'         => ['/* testMatchArrowSimpleMultiCaseWithTrailingComma */'],
+            'match_nested_outer'                     => ['/* testMatchArrowNestedMatchOuter */'],
+            'match_nested_inner'                     => ['/* testMatchArrowNestedMatchInner */'],
+
+            'in_long_array_value_1'                  => ['/* testMatchArrowInLongArrayValue1 */'],
+            'in_long_array_value_2'                  => ['/* testMatchArrowInLongArrayValue2 */'],
+            'in_long_array_value_3'                  => ['/* testMatchArrowInLongArrayValue3 */'],
+            'in_short_array_value_1'                 => ['/* testMatchArrowInShortArrayValue1 */'],
+            'in_short_array_value_2'                 => ['/* testMatchArrowInShortArrayValue2 */'],
+            'in_short_array_value_3'                 => ['/* testMatchArrowInShortArrayValue3 */'],
+
+            'in_long_array_key_1'                    => ['/* testMatchArrowInLongArrayKey1 */'],
+            'in_long_array_key_2'                    => ['/* testMatchArrowInLongArrayKey2 */'],
+            'in_short_array_key_1'                   => ['/* testMatchArrowInShortArrayKey1 */'],
+            'in_short_array_key_2'                   => ['/* testMatchArrowInShortArrayKey2 */'],
+
+            'with_long_array_value_with_keys'        => ['/* testMatchArrowWithLongArrayBodyWithKeys */'],
+            'with_short_array_value_without_keys'    => ['/* testMatchArrowWithShortArrayBodyWithoutKeys */'],
+            'with_long_array_value_without_keys'     => ['/* testMatchArrowWithLongArrayBodyWithoutKeys */'],
+            'with_short_array_value_with_keys'       => ['/* testMatchArrowWithShortArrayBodyWithKeys */'],
+
+            'with_short_array_with_keys_as_case'     => ['/* testMatchArrowWithShortArrayWithKeysAsCase */'],
+            'with_multiple_arrays_with_keys_as_case' => ['/* testMatchArrowWithMultipleArraysWithKeysAsCase */'],
+
+            'in_fn_body_case'                        => ['/* testMatchArrowInFnBody1 */'],
+            'in_fn_body_default'                     => ['/* testMatchArrowInFnBody2 */'],
+            'with_fn_body_case'                      => ['/* testMatchArrowWithFnBody1 */'],
+            'with_fn_body_default'                   => ['/* testMatchArrowWithFnBody2 */'],
+
+            'in_complex_short_array_key_1'           => ['/* testMatchArrowInComplexShortArrayKey1 */'],
+            'in_complex_short_array_key_2'           => ['/* testMatchArrowInComplexShortArrayKey2 */'],
+            'in_complex_short_array_value_1'         => ['/* testMatchArrowInComplexShortArrayValue1 */'],
+            'in_complex_short_array_key_2'           => ['/* testMatchArrowInComplexShortArrayValue1 */'],
+
+            'with_long_list_in_body'                 => ['/* testMatchArrowWithLongListBody */'],
+            'with_long_list_in_case'                 => ['/* testMatchArrowWithLongListInCase */'],
+            'with_short_list_in_body'                => ['/* testMatchArrowWithShortListBody */'],
+            'with_short_list_in_case'                => ['/* testMatchArrowWithShortListInCase */'],
+            'in_long_list_key'                       => ['/* testMatchArrowInLongListKey */'],
+            'in_short_list_key'                      => ['/* testMatchArrowInShortListKey */'],
+        ];
+
+    }//end dataMatchArrow()
+
+
+    /**
+     * Test that double arrows used as the scope opener for an arrow function
+     * are correctly tokenized as `T_FN_ARROW`.
+     *
+     * @param string $testMarker The comment prefacing the target token.
+     *
+     * @dataProvider dataFnArrow
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::processAdditional
+     *
+     * @return void
+     */
+    public function testFnArrow($testMarker)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken($testMarker, [T_DOUBLE_ARROW, T_MATCH_ARROW, T_FN_ARROW]);
+        $tokenArray = $tokens[$token];
+
+        $this->assertSame(T_FN_ARROW, $tokenArray['code'], 'Token tokenized as '.$tokenArray['type'].', not T_FN_ARROW (code)');
+        $this->assertSame('T_FN_ARROW', $tokenArray['type'], 'Token tokenized as '.$tokenArray['type'].', not T_FN_ARROW (type)');
+
+    }//end testFnArrow()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testFnArrow()
+     *
+     * @return array
+     */
+    public function dataFnArrow()
+    {
+        return [
+            'simple_fn'                             => ['/* testFnArrowSimple */'],
+
+            'with_match_as_value'                   => ['/* testFnArrowWithMatchInValue */'],
+            'in_match_value_case'                   => ['/* testFnArrowInMatchBody1 */'],
+            'in_match_value_default'                => ['/* testFnArrowInMatchBody2 */'],
+
+            'in_complex_match_value_in_short_array' => ['/* testFnArrowInComplexMatchValueInShortArrayValue */'],
+        ];
+
+    }//end dataFnArrow()
+
+
+}//end class


### PR DESCRIPTION
## TL;DR

PHP 8.0 introduces a new type of control structure: match expressions.
> A match expression is similar to a `switch` control structure but with safer semantics and the ability to return values.

Ref: https://wiki.php.net/rfc/match_expression_v2

This PR adds support for PHP 8.0 match expressions to PHPCS by backfilling the token for older PHP versions.
It also retokenizes the `default` keyword when used in match expressions to `T_MATCH_DEFAULT` and the double arrow separating the "case" from the return expression to `T_MATCH_ARROW`.

Note: if this PR is accepted as is, then, in contrast to the `switch` control structure, "cases" (including a potential `default` case)  in match expressions will not be considered scope owners and will not have any `scope_*` array indexes set.

The match structure itself *is* considered a scope owner and will have those indexes set.

Includes extensive unit tests for all aspects of the PR.

Fixes #3037

## Commit Details

### PHP 8.0 | Tokens: replicate the `T_MATCH` token

### PHP 8.0 | Tokens: add T_MATCH to $parenthesisOpeners and $scopeOpener

### PHP 8.0 | Tokenizer/PHP: backfill the `T_MATCH` tokenization

This commit adds initial support for match expressions to PHPCS.

* In PHP < 8: Retokenizes `T_STRING` tokens containing the `match` keyword to `T_MATCH` when they are in actual fact match expressions.
* In PHP 8: Retokenizes `T_MATCH` tokens to `T_STRING` when the `match` keyword is used outside the context of a match expression, like in a method declaration or call.
* Ensures that the `match` keyword for match expressions will be recognized as a scope owner and that the appropriate `scope_*` array indexes are set for the curly braces belonging to the match expression, as well as that the `match` condition is added to the tokens within the match expression.

Note: in contrast to `switch` control structures, "cases" in a match expression will not be recognized as scopes and no `scope_owner`, `scope_opener` or `scope_closer` array indexes will be set for the individual cases in a match expression.
This also applies to the `default` case when used in a match expression.

Includes extensive unit tests.
Note: at this point, not all unit tests will pass, this will be fixed in follow-on commits.

### PHP 8.0 | Tokenizer/PHP: retokenize `default` keywords within match expressions as `T_MATCH_DEFAULT`

The `default` keyword in match expressions is tokenized as `T_DEFAULT` by PHP.

However, for `switch` control structures, `default` (and `case`) are treated as scope owners/openers by PHPCS.

If the `default` keyword tokenization in match expressions was left as-is, the `Tokenizer::recurseScopeMap()` would search for the wrong scope opener/closer, throwing the scope setting for scope owners in the rest of the file off.
Adding the typical opener/closers for match expression `default` cases to the `PHP::$scopeOpeners` array would not prevent this and once the scope setting is out of kilter, a lot of sniffs start failing, including the `ScopeIndent` sniffs, `ScopeCloserBrace` sniffs etc.

The only stable solution I could find to prevent the scope setting potentially getting borked and existing sniffs breaking badly, was to retokenize the `default` keyword when used in a `match` expression to `T_MATCH_DEFAULT`.

Includes a separate set of unit tests which specifically tests the tokenization of the `default` keyword and verifies both the retokenization to `T_MATCH_DEFAULT` when used in `match` expressions, as well as the tokenization of the `default` keyword within `switch` control structures, including the scope setting for the `default` case.

### PHP 8.0 | Tokenizer/PHP: add support for match expressions in combination with arrow functions

As a match expression can be nested in an arrow function and visa versa, setting the scope openers/closers becomes _interesting_.

If the arrow function would be allowed to take over, it would break the scope setting for match expression, making the `scope_closer` and `scope_condition` indexes next to useless.

So in the interest of making things easier for sniff writers and keeping in mind that scope setting for arrow functions isn't perfect anyway, preference is given to keeping the scope setting for match structures intact.

This means that if a match expression is in the return value of an arrow function, like so:
```php
$fn = fn($x) => match($y) {...};
```
... the token _after_ the closing curly belonging to the `match` will be considered the scope closer for the arrow function. In this example, that is the `;` (semicolon).

While, if an arrow function is the return value of one of the match expression cases, generally speaking the comma at the end of the case will be the scope closer for the arrow function.
There is one exception to this: the comma after each case is optional for the last case in a match expression.
In that situation, the last non-empty token will be considered the scope closer for the arrow function.

Example:
```php
$match = match($y) {
    default => fn($x) => $y * $x
};
```
In this example, the `$x` at the end of the arrow expression would be considered the scope closer for the arrow function.

```php
$match = match($y) {
    default => fn($x) => ($y * $x)
};
```
And in this example, the parenthesis closer at the end of the arrow expression would be considered the scope closer for the arrow function.

### Tokenizer/PHP: retokenize the match double arrow to T_MATCH_ARROW

The double arrow in PHP is used in a number of contexts:
* Long/short arrays with keys;
* Long/short lists with keys;
* In the `as` part of `foreach()` statements with keys;
* For `yield` statements with keys;
* For arrow functions as the scope opener;
* And now for `match` expressions to separate the cases from the return value (body).

As most of these constructs can be nested in each other - an arrow function in an array value, a match expression in a list key -, every sniff handling any of these constructs has to take a lot of care when searching for the double arrow for the construct they are handling, to prevent matching a double arrow belonging to another type of construct nested in the target construct.

This type of detection and special handling has to be done in each individual sniff which in one way or another has to deal with the `T_DOUBLE_ARROW` token and can cause quite some processing overhead.

With that in mind, the double arrow as a scope opener for arrow functions has previously already been retokenized to `T_FN_ARROW`.

Following the same reasoning, I'm proposing to retokenize the double arrow which separates `match` case expressions from the body expression to `T_MATCH_ARROW`.

This should make life easier for any sniff dealing with any of the above constructs and will prevent potential false positives being introduced for sniffs currently handling any of these constructs, but not yet updated to allow for match expressions.

Includes a set of dedicated unit tests verifying the tokenization of the double arrow operator in all currently supported contexts, including in combined (nested) contexts.

