### PR TITLE
PHP 8.0 | Generic/AssignmentInCondition: include match expressions

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -60,6 +60,7 @@ class AssignmentInConditionSniff implements Sniff
             T_SWITCH,
             T_CASE,
             T_WHILE,
+            T_MATCH,
         ];
 
     }//end register()

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.inc
@@ -91,3 +91,5 @@ while ( $sample = false ) {}
 
 if ($a = 123) :
 endif;
+
+match ($a[0] = 123) {};

--- a/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/AssignmentInConditionUnitTest.php
@@ -74,6 +74,7 @@ class AssignmentInConditionUnitTest extends AbstractSniffUnitTest
             88 => 1,
             90 => 1,
             92 => 1,
+            95 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
Allows the sniff to also check for assignments in condition in the condition part of a match expression.

Includes unit test.