### PR TITLE
PHP 8.0 | Generic/EmptyStatement: include match expressions

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -50,6 +50,7 @@ class EmptyStatementSniff implements Sniff
             T_IF,
             T_SWITCH,
             T_WHILE,
+            T_MATCH,
         ];
 
     }//end register()

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.inc
@@ -70,3 +70,5 @@ try {
 }
 
 if (true) {} elseif (false) {}
+
+match($foo) {};

--- a/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/EmptyStatementUnitTest.php
@@ -39,6 +39,7 @@ class EmptyStatementUnitTest extends AbstractSniffUnitTest
             64 => 1,
             68 => 1,
             72 => 2,
+            74 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Allows the sniff to also check for empty match expressions.

Includes unit test.