### PR TITLE
PHP 8.0 | Generic/LowerCaseKeyword: add match to keyword list

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -73,6 +73,8 @@ class LowerCaseKeywordSniff implements Sniff
             T_LOGICAL_AND,
             T_LOGICAL_OR,
             T_LOGICAL_XOR,
+            T_MATCH,
+            T_MATCH_DEFAULT,
             T_NAMESPACE,
             T_NEW,
             T_PARENT,

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
@@ -29,5 +29,11 @@ class X extends Y {
     }
 }
 FN ($x) => $x;
+$r = Match ($x) {
+    1 => 1,
+    2 => 2,
+    DEFAULT, => 3,
+};
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
@@ -29,5 +29,11 @@ class X extends Y {
     }
 }
 fn ($x) => $x;
+$r = match ($x) {
+    1 => 1,
+    2 => 2,
+    default, => 3,
+};
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -38,6 +38,8 @@ class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
             25 => 1,
             28 => 1,
             31 => 1,
+            32 => 1,
+            35 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This adds the PHP 8.0 `match` keyword to the list handled by this sniff, as well as the `default` keyword when used in a match control structure.

Includes unit tests.