### PR TITLE
PHP 8.0 | PSR12/BooleanOperatorPlacement: include match expressions

### DIFF
--- a/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/BooleanOperatorPlacementSniff.php
@@ -37,6 +37,7 @@ class BooleanOperatorPlacementSniff implements Sniff
             T_WHILE,
             T_SWITCH,
             T_ELSEIF,
+            T_MATCH,
         ];
 
     }//end register()

--- a/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.inc
+++ b/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.inc
@@ -118,3 +118,14 @@ if (
 ) {
     return 5;
 }
+
+// Reset to default.
+// phpcs:set PSR12.ControlStructures.BooleanOperatorPlacement allowOnly
+
+match (
+    $expr1
+    && $expr2 &&
+    $expr3
+) {
+    // structure body
+};

--- a/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.inc.fixed
@@ -128,3 +128,14 @@ if (
 ) {
     return 5;
 }
+
+// Reset to default.
+// phpcs:set PSR12.ControlStructures.BooleanOperatorPlacement allowOnly
+
+match (
+    $expr1
+    && $expr2
+    && $expr3
+) {
+    // structure body
+};

--- a/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/BooleanOperatorPlacementUnitTest.php
@@ -35,6 +35,7 @@ class BooleanOperatorPlacementUnitTest extends AbstractSniffUnitTest
             90  => 1,
             98  => 1,
             104 => 1,
+            125 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Allows the sniff to also check the placement of boolean operators in match expressions.

Includes unit test.