### PR TITLE
PHP 8.0 | Squiz/PostStatementComment: include match expressions

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/PostStatementCommentSniff.php
@@ -40,6 +40,7 @@ class PostStatementCommentSniff implements Sniff
         T_WHILE   => true,
         T_FOR     => true,
         T_FOREACH => true,
+        T_MATCH   => true,
     ];
 
 

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc
@@ -46,3 +46,9 @@ for (
 if ( $condition === true // comment
     && $anotherCondition === false
 ) {}
+
+$match = match($foo // comment
+    && $bar
+) {
+    1 => 1, // comment
+};

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.inc.fixed
@@ -50,3 +50,10 @@ for (
 if ( $condition === true // comment
     && $anotherCondition === false
 ) {}
+
+$match = match($foo // comment
+    && $bar
+) {
+    1 => 1, 
+// comment
+};

--- a/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/PostStatementCommentUnitTest.php
@@ -34,6 +34,7 @@ class PostStatementCommentUnitTest extends AbstractSniffUnitTest
                 10 => 1,
                 18 => 1,
                 35 => 1,
+                53 => 1,
             ];
 
         case 'PostStatementCommentUnitTest.1.js':


### PR DESCRIPTION
Allows the sniff to make an exception for comments within the condition of a match expression, just like it does for other control structures.

Includes unit test.