### PR TITLE
PHP 8.0 | Squiz/LowercaseDeclaration: add match to keyword list

### DIFF
--- a/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/LowercaseDeclarationSniff.php
@@ -34,6 +34,7 @@ class LowercaseDeclarationSniff implements Sniff
             T_WHILE,
             T_TRY,
             T_CATCH,
+            T_MATCH,
         ];
 
     }//end register()

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc
@@ -20,3 +20,5 @@ If ($condition) {
 TRY {
 } Catch (Exception $e) {
 }
+
+$r = MATCH ($x) {};

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.inc.fixed
@@ -20,3 +20,5 @@ if ($condition) {
 try {
 } catch (Exception $e) {
 }
+
+$r = match ($x) {};

--- a/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/LowercaseDeclarationUnitTest.php
@@ -37,6 +37,7 @@ class LowercaseDeclarationUnitTest extends AbstractSniffUnitTest
             16 => 1,
             20 => 1,
             21 => 1,
+            24 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This adds the PHP 8.0 `match` keyword to the list handled by this sniff.

Includes unit test.