### PR TITLE
PHP 8.0 | Squiz/ControlSignature: check signature of match expressions

### DIFF
--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -53,6 +53,7 @@ class ControlSignatureSniff implements Sniff
             T_ELSE,
             T_ELSEIF,
             T_SWITCH,
+            T_MATCH,
         ];
 
     }//end register()

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc
@@ -299,6 +299,12 @@ while ( $level-- ):
 	ob_end_clean();
 endwhile;
 
+$r = match ($x) {
+    1 => 1,
+};
+
+$r = match($x){1 => 1};
+
 // Intentional parse error. This should be the last test in the file.
 foreach
    // Some unrelated comment.

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.inc.fixed
@@ -302,6 +302,13 @@ while ( $level-- ):
 	ob_end_clean();
 endwhile;
 
+$r = match ($x) {
+    1 => 1,
+};
+
+$r = match ($x) {
+1 => 1};
+
 // Intentional parse error. This should be the last test in the file.
 foreach
    // Some unrelated comment.

--- a/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
+++ b/src/Standards/Squiz/Tests/ControlStructures/ControlSignatureUnitTest.php
@@ -76,6 +76,7 @@ class ControlSignatureUnitTest extends AbstractSniffUnitTest
             $errors[276] = 1;
             $errors[279] = 1;
             $errors[283] = 1;
+            $errors[306] = 3;
         }//end if
 
         return $errors;


### PR DESCRIPTION
This adds support for checking the signature of `match` expressions to this sniff.

Includes unit test.