### PR TITLE
PHP 8.0 | Squiz/OperatorBracket: make exception for match expressions

### DIFF
--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -165,7 +165,7 @@ class OperatorBracketSniff implements Sniff
                     break;
                 }
 
-                if ($prevCode === T_STRING || $prevCode === T_SWITCH) {
+                if ($prevCode === T_STRING || $prevCode === T_SWITCH || $prevCode === T_MATCH) {
                     // We allow simple operations to not be bracketed.
                     // For example, ceil($one / $two).
                     for ($prev = ($stackPtr - 1); $prev > $bracket; $prev--) {
@@ -204,8 +204,8 @@ class OperatorBracketSniff implements Sniff
                 if (in_array($prevCode, Tokens::$scopeOpeners, true) === true) {
                     // This operation is inside a control structure like FOREACH
                     // or IF, but has no bracket of it's own.
-                    // The only control structure allowed to do this is SWITCH.
-                    if ($prevCode !== T_SWITCH) {
+                    // The only control structures allowed to do this are SWITCH and MATCH.
+                    if ($prevCode !== T_SWITCH && $prevCode !== T_MATCH) {
                         break;
                     }
                 }

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
@@ -176,3 +176,15 @@ $errorPos = $params[$x]?->getLine() + $commentStart;
 $foo = $this->gmail ?? $this->gmail = new Google_Service_Gmail($this->google);
 
 exit -1;
+
+$expr = match ($number - 10) {
+    -1 => 0,
+};
+
+$expr = match ($number % 10) {
+    1 => 2 * $num,
+};
+
+$expr = match (true) {
+    $num * 100 > 500 => 'expression in key',
+};

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
@@ -176,3 +176,15 @@ $errorPos = ($params[$x]?->getLine() + $commentStart);
 $foo = ($this->gmail ?? $this->gmail = new Google_Service_Gmail($this->google));
 
 exit -1;
+
+$expr = match ($number - 10) {
+    -1 => 0,
+};
+
+$expr = match ($number % 10) {
+    1 => (2 * $num),
+};
+
+$expr = match (true) {
+    ($num * 100) > 500 => 'expression in key',
+};

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -68,6 +68,8 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
                 169 => 1,
                 174 => 1,
                 176 => 1,
+                185 => 1,
+                189 => 1,
             ];
             break;
         case 'OperatorBracketUnitTest.js':


### PR DESCRIPTION
Make the same exception for match expressions as was already in place for switch control structures.

While at the same time safeguarding that the sniff will still apply itself correctly for code within a `match` expression, whether in a "case condition" or when in the value.

Includes unit tests.