### PR TITLE
PHP 8.0 | Squiz/DisallowMultipleAssignments: correct errorcode for assignment in match expression

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
@@ -165,6 +165,7 @@ class DisallowMultipleAssignmentsSniff implements Sniff
                 T_SWITCH => T_SWITCH,
                 T_CASE   => T_CASE,
                 T_FOR    => T_FOR,
+                T_MATCH  => T_MATCH,
             ];
             foreach ($nested as $opener => $closer) {
                 if (isset($tokens[$opener]['parenthesis_owner']) === true

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.inc
@@ -75,3 +75,15 @@ class Bar
     public bool $c = false, $d = true;
     protected int $e = 123, $f = 987;
 }
+
+switch ($b < 10 && $a = 10) {
+    case true:
+        break;
+}
+
+$array = [
+    match ($b < 10 && $a = 10) {
+        true => 10,
+        false => 0
+    },
+];

--- a/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/DisallowMultipleAssignmentsUnitTest.php
@@ -33,6 +33,8 @@ class DisallowMultipleAssignmentsUnitTest extends AbstractSniffUnitTest
             12 => 1,
             14 => 1,
             15 => 1,
+            79 => 1,
+            85 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The `Squiz.PHP.DisallowMultipleAssignments` sniff differentiates in the error code between "normal" assignments which aren't the only thing on a line and assignments in control structure conditions.

This adds `match` to the list of control structures, so it gets the correct error code.

Includes unit test.