### PR TITLE
PHP 8.0 | Squiz/ObjectInstantiation: prevent false positives on match/fn expressions

### DIFF
--- a/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -50,6 +50,8 @@ class ObjectInstantiationSniff implements Sniff
         $allowedTokens = [
             T_EQUAL        => true,
             T_DOUBLE_ARROW => true,
+            T_FN_ARROW     => true,
+            T_MATCH_ARROW  => true,
             T_THROW        => true,
             T_RETURN       => true,
             T_INLINE_THEN  => true,

--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -13,5 +13,16 @@ function foo() { return new MyClass(); }
 
 $doodad = $x ? new Foo : new Bar;
 
+function returnFn() {
+    $fn = fn($x) => new MyClass();
+}
+
+function returnMatch() {
+    $match = match($x) {
+        0 => new MyClass()
+    }
+}
+
+// Intentional parse error. This must be the last test in the file.
 function new
 ?>


### PR DESCRIPTION
This change ensures that when `new Class` is returned by a match control structure or an arrow function, the sniff will not throw a false positive.

Includes unit tests.