### PR TITLE
PHP 8.0 | Squiz/ControlStructureSpacing: check match expressions

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -46,6 +46,7 @@ class ControlStructureSpacingSniff implements Sniff
             T_TRY,
             T_CATCH,
             T_FINALLY,
+            T_MATCH,
         ];
 
     }//end register()
@@ -231,6 +232,16 @@ class ControlStructureSpacingSniff implements Sniff
                 $phpcsFile->recordMetric($stackPtr, 'Blank lines at end of control structure', 0);
             }//end if
         }//end if
+
+        if ($tokens[$stackPtr]['code'] === T_MATCH) {
+            // Move the scope closer to the semicolon/comma.
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($scopeCloser + 1), null, true);
+            if ($next !== false
+                && ($tokens[$next]['code'] === T_SEMICOLON || $tokens[$next]['code'] === T_COMMA)
+            ) {
+                $scopeCloser = $next;
+            }
+        }
 
         $trailingContent = $phpcsFile->findNext(
             T_WHITESPACE,

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -251,3 +251,13 @@ echo 'hi';
     ?>
     <?php endforeach; ?>
 <?php endforeach; ?>
+
+<?php
+
+$expr = match( $foo ){
+
+    1 => 1,
+    2 => 2,
+
+};
+echo $expr;

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -244,3 +244,12 @@ echo 'hi';
     ?>
     <?php endforeach; ?>
 <?php endforeach; ?>
+
+<?php
+
+$expr = match($foo){
+    1 => 1,
+    2 => 2,
+};
+
+echo $expr;

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.php
@@ -57,6 +57,9 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
                 242 => 1,
                 246 => 1,
                 248 => 1,
+                257 => 3,
+                261 => 1,
+                262 => 1,
             ];
             break;
         case 'ControlStructureSpacingUnitTest.js':


### PR DESCRIPTION
This adds support for checking the spacing for `match` expressions to the Squiz sniff.

Includes unit test.