### PR TITLE
PHP 8.0 | PSR2/PSR12/ControlStructureSpacing: check match expressions

### DIFF
--- a/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR12/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -41,6 +41,7 @@ class ControlStructureSpacingSniff implements Sniff
             T_ELSE,
             T_ELSEIF,
             T_CATCH,
+            T_MATCH,
         ];
 
     }//end register()

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
@@ -84,3 +84,17 @@ EOD
     ) {
         break;
     }
+
+match (
+    $expr1 &&
+    $expr2 &&
+    $expr3
+    ) {
+    // structure body
+};
+
+match ($expr1 &&
+$expr2 &&
+  $expr3) {
+      // structure body
+};

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
@@ -85,3 +85,19 @@ EOD
     ) {
         break;
     }
+
+match (
+    $expr1 &&
+    $expr2 &&
+    $expr3
+) {
+    // structure body
+};
+
+match (
+    $expr1 &&
+    $expr2 &&
+    $expr3
+) {
+      // structure body
+};

--- a/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR12/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -41,6 +41,10 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
             48 => 2,
             58 => 1,
             59 => 1,
+            92 => 1,
+            96 => 1,
+            97 => 1,
+            98 => 2,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/ControlStructureSpacingSniff.php
@@ -47,6 +47,7 @@ class ControlStructureSpacingSniff implements Sniff
             T_ELSE,
             T_ELSEIF,
             T_CATCH,
+            T_MATCH,
         ];
 
     }//end register()

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc
@@ -68,3 +68,14 @@ if ($expr1
     && $expr2
     /* comment */   ) {
 }
+
+$r = match ($x) {};
+$r = match ( $x ) {};
+
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesAfterOpen 1
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 1
+$r = match ($x) {};
+$r = match ( $x ) {};
+$r = match (  $x  ) {};
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesAfterOpen 0
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 0

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.inc.fixed
@@ -67,3 +67,14 @@ if ($expr1
     && $expr2
     /* comment */) {
 }
+
+$r = match ($x) {};
+$r = match ($x) {};
+
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesAfterOpen 1
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 1
+$r = match ( $x ) {};
+$r = match ( $x ) {};
+$r = match ( $x ) {};
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesAfterOpen 0
+// phpcs:set PSR2.ControlStructures.ControlStructureSpacing requiredSpacesBeforeClose 0

--- a/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/ControlStructureSpacingUnitTest.php
@@ -36,6 +36,9 @@ class ControlStructureSpacingUnitTest extends AbstractSniffUnitTest
             60 => 1,
             64 => 1,
             69 => 1,
+            73 => 2,
+            77 => 2,
+            79 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This adds support for checking the spacing inside single line conditions for `match` expressions to the PSR2 sniff and by extension to the PSR12 sniff, as well as explicitly for multiline conditions to the PSR12 sniff.

Includes unit tests.