### PR TITLE
PHP 8.1: fix deprecation notice

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -726,7 +726,7 @@ class Ruleset
         } else {
             // See if this is a whole standard being referenced.
             $path = Util\Standards::getInstalledStandardPath($ref);
-            if (Util\Common::isPharFile($path) === true && strpos($path, 'ruleset.xml') === false) {
+            if ($path !== null && Util\Common::isPharFile($path) === true && strpos($path, 'ruleset.xml') === false) {
                 // If the ruleset exists inside the phar file, use it.
                 if (file_exists($path.DIRECTORY_SEPARATOR.'ruleset.xml') === true) {
                     $path .= DIRECTORY_SEPARATOR.'ruleset.xml';


### PR DESCRIPTION
The `Util\Standards::getInstalledStandardPath()` method returns either a string or `null`, however the `strpos()` method which is used in both the `Util\Common::isPharFile()` method, as well as in the follow-on condition, only accepts a `string` as `$haystack`.

As of PHP 8.1, this will generate a deprecation notice `strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated`.

Discovered while testing an external standard against PHPCS `master` on PHP 8.1.

Fixed now.