### PR TITLE
GH Actions: various tweaks to the scripts

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   phpstan:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -25,14 +25,13 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
-
-      - name: 'Composer: require PHPStan'
-        run: composer require --no-update --dev phpstan/phpstan
+          tools: phpstan
 
       # Install dependencies and handle caching in one go.
+      # Dependencies need to be installed to make sure the PHPUnit classes are recognized.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse --configuration=phpstan.neon
+        run: phpstan analyse --configuration=phpstan.neon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,21 +85,16 @@ jobs:
       - name: 'PHPCS: set the path to PHP'
         run: php bin/phpcs --config-set php_path php
 
-      # We need to remove the config file so that PHPUnit doesn't try to read it.
-      # This causes an error on PHP 8.1+ with PHPunit 7, but it's not needed here anyway as the
-      # phpunit command (below) specifies all required settings.
-      - name: 'PHPUnit: remove config file'
-        run: rm phpunit.xml.dist
-
-      # Useless tests were not reported for before PHPUnit 6, so it doesn't
-      # understand the CLI argument.
       - name: 'PHPUnit: run the tests'
-        if: ${{ matrix.php < 7.0 }}
-        run: vendor/bin/phpunit tests/AllTests.php --bootstrap=tests/bootstrap.php
+        if: ${{ matrix.php != 8.1 }}
+        run: vendor/bin/phpunit tests/AllTests.php
 
-      - name: 'PHPUnit: run the tests, dont report useless'
-        if: ${{ matrix.php >= 7.0 }}
-        run: vendor/bin/phpunit tests/AllTests.php --bootstrap=tests/bootstrap.php --dont-report-useless-tests
+      # We need to ignore the config file so that PHPUnit doesn't try to read it.
+      # The config file causes an error on PHP 8.1+ with PHPunit 7, but it's not needed here anyway
+      # as we can pass all required settings in the phpunit command.
+      - name: 'PHPUnit: run the tests on PHP nightly'
+        if: ${{ matrix.php == 8.1 }}
+        run: vendor/bin/phpunit tests/AllTests.php --no-configuration --bootstrap=tests/bootstrap.php --dont-report-useless-tests
 
       - name: 'PHPCS: check code style without cache, no parallel'
         if: ${{ matrix.custom_ini == false }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+          tools: cs2pr
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -97,8 +98,17 @@ jobs:
         run: vendor/bin/phpunit tests/AllTests.php --no-configuration --bootstrap=tests/bootstrap.php --dont-report-useless-tests
 
       - name: 'PHPCS: check code style without cache, no parallel'
-        if: ${{ matrix.custom_ini == false }}
+        if: ${{ matrix.custom_ini == false && matrix.php != 7.4 }}
         run: php bin/phpcs --no-cache --parallel=1
+
+      - name: 'PHPCS: check code style to show results in PR'
+        if: ${{ matrix.custom_ini == false && matrix.php == 7.4 }}
+        continue-on-error: true
+        run: php bin/phpcs --no-cache --parallel=1 --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        if: ${{ matrix.custom_ini == false && matrix.php == 7.4 }}
+        run: cs2pr ./phpcs-report.xml
 
       - name: 'Composer: validate config'
         if: ${{ matrix.custom_ini == false }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
 
       # For PHP 8.0+, we need to install with ignore platform reqs as PHPUnit 7 is still used.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.custom_ini == false }}
+        if: ${{ matrix.php >= 8.0 }}
         uses: "ramsey/composer-install@v1"
         with:
           composer-options: --ignore-platform-reqs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   checkxml:


### PR DESCRIPTION
### GH Actions: simplify the PHPStan workflow

No need to install via Composer, the `setup-php` action can make PHPStan globally available.

### GH Actions: fix faulty condition

### GH Actions: improve fix to run the tests on PHP 8.1

There is no need to remove the config file and have all settings on the command-line as PHPUnit offers a `--no-configuration` option to ignore the config file.

Enabling that simplifies the action steps a little and isolates the customization for PHP 8.1 to PHP 8.1.

### GH Actions: report CS violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

As the CS run is run in every test run in the matrix, passing the results on to CS2PR would result in violations being displayed multiple times, so using conditions to only pass the CS violations on to the PR for one of the runs.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

Example of what this looks like in a PR:
![image](https://user-images.githubusercontent.com/663378/109408899-26e83080-798e-11eb-99c4-70c3b4bae2e0.png)

### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

This is useful if, for instance, an external action script or composer dependency has broken.
Once a fix is available, failing builds for open PRs can be retriggered manually instead of having to be re-pushed to retrigger the workflow.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
