### PR TITLE
 PHP 8.0 | Pear+PSR2/FunctionCallSignature: support named parameters

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -581,7 +581,7 @@ class FunctionCallSignatureSniff implements Sniff
 
                 if ($inArg === false) {
                     $argStart = $nextCode;
-                    $argEnd   = $phpcsFile->findEndOfStatement($nextCode);
+                    $argEnd   = $phpcsFile->findEndOfStatement($nextCode, [T_COLON]);
                 }
             }//end if
 
@@ -618,7 +618,7 @@ class FunctionCallSignatureSniff implements Sniff
                 }//end if
 
                 $argStart = $next;
-                $argEnd   = $phpcsFile->findEndOfStatement($next);
+                $argEnd   = $phpcsFile->findEndOfStatement($next, [T_COLON]);
             }//end if
         }//end for
 

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
@@ -525,3 +525,26 @@ return trim(preg_replace_callback(
 
 $a = ['a' => function ($b) { return $b; }];
 $a['a']( 1 );
+
+// PHP 8.0 named parameters.
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ),
+    value: true,
+);
+
+array_fill_keys(
+    keys: range( 1,
+            12,
+    ), value: true,
+);
+
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments false
+array_fill_keys(
+    keys: range( 1,
+            12,
+    ), value: true,
+);
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments true

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
@@ -537,3 +537,29 @@ return trim(
 
 $a = ['a' => function ($b) { return $b; }];
 $a['a'](1);
+
+// PHP 8.0 named parameters.
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ),
+    value: true,
+);
+
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ), value: true,
+);
+
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments false
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ),
+    value: true,
+);
+// phpcs:set PEAR.Functions.FunctionCallSignature allowMultipleArguments true

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -126,6 +126,11 @@ class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
             523 => 1,
             524 => 3,
             527 => 2,
+            539 => 1,
+            540 => 1,
+            546 => 1,
+            547 => 1,
+            548 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -48,7 +48,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
 
         $closeBracket = $tokens[$openBracket]['parenthesis_closer'];
 
-        $end = $phpcsFile->findEndOfStatement($openBracket + 1);
+        $end = $phpcsFile->findEndOfStatement(($openBracket + 1), [T_COLON]);
         while ($tokens[$end]['code'] === T_COMMA) {
             // If the next bit of code is not on the same line, this is a
             // multi-line function call.
@@ -61,7 +61,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
                 return true;
             }
 
-            $end = $phpcsFile->findEndOfStatement($next);
+            $end = $phpcsFile->findEndOfStatement($next, [T_COLON]);
         }
 
         // We've reached the last argument, so see if the next content

--- a/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc
@@ -242,3 +242,26 @@ function (array $term) use ($mode): string {
 },
 $search
 ));
+
+// PHP 8.0 named parameters.
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ),
+    value: true,
+);
+
+array_fill_keys(
+    keys: range( 1,
+            12,
+    ), value: true,
+);
+
+// phpcs:set PSR2.Methods.FunctionCallSignature allowMultipleArguments true
+array_fill_keys(
+    keys: range( 1,
+            12,
+    ), value: true,
+);
+// phpcs:set PSR2.Methods.FunctionCallSignature allowMultipleArguments false

--- a/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.inc.fixed
@@ -255,3 +255,29 @@ return trim(preg_replace_callback(
     },
     $search
 ));
+
+// PHP 8.0 named parameters.
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ),
+    value: true,
+);
+
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ),
+    value: true,
+);
+
+// phpcs:set PSR2.Methods.FunctionCallSignature allowMultipleArguments true
+array_fill_keys(
+    keys: range(
+        1,
+        12,
+    ), value: true,
+);
+// phpcs:set PSR2.Methods.FunctionCallSignature allowMultipleArguments false

--- a/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/FunctionCallSignatureUnitTest.php
@@ -66,6 +66,11 @@ class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
             234 => 1,
             242 => 1,
             243 => 1,
+            256 => 1,
+            257 => 1,
+            258 => 1,
+            263 => 1,
+            264 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The `File::findEndOfStatement()` method regards a `T_COLON` as the end of a statement, while for function call arguments using named parameters, the colon is part of the parameter name declaration and should be disregarded when determining the end of the statement.

Fixed now.

Includes unit tests for both affected sniffs.