### PR TITLE
Normalize and fix phpdoc typehints across the code

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1540,9 +1540,9 @@ class Config
      * @param string|null $value The value to set. If null, the config
      *                           entry is deleted, reverting it to the
      *                           default value.
-     * @param boolean     $temp  Set this config data temporarily for this
-     *                           script run. This will not write the config
-     *                           data to the config file.
+     * @param bool        $temp  Set this config data temporarily for this
+     *                           script run. This will not write the
+     *                           config data to the config file.
      *
      * @return bool
      * @see    getConfigData()

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -643,15 +643,16 @@ class File
     /**
      * Records an error against a specific token in the file.
      *
-     * @param string  $error    The error message.
-     * @param int     $stackPtr The stack position where the error occurred.
-     * @param string  $code     A violation code unique to the sniff message.
-     * @param array   $data     Replacements for the error message.
-     * @param int     $severity The severity level for this error. A value of 0
-     *                          will be converted into the default severity level.
-     * @param boolean $fixable  Can the error be fixed by the sniff?
+     * @param string $error    The error message.
+     * @param int    $stackPtr The stack position where the error occurred.
+     * @param string $code     A violation code unique to the sniff message.
+     * @param array  $data     Replacements for the error message.
+     * @param int    $severity The severity level for this error. A value of 0
+     *                         will be converted into the default severity
+     *                         level.
+     * @param bool   $fixable  Can the error be fixed by the sniff?
      *
-     * @return boolean
+     * @return bool
      */
     public function addError(
         $error,
@@ -677,15 +678,16 @@ class File
     /**
      * Records a warning against a specific token in the file.
      *
-     * @param string  $warning  The error message.
-     * @param int     $stackPtr The stack position where the error occurred.
-     * @param string  $code     A violation code unique to the sniff message.
-     * @param array   $data     Replacements for the warning message.
-     * @param int     $severity The severity level for this warning. A value of 0
-     *                          will be converted into the default severity level.
-     * @param boolean $fixable  Can the warning be fixed by the sniff?
+     * @param string $warning  The error message.
+     * @param int    $stackPtr The stack position where the error occurred.
+     * @param string $code     A violation code unique to the sniff message.
+     * @param array  $data     Replacements for the warning message.
+     * @param int    $severity The severity level for this warning. A value of 0
+     *                         will be converted into the default severity
+     *                         level.
+     * @param bool   $fixable  Can the warning be fixed by the sniff?
      *
-     * @return boolean
+     * @return bool
      */
     public function addWarning(
         $warning,
@@ -718,7 +720,7 @@ class File
      * @param int    $severity The severity level for this error. A value of 0
      *                         will be converted into the default severity level.
      *
-     * @return boolean
+     * @return bool
      */
     public function addErrorOnLine(
         $error,
@@ -742,7 +744,7 @@ class File
      * @param int    $severity The severity level for this warning. A value of 0 will
      *                         will be converted into the default severity level.
      *
-     * @return boolean
+     * @return bool
      */
     public function addWarningOnLine(
         $warning,
@@ -768,7 +770,7 @@ class File
      * @param int    $severity The severity level for this error. A value of 0
      *                         will be converted into the default severity level.
      *
-     * @return boolean
+     * @return bool
      */
     public function addFixableError(
         $error,
@@ -799,7 +801,7 @@ class File
      * @param int    $severity The severity level for this warning. A value of 0
      *                         will be converted into the default severity level.
      *
-     * @return boolean
+     * @return bool
      */
     public function addFixableWarning(
         $warning,
@@ -821,17 +823,18 @@ class File
     /**
      * Adds an error to the error stack.
      *
-     * @param boolean $error    Is this an error message?
-     * @param string  $message  The text of the message.
-     * @param int     $line     The line on which the message occurred.
-     * @param int     $column   The column at which the message occurred.
-     * @param string  $code     A violation code unique to the sniff message.
-     * @param array   $data     Replacements for the message.
-     * @param int     $severity The severity level for this message. A value of 0
-     *                          will be converted into the default severity level.
-     * @param boolean $fixable  Can the problem be fixed by the sniff?
+     * @param bool   $error    Is this an error message?
+     * @param string $message  The text of the message.
+     * @param int    $line     The line on which the message occurred.
+     * @param int    $column   The column at which the message occurred.
+     * @param string $code     A violation code unique to the sniff message.
+     * @param array  $data     Replacements for the message.
+     * @param int    $severity The severity level for this message. A value of 0
+     *                         will be converted into the default severity
+     *                         level.
+     * @param bool   $fixable  Can the problem be fixed by the sniff?
      *
-     * @return boolean
+     * @return bool
      */
     protected function addMessage($error, $message, $line, $column, $code, $data, $severity, $fixable)
     {
@@ -1093,7 +1096,7 @@ class File
      * @param string $metric   The name of the metric being recorded.
      * @param string $value    The value of the metric being recorded.
      *
-     * @return boolean
+     * @return bool
      */
     public function recordMetric($stackPtr, $metric, $value)
     {
@@ -1965,7 +1968,7 @@ class File
      *
      * @param int $stackPtr The position of the T_BITWISE_AND token.
      *
-     * @return boolean
+     * @return bool
      */
     public function isReference($stackPtr)
     {
@@ -2497,7 +2500,7 @@ class File
      * @param int              $stackPtr The position of the token we are checking.
      * @param int|string|array $types    The type(s) of tokens to search for.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasCondition($stackPtr, $types)
     {

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -220,7 +220,7 @@ class FileList implements \Iterator, \Countable
     /**
      * Checks if current position is valid.
      *
-     * @return boolean
+     * @return bool
      */
     public function valid()
     {

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -236,7 +236,7 @@ class FileList implements \Iterator, \Countable
     /**
      * Return the number of files in the list.
      *
-     * @return integer
+     * @return int
      */
     public function count()
     {

--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -135,7 +135,7 @@ class Fixer
     /**
      * Attempt to fix the file by processing it until no fixes are made.
      *
-     * @return boolean
+     * @return bool
      */
     public function fixFile()
     {
@@ -217,10 +217,10 @@ class Fixer
     /**
      * Generates a text diff of the original file and the new content.
      *
-     * @param string  $filePath Optional file path to diff the file against.
-     *                          If not specified, the original version of the
-     *                          file will be used.
-     * @param boolean $colors   Print coloured output or not.
+     * @param string $filePath Optional file path to diff the file against.
+     *                         If not specified, the original version of
+     *                         the file will be used.
+     * @param bool   $colors   Print coloured output or not.
      *
      * @return string
      */
@@ -374,7 +374,7 @@ class Fixer
     /**
      * Stop recording actions for a changeset, and apply logged changes.
      *
-     * @return boolean
+     * @return bool
      */
     public function endChangeset()
     {

--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -28,10 +28,10 @@ class Cbf implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException

--- a/src/Reports/Checkstyle.php
+++ b/src/Reports/Checkstyle.php
@@ -23,10 +23,10 @@ class Checkstyle implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Code.php
+++ b/src/Reports/Code.php
@@ -23,10 +23,10 @@ class Code implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Csv.php
+++ b/src/Reports/Csv.php
@@ -22,10 +22,10 @@ class Csv implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Diff.php
+++ b/src/Reports/Diff.php
@@ -22,10 +22,10 @@ class Diff implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Emacs.php
+++ b/src/Reports/Emacs.php
@@ -22,10 +22,10 @@ class Emacs implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Full.php
+++ b/src/Reports/Full.php
@@ -23,10 +23,10 @@ class Full implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Info.php
+++ b/src/Reports/Info.php
@@ -23,10 +23,10 @@ class Info implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Json.php
+++ b/src/Reports/Json.php
@@ -23,10 +23,10 @@ class Json implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Junit.php
+++ b/src/Reports/Junit.php
@@ -24,10 +24,10 @@ class Junit implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Notifysend.php
+++ b/src/Reports/Notifysend.php
@@ -88,10 +88,10 @@ class Notifysend implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -22,10 +22,10 @@ interface Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Source.php
+++ b/src/Reports/Source.php
@@ -23,10 +23,10 @@ class Source implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Summary.php
+++ b/src/Reports/Summary.php
@@ -23,10 +23,10 @@ class Summary implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -31,10 +31,10 @@ abstract class VersionControl implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Reports/Xml.php
+++ b/src/Reports/Xml.php
@@ -23,10 +23,10 @@ class Xml implements Report
      * and FALSE if it ignored the file. Returning TRUE indicates that the file and
      * its data should be counted in the grand totals.
      *
-     * @param array                 $report      Prepared report data.
-     * @param \PHP_CodeSniffer\File $phpcsFile   The file being reported on.
-     * @param bool                  $showSources Show sources?
-     * @param int                   $width       Maximum allowed line width.
+     * @param array                       $report      Prepared report data.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being reported on.
+     * @param bool                        $showSources Show sources?
+     * @param int                         $width       Maximum allowed line width.
      *
      * @return bool
      */

--- a/src/Sniffs/AbstractArraySniff.php
+++ b/src/Sniffs/AbstractArraySniff.php
@@ -104,9 +104,9 @@ abstract class AbstractArraySniff implements Sniff
     /**
      * Find next separator in array - either: comma or double arrow.
      *
-     * @param File $phpcsFile The current file being checked.
-     * @param int  $ptr       The position of current token.
-     * @param int  $arrayEnd  The token that ends the array definition.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being checked.
+     * @param int                         $ptr       The position of current token.
+     * @param int                         $arrayEnd  The token that ends the array definition.
      *
      * @return int
      */

--- a/src/Sniffs/AbstractPatternSniff.php
+++ b/src/Sniffs/AbstractPatternSniff.php
@@ -58,7 +58,7 @@ abstract class AbstractPatternSniff implements Sniff
     /**
      * Constructs a AbstractPatternSniff.
      *
-     * @param boolean $ignoreComments If true, comments will be ignored.
+     * @param bool $ignoreComments If true, comments will be ignored.
      */
     public function __construct($ignoreComments=null)
     {

--- a/src/Sniffs/AbstractScopeSniff.php
+++ b/src/Sniffs/AbstractScopeSniff.php
@@ -57,13 +57,13 @@ abstract class AbstractScopeSniff implements Sniff
     /**
      * Constructs a new AbstractScopeTest.
      *
-     * @param array   $scopeTokens   The type of scope the test wishes to listen to.
-     * @param array   $tokens        The tokens that the test wishes to listen to
-     *                               within the scope.
-     * @param boolean $listenOutside If true this test will also alert the
-     *                               extending class when a token is found outside
-     *                               the scope, by calling the
-     *                               processTokenOutsideScope method.
+     * @param array $scopeTokens   The type of scope the test wishes to listen to.
+     * @param array $tokens        The tokens that the test wishes to listen to
+     *                             within the scope.
+     * @param bool  $listenOutside If true this test will also alert the
+     *                             extending class when a token is found
+     *                             outside the scope, by calling the
+     *                             processTokenOutsideScope method.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified tokens arrays are empty
      *                                                      or invalid.

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/JumbledIncrementerSniff.php
@@ -100,8 +100,8 @@ class JumbledIncrementerSniff implements Sniff
     /**
      * Get all used variables in the incrementer part of a for statement.
      *
-     * @param array(integer=>array) $tokens Array with all code sniffer tokens.
-     * @param array(string=>mixed)  $token  Current for loop token
+     * @param array<int, array>    $tokens Array with all code sniffer tokens.
+     * @param array<string, mixed> $token  Current for loop token
      *
      * @return string[] List of all found incrementer variables.
      */

--- a/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperglobalSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DisallowRequestSuperglobalSniff.php
@@ -31,8 +31,8 @@ class DisallowRequestSuperglobalSniff implements Sniff
     /**
      * Processes this sniff, when one of its tokens is encountered.
      *
-     * @param File $phpcsFile The file being scanned.
-     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
      *
      * @return void
      */

--- a/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeSystemSniff.php
@@ -55,8 +55,8 @@ class IncludeSystemSniff extends AbstractScopeSniff
      * Processes the function tokens within the class.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param integer                     $stackPtr  The position where the token was found.
-     * @param integer                     $currScope The current scope opener token.
+     * @param int                         $stackPtr  The position where the token was found.
+     * @param int                         $currScope The current scope opener token.
      *
      * @return void
      */

--- a/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
+++ b/src/Standards/MySource/Sniffs/Strings/JoinStringsSniff.php
@@ -40,7 +40,7 @@ class JoinStringsSniff implements Sniff
      * Processes this test, when one of its tokens is encountered.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param integer                     $stackPtr  The position of the current token
+     * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
      * @return void

--- a/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
@@ -36,7 +36,7 @@ class ClassDeclarationSniff implements Sniff
      * Processes this test, when one of its tokens is encountered.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param integer                     $stackPtr  The position of the current token in the
+     * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
      * @return void

--- a/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -36,7 +36,7 @@ class ClassDeclarationSniff implements Sniff
      * Processes this test, when one of its tokens is encountered.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param integer                     $stackPtr  The position of the current token in
+     * @param int                         $stackPtr  The position of the current token in
      *                                               the token stack.
      *
      * @return void

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -728,7 +728,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
      *                                                  in the stack passed in $tokens.
      * @param int                         $commentStart The position in the stack where the comment started.
      *
-     * @return boolean TRUE if the docblock contains only {@inheritdoc} (case-insensitive).
+     * @return bool TRUE if the docblock contains only {@inheritdoc} (case-insensitive).
      */
     protected function checkInheritdoc(File $phpcsFile, $stackPtr, $commentStart)
     {

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -76,9 +76,9 @@ class StaticThisUsageSniff extends AbstractScopeSniff
     /**
      * Check for $this variable usage between $next and $end tokens.
      *
-     * @param File $phpcsFile The current file being scanned.
-     * @param int  $next      The position of the next token to check.
-     * @param int  $end       The position of the last token to check.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being scanned.
+     * @param int                         $next      The position of the next token to check.
+     * @param int                         $end       The position of the last token to check.
      *
      * @return void
      */

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -95,7 +95,7 @@ class ObjectOperatorSpacingSniff implements Sniff
      * @param mixed                       $before    The number of spaces found before the
      *                                               operator or the string 'newline'.
      *
-     * @return boolean true if there was no error, false otherwise.
+     * @return bool true if there was no error, false otherwise.
      */
     protected function checkSpacingBeforeOperator(File $phpcsFile, $stackPtr, $before)
     {
@@ -134,7 +134,7 @@ class ObjectOperatorSpacingSniff implements Sniff
      * @param mixed                       $after     The number of spaces found after the
      *                                               operator or the string 'newline'.
      *
-     * @return boolean true if there was no error, false otherwise.
+     * @return bool true if there was no error, false otherwise.
      */
     protected function checkSpacingAfterOperator(File $phpcsFile, $stackPtr, $after)
     {

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -320,7 +320,7 @@ class OperatorSpacingSniff implements Sniff
      * @param int                         $stackPtr  The position of the operator in
      *                                               the stack.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isOperator(File $phpcsFile, $stackPtr)
     {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -111,7 +111,7 @@ abstract class Tokenizer
      * @param string $content The content to tokenize.
      * @param string $eolChar The EOL char used in the content.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isMinifiedContent($content, $eolChar='\n')
     {

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -56,7 +56,7 @@ class Common
      *
      * @param string $path The path to the file.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isReadable($path)
     {
@@ -183,7 +183,7 @@ class Common
     /**
      * Check if STDIN is a TTY.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isStdinATTY()
     {
@@ -313,22 +313,22 @@ class Common
     /**
      * Returns true if the specified string is in the camel caps format.
      *
-     * @param string  $string      The string the verify.
-     * @param boolean $classFormat If true, check to see if the string is in the
-     *                             class format. Class format strings must start
-     *                             with a capital letter and contain no
-     *                             underscores.
-     * @param boolean $public      If true, the first character in the string
-     *                             must be an a-z character. If false, the
-     *                             character must be an underscore. This
-     *                             argument is only applicable if $classFormat
-     *                             is false.
-     * @param boolean $strict      If true, the string must not have two capital
-     *                             letters next to each other. If false, a
-     *                             relaxed camel caps policy is used to allow
-     *                             for acronyms.
+     * @param string $string      The string the verify.
+     * @param bool   $classFormat If true, check to see if the string is in the
+     *                            class format. Class format strings must start
+     *                            with a capital letter and contain no
+     *                            underscores.
+     * @param bool   $public      If true, the first character in the string
+     *                            must be an a-z character. If false, the
+     *                            character must be an underscore. This
+     *                            argument is only applicable if
+     *                            $classFormat is false.
+     * @param bool   $strict      If true, the string must not have two capital
+     *                            letters next to each other. If false, a
+     *                            relaxed camel caps policy is used to allow
+     *                            for acronyms.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isCamelCaps(
         $string,
@@ -400,7 +400,7 @@ class Common
      *
      * @param string $string The string to verify.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isUnderscoreName($string)
     {

--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -65,12 +65,12 @@ class Standards
      * use getInstalledStandardPaths() instead as it performs less work to
      * retrieve coding standard names.
      *
-     * @param boolean $includeGeneric If true, the special "Generic"
-     *                                coding standard will be included
-     *                                if installed.
-     * @param string  $standardsDir   A specific directory to look for standards
-     *                                in. If not specified, PHP_CodeSniffer will
-     *                                look in its default locations.
+     * @param bool   $includeGeneric If true, the special "Generic"
+     *                               coding standard will be
+     *                               included if installed.
+     * @param string $standardsDir   A specific directory to look for standards
+     *                               in. If not specified, PHP_CodeSniffer will
+     *                               look in its default locations.
      *
      * @return array
      * @see    getInstalledStandardPaths()
@@ -154,12 +154,12 @@ class Standards
      * CodeSniffer/Standards directory. Valid coding standards
      * include a Sniffs subdirectory.
      *
-     * @param boolean $includeGeneric If true, the special "Generic"
-     *                                coding standard will be included
-     *                                if installed.
-     * @param string  $standardsDir   A specific directory to look for standards
-     *                                in. If not specified, PHP_CodeSniffer will
-     *                                look in its default locations.
+     * @param bool   $includeGeneric If true, the special "Generic"
+     *                               coding standard will be
+     *                               included if installed.
+     * @param string $standardsDir   A specific directory to look for standards
+     *                               in. If not specified, PHP_CodeSniffer will
+     *                               look in its default locations.
      *
      * @return array
      * @see    isInstalledStandard()
@@ -222,7 +222,7 @@ class Standards
      *
      * @param string $standard The name of the coding standard.
      *
-     * @return boolean
+     * @return bool
      * @see    getInstalledStandards()
      */
     public static function isInstalledStandard($standard)

--- a/src/Util/Timing.php
+++ b/src/Util/Timing.php
@@ -43,8 +43,8 @@ class Timing
     /**
      * Print information about the run.
      *
-     * @param boolean $force If TRUE, prints the output even if it has
-     *                       already been printed during the run.
+     * @param bool $force If TRUE, prints the output even if it has
+     *                    already been printed during the run.
      *
      * @return void
      */


### PR DESCRIPTION
While writing my own github actions reporter format (to get annotations properly in github), I noticed that my PHPStan was complaining about types in some of the PHP_CodeSniffer code. As a result I noticed that there were several issues when it came to phpdoc types in the code base.

This PR introduces bunch of normalization and fixes to the type hints in the phpdocs of various methods. I tried to normalize the types to what was already the most common format. The following changes have been applied:

* All occurrences of `boolean` have been replaced with `bool`
* All occurrences of `integer` have been replaced with `int`
* Several instances of `\PHP_CodeSniffer\File` have been fixed to the correct type `\PHP_CodeSniffer\Files\File`
* Couple instanced of `File` have been replaced with `\PHP_CodeSniffer\Files\File` since rest of the code base used FQCNs exclusively
* Couple array types were normalized to what rest of the code base uses

I have not touched any actual code. Only phpdoc comments. Additionally, this PR does not modify any files in test directories, only those that are part of the actual code.