### PR TITLE
PHP 8.1: fix deprecation notice [2]

### DIFF
--- a/src/Fixer.php
+++ b/src/Fixer.php
@@ -255,6 +255,10 @@ class Fixer
             unlink($tempName);
         }
 
+        if ($diff === null) {
+            return '';
+        }
+
         if ($colors === false) {
             return $diff;
         }


### PR DESCRIPTION
The `Fixer::generateDiff()` method calls the `shell_exec()` method to retrieve the `diff` between two files.

In the unit tests, this is used to compare the expected content in a `.fixed` file with the generate fixed file contents.
If the expected content matches the generated content, the diff command will produce no output and `shell_exec()` will return `null`.
Ref: https://www.php.net/manual/en/function.shell-exec.php

This result is subsequently passed to `explode()` as the second parameter, but `explode()` only excepts strings as the second parameter.
Ref: https://www.php.net/manual/en/function.explode

As of PHP 8.1, this will generate a deprecation notice `explode(): Passing null to parameter #2 ($string) of type string is deprecated`.

Discovered while testing an external standard against PHPCS `master` on PHP 8.1.

Fixed now.

Note: I'm returning an empty string from the `Fixer::generateDiff()` method now for that case, as `string` is the declared return type, so returning `null` would not match that.