### PR TITLE
Squiz.Formatting.OperatorBracket duplicate error messages for unary minus

### DIFF
--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -80,7 +80,8 @@ class OperatorBracketSniff implements Sniff
                     $isAssignment = isset(Tokens::$assignmentTokens[$tokens[$previous]['code']]);
                     $isEquality   = isset(Tokens::$equalityTokens[$tokens[$previous]['code']]);
                     $isComparison = isset(Tokens::$comparisonTokens[$tokens[$previous]['code']]);
-                    if ($isAssignment === true || $isEquality === true || $isComparison === true) {
+                    $isUnary      = isset(Tokens::$operators[$tokens[$previous]['code']]);
+                    if ($isAssignment === true || $isEquality === true || $isComparison === true || $isUnary === true) {
                         // This is a negative assignment or comparison.
                         // We need to check that the minus and the number are
                         // adjacent.

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
@@ -188,3 +188,8 @@ $expr = match ($number % 10) {
 $expr = match (true) {
     $num * 100 > 500 => 'expression in key',
 };
+
+// PHP 8.0 named parameters.
+if ($pos === count(value: $this->tokens) - 1) {
+    $file = '...'.substr(string: $file, offset: $padding * -1 + 3);
+}

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
@@ -188,3 +188,8 @@ $expr = match ($number % 10) {
 $expr = match (true) {
     ($num * 100) > 500 => 'expression in key',
 };
+
+// PHP 8.0 named parameters.
+if ($pos === (count(value: $this->tokens) - 1)) {
+    $file = '...'.substr(string: $file, offset: ($padding * -1 + 3));
+}

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -70,6 +70,8 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
                 176 => 1,
                 185 => 1,
                 189 => 1,
+                193 => 1,
+                194 => 3,
             ];
             break;
         case 'OperatorBracketUnitTest.js':

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.php
@@ -71,7 +71,7 @@ class OperatorBracketUnitTest extends AbstractSniffUnitTest
                 185 => 1,
                 189 => 1,
                 193 => 1,
-                194 => 3,
+                194 => 2,
             ];
             break;
         case 'OperatorBracketUnitTest.js':


### PR DESCRIPTION
### PHP 8.0 | Squiz/OperatorBracket: add tests with named function call parameters

... to confirm that the sniff does not break on these.

### Squiz/OperatorBracket: bug fix - improve recognition of unary minus

The new test was giving _three_ instead of _two_ errors on line 194 for this snippet `$padding * -1 + 3`, with the errors being thrown on the `*`, `-` and the `+` operators.

The `-` operator, however, is a unary operator and should not trigger this error.

Fixed now.

