### PR TITLE
PHP 8.0 | Squiz/ScopeKeywordSpacing: add support for constructor property promotion

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -84,7 +84,23 @@ class ScopeKeywordSpacingSniff implements Sniff
             return;
         }
 
-        if ($nextToken !== false && $tokens[$nextToken]['code'] === T_VARIABLE) {
+        $isInFunctionDeclaration = false;
+        if (empty($tokens[$stackPtr]['nested_parenthesis']) === false) {
+            // Check if this is PHP 8.0 constructor property promotion.
+            // In that case, we can't have multi-property definitions.
+            $nestedParens    = $tokens[$stackPtr]['nested_parenthesis'];
+            $lastCloseParens = end($nestedParens);
+            if (isset($tokens[$lastCloseParens]['parenthesis_owner']) === true
+                && $tokens[$tokens[$lastCloseParens]['parenthesis_owner']]['code'] === T_FUNCTION
+            ) {
+                $isInFunctionDeclaration = true;
+            }
+        }
+
+        if ($nextToken !== false
+            && $tokens[$nextToken]['code'] === T_VARIABLE
+            && $isInFunctionDeclaration === false
+        ) {
             $endOfStatement = $phpcsFile->findNext(T_SEMICOLON, ($nextToken + 1));
             if ($endOfStatement === false) {
                 // Live coding.

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
@@ -107,3 +107,17 @@ class TypedProperties {
         $boolA,
         $boolB;
 }
+
+// PHP 8.0 constructor property promotion.
+class ConstructorPropertyPromotionTest {
+    public function __construct(
+        public    $x = 0.0,
+        protected $y = '',
+        private   $z = null,
+        $normalParam,
+    ) {}
+}
+
+class ConstructorPropertyPromotionWithTypesTest {
+    public function __construct(protected   float|int $x, public?string &$y = 'test', private mixed $z) {}
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
@@ -94,5 +94,16 @@ public function fCreate($attributes = []): object|static
 {
 }
 
-// Ensure that static as a scope keyword when preceeded by a colon which is not for a type dclaration is still handled.
+// Ensure that static as a scope keyword when preceeded by a colon which is not for a type declaration is still handled.
 $callback = $cond ? get_fn_name() : static  function ($a) { return $a * 10; };
+
+class TypedProperties {
+    public
+        int $var;
+
+    protected string $stringA, $stringB;
+
+    private   bool
+        $boolA,
+        $boolB;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
@@ -101,3 +101,17 @@ class TypedProperties {
         $boolA,
         $boolB;
 }
+
+// PHP 8.0 constructor property promotion.
+class ConstructorPropertyPromotionTest {
+    public function __construct(
+        public $x = 0.0,
+        protected $y = '',
+        private $z = null,
+        $normalParam,
+    ) {}
+}
+
+class ConstructorPropertyPromotionWithTypesTest {
+    public function __construct(protected float|int $x, public ?string &$y = 'test', private mixed $z) {}
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
@@ -89,5 +89,15 @@ public function fCreate($attributes = []): object|static
 {
 }
 
-// Ensure that static as a scope keyword when preceeded by a colon which is not for a type dclaration is still handled.
+// Ensure that static as a scope keyword when preceeded by a colon which is not for a type declaration is still handled.
 $callback = $cond ? get_fn_name() : static function ($a) { return $a * 10; };
+
+class TypedProperties {
+    public int $var;
+
+    protected string $stringA, $stringB;
+
+    private bool
+        $boolA,
+        $boolB;
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -41,6 +41,9 @@ class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
             98  => 1,
             101 => 1,
             106 => 1,
+            114 => 1,
+            116 => 1,
+            122 => 2,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -26,19 +26,21 @@ class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            7  => 2,
-            8  => 1,
-            13 => 1,
-            14 => 1,
-            15 => 1,
-            17 => 2,
-            26 => 1,
-            28 => 1,
-            29 => 1,
-            64 => 1,
-            67 => 1,
-            71 => 1,
-            98 => 1,
+            7   => 2,
+            8   => 1,
+            13  => 1,
+            14  => 1,
+            15  => 1,
+            17  => 2,
+            26  => 1,
+            28  => 1,
+            29  => 1,
+            64  => 1,
+            67  => 1,
+            71  => 1,
+            98  => 1,
+            101 => 1,
+            106 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
### PHP 7.4 | Squiz/ScopeKeywordSpacing: add tests with typed properties

### PHP 8.0 | Squiz/ScopeKeywordSpacing: add support for constructor property promotion

Prevent the sniff from ignoring the spacing after the scope keyword in case of PHP 8.0 constructor property promotion.

As it was, the sniff would presume "normal" property syntax, which meant that in the case of constructor property promotion in a multi-line constructor declaration, the sniff would look for a semicolon to end the statement and bow out when the semicolon wasn't found.

By explicitly checking for constructor property promotion and skipping the above mentioned check in that case, we ensure that scope keywords in constructors are still handled correctly.

Includes tests.

