### PR TITLE
PHP 8.0 | Generic/NoSilencedErrors: add tests with named function call parameters

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/NoSilencedErrorsSniff.php
@@ -55,7 +55,7 @@ class NoSilencedErrorsSniff implements Sniff
     {
         // Prepare the "Found" string to display.
         $contextLength  = 4;
-        $endOfStatement = $phpcsFile->findEndOfStatement($stackPtr, T_COMMA);
+        $endOfStatement = $phpcsFile->findEndOfStatement($stackPtr, [T_COMMA, T_COLON]);
         if (($endOfStatement - $stackPtr) < $contextLength) {
             $contextLength = ($endOfStatement - $stackPtr);
         }

--- a/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.inc
@@ -6,4 +6,5 @@ if (@in_array($array, $needle))
 {
     echo '@';
 }
-?>
+
+$hasValue = @in_array(haystack: $array, needle: $needle);

--- a/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/NoSilencedErrorsUnitTest.php
@@ -40,7 +40,10 @@ class NoSilencedErrorsUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [5 => 1];
+        return [
+            5  => 1,
+            10 => 1,
+        ];
 
     }//end getWarningList()
 


### PR DESCRIPTION

... to confirm that the code snippet in the error message will be correct (set the `$contextLength` to a higher value to confirm).