### PR TITLE
PHP 8.0 | PEAR/ObjectOperatorIndent: add tests with named function call parameters

### DIFF
--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc
@@ -134,3 +134,9 @@ $someObject?->someFunction("some", "parameter")
 ->someOtherFunc3(23, 42)
     ?->andAThirdFunction();
 // phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false
+
+$someObject
+    ->startSomething(paramName: $value)
+                    ->someOtherFunc(nameA: 23, nameB: 42)
+->endSomething($value, name: $value)
+->endEverything();

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.inc.fixed
@@ -134,3 +134,9 @@ $someObject?->someFunction("some", "parameter")
     ->someOtherFunc3(23, 42)
     ?->andAThirdFunction();
 // phpcs:set PEAR.WhiteSpace.ObjectOperatorIndent multilevel false
+
+$someObject
+    ->startSomething(paramName: $value)
+    ->someOtherFunc(nameA: 23, nameB: 42)
+    ->endSomething($value, name: $value)
+    ->endEverything();

--- a/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ObjectOperatorIndentUnitTest.php
@@ -48,6 +48,9 @@ class ObjectOperatorIndentUnitTest extends AbstractSniffUnitTest
             122 => 1,
             131 => 1,
             134 => 1,
+            140 => 1,
+            141 => 1,
+            142 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION

... to confirm that the sniff does not break on these.