### PR TITLE
PHP 8.0 | Tokenizer/PHP: bugfix for union type operator tokenization

### DIFF
--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
@@ -61,3 +61,5 @@ $fn = fn(array &$one) => 1;
 $fn = fn(array & $one) => 1;
 
 $fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
+
+function issue3267(string|int ...$values) {}

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
@@ -61,3 +61,5 @@ $fn = fn(array &$one) => 1;
 $fn = fn(array & $one) => 1;
 
 $fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
+
+function issue3267(string|int ...$values) {}

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2540,7 +2540,6 @@ class PHP extends Tokenizer
                         || $this->tokens[$x]['code'] === T_ELLIPSIS)
                     ) {
                         // Skip past reference and variadic indicators for parameter types.
-                        ++$x;
                         continue;
                     }
 

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -45,6 +45,9 @@ function namespaceOperatorTypeHint(?namespace\Name $var1) {}
 /* testPHP8UnionTypesSimple */
 function unionTypeSimple(int|float $number, self|parent &...$obj) {}
 
+/* testPHP8UnionTypesWithSpreadOperatorAndReference */
+function globalFunctionWithSpreadAndReference(float|null &$paramA, string|int ...$paramB) {}
+
 /* testPHP8UnionTypesSimpleWithBitwiseOrInDefault */
 $fn = fn(int|float $var = CONSTANT_A | CONSTANT_B) => $var;
 

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -371,6 +371,36 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of PHP8 union type declaration when the variable has either a spread operator or a reference.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesWithSpreadOperatorAndReference()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$paramA',
+            'content'           => 'float|null &$paramA',
+            'pass_by_reference' => true,
+            'variable_length'   => false,
+            'type_hint'         => 'float|null',
+            'nullable_type'     => false,
+        ];
+        $expected[1] = [
+            'name'              => '$paramB',
+            'content'           => 'string|int ...$paramB',
+            'pass_by_reference' => false,
+            'variable_length'   => true,
+            'type_hint'         => 'string|int',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP8UnionTypesWithSpreadOperatorAndReference()
+
+
+    /**
      * Verify recognition of PHP8 union type declaration with a bitwise or in the default value.
      *
      * @return void

--- a/tests/Core/Tokenizer/BitwiseOrTest.inc
+++ b/tests/Core/Tokenizer/BitwiseOrTest.inc
@@ -48,6 +48,13 @@ class TypeUnion
 /* testTypeUnionClosureParamIllegalNullable */
 $closureWithParamType = function (?string|null $string) {};
 
+function globalFunctionWithSpreadAndReference(
+    /* testTypeUnionWithReference */
+    float|null &$paramA,
+    /* testTypeUnionWithSpreadOperator */
+    string|int ...$paramB
+) {}
+
 /* testBitwiseOrClosureParamDefault */
 $closureWithReturnType = function ($string = NONSENSE | FAKE)/* testTypeUnionClosureReturn */ : \Package\MyA|PackageB {};
 

--- a/tests/Core/Tokenizer/BitwiseOrTest.php
+++ b/tests/Core/Tokenizer/BitwiseOrTest.php
@@ -110,6 +110,8 @@ class BitwiseOrTest extends AbstractMethodUnitTest
             ['/* testTypeUnionAbstractMethodReturnType1 */'],
             ['/* testTypeUnionAbstractMethodReturnType2 */'],
             ['/* testTypeUnionClosureParamIllegalNullable */'],
+            ['/* testTypeUnionWithReference */'],
+            ['/* testTypeUnionWithSpreadOperator */'],
             ['/* testTypeUnionClosureReturn */'],
             ['/* testTypeUnionArrowParam */'],
             ['/* testTypeUnionArrowReturnType */'],


### PR DESCRIPTION
In `PHP::processAdditional()`, in the part which retokenizes `T_BITWISE_OR` tokens to `T_TYPE_UNION`, the code already took reference operators and spread operators between the type declaration and the variable into account, but would also increment the current position in the loop, while this is already done in the `for()`. My bad.

Fixed now.

Includes additional unit tests for all relevant functions within the chain, as well as for the sniff for which the issue was reported.

Fixes #3267