### PR TITLE
PHP 8.0 | Generic/UnusedFunctionParameter: add support for constructor property promotion

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -90,6 +90,11 @@ class UnusedFunctionParameterSniff implements Sniff
         }
 
         foreach ($methodParams as $param) {
+            if (isset($param['property_visibility']) === true) {
+                // Ignore. Constructor property promotion.
+                continue;
+            }
+
             $params[$param['name']] = $stackPtr;
         }
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -137,3 +137,16 @@ function moreParamFirst(Exception $foo, LogicException $bar) {
 function moreParamSecond(LogicException $bar, Exception $foo) {
     return 'foobar' . $bar;
 }
+// phpcs:set Generic.CodeAnalysis.UnusedFunctionParameter ignoreTypeHints[]
+
+class ConstructorPropertyPromotionNoContentInMethod {
+    public function __construct(protected int $id) {}
+}
+
+class ConstructorPropertyPromotionWithContentInMethod {
+    public function __construct(protected int $id, $toggle = true) {
+        if ($toggle === true) {
+            doSomething();
+        }
+    }
+}


### PR DESCRIPTION
When constructor property promotion is used, the properties declared in the class constructor should never be marked as unused by this sniff.

Includes tests.

Fixes #3269