### PR TITLE
PHP 8.0 | Generic/LowerCaseType: add tests with Constructor Property Promotion

### DIFF
--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -73,3 +73,11 @@ class TypedProperties
     private ClassName|/*comment*/Float|STRING|False $unionTypeC;
     public sTRing | aRRaY | FaLSe $unionTypeD;
 }
+
+class ConstructorPropertyPromotionWithTypes {
+    public function __construct(protected Float|Int $x, public ?STRING &$y = 'test', private mixed $z) {}
+}
+
+class ConstructorPropertyPromotionAndNormalParams {
+    public function __construct(public Int $promotedProp, ?Int $normalArg) {}
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -73,3 +73,11 @@ class TypedProperties
     private ClassName|/*comment*/float|string|false $unionTypeC;
     public string | array | false $unionTypeD;
 }
+
+class ConstructorPropertyPromotionWithTypes {
+    public function __construct(protected float|int $x, public ?string &$y = 'test', private mixed $z) {}
+}
+
+class ConstructorPropertyPromotionAndNormalParams {
+    public function __construct(public int $promotedProp, ?int $normalArg) {}
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -63,6 +63,8 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             72 => 2,
             73 => 3,
             74 => 3,
+            78 => 3,
+            82 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The sniff already handles this correctly. This just adds some tests to confirm it and safeguard it for the future.