### PR TITLE
PHP 8.0 | PEAR/ValidDefaultValue: add tests with constructor property promotion

### DIFF
--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.inc
@@ -100,5 +100,20 @@ $closure = function(array $arg2=array(), array $arg1) {}
 
 $fn = fn($a = [], $b) => $a[] = $b;
 
+class OnlyConstructorPropertyPromotion {
+    public function __construct(
+        public string $name = '',
+        protected $bar
+    ) {}
+}
+
+class ConstructorPropertyPromotionMixedWithNormalParams {
+    public function __construct(
+        public string $name = '',
+        ?int $optionalParam = 0,
+        mixed $requiredParam,
+    ) {}
+}
+
 // Intentional syntax error. Must be last thing in the file.
 function

--- a/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/ValidDefaultValueUnitTest.php
@@ -35,6 +35,8 @@ class ValidDefaultValueUnitTest extends AbstractSniffUnitTest
             91  => 1,
             99  => 1,
             101 => 1,
+            106 => 1,
+            114 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
~~Properties declared using constructor property promotion, should be ignored for the purpose of determining whether an optional parameter is declared before a required one.~~

~~Includes tests.~~

The sniff already handles this correctly. This just adds some tests to confirm it and safeguard it for the future.