### PR TITLE
Spelling - seperator should be separator

### DIFF
--- a/tests/Core/File/FindEndOfStatementTest.php
+++ b/tests/Core/File/FindEndOfStatementTest.php
@@ -278,7 +278,7 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
 
 
     /**
-     * Test multiple comma-seperated match expression case values.
+     * Test multiple comma-separated match expression case values.
      *
      * @return void
      */

--- a/tests/Core/File/FindStartOfStatementTest.php
+++ b/tests/Core/File/FindStartOfStatementTest.php
@@ -315,7 +315,7 @@ class FindStartOfStatementTest extends AbstractMethodUnitTest
 
 
     /**
-     * Test multiple comma-seperated match expression case values.
+     * Test multiple comma-separated match expression case values.
      *
      * @return void
      */

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the backfilling of numeric seperators to PHP < 7.4.
+ * Tests the backfilling of numeric separators to PHP < 7.4.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2019 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -16,7 +16,7 @@ class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
 
 
     /**
-     * Test that numbers using numeric seperators are tokenized correctly.
+     * Test that numbers using numeric separators are tokenized correctly.
      *
      * @param array $testData The data required for the specific test case.
      *
@@ -145,7 +145,7 @@ class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
 
 
     /**
-     * Test that numbers using numeric seperators which are considered parse errors and/or
+     * Test that numbers using numeric separators which are considered parse errors and/or
      * which aren't relevant to the backfill, do not incorrectly trigger the backfill anyway.
      *
      * @param string $testMarker     The comment which prefaces the target token in the test file.


### PR DESCRIPTION
Just fixes some spelling in some comments. Nothing to test so no tests added.