### PR TITLE
Add support to show the alternative to deprecated functions

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -61,6 +61,18 @@ class DeprecatedFunctionsSniff extends ForbiddenFunctionsSniff
         $error = 'Function %s() has been deprecated';
         $type  = 'Deprecated';
 
+        if ($pattern === null) {
+            $pattern = strtolower($function);
+        }
+
+        if ($this->forbiddenFunctions[$pattern] !== null
+            && $this->forbiddenFunctions[$pattern] !== 'null'
+        ) {
+            $type  .= 'WithAlternative';
+            $data[] = $this->forbiddenFunctions[$pattern];
+            $error .= '; use %s() instead';
+        }
+
         if ($this->error === true) {
             $phpcsFile->addError($error, $stackPtr, $type, $data);
         } else {


### PR DESCRIPTION
The Generic DeprecatedFunctionsSniff is basically a wrapper
over the Generic ForbiddenFunctionsSniff, with only some
details making them different.

One of those details (that may be could be unified) is the
addError() method.

While the Forbidden Sniff supports showing the defined alternative,
curiously the Deprecated Sniff is missing that nice feature.

This PR simply implements it, when an alternative has been
defined, let's show it, like the Forbidden Sniff does.

Again, a nice thing would be to unify both Sniffs addError(), but
that falls out from this specific issue and, particularly, from
my time availability.