### PR TITLE
Fix bug in attributes tokenization on PHP < 8.0 (#3294)

### DIFF
--- a/tests/Core/Tokenizer/AttributesTest.inc
+++ b/tests/Core/Tokenizer/AttributesTest.inc
@@ -75,7 +75,16 @@ function multiline_attributes_on_parameter_test(#[
     )
                                                 ] int $param) {}
 
+/* testAttributeContainingTextLookingLikeCloseTag */
+#[DeprecationReason('reason: <https://some-website/reason?>')]
+function attribute_containing_text_looking_like_close_tag() {}
+
+/* testAttributeContainingMultilineTextLookingLikeCloseTag */
+#[DeprecationReason(
+    'reason: <https://some-website/reason?>'
+)]
+function attribute_containing_mulitline_text_looking_like_close_tag() {}
+
 /* testInvalidAttribute */
 #[ThisIsNotAnAttribute
 function invalid_attribute_test() {}
-


### PR DESCRIPTION
As per title, this fixes the bug described in #3294.

Only if the PHP version is less than 8.0 AND the attribute closer token is not found (not being on the same line or placed after a "?>" token which is interpreted as a php close tag for example), the remainder of the file will be re-tokenized and the attribute closed is searched in the new token stream.
If found the new token stream is injected into the token array and parsing continues, otherwise the re-tokenized stream will be ignored.