### PR TITLE
Generic/GitMergeConflict: check files using only short open echo tag

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -724,6 +724,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.4.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.5.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.6.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.7.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="GitMergeConflictUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SubversionPropertiesUnitTest.inc" role="test" />

--- a/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
@@ -34,7 +34,10 @@ class GitMergeConflictSniff implements Sniff
      */
     public function register()
     {
-        return [T_OPEN_TAG];
+        return [
+            T_OPEN_TAG,
+            T_OPEN_TAG_WITH_ECHO,
+        ];
 
     }//end register()
 

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.7.inc
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.7.inc
@@ -1,0 +1,19 @@
+<!-- Test detecting merge conflicts in inline HTML. -->
+<div class="abc">
+<<<<<<< HEAD
+	<p id="test-this">Testing a merge conflict.</p>
+=======
+	<p id="test-that">Another text string.</p>
+>>>>>>> ref/heads/feature-branch
+</div>
+
+<!-- Test detecting merge conflicts in inline HTML. -->
+<div class="abc">
+<<<<<<< HEAD
+	<p id="test-this"><?= 'Testing a merge conflict.'; ?></p>
+=======
+	<p id="test-that"><?= 'Another text string.'; ?></p>
+>>>>>>> ref/heads/feature-branch
+</div>
+
+<?= $text; ?>

--- a/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/GitMergeConflictUnitTest.php
@@ -99,6 +99,16 @@ class GitMergeConflictUnitTest extends AbstractSniffUnitTest
                 32 => 1,
             ];
 
+        case 'GitMergeConflictUnitTest.7.inc':
+            return [
+                3  => 1,
+                5  => 1,
+                7  => 1,
+                12 => 1,
+                14 => 1,
+                16 => 1,
+            ];
+
         case 'GitMergeConflictUnitTest.1.css':
             return [
                 3  => 1,

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -49,6 +49,7 @@ class SuperfluousWhitespaceSniff implements Sniff
     {
         return [
             T_OPEN_TAG,
+            T_OPEN_TAG_WITH_ECHO,
             T_CLOSE_TAG,
             T_WHITESPACE,
             T_COMMENT,


### PR DESCRIPTION
I can't think of any good reason why "template files", which typically use the short open echo tag, should be excluded from the check done by this sniff.

Includes unit tests.