### PR TITLE
Generic/DisallowSpaceIndent: check files using only short open echo tag

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -739,6 +739,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.1.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.2.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.3.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.3.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowSpaceIndentUnitTest.php" role="test" />

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -41,7 +41,10 @@ class DisallowSpaceIndentSniff implements Sniff
      */
     public function register()
     {
-        return [T_OPEN_TAG];
+        return [
+            T_OPEN_TAG,
+            T_OPEN_TAG_WITH_ECHO,
+        ];
 
     }//end register()
 

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.3.inc
@@ -1,0 +1,19 @@
+<?=
+    "$hello	$there";
+?>
+<html>
+    <head>
+		<title>Foo</title>
+	</head>
+	<body>
+		<div>
+    		<div>
+				<div>
+	    		</div>
+    	    </div>
+        </div>
+    </body>
+</html>
+
+<?=
+	"$hello	$there";

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.3.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.3.inc.fixed
@@ -1,0 +1,19 @@
+<?=
+	"$hello	$there";
+?>
+<html>
+	<head>
+		<title>Foo</title>
+	</head>
+	<body>
+		<div>
+			<div>
+				<div>
+				</div>
+			</div>
+		</div>
+	</body>
+</html>
+
+<?=
+	"$hello	$there";

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowSpaceIndentUnitTest.php
@@ -86,6 +86,17 @@ class DisallowSpaceIndentUnitTest extends AbstractSniffUnitTest
                 118 => 1,
             ];
             break;
+        case 'DisallowSpaceIndentUnitTest.3.inc':
+            return [
+                2  => 1,
+                5  => 1,
+                10 => 1,
+                12 => 1,
+                13 => 1,
+                14 => 1,
+                15 => 1,
+            ];
+            break;
         case 'DisallowSpaceIndentUnitTest.js':
             return [3 => 1];
             break;


### PR DESCRIPTION
I can't think of any good reason why "template files", which typically use the short open echo tag, should be excluded from the check done by this sniff. Currently spacing rules are basically applied inconsistently, based on what PHP tag is used.

Includes unit tests.