### PR TITLE
Squiz/BlockComment: also check for short open echo tag

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -363,6 +363,7 @@ class BlockCommentSniff implements Sniff
         if ((isset($tokens[$contentBefore]['scope_closer']) === true
             && $tokens[$contentBefore]['scope_opener'] === $contentBefore)
             || $tokens[$contentBefore]['code'] === T_OPEN_TAG
+            || $tokens[$contentBefore]['code'] === T_OPEN_TAG_WITH_ECHO
         ) {
             if (($tokens[$stackPtr]['line'] - $tokens[$contentBefore]['line']) !== 1) {
                 $error = 'Empty line not required before block comment';

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -256,3 +256,19 @@ $y = 10 + /* test */ -2;
 /*
  * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
  */
+
+?>
+<?=
+/*
+ * No blank line required above the comment if it's the first non-empty token after a PHP open tag.
+ */
+
+$contentToEcho
+?>
+<?=
+
+
+/*
+ * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
+ */
+$contentToEcho

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -258,3 +258,19 @@ $y = 10 + /* test */ -2;
 /*
  * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
  */
+
+?>
+<?=
+/*
+ * No blank line required above the comment if it's the first non-empty token after a PHP open tag.
+ */
+
+$contentToEcho
+?>
+<?=
+
+
+/*
+ * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
+ */
+$contentToEcho

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.php
@@ -77,6 +77,8 @@ class BlockCommentUnitTest extends AbstractSniffUnitTest
             232 => 1,
             233 => 1,
             256 => 1,
+            271 => 1,
+            273 => 1,
         ];
 
         return $errors;


### PR DESCRIPTION
The sniff has different behaviour when there is a PHP open tag before the block comment, however, this behaviour was not applied when the PHP short open echo tag was encountered.

Includes unit tests.