### PR TITLE
Continue to the next file when an ignored file is found when running checks in parallel.

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -487,6 +487,7 @@ class Runner
                         $file = $todo->current();
 
                         if ($file->ignored === true) {
+                            $todo->next();
                             continue;
                         }
 


### PR DESCRIPTION
This fixes #3317.