### PR TITLE
Comments - Tokenizer left-trims '#' to handle shell-style comments

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -250,7 +250,7 @@ abstract class Tokenizer
                 || $this->tokens[$i]['code'] === T_DOC_COMMENT_TAG
                 || ($inTests === true && $this->tokens[$i]['code'] === T_INLINE_HTML)
             ) {
-                $commentText      = ltrim($this->tokens[$i]['content'], " \t/*");
+                $commentText      = ltrim($this->tokens[$i]['content'], " \t/*#");
                 $commentText      = rtrim($commentText, " */\t\r\n");
                 $commentTextLower = strtolower($commentText);
                 if (strpos($commentText, '@codingStandards') !== false) {


### PR DESCRIPTION
This proposition aims to make possible the use of shell-style comments as Code Sniffer directives, for instance:
```php
  #phpcs:disable Never.Say.Never
  echo "Never say never";
  #phpcs:enable
```