### PR TITLE
ErrorSuppressionTest: refactor to use data providers + bug fixes for the tests

### DIFF
--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -579,7 +579,7 @@ EOD;
     {
         $config            = new Config();
         $config->standards = ['PEAR'];
-        $config->sniffs    = ['PEAR.NamingConventions.ValidVariableName'];
+        $config->sniffs    = ['PEAR.Functions.FunctionDeclaration'];
 
         $ruleset = new Ruleset($config);
 
@@ -590,8 +590,8 @@ EOD;
 
         $errors    = $file->getErrors();
         $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
+        $this->assertEquals(1, $numErrors);
+        $this->assertCount(1, $errors);
 
         // Process with suppression.
         $content = '<?php '.PHP_EOL.'class MyClass() {'.PHP_EOL.'//phpcs:disable'.PHP_EOL.'function myFunction() {'.PHP_EOL.'//phpcs:enable'.PHP_EOL.'$this->foo();'.PHP_EOL.'}'.PHP_EOL.'}';

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -849,8 +849,18 @@ EOD;
                 'expectedErrors' => 1,
             ],
             'disable: whole standard'                      => ['before' => '// phpcs:disable Generic'],
+            'disable: single errorcode'                    => [
+                'before'         => '# @phpcs:disable Generic.Commenting.Todo.TaskFound',
+                'expectedErrors' => 1,
+            ],
+            'disable: single errorcode and a category'     => ['before' => '// phpcs:disable Generic.PHP.LowerCaseConstant.Found,Generic.Commenting'],
 
-            // Wrong category using docblocks.
+            // Wrong category/sniff/code.
+            'disable: wrong error code and category'       => [
+                'before'           => '/**'.PHP_EOL.' * phpcs:disable Generic.PHP.LowerCaseConstant.Upper,Generic.Comments'.PHP_EOL.' */ ',
+                'expectedErrors'   => 1,
+                'expectedWarnings' => 1,
+            ],
             'disable: wrong category, docblock'            => [
                 'before'           => '/**'.PHP_EOL.' * phpcs:disable Generic.Files'.PHP_EOL.' */ ',
                 'expectedErrors'   => 1,

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -879,174 +879,176 @@ EOD;
     /**
      * Test re-enabling specific sniffs that have been disabled.
      *
+     * @param string $code             Code pattern to check.
+     * @param int    $expectedErrors   Number of errors expected.
+     * @param int    $expectedWarnings Number of warnings expected.
+     *
+     * @dataProvider dataEnableSelected
+     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
+     *
      * @return void
      */
-    public function testEnableSelected()
+    public function testEnableSelected($code, $expectedErrors, $expectedWarnings)
     {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-        $config->sniffs    = [
-            'Generic.PHP.LowerCaseConstant',
-            'Generic.Commenting.Todo',
-        ];
+        static $config, $ruleset;
 
-        $ruleset = new Ruleset($config);
+        if (isset($config, $ruleset) === false) {
+            $config            = new Config();
+            $config->standards = ['Generic'];
+            $config->sniffs    = [
+                'Generic.PHP.LowerCaseConstant',
+                'Generic.Commenting.Todo',
+            ];
 
-        // Suppress a single sniff and re-enable.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting.Todo'.PHP_EOL.'//TODO: write some code';
+            $ruleset = new Ruleset($config);
+        }
+
+        $content = '<?php '.$code;
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
+        $this->assertSame($expectedErrors, $file->getErrorCount());
+        $this->assertCount($expectedErrors, $file->getErrors());
 
-        // Suppress multiple sniffs and re-enable.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress multiple sniffs and re-enable one.
-        $content = '<?php '.PHP_EOL.'# phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'# phpcs:enable Generic.Commenting.Todo'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress a category of sniffs and re-enable.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic.Commenting'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting'.PHP_EOL.'//TODO: write some code';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress a whole standard and re-enable.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic'.PHP_EOL.'//TODO: write some code';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress a whole standard and re-enable a category.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting'.PHP_EOL.'//TODO: write some code';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress a category and re-enable a whole standard.
-        $content = '<?php '.PHP_EOL.'# phpcs:disable Generic.Commenting'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'# phpcs:enable Generic'.PHP_EOL.'//TODO: write some code';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress a sniff and re-enable a category.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting'.PHP_EOL.'//TODO: write some code';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress a whole standard and re-enable a sniff.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting.Todo'.PHP_EOL.'//TODO: write some code';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-        $this->assertEquals(1, $numWarnings);
-        $this->assertCount(1, $warnings);
-
-        // Suppress a whole standard and re-enable and re-disable a sniff.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting.Todo'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable'.PHP_EOL.'//TODO: write some code';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-        $this->assertEquals(2, $numWarnings);
-        $this->assertCount(2, $warnings);
-
-        // Suppress a whole standard and re-enable 2 specific sniffs independently.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable Generic'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:enable Generic.Commenting.Todo'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'// phpcs:enable Generic.PHP.LowerCaseConstant'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'$var = FALSE;'.PHP_EOL;
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors      = $file->getErrors();
-        $numErrors   = $file->getErrorCount();
-        $warnings    = $file->getWarnings();
-        $numWarnings = $file->getWarningCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-        $this->assertEquals(2, $numWarnings);
-        $this->assertCount(2, $warnings);
+        $this->assertSame($expectedWarnings, $file->getWarningCount());
+        $this->assertCount($expectedWarnings, $file->getWarnings());
 
     }//end testEnableSelected()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testEnableSelected()
+     *
+     * @return array
+     */
+    public function dataEnableSelected()
+    {
+        return [
+            'disable/enable: a single sniff'                                                                                => [
+                'code'             => '
+                    // phpcs:disable Generic.Commenting.Todo
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting.Todo
+                    //TODO: write some code',
+                'expectedErrors'   => 1,
+                'expectedWarnings' => 1,
+            ],
+            'disable/enable: multiple sniffs'                                                                               => [
+                'code'             => '
+                    // phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant
+                    //TODO: write some code
+                    $var = FALSE;',
+                'expectedErrors'   => 1,
+                'expectedWarnings' => 1,
+            ],
+            'disable: multiple sniffs; enable: one'                                                                         => [
+                'code'             => '
+                    # phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant
+                    $var = FALSE;
+                    //TODO: write some code
+                    # phpcs:enable Generic.Commenting.Todo
+                    //TODO: write some code
+                    $var = FALSE;',
+                'expectedErrors'   => 0,
+                'expectedWarnings' => 1,
+            ],
+            'disable/enable: complete category'                                                                             => [
+                'code'             => '
+                    // phpcs:disable Generic.Commenting
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting
+                    //TODO: write some code',
+                'expectedErrors'   => 1,
+                'expectedWarnings' => 1,
+            ],
+            'disable/enable: whole standard'                                                                                => [
+                'code'             => '
+                    // phpcs:disable Generic
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic
+                    //TODO: write some code',
+                'expectedErrors'   => 0,
+                'expectedWarnings' => 1,
+            ],
+            'disable: whole standard; enable: category from the standard'                                                   => [
+                'code'             => '
+                    // phpcs:disable Generic
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting
+                    //TODO: write some code',
+                'expectedErrors'   => 0,
+                'expectedWarnings' => 1,
+            ],
+            'disable: a category; enable: the whole standard containing the category'                                       => [
+                'code'             => '
+                    # phpcs:disable Generic.Commenting
+                    $var = FALSE;
+                    //TODO: write some code
+                    # phpcs:enable Generic
+                    //TODO: write some code',
+                'expectedErrors'   => 1,
+                'expectedWarnings' => 1,
+            ],
+            'disable: single sniff; enable: the category containing the sniff'                                              => [
+                'code'             => '
+                    // phpcs:disable Generic.Commenting.Todo
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting
+                    //TODO: write some code',
+                'expectedErrors'   => 1,
+                'expectedWarnings' => 1,
+            ],
+            'disable: whole standard; enable: single sniff from the standard'                                               => [
+                'code'             => '
+                    // phpcs:disable Generic
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting.Todo
+                    //TODO: write some code',
+                'expectedErrors'   => 0,
+                'expectedWarnings' => 1,
+            ],
+            'disable: whole standard; enable: single sniff from the standard; disable: that same sniff; enable: everything' => [
+                'code'             => '
+                    // phpcs:disable Generic
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting.Todo
+                    //TODO: write some code
+                    // phpcs:disable Generic.Commenting.Todo
+                    //TODO: write some code
+                    // phpcs:enable
+                    //TODO: write some code',
+                'expectedErrors'   => 0,
+                'expectedWarnings' => 2,
+            ],
+            'disable: whole standard; enable: single sniff from the standard; enable: other sniff from the standard'        => [
+                'code'             => '
+                    // phpcs:disable Generic
+                    $var = FALSE;
+                    //TODO: write some code
+                    // phpcs:enable Generic.Commenting.Todo
+                    //TODO: write some code
+                    $var = FALSE;
+                    // phpcs:enable Generic.PHP.LowerCaseConstant
+                    //TODO: write some code
+                    $var = FALSE;',
+                'expectedErrors'   => 1,
+                'expectedWarnings' => 2,
+            ],
+        ];
+
+    }//end dataEnableSelected()
 
 
     /**

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -424,16 +424,6 @@ EOD;
         $this->assertEquals(1, $numErrors);
         $this->assertCount(1, $errors);
 
-        // Process with @ suppression on line before inside docblock.
-        $content = '<?php '.PHP_EOL.'/**'.PHP_EOL.' * Comment here'.PHP_EOL.' * @phpcs:ignore'.PHP_EOL.' * '.str_repeat('a ', 50).PHP_EOL.'*/';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
         // Process with suppression on same line.
         $content = '<?php '.PHP_EOL.'$var = FALSE; // phpcs:ignore'.PHP_EOL.'$var = FALSE;';
         $file    = new DummyFile($content, $ruleset, $config);
@@ -485,6 +475,40 @@ EOD;
         $this->assertCount(1, $errors);
 
     }//end testSuppressLine()
+
+
+    /**
+     * Test suppressing a single error using a single line ignore within a docblock.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
+     *
+     * @return void
+     */
+    public function testSuppressLineWithinDocblock()
+    {
+        $config            = new Config();
+        $config->standards = ['Generic'];
+        $config->sniffs    = ['Generic.Files.LineLength'];
+
+        $ruleset = new Ruleset($config);
+
+        // Process with @ suppression on line before inside docblock.
+        $comment = str_repeat('a ', 50);
+        $content = <<<EOD
+<?php
+/**
+ * Comment here
+ * @phpcs:ignore
+ * $comment
+ */
+EOD;
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $this->assertSame(0, $file->getErrorCount());
+        $this->assertCount(0, $file->getErrors());
+
+    }//end testSuppressLineWithinDocblock()
 
 
     /**

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -423,6 +423,31 @@ EOD;
 
 
     /**
+     * Test suppressing a single error using a single line ignore in the middle of a line.
+     *
+     * @covers PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
+     *
+     * @return void
+     */
+    public function testSuppressLineMidLine()
+    {
+        $config            = new Config();
+        $config->standards = ['Generic'];
+        $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
+
+        $ruleset = new Ruleset($config);
+
+        $content = '<?php '.PHP_EOL.'$var = FALSE; /* @phpcs:ignore */ $var = FALSE;';
+        $file    = new DummyFile($content, $ruleset, $config);
+        $file->process();
+
+        $this->assertSame(0, $file->getErrorCount());
+        $this->assertCount(0, $file->getErrors());
+
+    }//end testSuppressLineMidLine()
+
+
+    /**
      * Test suppressing a single error using a single line ignore within a docblock.
      *
      * @covers PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -751,7 +751,7 @@ EOD;
         $this->assertCount(0, $warnings);
 
         // Process late comment.
-        $content = '<?php '.PHP_EOL.'class MyClass {}'.PHP_EOL.'$foo = new MyClass()'.PHP_EOL.'// phpcs:ignoreFile';
+        $content = '<?php '.PHP_EOL.'class MyClass {}'.PHP_EOL.'$foo = new MyClass();'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// phpcs:ignoreFile';
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 
@@ -761,7 +761,7 @@ EOD;
         $this->assertCount(0, $warnings);
 
         // Process late comment (deprecated syntax).
-        $content = '<?php '.PHP_EOL.'class MyClass {}'.PHP_EOL.'$foo = new MyClass()'.PHP_EOL.'// @codingStandardsIgnoreFile';
+        $content = '<?php '.PHP_EOL.'class MyClass {}'.PHP_EOL.'$foo = new MyClass();'.PHP_EOL.'//TODO: write some code'.PHP_EOL.'// @codingStandardsIgnoreFile';
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -21,197 +21,134 @@ class ErrorSuppressionTest extends TestCase
     /**
      * Test suppressing a single error.
      *
+     * @param string $before         Annotation to place before the code.
+     * @param string $after          Annotation to place after the code.
+     * @param int    $expectedErrors Optional. Number of errors expected.
+     *                               Defaults to 0.
+     *
+     * @dataProvider dataSuppressError
+     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
+     *
      * @return void
      */
-    public function testSuppressError()
+    public function testSuppressError($before, $after, $expectedErrors=0)
     {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-        $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
+        static $config, $ruleset;
 
-        $ruleset = new Ruleset($config);
+        if (isset($config, $ruleset) === false) {
+            $config            = new Config();
+            $config->standards = ['Generic'];
+            $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
 
-        // Process without suppression.
-        $content = '<?php '.PHP_EOL.'$var = FALSE;';
+            $ruleset = new Ruleset($config);
+        }
+
+        $content = '<?php '.PHP_EOL.$before.'$var = FALSE;'.PHP_EOL.$after;
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with inline comment suppression.
-        $content = '<?php '.PHP_EOL.'// phpcs:disable'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'// phpcs:enable';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with multi-line inline comment suppression, tab-indented.
-        $content = '<?php '.PHP_EOL."\t".'// For reasons'.PHP_EOL."\t".'// phpcs:disable'.PHP_EOL."\t".'$var = FALSE;'.PHP_EOL."\t".'// phpcs:enable';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with inline @ comment suppression.
-        $content = '<?php '.PHP_EOL.'// @phpcs:disable'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'// @phpcs:enable';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with inline comment suppression mixed case.
-        $content = '<?php '.PHP_EOL.'// PHPCS:Disable'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'// pHPcs:enabLE';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with inline hash comment suppression.
-        $content = '<?php '.PHP_EOL.'# phpcs:disable'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'# phpcs:enable';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with multi-line inline hash comment suppression, tab-indented.
-        $content = '<?php '.PHP_EOL."\t".'# For reasons'.PHP_EOL."\t".'# phpcs:disable'.PHP_EOL."\t".'$var = FALSE;'.PHP_EOL."\t".'# phpcs:enable';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with inline hash @ comment suppression.
-        $content = '<?php '.PHP_EOL.'# @phpcs:disable'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'# @phpcs:enable';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with inline hash comment suppression mixed case.
-        $content = '<?php '.PHP_EOL.'# PHPCS:Disable'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'# pHPcs:enabLE';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with inline comment suppression (deprecated syntax).
-        $content = '<?php '.PHP_EOL.'// @codingStandardsIgnoreStart'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'// @codingStandardsIgnoreEnd';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with block comment suppression.
-        $content = '<?php '.PHP_EOL.'/* phpcs:disable */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/* phpcs:enable */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with multi-line block comment suppression.
-        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' phpcs:disable'.PHP_EOL.' */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/*'.PHP_EOL.' phpcs:enable'.PHP_EOL.' */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with multi-line block comment suppression, each line starred.
-        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' * phpcs:disable'.PHP_EOL.' */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/*'.PHP_EOL.' * phpcs:enable'.PHP_EOL.' */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with multi-line block comment suppression, tab-indented.
-        $content = '<?php '.PHP_EOL."\t".'/*'.PHP_EOL."\t".' * phpcs:disable'.PHP_EOL."\t".' */'.PHP_EOL."\t".'$var = FALSE;'.PHP_EOL."\t".'/*'.PHP_EOL.' * phpcs:enable'.PHP_EOL.' */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with block comment suppression (deprecated syntax).
-        $content = '<?php '.PHP_EOL.'/* @codingStandardsIgnoreStart */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/* @codingStandardsIgnoreEnd */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with multi-line block comment suppression (deprecated syntax).
-        $content = '<?php '.PHP_EOL.'/*'.PHP_EOL.' @codingStandardsIgnoreStart'.PHP_EOL.' */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/*'.PHP_EOL.' @codingStandardsIgnoreEnd'.PHP_EOL.' */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with a docblock suppression.
-        $content = '<?php '.PHP_EOL.'/** phpcs:disable */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/** phpcs:enable */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
-
-        // Process with a docblock suppression (deprecated syntax).
-        $content = '<?php '.PHP_EOL.'/** @codingStandardsIgnoreStart */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'/** @codingStandardsIgnoreEnd */';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(0, $numErrors);
-        $this->assertCount(0, $errors);
+        $this->assertSame($expectedErrors, $file->getErrorCount());
+        $this->assertCount($expectedErrors, $file->getErrors());
 
     }//end testSuppressError()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testSuppressError()
+     *
+     * @return array
+     */
+    public function dataSuppressError()
+    {
+        return [
+            'no suppression'                                                           => [
+                'before'         => '',
+                'after'          => '',
+                'expectedErrors' => 1,
+            ],
+
+            // Inline slash comments.
+            'disable/enable: slash comment'                                            => [
+                'before' => '// phpcs:disable'.PHP_EOL,
+                'after'  => '// phpcs:enable',
+            ],
+            'disable/enable: multi-line slash comment, tab indented'                   => [
+                'before' => "\t".'// For reasons'.PHP_EOL."\t".'// phpcs:disable'.PHP_EOL."\t",
+                'after'  => "\t".'// phpcs:enable',
+            ],
+            'disable/enable: slash comment, with @'                                    => [
+                'before' => '// @phpcs:disable'.PHP_EOL,
+                'after'  => '// @phpcs:enable',
+            ],
+            'disable/enable: slash comment, mixed case'                                => [
+                'before' => '// PHPCS:Disable'.PHP_EOL,
+                'after'  => '// pHPcs:enabLE',
+            ],
+
+            // Inline hash comments.
+            'disable/enable: hash comment'                                             => [
+                'before' => '# phpcs:disable'.PHP_EOL,
+                'after'  => '# phpcs:enable',
+            ],
+            'disable/enable: multi-line hash comment, tab indented'                    => [
+                'before' => "\t".'# For reasons'.PHP_EOL."\t".'# phpcs:disable'.PHP_EOL."\t",
+                'after'  => "\t".'# phpcs:enable',
+            ],
+            'disable/enable: hash comment, with @'                                     => [
+                'before' => '# @phpcs:disable'.PHP_EOL,
+                'after'  => '# @phpcs:enable',
+            ],
+            'disable/enable: hash comment, mixed case'                                 => [
+                'before' => '# PHPCS:Disable'.PHP_EOL,
+                'after'  => '# pHPcs:enabLE',
+            ],
+
+            // Inline star (block) comments.
+            'disable/enable: star comment'                                             => [
+                'before' => '/* phpcs:disable */'.PHP_EOL,
+                'after'  => '/* phpcs:enable */',
+            ],
+            'disable/enable: multi-line star comment'                                  => [
+                'before' => '/*'.PHP_EOL.' phpcs:disable'.PHP_EOL.' */'.PHP_EOL,
+                'after'  => '/*'.PHP_EOL.' phpcs:enable'.PHP_EOL.' */',
+            ],
+            'disable/enable: multi-line star comment, each line starred'               => [
+                'before' => '/*'.PHP_EOL.' * phpcs:disable'.PHP_EOL.' */'.PHP_EOL,
+                'after'  => '/*'.PHP_EOL.' * phpcs:enable'.PHP_EOL.' */',
+            ],
+            'disable/enable: multi-line star comment, each line starred, tab indented' => [
+                'before' => "\t".'/*'.PHP_EOL."\t".' * phpcs:disable'.PHP_EOL."\t".' */'.PHP_EOL."\t",
+                'after'  => "\t".'/*'.PHP_EOL.' * phpcs:enable'.PHP_EOL.' */',
+            ],
+
+            // Docblock comments.
+            'disable/enable: single line docblock comment'                             => [
+                'before' => '/** phpcs:disable */'.PHP_EOL,
+                'after'  => '/** phpcs:enable */',
+            ],
+
+            // Deprecated syntax.
+            'old style: slash comment'                                                 => [
+                'before' => '// @codingStandardsIgnoreStart'.PHP_EOL,
+                'after'  => '// @codingStandardsIgnoreEnd',
+            ],
+            'old style: star comment'                                                  => [
+                'before' => '/* @codingStandardsIgnoreStart */'.PHP_EOL,
+                'after'  => '/* @codingStandardsIgnoreEnd */',
+            ],
+            'old style: multi-line star comment'                                       => [
+                'before' => '/*'.PHP_EOL.' @codingStandardsIgnoreStart'.PHP_EOL.' */'.PHP_EOL,
+                'after'  => '/*'.PHP_EOL.' @codingStandardsIgnoreEnd'.PHP_EOL.' */',
+            ],
+            'old style: single line docblock comment'                                  => [
+                'before' => '/** @codingStandardsIgnoreStart */'.PHP_EOL,
+                'after'  => '/** @codingStandardsIgnoreEnd */',
+            ],
+        ];
+
+    }//end dataSuppressError()
 
 
     /**

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -331,150 +331,95 @@ EOD;
     /**
      * Test suppressing a single error using a single line ignore.
      *
+     * @param string $before         Annotation to place before the code.
+     * @param string $after          Optional. Annotation to place after the code.
+     *                               Defaults to an empty string.
+     * @param int    $expectedErrors Optional. Number of errors expected.
+     *                               Defaults to 1.
+     *
+     * @dataProvider dataSuppressLine
+     * @covers       PHP_CodeSniffer\Tokenizers\Tokenizer::createPositionMap
+     *
      * @return void
      */
-    public function testSuppressLine()
+    public function testSuppressLine($before, $after='', $expectedErrors=1)
     {
-        $config            = new Config();
-        $config->standards = ['Generic'];
-        $config->sniffs    = [
-            'Generic.PHP.LowerCaseConstant',
-            'Generic.Files.LineLength',
-        ];
+        static $config, $ruleset;
 
-        $ruleset = new Ruleset($config);
+        if (isset($config, $ruleset) === false) {
+            $config            = new Config();
+            $config->standards = ['Generic'];
+            $config->sniffs    = ['Generic.PHP.LowerCaseConstant'];
 
-        // Process without suppression.
-        $content = '<?php '.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
+            $ruleset = new Ruleset($config);
+        }
+
+        $content = <<<EOD
+<?php
+$before
+\$var = FALSE;$after
+\$var = FALSE;
+EOD;
         $file    = new DummyFile($content, $ruleset, $config);
         $file->process();
 
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(2, $numErrors);
-        $this->assertCount(2, $errors);
-
-        // Process with suppression on line before.
-        $content = '<?php '.PHP_EOL.'// phpcs:ignore'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-         // Process with @ suppression on line before.
-        $content = '<?php '.PHP_EOL.'// @phpcs:ignore'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with suppression on line before (hash comment).
-        $content = '<?php '.PHP_EOL.'# phpcs:ignore'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-         // Process with @ suppression on line before (hash comment).
-        $content = '<?php '.PHP_EOL.'# @phpcs:ignore'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with suppression on line before.
-        $content = '<?php '.PHP_EOL.'/* phpcs:ignore */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with @ suppression on line before.
-        $content = '<?php '.PHP_EOL.'/* @phpcs:ignore */'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with suppression on line before (deprecated syntax).
-        $content = '<?php '.PHP_EOL.'// @codingStandardsIgnoreLine'.PHP_EOL.'$var = FALSE;'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with suppression on same line.
-        $content = '<?php '.PHP_EOL.'$var = FALSE; // phpcs:ignore'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with @ suppression on same line.
-        $content = '<?php '.PHP_EOL.'$var = FALSE; // @phpcs:ignore'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with suppression on same line (hash comment).
-        $content = '<?php '.PHP_EOL.'$var = FALSE; # phpcs:ignore'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with @ suppression on same line (hash comment).
-        $content = '<?php '.PHP_EOL.'$var = FALSE; # @phpcs:ignore'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
-
-        // Process with suppression on same line (deprecated syntax).
-        $content = '<?php '.PHP_EOL.'$var = FALSE; // @codingStandardsIgnoreLine'.PHP_EOL.'$var = FALSE;';
-        $file    = new DummyFile($content, $ruleset, $config);
-        $file->process();
-
-        $errors    = $file->getErrors();
-        $numErrors = $file->getErrorCount();
-        $this->assertEquals(1, $numErrors);
-        $this->assertCount(1, $errors);
+        $this->assertSame($expectedErrors, $file->getErrorCount());
+        $this->assertCount($expectedErrors, $file->getErrors());
 
     }//end testSuppressLine()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testSuppressLine()
+     *
+     * @return array
+     */
+    public function dataSuppressLine()
+    {
+        return [
+            'no suppression'                             => [
+                'before'         => '',
+                'after'          => '',
+                'expectedErrors' => 2,
+            ],
+
+            // With suppression on line before.
+            'ignore: line before, slash comment'         => ['before' => '// phpcs:ignore'],
+            'ignore: line before, slash comment, with @' => ['before' => '// @phpcs:ignore'],
+            'ignore: line before, hash comment'          => ['before' => '# phpcs:ignore'],
+            'ignore: line before, hash comment, with @'  => ['before' => '# @phpcs:ignore'],
+            'ignore: line before, star comment'          => ['before' => '/* phpcs:ignore */'],
+            'ignore: line before, star comment, with @'  => ['before' => '/* @phpcs:ignore */'],
+
+            // With suppression as trailing comment on code line.
+            'ignore: end of line, slash comment'         => [
+                'before' => '',
+                'after'  => ' // phpcs:ignore',
+            ],
+            'ignore: end of line, slash comment, with @' => [
+                'before' => '',
+                'after'  => ' // @phpcs:ignore',
+            ],
+            'ignore: end of line, hash comment'          => [
+                'before' => '',
+                'after'  => ' # phpcs:ignore',
+            ],
+            'ignore: end of line, hash comment, with @'  => [
+                'before' => '',
+                'after'  => ' # @phpcs:ignore',
+            ],
+
+            // Deprecated syntax.
+            'old style: line before, slash comment'      => ['before' => '// @codingStandardsIgnoreLine'],
+            'old style: end of line, slash comment'      => [
+                'before' => '',
+                'after'  => ' // @codingStandardsIgnoreLine',
+            ],
+        ];
+
+    }//end dataSuppressLine()
 
 
     /**


### PR DESCRIPTION
Follow up to https://github.com/squizlabs/PHP_CodeSniffer/pull/3071#issuecomment-828109667

This refactors all test methods in the `ErrorSuppresionTest` class to use data providers.

For each of these refactors, the following comment applies:

* Maintains the exact same existing tests, now using a data provider.
    The data provider uses keys which allows for much more descriptive output when using the PHPUnit `--testdox` option, as well as for easier debugging if/when a test would fail.
* Orders the tests in logical groups in the data provider.
* Switches out `assertEquals()` (loose type comparison) for `assertSame()` (strict type comparison).
* Caches the `$config` and `$ruleset` for the test via static local variables to prevent the test run from becoming slower due to the change to the data provider.

## Notable (other) commits/commit comments

### ErrorSuppressionTest: move one test case out of testSuppressLine()

... as it uses a different code pattern, so doesn't fit with the other tests for the (upcoming) data provider.

### ErrorSuppressionTest: add test for midline ignore

### ErrorSuppressionTest: fix bug in testSuppressScope()

As the "no suppression" test would yield no errors, the test wasn't actually testing anything as there were no errors to suppress.

Fixed now by using a different sniff to test against, which does yield an error on the line being suppressed by the rest of the tests.

### ErrorSuppressionTest::testSuppressFile(): fix bugs in test

This fixes two bugs in two test cases for the `testSuppressFile()` method:
1. The code snippet as was, contained a parse error (missing semi-colon after class instantiation).
2. The code snippet did not contain anything which would trigger the warning the test is looking for in the first place, so these two tests would always pass.

### ErrorSuppressionTest::testDisableSelected(): refactor to data provider

**Note**: the "docblock" tests have changed to use the same basic code sample as the other tests. In practice this means that instead of having 0 errors and 0/1 warnings, they will now yield 1 error and 0/1 warnings. Functionally these tests still test the same principle.

### ErrorSuppressionTest::testDisableSelected(): add some more tests

By the looks of it, combining disabling at different levels and disabling error codes wasn't covered in the tests.
