### PR TITLE
NamedFunctionCallArgumentsTest: minor fixes

### DIFF
--- a/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
@@ -38,7 +38,7 @@ class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
             $this->assertSame(
                 T_PARAM_NAME,
                 $tokens[$label]['code'],
-                'Token tokenized as '.$tokens[$label]['code'].', not T_PARAM_NAME (code)'
+                'Token tokenized as '.$tokens[$label]['type'].', not T_PARAM_NAME (code)'
             );
             $this->assertSame(
                 'T_PARAM_NAME',
@@ -278,7 +278,7 @@ class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $this->assertSame(
             T_STRING,
             $tokens[$label]['code'],
-            'Token tokenized as '.$tokens[$label]['code'].', not T_STRING (code)'
+            'Token tokenized as '.$tokens[$label]['type'].', not T_STRING (code)'
         );
         $this->assertSame(
             'T_STRING',
@@ -709,7 +709,7 @@ class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
         $this->assertSame(
             T_PARAM_NAME,
             $tokens[$label]['code'],
-            'Token tokenized as '.$tokens[$label]['code'].', not T_PARAM_NAME (code)'
+            'Token tokenized as '.$tokens[$label]['type'].', not T_PARAM_NAME (code)'
         );
         $this->assertSame(
             'T_PARAM_NAME',


### PR DESCRIPTION
The error message would display the token code, which is not helfpul for a human, so changing it to the token `type`.