### PR TITLE
Ensure interface and trait names are always tokenized as T_STRING

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1899,6 +1899,8 @@ class PHP extends Tokenizer
                         T_NULLSAFE_OBJECT_OPERATOR => true,
                         T_FUNCTION                 => true,
                         T_CLASS                    => true,
+                        T_INTERFACE                => true,
+                        T_TRAIT                    => true,
                         T_EXTENDS                  => true,
                         T_IMPLEMENTS               => true,
                         T_ATTRIBUTE                => true,


### PR DESCRIPTION
Interface and trait names should always be `T_STRING`.