### PR TITLE
Tokenizer/PHP: stabilize T_FINALLY backfill

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -137,6 +137,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="DefaultKeywordTest.php" role="test" />
       <file baseinstalldir="" name="DoubleArrowTest.inc" role="test" />
       <file baseinstalldir="" name="DoubleArrowTest.php" role="test" />
+      <file baseinstalldir="" name="FinallyTest.inc" role="test" />
+      <file baseinstalldir="" name="FinallyTest.php" role="test" />
       <file baseinstalldir="" name="GotoLabelTest.inc" role="test" />
       <file baseinstalldir="" name="GotoLabelTest.php" role="test" />
       <file baseinstalldir="" name="NamedFunctionCallArgumentsTest.inc" role="test" />
@@ -2054,6 +2056,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.php" name="tests/Core/Tokenizer/DoubleArrowTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.inc" name="tests/Core/Tokenizer/DoubleArrowTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/FinallyTest.php" name="tests/Core/Tokenizer/FinallyTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/FinallyTest.inc" name="tests/Core/Tokenizer/FinallyTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.php" name="tests/Core/Tokenizer/GotoLabelTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.inc" name="tests/Core/Tokenizer/GotoLabelTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" name="tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" />
@@ -2140,6 +2144,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.php" name="tests/Core/Tokenizer/DoubleArrowTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.inc" name="tests/Core/Tokenizer/DoubleArrowTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/FinallyTest.php" name="tests/Core/Tokenizer/FinallyTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/FinallyTest.inc" name="tests/Core/Tokenizer/FinallyTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.php" name="tests/Core/Tokenizer/GotoLabelTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/GotoLabelTest.inc" name="tests/Core/Tokenizer/GotoLabelTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" name="tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php" />

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2084,6 +2084,7 @@ class PHP extends Tokenizer
                 // where "finally" should be T_FINALLY instead of T_STRING.
                 if ($newToken['code'] === T_STRING
                     && strtolower($newToken['content']) === 'finally'
+                    && $finalTokens[$lastNotEmptyToken]['code'] === T_CLOSE_CURLY_BRACKET
                 ) {
                     $newToken['code'] = T_FINALLY;
                     $newToken['type'] = 'T_FINALLY';

--- a/tests/Core/Tokenizer/FinallyTest.inc
+++ b/tests/Core/Tokenizer/FinallyTest.inc
@@ -1,0 +1,40 @@
+<?php
+
+try {
+    // Do something.
+} catch(Exception $e) {
+    // Do something.
+}
+/* testTryCatchFinally */
+finally {
+    // Do something.
+}
+
+/* testTryFinallyCatch */
+try {
+    // Do something.
+} finally {
+    // Do something.
+} catch(Exception $e) {
+    // Do something.
+}
+
+/* testTryFinally */
+try {
+    // Do something.
+} FINALLY {
+    // Do something.
+}
+
+class FinallyAsMethod {
+    /* testFinallyUsedAsClassConstantName */
+    const FINALLY = 'foo';
+
+    /* testFinallyUsedAsMethodName */
+    public function finally() {
+        // Do something.
+
+        /* testFinallyUsedAsPropertyName */
+        $this->finally = 'foo';
+    }
+}

--- a/tests/Core/Tokenizer/FinallyTest.php
+++ b/tests/Core/Tokenizer/FinallyTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests the tokenization of the finally keyword.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2021 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class FinallyTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that the finally keyword is tokenized as such.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @dataProvider dataFinallyKeyword
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testFinallyKeyword($testMarker)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $target = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
+        $this->assertSame(T_FINALLY, $tokens[$target]['code']);
+        $this->assertSame('T_FINALLY', $tokens[$target]['type']);
+
+    }//end testFinallyKeyword()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testFinallyKeyword()
+     *
+     * @return array
+     */
+    public function dataFinallyKeyword()
+    {
+        return [
+            ['/* testTryCatchFinally */'],
+            ['/* testTryFinallyCatch */'],
+            ['/* testTryFinally */'],
+        ];
+
+    }//end dataFinallyKeyword()
+
+
+    /**
+     * Test that 'finally' when not used as the reserved keyword is tokenized as `T_STRING`.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @dataProvider dataFinallyNonKeyword
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testFinallyNonKeyword($testMarker)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $target = $this->getTargetToken($testMarker, [T_FINALLY, T_STRING]);
+        $this->assertSame(T_STRING, $tokens[$target]['code']);
+        $this->assertSame('T_STRING', $tokens[$target]['type']);
+
+    }//end testFinallyNonKeyword()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testFinallyNonKeyword()
+     *
+     * @return array
+     */
+    public function dataFinallyNonKeyword()
+    {
+        return [
+            ['/* testFinallyUsedAsClassConstantName */'],
+            ['/* testFinallyUsedAsMethodName */'],
+            ['/* testFinallyUsedAsPropertyName */'],
+        ];
+
+    }//end dataFinallyNonKeyword()
+
+
+}//end class


### PR DESCRIPTION
Make the backfill for T_FINALLY a little more stable by preventing re-tokenizing non-keyword `finally` strings to `T_FINALLY`.

Includes unit tests.