### PR TITLE
Squiz/ObjectInstantiation: bug fix - account for null coalesce

### DIFF
--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -23,6 +23,24 @@ function returnMatch() {
     }
 }
 
+// Issue 3333.
+$time2 ??= new \DateTime();
+$time3 = $time1 ?? new \DateTime();
+$time3 = $time1 ?? $time2 ?? new \DateTime();
+
+function_call($time1 ?? new \DateTime());
+$return = function_call($time1 ?? new \DateTime()); // False negative depending on interpretation of the sniff.
+
+function returnViaTernary() {
+    return ($y == false ) ? ($x === true ? new Foo : new Bar) : new FooBar;
+}
+
+function nonAssignmentTernary() {
+    if (($x ? new Foo() : new Bar) instanceof FooBar) {
+        // Do something.
+    }
+}
+
 // Intentional parse error. This must be the last test in the file.
 function new
 ?>

--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -26,8 +26,10 @@ class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            5 => 1,
-            8 => 1,
+            5  => 1,
+            8  => 1,
+            31 => 1,
+            39 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The `Squiz.Objects.ObjectInstantiation` did not take null coalesce into account.

It also was potentially a little too lenient for ternaries as an inline then or inline else token before the `new` keyword would be considered an assignment, while it was never checked that the result of the ternary was actually assigned to something.

While still not 100%, this commit improves the sniffs to:
1. Allow for null coalesce assignments `??=`.
2. For ternary tokens + null coalesce `??`: verify if the result of either of these is actually "assigned" to something (or preceded by one of the other "allowed" tokens).

This should reduce the number of both false positives as well as false negatives, though there is still the potential for some false negatives - see the test on line 32 of the test case file.
This could be further reduced in a future iteration on this sniff, but for now, this fix can be considered a significant step forward.

Includes unit tests.

Fixes #3333