### PR TITLE
Tokenizer/PHP: fix tokenization of the default keyword

### DIFF
--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -468,3 +468,13 @@ $resource = new class() {
 
 $one       <<= 8;
 $onetwothree = 3;
+
+// Issue 3326.
+class Test
+{
+    public const DEFAULT = 'default';
+    public const SOS     = 'sos';
+    public const HELP    = 'help';
+
+    protected static $thisIsAReallyLongVariableName = [];
+}

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -468,3 +468,13 @@ $resource = new class() {
 
 $one       <<= 8;
 $onetwothree = 3;
+
+// Issue 3326.
+class Test
+{
+    public const DEFAULT = 'default';
+    public const SOS     = 'sos';
+    public const HELP    = 'help';
+
+    protected static $thisIsAReallyLongVariableName = [];
+}

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -455,6 +455,29 @@ class PHP extends Tokenizer
     ];
 
     /**
+     * Contexts in which keywords should always be tokenized as T_STRING.
+     *
+     * @var array
+     */
+    protected $tstringContexts = [
+        T_OBJECT_OPERATOR          => true,
+        T_NULLSAFE_OBJECT_OPERATOR => true,
+        T_FUNCTION                 => true,
+        T_CLASS                    => true,
+        T_INTERFACE                => true,
+        T_TRAIT                    => true,
+        T_EXTENDS                  => true,
+        T_IMPLEMENTS               => true,
+        T_ATTRIBUTE                => true,
+        T_NEW                      => true,
+        T_CONST                    => true,
+        T_NS_SEPARATOR             => true,
+        T_USE                      => true,
+        T_NAMESPACE                => true,
+        T_PAAMAYIM_NEKUDOTAYIM     => true,
+    ];
+
+    /**
      * A cache of different token types, resolved into arrays.
      *
      * @var array
@@ -1332,16 +1355,7 @@ class PHP extends Tokenizer
                         break;
                     }
 
-                    $notMatchContext = [
-                        T_PAAMAYIM_NEKUDOTAYIM     => true,
-                        T_OBJECT_OPERATOR          => true,
-                        T_NULLSAFE_OBJECT_OPERATOR => true,
-                        T_NS_SEPARATOR             => true,
-                        T_NEW                      => true,
-                        T_FUNCTION                 => true,
-                    ];
-
-                    if (isset($notMatchContext[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
+                    if (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
                         // Also not a match expression.
                         break;
                     }
@@ -1389,14 +1403,7 @@ class PHP extends Tokenizer
             if ($tokenIsArray === true
                 && $token[0] === T_DEFAULT
             ) {
-                $ignoreContext = [
-                    T_OBJECT_OPERATOR          => true,
-                    T_NULLSAFE_OBJECT_OPERATOR => true,
-                    T_NS_SEPARATOR             => true,
-                    T_PAAMAYIM_NEKUDOTAYIM     => true,
-                ];
-
-                if (isset($ignoreContext[$finalTokens[$lastNotEmptyToken]['code']]) === false) {
+                if (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === false) {
                     for ($x = ($stackPtr + 1); $x < $numTokens; $x++) {
                         if ($tokens[$x] === ',') {
                             // Skip over potential trailing comma (supported in PHP).
@@ -1894,25 +1901,7 @@ class PHP extends Tokenizer
                 if ($tokenIsArray === true && $token[0] === T_STRING) {
                     // Some T_STRING tokens should remain that way
                     // due to their context.
-                    $context = [
-                        T_OBJECT_OPERATOR          => true,
-                        T_NULLSAFE_OBJECT_OPERATOR => true,
-                        T_FUNCTION                 => true,
-                        T_CLASS                    => true,
-                        T_INTERFACE                => true,
-                        T_TRAIT                    => true,
-                        T_EXTENDS                  => true,
-                        T_IMPLEMENTS               => true,
-                        T_ATTRIBUTE                => true,
-                        T_NEW                      => true,
-                        T_CONST                    => true,
-                        T_NS_SEPARATOR             => true,
-                        T_USE                      => true,
-                        T_NAMESPACE                => true,
-                        T_PAAMAYIM_NEKUDOTAYIM     => true,
-                    ];
-
-                    if (isset($context[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
+                    if (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
                         // Special case for syntax like: return new self
                         // where self should not be a string.
                         if ($finalTokens[$lastNotEmptyToken]['code'] === T_NEW
@@ -2784,13 +2773,7 @@ class PHP extends Tokenizer
                     }
                 }
 
-                $context = [
-                    T_OBJECT_OPERATOR          => true,
-                    T_NULLSAFE_OBJECT_OPERATOR => true,
-                    T_NS_SEPARATOR             => true,
-                    T_PAAMAYIM_NEKUDOTAYIM     => true,
-                ];
-                if (isset($context[$this->tokens[$x]['code']]) === true) {
+                if (isset($this->tstringContexts[$this->tokens[$x]['code']]) === true) {
                     if (PHP_CODESNIFFER_VERBOSITY > 1) {
                         $line = $this->tokens[$i]['line'];
                         $type = $this->tokens[$i]['type'];

--- a/tests/Core/Tokenizer/DefaultKeywordTest.inc
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.inc
@@ -193,3 +193,11 @@ function switchWithConstantNonDefault($i) {
             return 2;
     }
 }
+
+class Foo {
+    /* testClassConstant */
+    const DEFAULT = 'foo';
+
+    /* testMethodDeclaration */
+    public function default() {}
+}

--- a/tests/Core/Tokenizer/DefaultKeywordTest.php
+++ b/tests/Core/Tokenizer/DefaultKeywordTest.php
@@ -267,9 +267,36 @@ class DefaultKeywordTest extends AbstractMethodUnitTest
             'class-property-in-switch-case'                       => ['/* testClassPropertyInSwitchCase */'],
             'namespaced-constant-in-switch-case'                  => ['/* testNamespacedConstantInSwitchCase */'],
             'namespace-relative-constant-in-switch-case'          => ['/* testNamespaceRelativeConstantInSwitchCase */'],
+
+            'class-constant-declaration'                          => ['/* testClassConstant */'],
+            'class-method-declaration'                            => [
+                '/* testMethodDeclaration */',
+                'default',
+            ],
         ];
 
     }//end dataNotDefaultKeyword()
+
+
+    /**
+     * Test a specific edge case where a scope opener would be incorrectly set.
+     *
+     * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/3326
+     *
+     * @return void
+     */
+    public function testIssue3326()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $token      = $this->getTargetToken('/* testClassConstant */', [T_SEMICOLON]);
+        $tokenArray = $tokens[$token];
+
+        $this->assertArrayNotHasKey('scope_condition', $tokenArray, 'Scope condition is set');
+        $this->assertArrayNotHasKey('scope_opener', $tokenArray, 'Scope opener is set');
+        $this->assertArrayNotHasKey('scope_closer', $tokenArray, 'Scope closer is set');
+
+    }//end testIssue3326()
 
 
 }//end class


### PR DESCRIPTION
### Generic/MultipleStatementAlignment: add extra tests

.. safeguarding the tokenizer fix which should prevent the issue as reported in #3326.

### Tests: add extra tests for the default keyword tokenization

### Tokenizer/PHP: fix tokenization of the default keyword

As per: #3326 (comment)

> After `PHP::tokenize()`, the `DEFAULT` is still tokenized as `T_DEFAULT`. This causes the `Tokenizer::recurseScopeMap()` to assign it as the `scope_opener` to the `;` semi-colon at the end of the constant declaration, with the class close curly brace being set as the `scope_closer`.
> In the `PHP::processAdditional()` method, the `DEFAULT` is subsequently retokenized to `T_STRING` as it is preceded by a `const` keyword, but that is too late.
>
> The `scope_opener` being set on the semi-colon is what is causing the errors to be displayed for the above code sample.

The commit fixes this by:
1. Abstracting the list of `T_STRING` contexts out to a class property.
2. Using the list from the property in all places in the `Tokenizer\PHP` class where keyword tokens are (potentially) being re-tokenized to `T_STRING`, including in the `T_DEFAULT` tokenization code which was added to address the PHP 8.0 `match` expressions.
    Note: the issue was not introduced by the `match` related code, however, that code being there does make it relatively easy now to fix this particular case.

While this doesn't address #3336 yet, it is a step towards addressing it and will sort out one of the most common causes for bugs.

Fixes #3326 

Closes #3340 as superseded