### PR TITLE
PSR2/SwitchDeclaration: various bug fixes

### DIFF
--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -264,7 +264,7 @@ class SwitchDeclarationSniff implements Sniff
                 $scopeOpener = $tokens[$currentCloser]['scope_opener'];
                 $scopeCloser = $tokens[$currentCloser]['scope_closer'];
 
-                $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($scopeOpener - 1), $stackPtr, true);
+                $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($scopeOpener - 1), $stackPtr, true);
                 if ($prevToken === false) {
                     return false;
                 }
@@ -292,7 +292,7 @@ class SwitchDeclarationSniff implements Sniff
                         return false;
                     }
 
-                    $currentCloser = $phpcsFile->findPrevious(T_WHITESPACE, ($prevToken - 1), $stackPtr, true);
+                    $currentCloser = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), $stackPtr, true);
                     if ($tokens[$prevToken]['code'] === T_ELSE) {
                         $hasElseBlock = true;
                     }
@@ -309,7 +309,7 @@ class SwitchDeclarationSniff implements Sniff
 
                         $opener = $tokens[$nextCase]['scope_opener'];
 
-                        $nextCode = $phpcsFile->findNext(T_WHITESPACE, ($opener + 1), $endOfSwitch, true);
+                        $nextCode = $phpcsFile->findNext(Tokens::$emptyTokens, ($opener + 1), $endOfSwitch, true);
                         if ($tokens[$nextCode]['code'] === T_CASE || $tokens[$nextCode]['code'] === T_DEFAULT) {
                             // This case statement has no content, so skip it.
                             continue;

--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -343,15 +343,15 @@ class SwitchDeclarationSniff implements Sniff
             // We found the last statement of the CASE. Now we want to
             // check whether it is a terminating one.
             $terminators = [
-                T_RETURN,
-                T_BREAK,
-                T_CONTINUE,
-                T_THROW,
-                T_EXIT,
+                T_RETURN   => T_RETURN,
+                T_BREAK    => T_BREAK,
+                T_CONTINUE => T_CONTINUE,
+                T_THROW    => T_THROW,
+                T_EXIT     => T_EXIT,
             ];
 
             $terminator = $phpcsFile->findStartOfStatement(($lastToken - 1));
-            if (in_array($tokens[$terminator]['code'], $terminators, true) === true) {
+            if (isset($terminators[$tokens[$terminator]['code']]) === true) {
                 return $terminator;
             }
         }//end if

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -340,3 +340,41 @@ switch ($foo) {
     case 3:
         return 2;
 }
+
+// Issue 3352.
+switch ( $test ) {
+    case 2: // comment followed by empty line
+
+        break;
+
+    case 3: /* phpcs:ignore Stnd.Cat.SniffName -- Verify correct handling of ignore comments. */
+
+
+
+        break;
+
+    case 4: /** inline docblock */
+
+
+
+        break;
+
+    case 5: /* checking how it handles */ /* two trailing comments */
+
+        break;
+
+    case 6:
+       // Comment as first content of the body.
+
+        break;
+
+    case 7:
+        /* phpcs:ignore Stnd.Cat.SniffName -- Verify correct handling of ignore comments at start of body. */
+
+        break;
+
+    case 8:
+        /** inline docblock */
+
+        break;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -378,3 +378,29 @@ switch ( $test ) {
 
         break;
 }
+
+// Handle comments correctly.
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            doSomething();
+        }
+        // Comment
+        else {
+            return 1;
+        }
+    case 2:
+        return 2;
+}
+
+switch ($foo) {
+    case 1:
+        if ($bar > 0) /*comment*/ {
+            return doSomething();
+        }
+        else {
+            return 1;
+        }
+    case 2:
+        return 2;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -404,3 +404,183 @@ switch ($foo) {
     case 2:
         return 2;
 }
+
+// Issue #3297.
+// Okay - finally will always be executed, so all branches are covered by the `return` in finally.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } catch (Exception $e) {
+            doSomething();
+        } catch (AnotherException $e) {
+            doSomething();
+        } finally {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Okay - all - non-finally - branches have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (Exception $e) /*comment*/ {
+            return true;
+        }
+        // Comment
+        catch (AnotherException $e) {
+            return true;
+        } finally {
+            doSomething();
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Okay - finally will always be executed, so all branches are covered by the `return` in finally.
+// Non-standard structure order.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } catch (Exception $e) {
+            doSomething();
+        } finally {
+            return true;
+        } catch (AnotherException $e) {
+            doSomething();
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Okay - all - non-finally - branches have a terminating statement.
+// Non-standard structure order.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } finally {
+            doSomething();
+        } catch (MyException $e) {
+            return true;
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// All okay, no finally. Any exception still uncaught will terminate the case anyhow, so we're good.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (MyException $e) {
+            return true;
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// All okay, no catch
+switch ( $a ) {
+    case 1:
+        try {
+            return true;
+        } finally {
+            doSomething();
+        }
+    case 2:
+        $other = $code;
+        break;
+}
+
+// All okay, try-catch nested in if.
+switch ( $a ) {
+    case 1:
+        if ($a) {
+            try {
+                return true;
+            } catch (MyException $e) {
+                throw new Exception($e->getMessage());
+            }
+        } else {
+            return true;
+        }
+    case 2:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } finally {
+            doSomething();
+        }
+    case 2:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment. One of the catches does not have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (Exception $e) {
+            doSomething();
+        } catch (AnotherException $e) {
+            return true;
+        } finally {
+            doSomething();
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment. Try does not have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } finally {
+            doSomething();
+        } catch (Exception $e) {
+            return true;
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment. One of the catches does not have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (Exception $e) {
+            doSomething();
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -399,3 +399,183 @@ switch ($foo) {
     case 2:
         return 2;
 }
+
+// Issue #3297.
+// Okay - finally will always be executed, so all branches are covered by the `return` in finally.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } catch (Exception $e) {
+            doSomething();
+        } catch (AnotherException $e) {
+            doSomething();
+        } finally {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Okay - all - non-finally - branches have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (Exception $e) /*comment*/ {
+            return true;
+        }
+        // Comment
+        catch (AnotherException $e) {
+            return true;
+        } finally {
+            doSomething();
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Okay - finally will always be executed, so all branches are covered by the `return` in finally.
+// Non-standard structure order.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } catch (Exception $e) {
+            doSomething();
+        } finally {
+            return true;
+        } catch (AnotherException $e) {
+            doSomething();
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Okay - all - non-finally - branches have a terminating statement.
+// Non-standard structure order.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } finally {
+            doSomething();
+        } catch (MyException $e) {
+            return true;
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// All okay, no finally. Any exception still uncaught will terminate the case anyhow, so we're good.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (MyException $e) {
+            return true;
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// All okay, no catch
+switch ( $a ) {
+    case 1:
+        try {
+            return true;
+        } finally {
+            doSomething();
+        }
+    case 2:
+        $other = $code;
+        break;
+}
+
+// All okay, try-catch nested in if.
+switch ( $a ) {
+    case 1:
+        if ($a) {
+            try {
+                return true;
+            } catch (MyException $e) {
+                throw new Exception($e->getMessage());
+            }
+        } else {
+            return true;
+        }
+    case 2:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } finally {
+            doSomething();
+        }
+    case 2:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment. One of the catches does not have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (Exception $e) {
+            doSomething();
+        } catch (AnotherException $e) {
+            return true;
+        } finally {
+            doSomething();
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment. Try does not have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            doSomething();
+        } finally {
+            doSomething();
+        } catch (Exception $e) {
+            return true;
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}
+
+// Missing fall-through comment. One of the catches does not have a terminating statement.
+switch ( $a ) {
+    case 1:
+        try {
+            return false;
+        } catch (Exception $e) {
+            doSomething();
+        } catch (AnotherException $e) {
+            return true;
+        }
+    default:
+        $other = $code;
+        break;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -373,3 +373,29 @@ switch ( $test ) {
 
         break;
 }
+
+// Handle comments correctly.
+switch ($foo) {
+    case 1:
+        if ($bar > 0) {
+            doSomething();
+        }
+        // Comment
+        else {
+            return 1;
+        }
+    case 2:
+        return 2;
+}
+
+switch ($foo) {
+    case 1:
+        if ($bar > 0) /*comment*/ {
+            return doSomething();
+        }
+        else {
+            return 1;
+        }
+    case 2:
+        return 2;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -343,3 +343,33 @@ switch ($foo) {
     case 3:
         return 2;
 }
+
+// Issue 3352.
+switch ( $test ) {
+    case 2: // comment followed by empty line
+        break;
+
+    case 3: /* phpcs:ignore Stnd.Cat.SniffName -- Verify correct handling of ignore comments. */
+        break;
+
+    case 4: /** inline docblock */
+        break;
+
+    case 5: /* checking how it handles */ /* two trailing comments */
+        break;
+
+    case 6:
+       // Comment as first content of the body.
+
+        break;
+
+    case 7:
+        /* phpcs:ignore Stnd.Cat.SniffName -- Verify correct handling of ignore comments at start of body. */
+
+        break;
+
+    case 8:
+        /** inline docblock */
+
+        break;
+}

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -49,6 +49,10 @@ class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
             260 => 1,
             300 => 1,
             311 => 1,
+            346 => 1,
+            350 => 1,
+            356 => 1,
+            362 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -54,6 +54,10 @@ class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
             356 => 1,
             362 => 1,
             384 => 1,
+            528 => 1,
+            541 => 1,
+            558 => 1,
+            575 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.php
@@ -53,6 +53,7 @@ class SwitchDeclarationUnitTest extends AbstractSniffUnitTest
             350 => 1,
             356 => 1,
             362 => 1,
+            384 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
### PSR2/SwitchDeclaration: bug fix - don't remove trailing comments

As reported in #3352, the `PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE` fixer could inadvertently remove trailing comments.

This commit improves on the fix which was put in place in response to #683, by making the detection of what should be considered the start of the body more precise:
* Any amount of trailing comments on the same line as the `case` will be ignored.
* Any type of comment will be taken into consideration, not just PHPCS annotations and `T_COMMENT` tokens.
* Comments _not_ on the same line as the `case` and non-empty tokens on the same line as the `case` will both be considered as the "start of the body".

As for the fixer. The "body starts on same line" fixer was already okay. The "empty lines between case and body" fixer, however, will now ignore anything on the same line as the `case`, which prevents us having to account for comments which already include a new line.

Includes unit tests.

Fixes #3352


### PSR2/SwitchDeclaration: bug fix - improve handling of comments

Comments in certain places in the code flow would throw the `findNestedTerminator()` method used for determining the `TerminatingComment` error off.

Fixed now.

Includes unit tests.
Without this fix, the first test would not throw an error (false negative), while the second would (false positive).

### PSR2/SwitchDeclaration: minor efficiency tweak

### PSR2/SwitchDeclaration: bug fix - handle try/catch/finally correctly

Add code to handle `try-catch-finally` statements correctly when determining whether a `case` needs a terminating comment.

As per #3297 (comment):

> * If there is a `finally` statement and the body of that contains a "terminating statement" (`return`, `break` etc), we don't need to check the body of the `try` or any of the `catch` statements as, no matter what, all execution branches are then covered by that one terminating statement.
> * If there is **_no_** `finally` or if there is, but it does not contain a terminating statement, then all `try` and `catch` structures should each contain a terminating statement in the body.

Includes plenty of unit tests.

Fixes #3297

