### PR TITLE
Normalise License file

### DIFF
--- a/licence.txt
+++ b/licence.txt
@@ -8,7 +8,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the license holder nor the
+    * Neither the name of the copyright holder nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 

--- a/licence.txt
+++ b/licence.txt
@@ -8,7 +8,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of Squiz Pty Ltd nor the
+    * Neither the name of the license holder nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 


### PR DESCRIPTION
As the BSD-3 licence has been adjusted github doesn't notice this is the BSD-3 licence, after these changes github will pick up the correct licence