### PR TITLE
Generic/OpeningFunctionBraceBsdAllman: bug fix - prevent removing return types

### DIFF
--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc
@@ -236,3 +236,28 @@ function myFunction($a, $lot, $of, $params)
     : array /* comment */ {
     return null;
 }
+
+class Issue3357
+{
+    public function extraLine(string: $a): void
+
+    {
+        // code here.
+    }
+}
+
+function issue3357WithoutIndent(string: $a): void
+
+
+{
+    // code here.
+}
+
+class Issue3357WithComment
+{
+    public function extraLine(string: $a): void
+    // Comment.
+    {
+        // code here.
+    }
+}

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc.fixed
@@ -256,3 +256,25 @@ function myFunction($a, $lot, $of, $params)
 {
     return null;
 }
+
+class Issue3357
+{
+    public function extraLine(string: $a): void
+    {
+        // code here.
+    }
+}
+
+function issue3357WithoutIndent(string: $a): void
+{
+    // code here.
+}
+
+class Issue3357WithComment
+{
+    public function extraLine(string: $a): void
+    // Comment.
+    {
+        // code here.
+    }
+}

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
@@ -58,6 +58,9 @@ class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffUnitTest
             220 => 1,
             231 => 1,
             236 => 1,
+            244 => 1,
+            252 => 1,
+            260 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
As reported in #3357, the `Generic.Functions.OpeningFunctionBraceBsdAllman` sniff would remove return types (and comments) when fixing code where blank lines existed between the end of the function declaration and the open brace.

This commit fixes that bug.

In the case of comments, the `BraceSpacing` error will no longer auto-fix as a dev should decide where the comment should go and/or whether it should be removed.

Includes unit tests.

Fixes #3357

Previously #1931, #1938