### PR TITLE
Generic/ScopeIndent: minor bug fix (undefined array index)

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -616,11 +616,11 @@ class ScopeIndentSniff implements Sniff
 
             // Scope closers reset the required indent to the same level as the opening condition.
             if (($checkToken !== null
-                && isset($openScopes[$checkToken]) === true
+                && (isset($openScopes[$checkToken]) === true
                 || (isset($tokens[$checkToken]['scope_condition']) === true
                 && isset($tokens[$checkToken]['scope_closer']) === true
                 && $tokens[$checkToken]['scope_closer'] === $checkToken
-                && $tokens[$checkToken]['line'] !== $tokens[$tokens[$checkToken]['scope_opener']]['line']))
+                && $tokens[$checkToken]['line'] !== $tokens[$tokens[$checkToken]['scope_opener']]['line'])))
                 || ($checkToken === null
                 && isset($openScopes[$i]) === true)
             ) {


### PR DESCRIPTION
While looking at issue #3362 in an attempt to debug it, @BinaryKitten and me came across a `An error occurred during processing; checking has been aborted. The error message was: Undefined array key "" in /src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php on line 646 (Internal.Exception)` error notice.

While this will probably only occur in exceptional circumstances, it was caused by an operator precedence issue in the scope closer check condition.

Adding the extra parentheses fixes the operator precedence snafu and prevents the above error notice.

Note: this does not fix #3362, but still, is one less bug to worry about ;-)