### PR TITLE
Replace hot Tokenizer loop with a mathematical expression

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -643,7 +643,7 @@ abstract class Tokenizer
 
                 // Move the pointer to the next tab stop.
                 $length      = $tabWidth - ($currColumn + $tabWidth - 1) % $tabWidth;
-	            $currColumn += $length;
+                $currColumn += $length;
                 $newContent .= $prefix.str_repeat($padding, ($length - 1));
             }//end foreach
         }//end if

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -642,7 +642,7 @@ abstract class Tokenizer
                 $tabNum++;
 
                 // Move the pointer to the next tab stop.
-                $pad         = $tabWidth - ($currColumn + $tabWidth - 1) % $tabWidth;
+                $pad         = ($tabWidth - ($currColumn + $tabWidth - 1) % $tabWidth);
                 $currColumn += $pad;
                 $length     += $pad;
                 $newContent .= $prefix.str_repeat($padding, ($pad - 1));

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -642,9 +642,10 @@ abstract class Tokenizer
                 $tabNum++;
 
                 // Move the pointer to the next tab stop.
-                $length      = $tabWidth - ($currColumn + $tabWidth - 1) % $tabWidth;
-                $currColumn += $length;
-                $newContent .= $prefix.str_repeat($padding, ($length - 1));
+                $pad         = $tabWidth - ($currColumn + $tabWidth - 1) % $tabWidth;
+                $currColumn += $pad;
+                $length     += $pad;
+                $newContent .= $prefix.str_repeat($padding, ($pad - 1));
             }//end foreach
         }//end if
 

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -642,21 +642,9 @@ abstract class Tokenizer
                 $tabNum++;
 
                 // Move the pointer to the next tab stop.
-                if (($currColumn % $tabWidth) === 0) {
-                    // This is the first tab, and we are already at a
-                    // tab stop, so this tab counts as a single space.
-                    $currColumn++;
-                } else {
-                    $currColumn++;
-                    while (($currColumn % $tabWidth) !== 0) {
-                        $currColumn++;
-                    }
-
-                    $currColumn++;
-                }
-
-                $length     += ($currColumn - $lastCurrColumn);
-                $newContent .= $prefix.str_repeat($padding, ($currColumn - $lastCurrColumn - 1));
+                $length      = $tabWidth - ($currColumn + $tabWidth - 1) % $tabWidth;
+	            $currColumn += $length;
+                $newContent .= $prefix.str_repeat($padding, ($length - 1));
             }//end foreach
         }//end if
 

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -638,7 +638,6 @@ abstract class Tokenizer
                 }
 
                 // Process the tab that comes after the content.
-                $lastCurrColumn = $currColumn;
                 $tabNum++;
 
                 // Move the pointer to the next tab stop.


### PR DESCRIPTION
This piece of code is very hot, executed thousands, possibly millions of times.

I found this when I benchmarked our custom sniffs. The replaceTabsInToken() method is consistently reported as one of the absolute hottest ones. I looked at the method and was wondering why this particular piece is a loop when it can be a mathematical expression. According to my micro-benchmark (only measuring the changed piece) it's about twice as fast now. This will probably not have much of an effect in a real-world scenario. Still I find it worth it.