### PR TITLE
Allow the filter to return LocalFile objects to FileList

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -29,9 +29,9 @@ class File
     /**
      * The content of the file.
      *
-     * @var string
+     * @var string|null
      */
-    protected $content = '';
+    protected $content = null;
 
     /**
      * The config data for the run.
@@ -552,12 +552,18 @@ class File
      * Tokenizes the file and prepares it for the test run.
      *
      * @return void
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If no content is set.
      */
     public function parse()
     {
         if (empty($this->tokens) === false) {
             // File has already been parsed.
             return;
+        }
+
+        if ($this->content === null) {
+            // No content has been set.
+            throw new RuntimeException('No content has been set');
         }
 
         try {

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -84,7 +84,12 @@ class FileList implements \Iterator, \Countable
                 $iterator = new \RecursiveIteratorIterator($filter);
 
                 foreach ($iterator as $file) {
-                    $this->files[$file->getPathname()] = null;
+                    if ($file instanceof LocalFile) {
+                        $this->files[$file->getFilename()] = $file;
+                    } else {
+                        $this->files[$file->getPathname()] = null;
+                    }
+
                     $this->numFiles++;
                 }
             } else {
@@ -125,7 +130,12 @@ class FileList implements \Iterator, \Countable
         $iterator = new \RecursiveIteratorIterator($filter);
 
         foreach ($iterator as $path) {
-            $this->files[$path] = $file;
+            if ($path instanceof LocalFile) {
+                $this->files[$path->getFilename()] = ($file ?? $path);
+            } else {
+                $this->files[$path] = null;
+            }
+
             $this->numFiles++;
         }
 

--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -19,7 +19,7 @@ class LocalFile extends File
 
 
     /**
-     * Creates a LocalFile object and sets the content.
+     * Creates a LocalFile object. Content is not set, call reloadContent() before use.
      *
      * @param string                   $path    The absolute path to the file.
      * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset used for the run.
@@ -57,8 +57,6 @@ class LocalFile extends File
                 }
             }
         }
-
-        $this->reloadContent();
 
         parent::__construct($this->path, $ruleset, $config);
 

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -9,9 +9,11 @@
 
 namespace PHP_CodeSniffer\Filters;
 
+use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Util;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Config;
+use SplFileInfo;
 
 class Filter extends \RecursiveFilterIterator
 {
@@ -60,6 +62,15 @@ class Filter extends \RecursiveFilterIterator
      */
     protected $acceptedPaths = [];
 
+    /**
+     * Whether to generate LocalFile objects instead of string|SplFileInfo.
+     *
+     * This is intended to be set in subclasses that want that behavior.
+     *
+     * @var boolean
+     */
+    protected $produceLocalFileObjects = false;
+
 
     /**
      * Constructs a filter.
@@ -91,7 +102,7 @@ class Filter extends \RecursiveFilterIterator
      */
     public function accept()
     {
-        $filePath = $this->current();
+        $filePath = $this->getInnerIterator()->current();
         $realPath = Util\Common::realpath($filePath);
 
         if ($realPath !== false) {
@@ -103,7 +114,6 @@ class Filter extends \RecursiveFilterIterator
             }
         }
 
-        $filePath = $this->current();
         if (is_dir($filePath) === true) {
             if ($this->config->local === true) {
                 return false;
@@ -123,6 +133,23 @@ class Filter extends \RecursiveFilterIterator
 
 
     /**
+     * Map the input string or SplFileInfo into a LocalFile, if desired.
+     *
+     * @return string|SplFileInfo|LocalFile
+     */
+    public function current()
+    {
+        if ($this->produceLocalFileObjects === false) {
+            return parent::current();
+        }
+
+        $filePath = (string) parent::current();
+        return new LocalFile($filePath, $this->ruleset, $this->config);
+
+    }//end current()
+
+
+    /**
      * Returns an iterator for the current entry.
      *
      * Ensures that the ignore patterns are preserved so they don't have
@@ -134,7 +161,7 @@ class Filter extends \RecursiveFilterIterator
     {
         $filterClass = get_called_class();
         $children    = new $filterClass(
-            new \RecursiveDirectoryIterator($this->current(), (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)),
+            new \RecursiveDirectoryIterator($this->getInnerIterator()->current(), (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)),
             $this->basedir,
             $this->config,
             $this->ruleset
@@ -154,7 +181,7 @@ class Filter extends \RecursiveFilterIterator
      *
      * Checks both file extension filters and path ignore filters.
      *
-     * @param string $path The path to the file being checked.
+     * @param string|SplFileInfo $path The path to the file being checked.
      *
      * @return bool
      */
@@ -191,7 +218,7 @@ class Filter extends \RecursiveFilterIterator
     /**
      * Checks filtering rules to see if a path should be ignored.
      *
-     * @param string $path The path to the file or directory being checked.
+     * @param string|SplFileInfo $path The path to the file or directory being checked.
      *
      * @return bool
      */

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -628,6 +628,7 @@ class Runner
         }
 
         try {
+            $file->reloadContent();
             $file->process();
 
             if (PHP_CODESNIFFER_VERBOSITY > 0) {

--- a/tests/Core/Filters/Filter/AcceptTest.php
+++ b/tests/Core/Filters/Filter/AcceptTest.php
@@ -11,6 +11,7 @@
 namespace PHP_CodeSniffer\Tests\Core\Filters\Filter;
 
 use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Filters\Filter;
 use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\TestCase;
@@ -93,6 +94,39 @@ class AcceptTest extends TestCase
         $this->assertEquals($expectedOutput, $files);
 
     }//end testExcludePatterns()
+
+
+    /**
+     * Test filtering a file list for excluded paths, when producing LocalFile objects.
+     *
+     * @param array $inputPaths     List of file paths to be filtered.
+     * @param array $expectedOutput Expected filtering result.
+     *
+     * @dataProvider dataExcludePatterns
+     *
+     * @return void
+     */
+    public function testExcludePatternsProducingLocalFileObjects($inputPaths, $expectedOutput)
+    {
+        $fakeDI   = new \RecursiveArrayIterator($inputPaths);
+        $filter   = new Filter($fakeDI, '/', self::$config, self::$ruleset);
+        $iterator = new \RecursiveIteratorIterator($filter);
+        $files    = [];
+
+        // Set the filter object to produce LocalFile objects.
+        $rc = new \ReflectionClass($filter);
+        $rp = $rc->getProperty('produceLocalFileObjects');
+        $rp->setAccessible(true);
+        $rp->setValue($filter, true);
+
+        foreach ($iterator as $file) {
+            $this->assertInstanceOf(LocalFile::class, $file);
+            $files[] = $file->getFilename();
+        }
+
+        $this->assertEquals($expectedOutput, $files);
+
+    }//end testExcludePatternsProducingLocalFileObjects()
 
 
     /**

--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -170,6 +170,7 @@ abstract class AbstractSniffUnitTest extends TestCase
             try {
                 $this->setCliValues($filename, $config);
                 $phpcsFile = new LocalFile($testFile, $ruleset, $config);
+                $phpcsFile->reloadContent();
                 $phpcsFile->process();
             } catch (RuntimeException $e) {
                 $this->fail('An unexpected exception has been caught: '.$e->getMessage());


### PR DESCRIPTION
This gets us most of the way to fixing #2551. Now it's just a matter of writing a filter that updates the Config and/or Ruleset as appropriate while processing the directory tree.

I've written such a filter in [anomiex/phpcs-filter-draft](https://github.com/anomiex/phpcs-filter-draft/tree/master/phpcs-filter), which you can look at if you want to see how we intend to make use of this if this PR is accepted. Other people could do something similar but make other decisions, such as the looking for `composer.json` as suggested in #2551.

Since this change to `Filter::current()` may break expectations of existing filters, a filter must opt in to this change by overriding the protected `$this->produceLocalFileObjects` to true.