### PR TITLE
GH Actions: set error reporting to E_ALL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,15 +51,14 @@ jobs:
       - name: Setup ini config
         id: set_ini
         run: |
-          # On stable PHPCS versions, allow for PHP deprecation notices.
-          # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-          # Also set the "short_open_tag" ini to make sure specific conditions are tested.
+          # Set the "short_open_tag" ini to make sure specific conditions are tested.
+          # Also turn on error_reporting to ensure all notices are shown.
           if [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '5.5' ]]; then
-            echo '::set-output name=PHP_INI::phar.readonly=Off, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On'
+            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=E_ALL, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On'
           elif [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '7.0' ]]; then
-            echo '::set-output name=PHP_INI::phar.readonly=Off, date.timezone=Australia/Sydney, short_open_tag=On'
+            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=E_ALL, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On'
           else
-            echo '::set-output name=PHP_INI::phar.readonly=Off'
+            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=E_ALL, display_errors=On'
           fi
 
       - name: Install PHP


### PR DESCRIPTION
Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

Includes minor fix to the documentation of that part of the script.