### PR TITLE
PHP 8.1: Generic/ConstructorName: fix deprecation notices

### DIFF
--- a/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
+++ b/src/Standards/Generic/Sniffs/NamingConventions/ConstructorNameSniff.php
@@ -66,7 +66,12 @@ class ConstructorNameSniff extends AbstractScopeSniff
             return;
         }
 
-        $className = strtolower($phpcsFile->getDeclarationName($currScope));
+        $className = $phpcsFile->getDeclarationName($currScope);
+        if (empty($className) === false) {
+            // Not an anonymous class.
+            $className = strtolower($className);
+        }
+
         if ($className !== $this->currentClass) {
             $this->loadFunctionNamesInScope($phpcsFile, $currScope);
             $this->currentClass = $className;


### PR DESCRIPTION
On PHP 8.1, passing `null` to `strtolower()` generates a `strtolower(): Passing null to parameter #1 ($string) of type string is deprecated` notice.

The `File::getDeclarationName()` will return `null` for anonymous classes, so we need an extra safeguard here.

This fix is covered by the existing unit tests and was exposed when running the tests on PHP 8.1 with `error_reporting` set to `E_ALL`. (see the GH actions script output for #3380)