### PR TITLE
PHP 8.0 | Squiz/InlineComment: prevent false positives with attributes

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -59,12 +59,16 @@ class InlineCommentSniff implements Sniff
         // We are only interested in inline doc block comments, which are
         // not allowed.
         if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
-            $nextToken = $phpcsFile->findNext(
-                Tokens::$emptyTokens,
-                ($stackPtr + 1),
-                null,
-                true
-            );
+            $nextToken = $stackPtr;
+            do {
+                $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextToken + 1), null, true);
+                if ($tokens[$nextToken]['code'] === T_ATTRIBUTE) {
+                    $nextToken = $tokens[$nextToken]['attribute_closer'];
+                    continue;
+                }
+
+                break;
+            } while (true);
 
             $ignore = [
                 T_CLASS,

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
@@ -149,6 +149,22 @@ if ($foo) {
 // another comment here.
 $foo++;
 
+/**
+ * Comment should be ignored, even though there is an attribute between the docblock and the class declaration.
+ */
+
+#[AttributeA]
+
+final class MyClass
+{
+    /**
+     * Comment should be ignored, even though there is an attribute between the docblock and the function declaration
+     */
+    #[AttributeA]
+    #[AttributeB]
+    final public function test() {}
+}
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
@@ -142,6 +142,22 @@ if ($foo) {
 // another comment here.
 $foo++;
 
+/**
+ * Comment should be ignored, even though there is an attribute between the docblock and the class declaration.
+ */
+
+#[AttributeA]
+
+final class MyClass
+{
+    /**
+     * Comment should be ignored, even though there is an attribute between the docblock and the function declaration
+     */
+    #[AttributeA]
+    #[AttributeB]
+    final public function test() {}
+}
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace


### PR DESCRIPTION
PHP 8.0+ attributes can be placed between a docblock and the function/class declaration it applies to.

The `Squiz.Commenting.InlineComment` sniff did not yet take this into account when determining whether a comment was a docblock or an single line comment incorrectly using the docblock syntax.

This would result in false positive `Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead` errors.

Fixed now.