### PR TITLE
PHP 8.0 | Squiz/BlockComment: prevent false positives with attributes

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -69,8 +69,18 @@ class BlockCommentSniff implements Sniff
         // If this is a function/class/interface doc block comment, skip it.
         // We are only interested in inline doc block comments.
         if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
-            $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-            $ignore    = [
+            $nextToken = $stackPtr;
+            do {
+                $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextToken + 1), null, true);
+                if ($tokens[$nextToken]['code'] === T_ATTRIBUTE) {
+                    $nextToken = $tokens[$nextToken]['attribute_closer'];
+                    continue;
+                }
+
+                break;
+            } while (true);
+
+            $ignore = [
                 T_CLASS     => true,
                 T_INTERFACE => true,
                 T_TRAIT     => true,

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -272,3 +272,19 @@ $contentToEcho
  * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
  */
 $contentToEcho
+
+/**
+ * Comment should be ignored, even though there is an attribute between the docblock and the class declaration.
+ */
+
+#[AttributeA]
+
+final class MyClass
+{
+    /**
+     * Comment should be ignored, even though there is an attribute between the docblock and the function declaration
+     */
+    #[AttributeA]
+    #[AttributeB]
+    final public function test() {}
+}

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -274,3 +274,19 @@ $contentToEcho
  * No blank line allowed above the comment if it's the first non-empty token after a PHP open tag.
  */
 $contentToEcho
+
+/**
+ * Comment should be ignored, even though there is an attribute between the docblock and the class declaration.
+ */
+
+#[AttributeA]
+
+final class MyClass
+{
+    /**
+     * Comment should be ignored, even though there is an attribute between the docblock and the function declaration
+     */
+    #[AttributeA]
+    #[AttributeB]
+    final public function test() {}
+}


### PR DESCRIPTION
PHP 8.0+ attributes can be placed between a docblock and the function/class declaration it applies to.

The `Squiz.Commenting.BlockComment` sniff did not yet take this into account when determining whether a comment was a docblock or an block comment incorrectly using the docblock syntax.

This would result in false positive `Block comments must be started with /*` errors.

Fixed now.