### PR TITLE
PHP 8.0 | PEAR/VariableComment: prevent false positives with attributes

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -30,18 +30,32 @@ class VariableCommentSniff extends AbstractVariableSniff
     {
         $tokens = $phpcsFile->getTokens();
         $ignore = [
-            T_PUBLIC,
-            T_PRIVATE,
-            T_PROTECTED,
-            T_VAR,
-            T_STATIC,
-            T_WHITESPACE,
-            T_STRING,
-            T_NS_SEPARATOR,
-            T_NULLABLE,
+            T_PUBLIC       => T_PUBLIC,
+            T_PRIVATE      => T_PRIVATE,
+            T_PROTECTED    => T_PROTECTED,
+            T_VAR          => T_VAR,
+            T_STATIC       => T_STATIC,
+            T_WHITESPACE   => T_WHITESPACE,
+            T_STRING       => T_STRING,
+            T_NS_SEPARATOR => T_NS_SEPARATOR,
+            T_NULLABLE     => T_NULLABLE,
         ];
 
-        $commentEnd = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
+        for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
+            if (isset($ignore[$tokens[$commentEnd]['code']]) === true) {
+                continue;
+            }
+
+            if ($tokens[$commentEnd]['code'] === T_ATTRIBUTE_END
+                && isset($tokens[$commentEnd]['attribute_opener']) === true
+            ) {
+                $commentEnd = $tokens[$commentEnd]['attribute_opener'];
+                continue;
+            }
+
+            break;
+        }
+
         if ($commentEnd === false
             || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
             && $tokens[$commentEnd]['code'] !== T_COMMENT)

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -363,3 +363,23 @@ class Foo
 
      var int $noComment = 1;
  }
+
+class HasAttributes
+{
+    /**
+     * Short description of the member variable.
+     *
+     * @var array
+     */
+    #[ORM\Id]#[ORM\Column("integer")]
+    private $id;
+
+    /**
+     * Short description of the member variable.
+     *
+     * @var array
+     */
+    #[ORM\GeneratedValue]
+    #[ORM\Column(ORM\Column::T_INTEGER)]
+    protected $height;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -363,3 +363,23 @@ class Foo
 
      var int $noComment = 1;
  }
+
+class HasAttributes
+{
+    /**
+     * Short description of the member variable.
+     *
+     * @var array
+     */
+    #[ORM\Id]#[ORM\Column("integer")]
+    private $id;
+
+    /**
+     * Short description of the member variable.
+     *
+     * @var array
+     */
+    #[ORM\GeneratedValue]
+    #[ORM\Column(ORM\Column::T_INTEGER)]
+    protected $height;
+}


### PR DESCRIPTION
PHP 8.0+ attributes can be placed between a docblock and the property declaration it applies to.

The `Squiz.Commenting.VariableComment` sniff did not yet take this into account.

This would result in a false positive `Missing member variable doc comment` error.

Fixed now.