### PR TITLE
Generic/One*PerFile sniffs: efficiency tweak

### DIFF
--- a/src/Standards/Generic/Sniffs/Files/OneClassPerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneClassPerFileSniff.php
@@ -39,7 +39,13 @@ class OneClassPerFileSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $nextClass = $phpcsFile->findNext($this->register(), ($stackPtr + 1));
+        $tokens = $phpcsFile->getTokens();
+        $start  = ($stackPtr + 1);
+        if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+            $start = ($tokens[$stackPtr]['scope_closer'] + 1);
+        }
+
+        $nextClass = $phpcsFile->findNext($this->register(), $start);
         if ($nextClass !== false) {
             $error = 'Only one class is allowed in a file';
             $phpcsFile->addError($error, $nextClass, 'MultipleFound');

--- a/src/Standards/Generic/Sniffs/Files/OneInterfacePerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneInterfacePerFileSniff.php
@@ -39,7 +39,13 @@ class OneInterfacePerFileSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $nextInterface = $phpcsFile->findNext($this->register(), ($stackPtr + 1));
+        $tokens = $phpcsFile->getTokens();
+        $start  = ($stackPtr + 1);
+        if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+            $start = ($tokens[$stackPtr]['scope_closer'] + 1);
+        }
+
+        $nextInterface = $phpcsFile->findNext($this->register(), $start);
         if ($nextInterface !== false) {
             $error = 'Only one interface is allowed in a file';
             $phpcsFile->addError($error, $nextInterface, 'MultipleFound');

--- a/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
@@ -43,7 +43,13 @@ class OneObjectStructurePerFileSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $nextClass = $phpcsFile->findNext($this->register(), ($stackPtr + 1));
+        $tokens = $phpcsFile->getTokens();
+        $start  = ($stackPtr + 1);
+        if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+            $start = ($tokens[$stackPtr]['scope_closer'] + 1);
+        }
+
+        $nextClass = $phpcsFile->findNext($this->register(), $start);
         if ($nextClass !== false) {
             $error = 'Only one object structure is allowed in a file';
             $phpcsFile->addError($error, $nextClass, 'MultipleFound');

--- a/src/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneTraitPerFileSniff.php
@@ -39,7 +39,13 @@ class OneTraitPerFileSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $nextClass = $phpcsFile->findNext($this->register(), ($stackPtr + 1));
+        $tokens = $phpcsFile->getTokens();
+        $start  = ($stackPtr + 1);
+        if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+            $start = ($tokens[$stackPtr]['scope_closer'] + 1);
+        }
+
+        $nextClass = $phpcsFile->findNext($this->register(), $start);
         if ($nextClass !== false) {
             $error = 'Only one trait is allowed in a file';
             $phpcsFile->addError($error, $nextClass, 'MultipleFound');


### PR DESCRIPTION
Each of these sniffs would start walking the rest of the file from the token next to the OO keyword to the end of the file in search of the next (class/interface/trait) keyword.

As nested OO structure declarations (with the exception of anonymous classes, but those are outside the realm of these sniffs) are not supported in PHP, we can make these sniffs a lot faster by starting the search _after_ the scope closer for the current OO structure.