### PR TITLE
Fix autoload issue

### DIFF
--- a/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php
@@ -10,7 +10,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
-class InterfaceSuffixNameUnitTest extends AbstractSniffUnitTest
+class InterfaceNameSuffixUnitTest extends AbstractSniffUnitTest
 {
 
 


### PR DESCRIPTION
WIthout this fix, composer warning is appears...

```bash
Generating optimized autoload files
Class PHP_CodeSniffer\Standards\Generic\Tests\NamingConventions\InterfaceSuffixNameUnitTest located in ./vendor/squizlabs/php_codesniffer/src/Standards/Generic/Tests/NamingConventions/InterfaceNameSuffixUnitTest.php does not comply with psr-4 autoloading standard. Skipping.
```

```bash
[root@b1d0aac4f4d2 /var/www]$ composer diagnose
Checking composer.json: OK
Checking platform settings: OK
Checking git settings: OK
Checking http connectivity to packagist: OK
Checking https connectivity to packagist: OK
Checking github.com rate limit: OK
Checking disk free space: OK
Checking pubkeys:
Tags Public Key Fingerprint: 57815BA2 7E54DC31 7ECC7CC5 573090D0  87719BA6 8F3BB723 4E5D42D0 84A14642
Dev Public Key Fingerprint: 4AC45767 E5EC2265 2F0C1167 CBBB8A2B  0C708369 153E328C AD90147D AFE50952
OK
Checking composer version: OK
Composer version: 2.1.5
PHP version: 7.4.20
PHP binary path: /usr/local/bin/php
OpenSSL version: OpenSSL 1.1.1k  25 Mar 2021
cURL version: 7.77.0 libz 1.2.11 ssl OpenSSL/1.1.1k
zip: extension not loaded, unzip present, 7-Zip not available
```