### PR TITLE
Modification so that the file path is read

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -962,7 +962,13 @@ class Config
                 if ($this->stdinPath === false) {
                     $this->stdinPath = trim(substr($arg, 11));
                 }
-
+                /**
+                * eXtreme Go Horse (XGH)
+                *
+                * Modification so that the file path is read and the error does not appear:
+                * ERROR: You must supply at least one file or directory to process.
+                */
+                $this->processFilePath($this->stdinPath);
                 self::$overriddenDefaults['stdinPath'] = true;
             } else if (PHP_CODESNIFFER_CBF === false && substr($arg, 0, 12) === 'report-file=') {
                 if (isset(self::$overriddenDefaults['reportFile']) === true) {


### PR DESCRIPTION
This modification was the simplest way I found to get php_codesniffer to work on my computer. I had a problem where the call to the file was being made with
--stdin-path=

but the correct should be this way:
C:\user\my-user\vendor\bin\phpcs.bat --report=json -q --encoding=UTF-8 --standard=PSR1 --error-severity=5 --warning-severity=5 C :\xampp\htdocs\file.php

Since I couldn't find the place to modify this argument, I found an XGH way to work.