### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,29 +20,20 @@ jobs:
       # Keys:
       # - custom_ini: Whether to run with specific custom ini settings to hit very specific
       #   code conditions.
-      # - experimental: Whether the build is "allowed to fail".
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         custom_ini: [false]
-        experimental: [false]
 
         include:
           # Builds running the basic tests with different PHP ini settings.
           - php: '5.5'
             custom_ini: true
-            experimental: false
           - php: '7.0'
             custom_ini: true
-            experimental: false
-
-          # Nightly.
-          - php: '8.1'
-            custom_ini: false
-            experimental: true
 
     name: "PHP: ${{ matrix.php }} ${{ matrix.custom_ini && ' with custom ini settings' || '' }}"
 
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.php == '8.1' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,11 @@ jobs:
           # Set the "short_open_tag" ini to make sure specific conditions are tested.
           # Also turn on error_reporting to ensure all notices are shown.
           if [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '5.5' ]]; then
-            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=E_ALL, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On'
+            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On'
           elif [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '7.0' ]]; then
-            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=E_ALL, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On'
+            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On'
           else
-            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,12 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.0 }}
+        if: ${{ matrix.php < '8.0' }}
         uses: "ramsey/composer-install@v1"
 
       # For PHP 8.0+, we need to install with ignore platform reqs as PHPUnit 7 is still used.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.0 }}
+        if: ${{ matrix.php >= '8.0' }}
         uses: "ramsey/composer-install@v1"
         with:
           composer-options: --ignore-platform-reqs
@@ -79,27 +79,27 @@ jobs:
         run: php bin/phpcs --config-set php_path php
 
       - name: 'PHPUnit: run the tests'
-        if: ${{ matrix.php != 8.1 }}
+        if: ${{ matrix.php != '8.1' }}
         run: vendor/bin/phpunit tests/AllTests.php
 
       # We need to ignore the config file so that PHPUnit doesn't try to read it.
       # The config file causes an error on PHP 8.1+ with PHPunit 7, but it's not needed here anyway
       # as we can pass all required settings in the phpunit command.
       - name: 'PHPUnit: run the tests on PHP nightly'
-        if: ${{ matrix.php == 8.1 }}
+        if: ${{ matrix.php == '8.1' }}
         run: vendor/bin/phpunit tests/AllTests.php --no-configuration --bootstrap=tests/bootstrap.php --dont-report-useless-tests
 
       - name: 'PHPCS: check code style without cache, no parallel'
-        if: ${{ matrix.custom_ini == false && matrix.php != 7.4 }}
+        if: ${{ matrix.custom_ini == false && matrix.php != '7.4' }}
         run: php bin/phpcs --no-cache --parallel=1
 
       - name: 'PHPCS: check code style to show results in PR'
-        if: ${{ matrix.custom_ini == false && matrix.php == 7.4 }}
+        if: ${{ matrix.custom_ini == false && matrix.php == '7.4' }}
         continue-on-error: true
         run: php bin/phpcs --no-cache --parallel=1 --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
-        if: ${{ matrix.custom_ini == false && matrix.php == 7.4 }}
+        if: ${{ matrix.custom_ini == false && matrix.php == '7.4' }}
         run: cs2pr ./phpcs-report.xml
 
       - name: 'Composer: validate config'


### PR DESCRIPTION
### GH Actions: minor matrix simplification

We can remove the `experimental` key in favour of checking against the PHP version in `continue-on-error`.

### GH Actions: stablelize the error_reporting

What is included in `E_ALL` can vary across PHP versions. Setting `error_reporting` to `-1` will ensure ALL errors are always shown, no matter what.

### GH Actions: minor tweaks to the conditions

The `matrix.php` setting is a text string, so let's compare against it as a text string.

