### PR TITLE
PEAR/FunctionDeclaration: ignore multi-line promoted properties

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -507,6 +507,13 @@ class FunctionDeclarationSniff implements Sniff
                 $lastLine = $tokens[$i]['line'];
                 continue;
             }
+
+            if ($tokens[$i]['code'] === T_ATTRIBUTE) {
+                // Skip attributes as they have their own indentation rules.
+                $i        = $tokens[$i]['attribute_closer'];
+                $lastLine = $tokens[$i]['line'];
+                continue;
+            }
         }//end for
 
     }//end processArgumentList()

--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -460,14 +460,14 @@ class FunctionDeclarationSniff implements Sniff
                 if ($tokens[$i]['code'] === T_WHITESPACE
                     && $tokens[$i]['line'] !== $tokens[($i + 1)]['line']
                 ) {
-                    // This is an empty line, so don't check the indent.
-                    $foundIndent = $expectedIndent;
-
                     $error = 'Blank lines are not allowed in a multi-line '.$type.' declaration';
                     $fix   = $phpcsFile->addFixableError($error, $i, 'EmptyLine');
                     if ($fix === true) {
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
+
+                    // This is an empty line, so don't check the indent.
+                    continue;
                 } else if ($tokens[$i]['code'] === T_WHITESPACE) {
                     $foundIndent = $tokens[$i]['length'];
                 } else if ($tokens[$i]['code'] === T_DOC_COMMENT_WHITESPACE) {

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -372,3 +372,47 @@ private string $private,
     ) {
     }
 }
+
+class ConstructorPropertyPromotionMultiLineAttributesOK
+    public function __construct(
+        #[ORM\ManyToOne(
+            Something: true,
+            SomethingElse: 'text',
+        )]
+        #[Groups([
+            'ArrayEntry',
+            'Another.ArrayEntry',
+        ])]
+        #[MoreGroups(
+            [
+                'ArrayEntry',
+                'Another.ArrayEntry',
+            ]
+        )]
+        private Type $property
+    ) {
+        // Do something.
+    }
+}
+
+class ConstructorPropertyPromotionMultiLineAttributesIncorrectIndent
+    public function __construct(
+    #[ORM\ManyToOne(
+        Something: true,
+        SomethingElse: 'text',
+    )]
+            #[Groups([
+                'ArrayEntry',
+                'Another.ArrayEntry',
+            ])]
+        #[MoreGroups(
+    [
+        'ArrayEntry',
+        'Another.ArrayEntry',
+    ]
+        )]
+        private Type $property
+    ) {
+        // Do something.
+    }
+}

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
@@ -370,3 +370,47 @@ class ConstructorPropertyPromotionMultiLineDocblockAndAttributeIncorrectIndent
     ) {
     }
 }
+
+class ConstructorPropertyPromotionMultiLineAttributesOK
+    public function __construct(
+        #[ORM\ManyToOne(
+            Something: true,
+            SomethingElse: 'text',
+        )]
+        #[Groups([
+            'ArrayEntry',
+            'Another.ArrayEntry',
+        ])]
+        #[MoreGroups(
+            [
+                'ArrayEntry',
+                'Another.ArrayEntry',
+            ]
+        )]
+        private Type $property
+    ) {
+        // Do something.
+    }
+}
+
+class ConstructorPropertyPromotionMultiLineAttributesIncorrectIndent
+    public function __construct(
+        #[ORM\ManyToOne(
+        Something: true,
+        SomethingElse: 'text',
+    )]
+        #[Groups([
+                'ArrayEntry',
+                'Another.ArrayEntry',
+            ])]
+        #[MoreGroups(
+    [
+        'ArrayEntry',
+        'Another.ArrayEntry',
+    ]
+        )]
+        private Type $property
+    ) {
+        // Do something.
+    }
+}

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -97,6 +97,8 @@ class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
                 369 => 1,
                 370 => 1,
                 371 => 1,
+                400 => 1,
+                404 => 1,
             ];
         } else {
             $errors = [


### PR DESCRIPTION
### PEAR/FunctionDeclaration: ignore multi-line promoted properties

Similar to (multi-line) arrays in a multi-line function declaration, ignore (multi-line) attributes for the purposes of the indentation checks in this sniff.

This does mean that inconsistent indentation within multi-line attributes/ for an attribute closer will not be fixed, but that should be handled by a dedicated attribute formatting sniff in my opinion.

Includes unit tests.

Fixes #3424

### PEAR/FunctionDeclaration: minor efficiency tweak 

(noticed while investigating the above)