### PR TITLE
WSL support: replace remaining calls to `is_readable()`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -14,6 +14,7 @@ namespace PHP_CodeSniffer;
 
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Util\Common;
 
 /**
  * Stores the configuration used to run PHPCS and PHPCBF.
@@ -363,7 +364,7 @@ class Config
 
                 $lastDir    = $currentDir;
                 $currentDir = dirname($currentDir);
-            } while ($currentDir !== '.' && $currentDir !== $lastDir && @is_readable($currentDir) === true);
+            } while ($currentDir !== '.' && $currentDir !== $lastDir && Common::isReadable($currentDir) === true);
         }//end if
 
         if (defined('STDIN') === false
@@ -1656,7 +1657,7 @@ class Config
             return [];
         }
 
-        if (is_readable($configFile) === false) {
+        if (Common::isReadable($configFile) === false) {
             $error = 'ERROR: Config file '.$configFile.' is not readable'.PHP_EOL.PHP_EOL;
             throw new DeepExitException($error, 3);
         }

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -60,11 +60,11 @@ class Common
      */
     public static function isReadable($path)
     {
-        if (is_readable($path) === true) {
+        if (@is_readable($path) === true) {
             return true;
         }
 
-        if (file_exists($path) === true && is_file($path) === true) {
+        if (@file_exists($path) === true && @is_file($path) === true) {
             $f = @fopen($path, 'rb');
             if (fclose($f) === true) {
                 return true;


### PR DESCRIPTION
... with calls to `Common::isReadable()` as introduced in d56e167a5dea3550996f197b5d92b1418b1e3fab .

Includes adding additional error silencing to the `Common::isReadable()` function as each of these PHP native functions will throw a warning upon failure.

Fixes #3388