### PR TITLE
Squiz.WhiteSpace.MemberVarSpacing false positives when attributes used without docblock

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/MemberVarSpacingSniff.php
@@ -67,7 +67,8 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
             if ($tokens[$prev]['code'] === T_ATTRIBUTE_END
                 && isset($tokens[$prev]['attribute_opener']) === true
             ) {
-                $prev = $tokens[$prev]['attribute_opener'];
+                $prev  = $tokens[$prev]['attribute_opener'];
+                $start = $prev;
                 continue;
             }
 
@@ -140,7 +141,7 @@ class MemberVarSpacingSniff extends AbstractVariableSniff
             $first = $tokens[$start]['comment_opener'];
         } else {
             $first = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($start - 1), null, true);
-            $first = $phpcsFile->findNext(Tokens::$commentTokens, ($first + 1));
+            $first = $phpcsFile->findNext(array_merge(Tokens::$commentTokens, [T_ATTRIBUTE]), ($first + 1));
         }
 
         // Determine if this is the first member var.

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
@@ -355,4 +355,13 @@ class HasAttributes
 
     #[ORM\Column(ORM\Column::T_INTEGER)]
     protected $height;
+
+    #[SingleAttribute]
+    protected $propertySingle;
+
+    #[FirstAttribute]
+    #[SecondAttribute]
+    protected $propertyDouble;
+    #[ThirdAttribute]
+    protected $propertyWithoutSpacing;
 }

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -339,4 +339,14 @@ class HasAttributes
     #[ORM\GeneratedValue]
     #[ORM\Column(ORM\Column::T_INTEGER)]
     protected $height;
+
+    #[SingleAttribute]
+    protected $propertySingle;
+
+    #[FirstAttribute]
+    #[SecondAttribute]
+    protected $propertyDouble;
+
+    #[ThirdAttribute]
+    protected $propertyWithoutSpacing;
 }

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.php
@@ -61,6 +61,7 @@ class MemberVarSpacingUnitTest extends AbstractSniffUnitTest
             346 => 1,
             353 => 1,
             357 => 1,
+            366 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Fixes false positives when class properties are declared with attributes and without DocComment.
Without this fix it's impossible to use only attributes for properties without DocComments, because this sniff forces you to insert blank line between the property and the attribute:
```
Expected 1 blank line(s) before member var; 0 found (Squiz.WhiteSpace.MemberVarSpacing.Incorrect)
```

Actual result:
```diff
--- src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ PHP_CodeSniffer
@@ -363,12 +363,14 @@
{
     protected $propertyDouble;
     #[ThirdAttribute]
+
     protected $propertyWithoutSpacing;
 }
```

Expected result:
```diff
--- src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ PHP_CodeSniffer
@@ -363,12 +363,14 @@
{
     protected $propertyDouble;
+
     #[ThirdAttribute]
     protected $propertyWithoutSpacing;
 }
```
