### PR TITLE
GH Actions: split PHAR build test from other tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload the PHPCS phar
         uses: actions/upload-artifact@v2
-        if: ${{ success() && matrix.php == '7.4' }}
+        if: ${{ success() && matrix.php == '8.0' }}
         with:
           name: phpcs-phar
           path: ./phpcs.phar
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload the PHPCBF phar
         uses: actions/upload-artifact@v2
-        if: ${{ success() && matrix.php == '7.4' }}
+        if: ${{ success() && matrix.php == '8.0' }}
         with:
           name: phpcbf-phar
           path: ./phpcbf.phar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,60 @@ on:
   workflow_dispatch:
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+
+    name: "Build Phar on PHP: ${{ matrix.php }}"
+
+    continue-on-error: ${{ matrix.php == '8.2' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On
+
+      - name: Build the phar
+        run: php scripts/build-phar.php
+
+      - name: Upload the PHPCS phar
+        uses: actions/upload-artifact@v2
+        if: ${{ success() && matrix.php == '7.4' }}
+        with:
+          name: phpcs-phar
+          path: ./phpcs.phar
+          if-no-files-found: error
+          retention-days: 28
+
+      - name: Upload the PHPCBF phar
+        uses: actions/upload-artifact@v2
+        if: ${{ success() && matrix.php == '7.4' }}
+        with:
+          name: phpcbf-phar
+          path: ./phpcbf.phar
+          if-no-files-found: error
+          retention-days: 28
+
+      # Both the below only check a few files which are rarely changed and therefore unlikely to have issues.
+      # This test is about testing that the phars are functional, *not* about whether the code style complies.
+      - name: 'PHPCS: check code style using the Phar file to test the Phar is functional'
+        run: php phpcs.phar ./scripts
+
+      - name: 'PHPCBF: fix code style using the Phar file to test the Phar is functional'
+        run: php phpcbf.phar ./scripts
+
   test:
     runs-on: ubuntu-latest
+    needs: build
 
     strategy:
       # Keys:
@@ -45,11 +97,11 @@ jobs:
           # Set the "short_open_tag" ini to make sure specific conditions are tested.
           # Also turn on error_reporting to ensure all notices are shown.
           if [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '5.5' ]]; then
-            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On, asp_tags=On'
           elif [[ ${{ matrix.custom_ini }} == true && "${{ matrix.php }}" == '7.0' ]]; then
-            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, date.timezone=Australia/Sydney, short_open_tag=On'
           else
-            echo '::set-output name=PHP_INI::phar.readonly=Off, error_reporting=-1, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP
@@ -106,10 +158,12 @@ jobs:
         if: ${{ matrix.custom_ini == false }}
         run: composer validate --no-check-all --strict
 
-      - name: Build the phar
-        if: ${{ matrix.custom_ini == false }}
-        run: php scripts/build-phar.php
+      - name: Download the PHPCS phar
+        uses: actions/download-artifact@v2
+        with:
+          name: phpcs-phar
 
+      # This test specifically tests that the Phar which will be released works correctly on all PHP versions.
       - name: 'PHPCS: check code style using the Phar file'
         if: ${{ matrix.custom_ini == false }}
         run: php phpcs.phar

--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -21,6 +21,8 @@ if (ini_get('phar.readonly') === '1') {
     exit(1);
 }
 
+$startTime = microtime(true);
+
 $scripts = [
     'phpcs',
     'phpcbf',
@@ -51,6 +53,7 @@ foreach ($scripts as $script) {
     $rdi = new \RecursiveDirectoryIterator($srcDir, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
     $di  = new \RecursiveIteratorIterator($rdi, 0, \RecursiveIteratorIterator::CATCH_GET_CHILD);
 
+    $fileCount = 0;
     foreach ($di as $file) {
         $filename = $file->getFilename();
 
@@ -66,7 +69,9 @@ foreach ($scripts as $script) {
 
         $path = 'src'.substr($fullpath, $srcDirLen);
         $phar->addFile($fullpath, $path);
-    }
+
+        ++$fileCount;
+    }//end foreach
 
     // Add autoloader.
     $phar->addFile(realpath(__DIR__.'/../autoload.php'), 'autoload.php');
@@ -75,6 +80,7 @@ foreach ($scripts as $script) {
     $phar->addFile(realpath(__DIR__.'/../licence.txt'), 'licence.txt');
 
     echo 'done'.PHP_EOL;
+    echo "\t   Added ".$fileCount.' files'.PHP_EOL;
 
     /*
         Add the stub.
@@ -93,3 +99,16 @@ foreach ($scripts as $script) {
 
     echo 'done'.PHP_EOL;
 }//end foreach
+
+$timeTaken = ((microtime(true) - $startTime) * 1000);
+if ($timeTaken < 1000) {
+    $timeTaken = round($timeTaken);
+    echo "DONE in {$timeTaken}ms".PHP_EOL;
+} else {
+    $timeTaken = round(($timeTaken / 1000), 2);
+    echo "DONE in $timeTaken secs".PHP_EOL;
+}
+
+echo PHP_EOL;
+echo 'Filesize generated phpcs.phar file: '.filesize(dirname(__DIR__).'/phpcs.phar').' bytes'.PHP_EOL;
+echo 'Filesize generated phpcs.phar file: '.filesize(dirname(__DIR__).'/phpcbf.phar').' bytes'.PHP_EOL;

--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -14,12 +14,70 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Exceptions\TokenizerException;
+use PHP_CodeSniffer\Tokenizers\PHP;
+use PHP_CodeSniffer\Util\Tokens;
+
 error_reporting(E_ALL | E_STRICT);
 
 if (ini_get('phar.readonly') === '1') {
     echo 'Unable to build, phar.readonly in php.ini is set to read only.'.PHP_EOL;
     exit(1);
 }
+
+require_once dirname(__DIR__).'/autoload.php';
+require_once dirname(__DIR__).'/src/Util/Tokens.php';
+
+if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
+    define('PHP_CODESNIFFER_VERBOSITY', 0);
+}
+
+
+/**
+ * Replacement for the PHP native php_strip_whitespace() function,
+ * which doesn't handle attributes correctly for cross-version PHP.
+ *
+ * @param string                  $fullpath Path to file.
+ * @param \PHP_CodeSniffer\Config $config   Perfunctory Config.
+ *
+ * @return string
+ *
+ * @throws \PHP_CodeSniffer\Exceptions\RuntimeException When tokenizer errors are encountered.
+ */
+function stripWhitespaceAndComments($fullpath, $config)
+{
+    $contents = file_get_contents($fullpath);
+
+    try {
+        $tokenizer = new PHP($contents, $config, "\n");
+        $tokens    = $tokenizer->getTokens();
+    } catch (TokenizerException $e) {
+        throw new RuntimeException('Failed to tokenize file '.$fullpath);
+    }
+
+    $stripped = '';
+    foreach ($tokens as $token) {
+        if ($token['code'] === T_ATTRIBUTE_END || $token['code'] === T_OPEN_TAG) {
+            $stripped .= $token['content']."\n";
+            continue;
+        }
+
+        if (isset(Tokens::$emptyTokens[$token['code']]) === false) {
+            $stripped .= $token['content'];
+            continue;
+        }
+
+        if ($token['code'] === T_WHITESPACE) {
+            $stripped .= ' ';
+        }
+    }
+
+    return $stripped;
+
+}//end stripWhitespaceAndComments()
+
 
 $startTime = microtime(true);
 
@@ -53,7 +111,9 @@ foreach ($scripts as $script) {
     $rdi = new \RecursiveDirectoryIterator($srcDir, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
     $di  = new \RecursiveIteratorIterator($rdi, 0, \RecursiveIteratorIterator::CATCH_GET_CHILD);
 
+    $config    = new Config();
     $fileCount = 0;
+
     foreach ($di as $file) {
         $filename = $file->getFilename();
 
@@ -68,13 +128,19 @@ foreach ($scripts as $script) {
         }
 
         $path = 'src'.substr($fullpath, $srcDirLen);
-        $phar->addFile($fullpath, $path);
+
+        if (substr($filename, -4) === '.xml') {
+            $phar->addFile($fullpath, $path);
+        } else {
+            // PHP file.
+            $phar->addFromString($path, stripWhitespaceAndComments($fullpath, $config));
+        }
 
         ++$fileCount;
     }//end foreach
 
     // Add autoloader.
-    $phar->addFile(realpath(__DIR__.'/../autoload.php'), 'autoload.php');
+    $phar->addFromString('autoload.php', stripWhitespaceAndComments(realpath(__DIR__.'/../autoload.php'), $config));
 
     // Add licence file.
     $phar->addFile(realpath(__DIR__.'/../licence.txt'), 'licence.txt');

--- a/scripts/build-phar.php
+++ b/scripts/build-phar.php
@@ -60,7 +60,7 @@ foreach ($scripts as $script) {
         }
 
         $fullpath = $file->getPathname();
-        if (strpos($fullpath, '/Tests/') !== false) {
+        if (strpos($fullpath, DIRECTORY_SEPARATOR.'Tests'.DIRECTORY_SEPARATOR) !== false) {
             continue;
         }
 


### PR DESCRIPTION
As things were in the CI script, the `phpcs` and `phpcbf` Phars would be build against each supported PHP version and the tests run with the `phpcs` Phar would use the Phar as build on the same PHP version as the test was being run on.

This test was not representative of the reality as with each release, only one `phpcs` and one `phpcbf` phar is released.

The changes in this commit:
* Split the building of the Phar off from the main test script.
* This new `build` job:
    - Tests building the Phar against all supported PHP versions as an early detection system for problems in the Phar extension/Phar building script.
    - Uploads both phars as build against PHP 7.4.
        The uploaded Phars match the Phars as would be included on a release as they are build against the same PHP version as used for releases.
        **_These Phars will now also be available for PRs and merges to `master` to allow for easier testing of change proposals by issue reporters who may not have a git clone of the repo._**
        The uploaded Phars will be available for 28 days (default 90).
    - Does a cursory test with both the `phpcs.phar` as well as the `phpcbf.phar` to test that the build phar files are _functional_.
* In the `test` job, which now depends on the `build` job, the Phar will now no longer be build, but the Phar as uploaded in the `build` job - i.e. the Phar build against the same PHP version as used when releasing Phars - is downloaded and used to run the Phar test.

The uploaded Phar files can be found on the "Summary" page of the `test` workflow after the build has finished for each build run.

---

### 🆕 GH Actions: change the building of the (release) PHARs to PHP 8.0

The PHP native `php_strip_whitespace()` function used in the PHAR build script is PHP version sensitive.

The function strips comments and whitespace out of the code, but in PHP 7.4, attributes are seen as comments due to the `#[]` syntax, which means that if the PHAR files were being generated on PHP 7.4, the PHP 8.1 `#[ReturnTypeWillChange]` attributes as put in via PR #3400 would be stripped out.

In other words: for the PHAR files to be cross-version compatible, they *MUST* be generated on PHP 8.0 or higher.

This fixes this for the CI part of things. This partially addresses #3497 .

Ref: https://www.php.net/manual/en/function.php-strip-whitespace.php

---

### 🆕 Build Phar: minor tweak to allow testing the script on Windows

### 🆕 Build Phar: show more debug information

* Number of files added for each PHAR.
* Total time the script took to run.

### 🆕 Build Phar: add custom "strip whitespace and comments" function

This implements option 3 as per the discussion in the thread for PR #3442.

A custom `stripWhitespaceAndComments()` function has been created and added to the script used to build the PHAR files and replaces the use of the PHP native `php_strip_whitespace()` function, which does not allow for creating PHP cross-version compatible PHAR files if attributes are used anywhere in the code.

The problem with the PHP native `php_strip_whitespace()` function is this:
* When run on PHP <= 7.4, attributes would be stripped from the code as they are seen as `#` comments. This undoes the deprecation silencing for methods for which no return type can be added yet (as needed for full PHP 8.1 compatibility).
* When run on PHP >= 8.0, attributes are _not_ stripped, but recognized correctly, however, the function strips **all** new lines, turning the file effectively into one long line of code. This is problematic when the PHAR would subsequently be run on PHP < 8.0, as any code after the first attribute would then be seen as "commented out", leading to the PHAR not running with a parse error.

To solve this, the new `stripWhitespaceAndComments()` function emulates the PHP native function, with two important differences:
* New lines are very selectively left in the regenerated content of the files. By ensuring that there is always a new line after an attribute closer, we can prevent code from being seen as commented out in PHP < 8.0.
* As the PHPCS native PHP tokenizer is used to interpret the file content, the token stream will be the same PHP cross-version, meaning that attributes will be recognized on all supported PHP versions and the script can now be run again on any supported PHP version and the generated PHAR files will be the same.

As an additional performance tweak, `xml` files will no longer be passed to the whitespace/comment stripping. This had no effect previously and as XML files would tokenize as 100% `T_INLINE_HTML`, passing these to the new function would have no effect either (other than slowing down the script).
Same goes for the `license.txt` file.