### PR TITLE
Tokenizer/PHP: fix ? tokenization after attribute

### DIFF
--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc
@@ -63,3 +63,15 @@ $fn = fn(array & $one) => 1;
 $fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
 
 function issue3267(string|int ...$values) {}
+
+function setDefault(#[ImportValue(
+        constraints: [
+            [
+                Assert\Type::class,
+                ['type' => 'bool'],
+            ],
+        ]
+    )] ?bool $value = null): void
+    {
+        // Do something
+    }

--- a/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Operators/OperatorSpacingUnitTest.inc.fixed
@@ -63,3 +63,15 @@ $fn = fn(array & $one) => 1;
 $fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
 
 function issue3267(string|int ...$values) {}
+
+function setDefault(#[ImportValue(
+        constraints: [
+            [
+                Assert\Type::class,
+                ['type' => 'bool'],
+            ],
+        ]
+    )] ?bool $value = null): void
+    {
+        // Do something
+    }

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1576,7 +1576,7 @@ class PHP extends Tokenizer
                         && isset(Util\Tokens::$emptyTokens[$tokenType]) === false
                     ) {
                         // Found the previous non-empty token.
-                        if ($tokenType === ':' || $tokenType === ',') {
+                        if ($tokenType === ':' || $tokenType === ',' || $tokenType === T_ATTRIBUTE_END) {
                             $newToken['code'] = T_NULLABLE;
                             $newToken['type'] = 'T_NULLABLE';
 


### PR DESCRIPTION
In a select set of circumstance, when a `?` would follow an attribute with a nested array in it, the `?` would be tokenized as `T_INLINE_THEN`, not `T_NULLABLE`.
Fixed now.

Includes unit test via the `PSR12.Operators.OperatorSpacing` sniff.

Note: Ternary `?` vs nullable (and ternary `:` vs colon) should really get a full set of unit tests, but I don't currently have the time to set that up.

Fixes #3445