### PR TITLE
Squiz/ScopeClosingBrace: bug fix - prevent removing inline HTML when fixing

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -65,11 +65,20 @@ class ScopeClosingBraceSniff implements Sniff
 
         // Check that the closing brace is on it's own line.
         $lastContent = $phpcsFile->findPrevious([T_INLINE_HTML, T_WHITESPACE, T_OPEN_TAG], ($scopeEnd - 1), $scopeStart, true);
-        if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']) {
+        for ($lineStart = $scopeEnd; $tokens[$lineStart]['column'] > 1; $lineStart--);
+
+        if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']
+            || ($tokens[$lineStart]['code'] === T_INLINE_HTML
+            && trim($tokens[$lineStart]['content']) !== '')
+        ) {
             $error = 'Closing brace must be on a line by itself';
             $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'ContentBefore');
             if ($fix === true) {
-                $phpcsFile->fixer->addNewlineBefore($scopeEnd);
+                if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']) {
+                    $phpcsFile->fixer->addNewlineBefore($scopeEnd);
+                } else {
+                    $phpcsFile->fixer->addNewlineBefore(($lineStart + 1));
+                }
             }
 
             return;

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
@@ -114,3 +114,9 @@ $match = match ($test) {
     1 => 'a',
     2 => 'b'
     };
+
+?>
+<?php if ($someConditional) : ?>
+<div class="container">
+
+</div> <?php endif; ?>

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
@@ -116,3 +116,10 @@ $match = match ($test) {
     1 => 'a',
     2 => 'b'
 };
+
+?>
+<?php if ($someConditional) : ?>
+<div class="container">
+
+</div> 
+<?php endif; ?>

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -33,6 +33,7 @@ class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
             102 => 1,
             111 => 1,
             116 => 1,
+            122 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
When non-empty inline HTML is on the same line, before the scope closing, the sniff would incorrectly throw the `Closing brace indented incorrectly; expected %s spaces, found %s` error, instead of the `Closing brace must be on a line by itself` error.

This would ultimately lead to the fixer removing the non-empty inline HTML, potentially breaking HTML display/structure.

Fixed now. Includes unit test.

Fixes #3422