### PR TITLE
Auto-add fullstop to @throws if rule is used

### DIFF
--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -45,7 +45,7 @@ class ExecutableFileUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'ExecutableFileUnitTest.2.inc':
         case 'ExecutableFileUnitTest.4.inc':
-            return [1 => 0];
+            return [1 => 1];
         default:
             return [];
         }//end switch

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -45,7 +45,7 @@ class ExecutableFileUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'ExecutableFileUnitTest.2.inc':
         case 'ExecutableFileUnitTest.4.inc':
-            return [1 => 1];
+            return [1 => 0];
         default:
             return [];
         }//end switch

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -241,7 +241,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 
                 for ($i = ($tag + 3); $i < $end; $i++) {
                     if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                        $comment .= ' '.$tokens[$i]['content'];
+                        $comment .= ' ' . $tokens[$i]['content'];
                     }
                 }
 
@@ -255,7 +255,11 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 $lastChar = substr($comment, -1);
                 if ($lastChar !== '.') {
                     $error = '@throws tag comment must end with a full stop';
-                    $phpcsFile->addError($error, ($tag + 2), 'ThrowsNoFullStop');
+                    $fix = $phpcsFile->addFixableError($error, ($tag + 2), 'ThrowsNoFullStop');
+
+                    if ($fix) {
+                        $phpcsFile->fixer->replaceToken(($tag + 2), $tokens[($tag + 2)]['content'] . '.');
+                    }
                 }
             }//end if
         }//end foreach

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -241,7 +241,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 
                 for ($i = ($tag + 3); $i < $end; $i++) {
                     if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                        $comment .= ' ' . $tokens[$i]['content'];
+                        $comment .= ' '.$tokens[$i]['content'];
                     }
                 }
 
@@ -255,10 +255,10 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                 $lastChar = substr($comment, -1);
                 if ($lastChar !== '.') {
                     $error = '@throws tag comment must end with a full stop';
-                    $fix = $phpcsFile->addFixableError($error, ($tag + 2), 'ThrowsNoFullStop');
+                    $fix   = $phpcsFile->addFixableError($error, ($tag + 2), 'ThrowsNoFullStop');
 
-                    if ($fix) {
-                        $phpcsFile->fixer->replaceToken(($tag + 2), $tokens[($tag + 2)]['content'] . '.');
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($tag + 2), $tokens[($tag + 2)]['content'].'.');
                     }
                 }
             }//end if

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -196,7 +196,7 @@ public function noReturnOutsideClass()
  * @see
  * @return void
  * @extra  Invalid tag
- * @throws UnknownException unknown
+ * @throws UnknownException unknown.
  */
 public function missingTwoParamComment($one, $two, $three)
 {


### PR DESCRIPTION
Automatic fix for cases like

```php
/**
 * @throws FoobarException throws
*/
```

will be

```php
/**
 * @throws FoobarException throws.
*/
```