### PR TITLE
PSR12/ClassInstantiation: bug fix for attributes with anonymous classes

### DIFF
--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -63,6 +63,14 @@ class ClassInstantiationSniff implements Sniff
                 continue;
             }
 
+            // Skip over potential attributes for anonymous classes.
+            if ($tokens[$i]['code'] === T_ATTRIBUTE
+                && isset($tokens[$i]['attribute_closer']) === true
+            ) {
+                $i = $tokens[$i]['attribute_closer'];
+                continue;
+            }
+
             if ($tokens[$i]['code'] === T_OPEN_SQUARE_BRACKET
                 || $tokens[$i]['code'] === T_OPEN_CURLY_BRACKET
             ) {
@@ -72,7 +80,7 @@ class ClassInstantiationSniff implements Sniff
 
             $classNameEnd = $i;
             break;
-        }
+        }//end for
 
         if ($classNameEnd === null) {
             return;
@@ -85,6 +93,11 @@ class ClassInstantiationSniff implements Sniff
 
         if ($tokens[$classNameEnd]['code'] === T_OPEN_PARENTHESIS) {
             // Using parenthesis.
+            return;
+        }
+
+        if ($classNameEnd === $stackPtr) {
+            // Failed to find the class name.
             return;
         }
 

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
@@ -36,3 +36,9 @@ $a = new ${$varHoldingClassName};
 $class = new $obj?->classname();
 $class = new $obj?->classname;
 $class = new ${$obj?->classname};
+
+// Issue 3456.
+// Anon classes should be skipped, even when there is an attribute between the new and the class keywords.
+$anonWithAttribute = new #[SomeAttribute('summary')] class {
+    public const SOME_STUFF = 'foo';
+};

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
@@ -36,3 +36,9 @@ $a = new ${$varHoldingClassName}();
 $class = new $obj?->classname();
 $class = new $obj?->classname();
 $class = new ${$obj?->classname}();
+
+// Issue 3456.
+// Anon classes should be skipped, even when there is an attribute between the new and the class keywords.
+$anonWithAttribute = new #[SomeAttribute('summary')] class {
+    public const SOME_STUFF = 'foo';
+};


### PR DESCRIPTION
The `class` keyword was correctly tokenized as `T_ANON_CLASS`, even when there is an attribute between the `new` and the `class` keyword, however, the `PSR12.Classes.ClassInstantiation` sniff did not take that possibility into account, leading to false positives.

This commit:
* Adds code to skip over attributes.
    Note: I've elected to skip over attributes, but as these attributes AFAICS can only be added in combination with an anonymous class and anonymous classes are ignored by this sniff, it would also be a valid option to bow out of the sniff when an attribute is encountered. As this would be inconsistent with how the `T_ANON_CLASS` token was handled so far, I've not gone with that option.
* Adds some additional extra guard code to prevent future false positives for when the class name could not be determined.

Includes unit test.

Fixes #3456