### PR TITLE
Generic/MultipleStatementAlignment: bug fix for closure params with defaults

### DIFF
--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc
@@ -478,3 +478,27 @@ class Test
 
     protected static $thisIsAReallyLongVariableName = [];
 }
+
+// Issue #3460.
+function issue3460_invalid() {
+    $a = static function ($variables = false) use ($foo) {
+        return $variables;
+    };
+    $b   = $a;
+}
+
+function issue3460_valid() {
+    $a = static function ($variables = false) use ($foo) {
+        return $variables;
+    };
+    $b = $a;
+}
+
+function makeSureThatAssignmentWithinClosureAreStillHandled() {
+    $a = static function ($variables = []) use ($temp) {
+        $a = 'foo';
+        $bar = 'bar';
+        $longer = 'longer';
+        return $variables;
+    };
+}

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.inc.fixed
@@ -478,3 +478,27 @@ class Test
 
     protected static $thisIsAReallyLongVariableName = [];
 }
+
+// Issue #3460.
+function issue3460_invalid() {
+    $a = static function ($variables = false) use ($foo) {
+        return $variables;
+    };
+    $b = $a;
+}
+
+function issue3460_valid() {
+    $a = static function ($variables = false) use ($foo) {
+        return $variables;
+    };
+    $b = $a;
+}
+
+function makeSureThatAssignmentWithinClosureAreStillHandled() {
+    $a = static function ($variables = []) use ($temp) {
+        $a      = 'foo';
+        $bar    = 'bar';
+        $longer = 'longer';
+        return $variables;
+    };
+}

--- a/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
+++ b/src/Standards/Generic/Tests/Formatting/MultipleStatementAlignmentUnitTest.php
@@ -118,6 +118,9 @@ class MultipleStatementAlignmentUnitTest extends AbstractSniffUnitTest
                 442 => 1,
                 443 => 1,
                 454 => 1,
+                487 => 1,
+                499 => 1,
+                500 => 1,
             ];
         break;
         case 'MultipleStatementAlignmentUnitTest.js':


### PR DESCRIPTION
For use within the loop in the `checkAlignment()` method, closures are explicitly removed for the `$scopeOpeners` array as they can be (and often are) assigned to a variable.

However, a closure which contained a parameter with a default value would take the equal sign for the default value as the start of a new block.

The `process()` method already contained a safeguard against this, but it's the `checkAlignment()` method which is being called recursively, so this check was not executed for those recursive calls.

Calling the `process()` method recursively would be troublesome as the returned stackPtr is incremented by one in the `process()` method, so moving the initial check from the `process()` method to the `checkAlignment()` method seemed a reasonable solution.

There will probably be other ways in which this could be solved and I'm not 100% sure this is the best solution, but it is a solution which works without breaking any of the existing unit tests.

Includes a few additional unit tests to further safeguard against this issue and make sure nothing new is broken.

Fixes #3460