### PR TITLE
Resolve double-increment of CYC count for do/while loop in Generic.Metrics.CyclomaticComplexity sniff

### DIFF
--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -78,7 +78,8 @@ class CyclomaticComplexitySniff implements Sniff
             T_FOR     => true,
             T_FOREACH => true,
             T_WHILE   => true,
-            T_DO      => true,
+#           T_DO is not required for incrementing CYC, as the terminating while in a do/while loop triggers the branch
+#           T_DO      => true,
             T_ELSEIF  => true,
         ];
 

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.1.inc
@@ -79,9 +79,11 @@ function complexityTwenty()
 
     switch ($condition) {
         case '1':
-            if ($condition) {
-            } else if ($cond) {
-            }
+            do {
+                if ($condition) {
+                } else if ($cond) {
+                }
+            } while ($cond);
         break;
         case '2':
             while ($cond) {
@@ -116,9 +118,11 @@ function complexityTwenty()
 function complexityTwentyOne()
 {
     while ($condition === true) {
-        if ($condition) {
-        } else if ($cond) {
-        }
+        do {
+            if ($condition) {
+            } else if ($cond) {
+            }
+        } while ($cond);
     }
 
     switch ($condition) {

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -21,11 +21,20 @@ class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of errors that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getErrorList()
+    public function getErrorList($testFile='')
     {
-        return [116 => 1];
+        switch ($testFile) {
+        case 'CyclomaticComplexityUnitTest.1.inc':
+            return [118 => 1];
+            break;
+        default:
+            return [];
+            break;
+        }//end switch
 
     }//end getErrorList()
 
@@ -36,14 +45,23 @@ class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
      * The key of the array should represent the line number and the value
      * should represent the number of warnings that should occur on that line.
      *
+     * @param string $testFile The name of the file being tested.
+     *
      * @return array<int, int>
      */
-    public function getWarningList()
+    public function getWarningList($testFile='')
     {
-        return [
-            45 => 1,
-            72 => 1,
-        ];
+        switch ($testFile) {
+        case 'CyclomaticComplexityUnitTest.1.inc':
+            return [
+                45 => 1,
+                72 => 1,
+            ];
+            break;
+        default:
+            return [];
+            break;
+        }//end switch
 
     }//end getWarningList()
 


### PR DESCRIPTION
Fix for Issue #3468

Resolve double-increment of CYC count for do/while loop