### PR TITLE
PHP 8.1: Added `enum` support to sniffs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1101,6 +1101,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
        <dir name="Classes">
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDeclarationUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDeclarationUnitTest.2.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="ClassDeclarationUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ClassDeclarationUnitTest.php" role="test" />
        </dir>
        <dir name="Files">

--- a/package.xml
+++ b/package.xml
@@ -1771,6 +1771,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="FileExtensionUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileExtensionUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileExtensionUnitTest.4.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FileExtensionUnitTest.5.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileExtensionUnitTest.php" role="test" />
        </dir>
        <dir name="Formatting">

--- a/package.xml
+++ b/package.xml
@@ -1653,6 +1653,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.6.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.7.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.8.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.9.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.2.js" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -1012,6 +1012,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="ClassCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.2.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FunctionCommentUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FunctionCommentUnitTest.inc.fixed" role="test" />

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1223,7 +1223,7 @@ class File
 
 
     /**
-     * Returns the declaration names for classes, interfaces, traits, and functions.
+     * Returns the declaration name for classes, interfaces, traits, enums, and functions.
      *
      * @param int $stackPtr The position of the declaration token which
      *                      declared the class, interface, trait, or function.

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1232,7 +1232,7 @@ class File
      *                     or NULL if the function or class is anonymous.
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
      *                                                      T_FUNCTION, T_CLASS, T_ANON_CLASS,
-     *                                                      T_CLOSURE, T_TRAIT, or T_INTERFACE.
+     *                                                      T_CLOSURE, T_TRAIT, T_ENUM, or T_INTERFACE.
      */
     public function getDeclarationName($stackPtr)
     {
@@ -1246,8 +1246,9 @@ class File
             && $tokenCode !== T_CLASS
             && $tokenCode !== T_INTERFACE
             && $tokenCode !== T_TRAIT
+            && $tokenCode !== T_ENUM
         ) {
-            throw new RuntimeException('Token type "'.$this->tokens[$stackPtr]['type'].'" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
+            throw new RuntimeException('Token type "'.$this->tokens[$stackPtr]['type'].'" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
         }
 
         if ($tokenCode === T_FUNCTION

--- a/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/DuplicateClassNameSniff.php
@@ -53,6 +53,7 @@ class DuplicateClassNameSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
             T_NAMESPACE,
             T_CLOSE_TAG,
         ];

--- a/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
+++ b/src/Standards/Generic/Sniffs/Classes/OpeningBraceSameLineSniff.php
@@ -27,6 +27,7 @@ class OpeningBraceSameLineSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()

--- a/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/OneObjectStructurePerFileSniff.php
@@ -27,6 +27,7 @@ class OneObjectStructurePerFileSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()

--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -50,6 +50,7 @@ class LowerCaseKeywordSniff implements Sniff
             T_ENDIF,
             T_ENDSWITCH,
             T_ENDWHILE,
+            T_ENUM,
             T_EVAL,
             T_EXIT,
             T_EXTENDS,

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.1.inc
@@ -4,8 +4,9 @@ class YourClass {}
 interface MyInterface {}
 interface YourInterface {}
 trait MyTrait {}
-enum MyEnum {}
 trait YourTrait {}
+enum MyEnum {}
+enum YourEnum {}
 class MyClass {}
 interface MyInterface {}
 trait MyTrait {}

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.1.inc
@@ -4,8 +4,10 @@ class YourClass {}
 interface MyInterface {}
 interface YourInterface {}
 trait MyTrait {}
+enum MyEnum {}
 trait YourTrait {}
 class MyClass {}
 interface MyInterface {}
 trait MyTrait {}
+enum MyEnum {}
 ?>

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.2.inc
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.2.inc
@@ -2,4 +2,5 @@
 class MyClass {}
 interface MyInterface {}
 trait MyTrait {}
+enum MyEnum {}
 ?>

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -45,10 +45,10 @@ class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'DuplicateClassNameUnitTest.1.inc':
             return [
-                9  => 1,
                 10 => 1,
                 11 => 1,
                 12 => 1,
+                13 => 1,
             ];
             break;
         case 'DuplicateClassNameUnitTest.2.inc':
@@ -56,6 +56,7 @@ class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
                 2 => 1,
                 3 => 1,
                 4 => 1,
+                5 => 1,
             ];
             break;
         case 'DuplicateClassNameUnitTest.5.inc':

--- a/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/DuplicateClassNameUnitTest.php
@@ -45,9 +45,10 @@ class DuplicateClassNameUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
         case 'DuplicateClassNameUnitTest.1.inc':
             return [
-                8  => 1,
                 9  => 1,
                 10 => 1,
+                11 => 1,
+                12 => 1,
             ];
             break;
         case 'DuplicateClassNameUnitTest.2.inc':

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc
@@ -89,3 +89,7 @@ class Test_Class_Bad_G
     /*some comment*/
 {
 }
+
+enum Test_Enum
+{
+}

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.inc.fixed
@@ -89,3 +89,7 @@ class Test_Class_Bad_G
     /*some comment*/ {
 
 }
+
+enum Test_Enum {
+
+}

--- a/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
+++ b/src/Standards/Generic/Tests/Classes/OpeningBraceSameLineUnitTest.php
@@ -38,6 +38,7 @@ class OpeningBraceSameLineUnitTest extends AbstractSniffUnitTest
             70 => 1,
             79 => 1,
             90 => 1,
+            94 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.inc
+++ b/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.inc
@@ -12,10 +12,15 @@ class baz {
 }
 
 trait barTrait {
-    
+
 }
 
 interface barInterface {
 
 }
+
+enum barEnum {
+
+}
+
 ?>

--- a/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/OneObjectStructurePerFileUnitTest.php
@@ -30,6 +30,7 @@ class OneObjectStructurePerFileUnitTest extends AbstractSniffUnitTest
             10 => 1,
             14 => 1,
             18 => 1,
+            22 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
@@ -166,7 +166,20 @@ abstract class My_Class {
     public function _MY_CLASS() {}
 }
 
-enum My_Enum {
-    public function my_class() {}
-    public function _MY_CLASS() {}
+enum Suit: string implements Colorful, CardGame {
+    // Magic methods.
+    function __call($name, $args) {}
+    static function __callStatic($name, $args) {}
+    function __invoke() {}
+
+    // Valid Method Name.
+    public function getSomeValue() {}
+
+    // Double underscore non-magic methods not allowed.
+    function __myFunction() {}
+    function __my_function() {}
+
+    // Non-camelcase.
+    public function parseMyDSN() {}
+    public function get_some_value() {}
 }

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.inc
@@ -165,3 +165,8 @@ abstract class My_Class {
     public function my_class() {}
     public function _MY_CLASS() {}
 }
+
+enum My_Enum {
+    public function my_class() {}
+    public function _MY_CLASS() {}
+}

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -63,8 +63,10 @@ class CamelCapsFunctionNameUnitTest extends AbstractSniffUnitTest
             147 => 2,
             158 => 1,
             159 => 1,
-            170 => 1,
-            171 => 1,
+            179 => 1,
+            180 => 2,
+            183 => 1,
+            184 => 1,
         ];
 
         return $errors;

--- a/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
+++ b/src/Standards/Generic/Tests/NamingConventions/CamelCapsFunctionNameUnitTest.php
@@ -63,6 +63,8 @@ class CamelCapsFunctionNameUnitTest extends AbstractSniffUnitTest
             147 => 2,
             158 => 1,
             159 => 1,
+            170 => 1,
+            171 => 1,
         ];
 
         return $errors;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
@@ -39,5 +39,8 @@ class Reading {
     Public READOnly int $var;
 }
 
+EnuM Enum {
+}
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
@@ -39,5 +39,8 @@ class Reading {
     public readonly int $var;
 }
 
+enum Enum {
+}
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -41,6 +41,7 @@ class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
             32 => 1,
             35 => 1,
             39 => 2,
+            42 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Classes/ClassDeclarationSniff.php
@@ -27,6 +27,7 @@ class ClassDeclarationSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()

--- a/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
@@ -27,6 +27,7 @@ class ClassCommentSniff extends FileCommentSniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -161,6 +161,7 @@ class FileCommentSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
             T_FUNCTION,
             T_CLOSURE,
             T_PUBLIC,

--- a/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/src/Standards/PEAR/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -27,6 +27,7 @@ class ValidClassNameSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.1.inc
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.1.inc
@@ -110,3 +110,5 @@ if (!class_exists('ClassOpeningBraceTooMuchIndentation')) {
         {
         }
 }
+
+enum IncorrectBracePlacement {}

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.1.inc.fixed
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.1.inc.fixed
@@ -119,3 +119,7 @@ if (!class_exists('ClassOpeningBraceTooMuchIndentation')) {
     {
         }
 }
+
+enum IncorrectBracePlacement
+{
+}

--- a/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Classes/ClassDeclarationUnitTest.php
@@ -61,6 +61,7 @@ class ClassDeclarationUnitTest extends AbstractSniffUnitTest
                 99  => 1,
                 104 => 1,
                 110 => 1,
+                114 => 1,
             ];
 
         default:

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.inc
@@ -121,6 +121,16 @@ trait Empty_Trait_Doc
 
 
 /**
+ *
+ *
+ */
+enum Empty_Enum_Doc
+{
+
+}//end enum
+
+
+/**
  * Sample class comment
  *
  * @category  PHP

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -44,6 +44,7 @@ class ClassCommentUnitTest extends AbstractSniffUnitTest
             96  => 5,
             106 => 5,
             116 => 5,
+            126 => 5,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.3.inc
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.3.inc
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Some comment
+ */
+enum SomeEnum
+{
+}

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -50,6 +50,9 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
         case 'FileCommentUnitTest.2.inc':
             return [1 => 1];
 
+        case 'FileCommentUnitTest.3.inc':
+            return [1 => 1];
+
         default:
             return [];
         }//end switch

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.inc
@@ -66,3 +66,25 @@ trait _Invalid_Name {}
 trait ___ {}
 
 trait Invalid__Name {}
+
+enum Valid_Name {}
+
+enum invalid_Name {}
+
+enum invalid_name {}
+
+enum Invalid_name {}
+
+enum VALID_Name {}
+
+enum VALID_NAME {}
+
+enum VALID_Name {}
+
+enum ValidName {}
+
+enum _Invalid_Name {}
+
+enum ___ {}
+
+enum Invalid__Name {}

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.inc
@@ -67,19 +67,19 @@ trait ___ {}
 
 trait Invalid__Name {}
 
-enum Valid_Name {}
+enum Valid_Name: string {}
 
-enum invalid_Name {}
+enum invalid_Name : String {}
 
 enum invalid_name {}
 
-enum Invalid_name {}
+enum Invalid_name: Int {}
 
 enum VALID_Name {}
 
 enum VALID_NAME {}
 
-enum VALID_Name {}
+enum VALID_Name : int {}
 
 enum ValidName {}
 

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidClassNameUnitTest.php
@@ -44,6 +44,12 @@ class ValidClassNameUnitTest extends AbstractSniffUnitTest
             64 => 1,
             66 => 2,
             68 => 1,
+            72 => 1,
+            74 => 2,
+            76 => 1,
+            86 => 1,
+            88 => 2,
+            90 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -220,3 +220,8 @@ abstract class My_Class {
     public function my_class() {}
     public function _MY_CLASS() {}
 }
+
+enum My_Enum {
+    public function my_class() {}
+    public function _MY_CLASS() {}
+}

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.inc
@@ -221,7 +221,23 @@ abstract class My_Class {
     public function _MY_CLASS() {}
 }
 
-enum My_Enum {
-    public function my_class() {}
-    public function _MY_CLASS() {}
+enum Suit: string implements Colorful, CardGame {
+    // Magic methods.
+    function __call($name, $args) {}
+    static function __callStatic($name, $args) {}
+    function __invoke() {}
+
+    // Valid Method Name.
+    public function parseMyDSN() {}
+    private function _getAnotherValue() {}
+
+    // Double underscore non-magic methods not allowed.
+    function __myFunction() {}
+    function __my_function() {}
+
+    // Non-camelcase.
+    public function get_some_value() {}
+
+	// Private without underscore prefix.
+    private function getMe() {}
 }

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -122,6 +122,8 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
             212 => 1,
             213 => 1,
             214 => 1,
+            225 => 1,
+            226 => 2,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
+++ b/src/Standards/PEAR/Tests/NamingConventions/ValidFunctionNameUnitTest.php
@@ -122,8 +122,10 @@ class ValidFunctionNameUnitTest extends AbstractSniffUnitTest
             212 => 1,
             213 => 1,
             214 => 1,
-            225 => 1,
-            226 => 2,
+            235 => 1,
+            236 => 2,
+            239 => 1,
+            242 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR1/Sniffs/Classes/ClassDeclarationSniff.php
@@ -27,6 +27,7 @@ class ClassDeclarationSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()
@@ -50,7 +51,7 @@ class ClassDeclarationSniff implements Sniff
 
         $errorData = [strtolower($tokens[$stackPtr]['content'])];
 
-        $nextClass = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT], ($tokens[$stackPtr]['scope_closer'] + 1));
+        $nextClass = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], ($tokens[$stackPtr]['scope_closer'] + 1));
         if ($nextClass !== false) {
             $error = 'Each %s must be in a file by itself';
             $phpcsFile->addError($error, $nextClass, 'MultipleClasses', $errorData);
@@ -59,7 +60,7 @@ class ClassDeclarationSniff implements Sniff
             $phpcsFile->recordMetric($stackPtr, 'One class per file', 'yes');
         }
 
-        $namespace = $phpcsFile->findNext([T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT], 0);
+        $namespace = $phpcsFile->findNext([T_NAMESPACE, T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], 0);
         if ($tokens[$namespace]['code'] !== T_NAMESPACE) {
             $error = 'Each %s must be in a namespace of at least one level (a top-level vendor name)';
             $phpcsFile->addError($error, $stackPtr, 'MissingNamespace', $errorData);

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -82,6 +82,7 @@ class SideEffectsSniff implements Sniff
             T_CLASS     => T_CLASS,
             T_INTERFACE => T_INTERFACE,
             T_TRAIT     => T_TRAIT,
+            T_ENUM      => T_ENUM,
             T_FUNCTION  => T_FUNCTION,
         ];
 

--- a/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.3.inc
+++ b/src/Standards/PSR1/Tests/Classes/ClassDeclarationUnitTest.3.inc
@@ -1,0 +1,3 @@
+<?php
+class Foo {}
+enum Bar {}

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.1.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.1.inc
@@ -6,6 +6,7 @@ const CONSTANT2 = 2;
 
 use Something;
 use SomethingElse;
+use function interface_exists;
 
 declare(ticks=1);
 
@@ -61,6 +62,11 @@ if (!class_exists('MyClass')) {
 if (!interface_exists('MyInterface')) {
     // Define an interface.
     interface MyInterface {}
+}
+
+if (!interface_exists('MyEnum')) {
+    // Define an enum.
+    enum MyEnum {}
 }
 
 #[\Attribute]

--- a/src/Standards/PSR12/Sniffs/Classes/ClosingBraceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClosingBraceSniff.php
@@ -27,6 +27,7 @@ class ClosingBraceSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
             T_FUNCTION,
         ];
 

--- a/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.inc
@@ -45,3 +45,8 @@ $instance = new class extends \Foo implements \HandleableInterface {
 $app->get('/hello/{name}', function ($name) use ($app) {
     return 'Hello ' . $app->escape($name);
 });
+
+enum Foo4
+{
+
+}//end

--- a/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClosingBraceUnitTest.php
@@ -31,6 +31,7 @@ class ClosingBraceUnitTest extends AbstractSniffUnitTest
             19 => 1,
             24 => 1,
             31 => 1,
+            52 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.inc
@@ -17,3 +17,10 @@ class ClassName3
 }
 
 $foo = function() use($bar) {};
+
+enum SomeEnum
+{
+    use \FirstTrait;
+    use SecondTrait;
+    use ThirdTrait;
+}

--- a/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Files/ImportStatementUnitTest.inc.fixed
@@ -17,3 +17,10 @@ class ClassName3
 }
 
 $foo = function() use($bar) {};
+
+enum SomeEnum
+{
+    use \FirstTrait;
+    use SecondTrait;
+    use ThirdTrait;
+}

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.inc
@@ -15,3 +15,8 @@ class SampleEnum
 
     final private const BAZ = 'SAMPLE';
 }
+
+enum SomeEnum {
+    public const BAR = 'bar';
+    const BAZ = 'baz';
+}

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
@@ -43,6 +43,7 @@ class ConstantVisibilityUnitTest extends AbstractSniffUnitTest
         return [
             4  => 1,
             12 => 1,
+            21 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc
@@ -215,6 +215,7 @@ enum SomeEnum1
 
 enum SomeEnum2
 {
-    use FirstTrait;
+
+    use   FirstTrait;
 
 }

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc
@@ -207,3 +207,14 @@ class Foo implements Bar
      */
     use Baz;
 }
+
+enum SomeEnum1
+{
+    use FirstTrait;
+}
+
+enum SomeEnum2
+{
+    use FirstTrait;
+
+}

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc.fixed
@@ -201,3 +201,13 @@ class Foo implements Bar
      */
     use Baz;
 }
+
+enum SomeEnum1
+{
+    use FirstTrait;
+}
+
+enum SomeEnum2
+{
+    use FirstTrait;
+}

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
@@ -47,7 +47,7 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
             165 => 1,
             170 => 1,
             208 => 1,
-            218 => 1,
+            219 => 3,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
@@ -47,6 +47,7 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
             165 => 1,
             170 => 1,
             208 => 1,
+            218 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -285,7 +285,7 @@ class UseDeclarationSniff implements Sniff
         }
 
         // Ignore USE keywords for traits.
-        if ($phpcsFile->hasCondition($stackPtr, [T_CLASS, T_TRAIT]) === true) {
+        if ($phpcsFile->hasCondition($stackPtr, [T_CLASS, T_TRAIT, T_ENUM]) === true) {
             return true;
         }
 

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc
@@ -64,3 +64,12 @@ class Nested_Function {
         };
     }
 }
+
+enum MyEnum
+{
+    function _myFunction() {}
+    function __myFunction() {}
+    public static function myFunction() {}
+    static public function myFunction() {}
+    public function _() {}
+}

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc.fixed
@@ -64,3 +64,12 @@ class Nested_Function {
         };
     }
 }
+
+enum MyEnum
+{
+    function _myFunction() {}
+    function __myFunction() {}
+    public static function myFunction() {}
+    public static function myFunction() {}
+    public function _() {}
+}

--- a/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.php
@@ -40,6 +40,7 @@ class MethodDeclarationUnitTest extends AbstractSniffUnitTest
             54 => 1,
             56 => 3,
             63 => 2,
+            73 => 1,
         ];
 
     }//end getErrorList()
@@ -61,6 +62,7 @@ class MethodDeclarationUnitTest extends AbstractSniffUnitTest
             30 => 1,
             46 => 1,
             63 => 1,
+            70 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.1.inc
+++ b/src/Standards/PSR2/Tests/Namespaces/UseDeclarationUnitTest.1.inc
@@ -30,6 +30,11 @@ trait HelloWorld
     use Hello, World;
 }
 
+enum SomeEnum
+{
+    use Hello, World;
+}
+
 $x = $foo ? function ($foo) use /* comment */ ($bar): int {
     return 1;
 } : $bar;

--- a/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassFileNameSniff.php
@@ -27,6 +27,7 @@ class ClassFileNameSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()

--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -28,6 +28,7 @@ class ValidClassNameSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
         ];
 
     }//end register()

--- a/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ValidClassNameSniff.php
@@ -59,7 +59,7 @@ class ValidClassNameSniff implements Sniff
         // starting with the number will be multiple tokens.
         $opener    = $tokens[$stackPtr]['scope_opener'];
         $nameStart = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), $opener, true);
-        $nameEnd   = $phpcsFile->findNext(T_WHITESPACE, $nameStart, $opener);
+        $nameEnd   = $phpcsFile->findNext([T_WHITESPACE, T_COLON], $nameStart, $opener);
         if ($nameEnd === false) {
             $name = $tokens[$nameStart]['content'];
         } else {

--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -84,6 +84,7 @@ class BlockCommentSniff implements Sniff
                 T_CLASS     => true,
                 T_INTERFACE => true,
                 T_TRAIT     => true,
+                T_ENUM      => true,
                 T_FUNCTION  => true,
                 T_PUBLIC    => true,
                 T_PRIVATE   => true,

--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -95,6 +95,7 @@ class FileCommentSniff implements Sniff
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
+            T_ENUM,
             T_FUNCTION,
             T_CLOSURE,
             T_PUBLIC,

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -74,6 +74,7 @@ class InlineCommentSniff implements Sniff
                 T_CLASS,
                 T_INTERFACE,
                 T_TRAIT,
+                T_ENUM,
                 T_FUNCTION,
                 T_CLOSURE,
                 T_PUBLIC,

--- a/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
+++ b/src/Standards/Squiz/Sniffs/Files/FileExtensionSniff.php
@@ -42,7 +42,7 @@ class FileExtensionSniff implements Sniff
         $tokens    = $phpcsFile->getTokens();
         $fileName  = $phpcsFile->getFilename();
         $extension = substr($fileName, strrpos($fileName, '.'));
-        $nextClass = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT], $stackPtr);
+        $nextClass = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], $stackPtr);
 
         if ($nextClass !== false) {
             $phpcsFile->recordMetric($stackPtr, 'File extension for class files', $extension);

--- a/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/StaticThisUsageSniff.php
@@ -22,7 +22,7 @@ class StaticThisUsageSniff extends AbstractScopeSniff
      */
     public function __construct()
     {
-        parent::__construct([T_CLASS, T_TRAIT, T_ANON_CLASS], [T_FUNCTION]);
+        parent::__construct([T_CLASS, T_TRAIT, T_ENUM, T_ANON_CLASS], [T_FUNCTION]);
 
     }//end __construct()
 

--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -145,6 +145,7 @@ class ControlStructureSpacingSniff implements Sniff
             T_CLASS                => true,
             T_INTERFACE            => true,
             T_TRAIT                => true,
+            T_ENUM                 => true,
             T_DOC_COMMENT_OPEN_TAG => true,
         ];
 

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
@@ -6,7 +6,7 @@ class ClassFileNameUnitTest {}
 interface ClassFileNameUnitTest {}
 trait ClassFileNameUnitTest {}
 enum ClassFileNameUnitTest {}
-
+enum ClassFileNameUnitTest: int {}
 
 // Invalid filename matching class name (case sensitive).
 class classFileNameUnitTest {}

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.inc
@@ -5,6 +5,7 @@
 class ClassFileNameUnitTest {}
 interface ClassFileNameUnitTest {}
 trait ClassFileNameUnitTest {}
+enum ClassFileNameUnitTest {}
 
 
 // Invalid filename matching class name (case sensitive).
@@ -17,6 +18,9 @@ interface CLASSFILENAMEUNITTEST {}
 trait classFileNameUnitTest {}
 trait classfilenameunittest {}
 trait CLASSFILENAMEUNITTEST {}
+enum classFileNameUnitTest {}
+enum classfilenameunittest {}
+enum CLASSFILENAMEUNITTEST {}
 
 
 // Invalid non-filename matching class names.
@@ -32,6 +36,10 @@ trait CompletelyWrongClassName {}
 trait ClassFileNameUnitTestExtra {}
 trait ClassFileNameUnitTestInc {}
 trait ExtraClassFileNameUnitTest {}
+enum CompletelyWrongClassName {}
+enum ClassFileNameUnitTestExtra {}
+enum ClassFileNameUnitTestInc {}
+enum ExtraClassFileNameUnitTest {}
 
 
 ?>

--- a/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassFileNameUnitTest.php
@@ -26,7 +26,6 @@ class ClassFileNameUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            11 => 1,
             12 => 1,
             13 => 1,
             14 => 1,
@@ -35,10 +34,10 @@ class ClassFileNameUnitTest extends AbstractSniffUnitTest
             17 => 1,
             18 => 1,
             19 => 1,
+            20 => 1,
+            21 => 1,
+            22 => 1,
             23 => 1,
-            24 => 1,
-            25 => 1,
-            26 => 1,
             27 => 1,
             28 => 1,
             29 => 1,
@@ -47,6 +46,14 @@ class ClassFileNameUnitTest extends AbstractSniffUnitTest
             32 => 1,
             33 => 1,
             34 => 1,
+            35 => 1,
+            36 => 1,
+            37 => 1,
+            38 => 1,
+            39 => 1,
+            40 => 1,
+            41 => 1,
+            42 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
@@ -3,6 +3,7 @@ Abstract Class MyClass Extends MyClass {}
 Final Class MyClass Implements MyInterface {}
 Interface MyInterface {}
 Trait MyTrait {}
+Enum MyEnum {}
 
 class MyClass
 {

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
@@ -3,7 +3,7 @@ Abstract Class MyClass Extends MyClass {}
 Final Class MyClass Implements MyInterface {}
 Interface MyInterface {}
 Trait MyTrait {}
-Enum MyEnum {}
+Enum MyEnum IMPLEMENTS Colorful {}
 
 class MyClass
 {

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
@@ -3,7 +3,7 @@ abstract class MyClass extends MyClass {}
 final class MyClass implements MyInterface {}
 interface MyInterface {}
 trait MyTrait {}
-enum MyEnum {}
+enum MyEnum implements Colorful {}
 
 class MyClass
 {

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
@@ -3,6 +3,7 @@ abstract class MyClass extends MyClass {}
 final class MyClass implements MyInterface {}
 interface MyInterface {}
 trait MyTrait {}
+enum MyEnum {}
 
 class MyClass
 {

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -30,9 +30,10 @@ class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
             3  => 3,
             4  => 1,
             5  => 1,
-            9  => 1,
+            6  => 1,
             10 => 1,
-            13 => 1,
+            11 => 1,
+            14 => 1,
         ];
 
         return $errors;

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -30,7 +30,7 @@ class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
             3  => 3,
             4  => 1,
             5  => 1,
-            6  => 1,
+            6  => 2,
             10 => 1,
             11 => 1,
             14 => 1,

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.inc
@@ -137,6 +137,50 @@ trait Base
     }
 }
 
+// Valid enum name.
+enum ValidCamelCaseClass {}
+
+
+// Incorrect usage of camel case.
+enum invalidCamelCaseClass {}
+enum Invalid_Camel_Case_Class_With_Underscores {}
+
+
+// All lowercase.
+enum invalidlowercaseclass {}
+enum invalid_lowercase_class_with_underscores {}
+
+
+// All uppercase.
+enum VALIDUPPERCASECLASS {}
+enum INVALID_UPPERCASE_CLASS_WITH_UNDERSCORES {}
+
+
+// Mix camel case with uppercase.
+enum ValidCamelCaseClassWithUPPERCASE {}
+
+
+// Usage of numeric characters.
+enum ValidCamelCaseClassWith1Number {}
+enum ValidCamelCaseClassWith12345Numbers {}
+enum ValidCamelCaseClassEndingWithNumber5 {}
+
+enum Testing{}
+
+enum Base
+{
+    public function __construct()
+    {
+        $this->anonymous = new class extends ArrayObject
+        {
+            public function __construct()
+            {
+                parent::__construct(['a' => 1, 'b' => 2]);
+            }
+        };
+    }
+}
+
 if ( class_exists( Test :: class ) ) {}
 if ( class_exists( Test2 ::class ) ) {}
 

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.inc
@@ -138,7 +138,7 @@ trait Base
 }
 
 // Valid enum name.
-enum ValidCamelCaseClass {}
+enum ValidCamelCaseClass: string {}
 
 
 // Incorrect usage of camel case.
@@ -147,22 +147,22 @@ enum Invalid_Camel_Case_Class_With_Underscores {}
 
 
 // All lowercase.
-enum invalidlowercaseclass {}
+enum invalidlowercaseclass: INT {}
 enum invalid_lowercase_class_with_underscores {}
 
 
 // All uppercase.
-enum VALIDUPPERCASECLASS {}
+enum VALIDUPPERCASECLASS: int {}
 enum INVALID_UPPERCASE_CLASS_WITH_UNDERSCORES {}
 
 
 // Mix camel case with uppercase.
-enum ValidCamelCaseClassWithUPPERCASE {}
+enum ValidCamelCaseClassWithUPPERCASE : string {}
 
 
 // Usage of numeric characters.
 enum ValidCamelCaseClassWith1Number {}
-enum ValidCamelCaseClassWith12345Numbers {}
+enum ValidCamelCaseClassWith12345Numbers : string {}
 enum ValidCamelCaseClassEndingWithNumber5 {}
 
 enum Testing{}

--- a/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ValidClassNameUnitTest.php
@@ -47,6 +47,11 @@ class ValidClassNameUnitTest extends AbstractSniffUnitTest
             108 => 1,
             118 => 1,
             120 => 1,
+            145 => 1,
+            146 => 1,
+            150 => 1,
+            151 => 1,
+            156 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -299,3 +299,11 @@ abstract class MyClass
      */
     readonly public string $prop;
 }
+
+/**
+ * Comment should be ignored
+ *
+ */
+enum MyEnum {
+
+}

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -301,3 +301,11 @@ abstract class MyClass
      */
     readonly public string $prop;
 }
+
+/**
+ * Comment should be ignored
+ *
+ */
+enum MyEnum {
+
+}

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.9.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.9.inc
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This should not be recognized as a file comment, but as a enum comment.
+ *
+ * @package    Package
+ * @subpackage Subpackage
+ * @author     Squiz Pty Ltd <products@squiz.net>
+ * @copyright  2010-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ */
+
+enum Foo {
+}

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -45,6 +45,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
         case 'FileCommentUnitTest.4.inc':
         case 'FileCommentUnitTest.6.inc':
         case 'FileCommentUnitTest.7.inc':
+        case 'FileCommentUnitTest.9.inc':
             return [1 => 1];
 
         case 'FileCommentUnitTest.5.inc':

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
@@ -173,3 +173,11 @@ final class MyClass
  */
 
 // For this test line having an empty line below it, is fine.
+
+/**
+ * Comment should be ignored.
+ *
+ */
+enum MyEnum {
+
+}

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
@@ -165,6 +165,14 @@ final class MyClass
     final public function test() {}
 }
 
+/**
+ * Comment should be ignored.
+ *
+ */
+enum MyEnum {
+
+}
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace
@@ -173,11 +181,3 @@ final class MyClass
  */
 
 // For this test line having an empty line below it, is fine.
-
-/**
- * Comment should be ignored.
- *
- */
-enum MyEnum {
-
-}

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
@@ -158,6 +158,14 @@ final class MyClass
     final public function test() {}
 }
 
+/**
+ * Comment should be ignored.
+ *
+ */
+enum MyEnum {
+
+}
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace
@@ -166,11 +174,3 @@ final class MyClass
  */
 
 // For this test line having an empty line below it, is fine.
-
-/**
- * Comment should be ignored.
- *
- */
-enum MyEnum {
-
-}

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
@@ -166,3 +166,11 @@ final class MyClass
  */
 
 // For this test line having an empty line below it, is fine.
+
+/**
+ * Comment should be ignored.
+ *
+ */
+enum MyEnum {
+
+}

--- a/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.5.inc
+++ b/src/Standards/Squiz/Tests/Files/FileExtensionUnitTest.5.inc
@@ -1,0 +1,3 @@
+<?php
+enum MyEnum {}
+?>

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -146,3 +146,12 @@ echo $obj?->varName;
 echo $obj?->var_name;
 echo $obj?->varname;
 echo $obj?->_varName;
+
+enum SomeEnum
+{
+    public function foo($foo, $_foo, $foo_bar) {
+        $bar = 1;
+        $_bar = 2;
+        $bar_foo = 3;
+    }
+}

--- a/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Squiz/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -61,6 +61,8 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest
             138 => 1,
             141 => 1,
             146 => 1,
+            152 => 1,
+            155 => 1,
         ];
 
         return $errors;

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
@@ -46,9 +46,9 @@ trait Something {
 }
 
 enum Something {
-	function getReturnType() {
-	    echo 'no error';
-	}
+    function getReturnType() {
+        echo 'no error';
+    }
 }
 
 $a = new class {

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
@@ -45,6 +45,12 @@ trait Something {
 	}
 }
 
+enum Something {
+	function getReturnType() {
+	    echo 'no error';
+	}
+}
+
 $a = new class {
     public function log($msg)
     {

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -83,7 +83,7 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 9  => 1,
                 10 => 2,
                 14 => 1,
-                48 => 2,
+                54 => 2,
             ];
             break;
         default:

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
@@ -40,3 +40,11 @@ class Nested {
         };
     }
 }
+
+enum SomeEnum
+{
+    function func1() {}
+    public function func1() {}
+    private function func1() {}
+    protected function func1() {}
+}

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.php
@@ -29,6 +29,7 @@ class MethodScopeUnitTest extends AbstractSniffUnitTest
             6  => 1,
             30 => 1,
             39 => 1,
+            46 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -115,3 +115,9 @@ $b = new class()
         return $This;
     }
 }
+
+enum MyEnum {
+    public static function myFunc() {
+        $this->doSomething();
+    }
+}

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.inc
@@ -117,6 +117,10 @@ $b = new class()
 }
 
 enum MyEnum {
+    private function notStatic () {
+        $this->doSomething();
+    }
+
     public static function myFunc() {
         $this->doSomething();
     }

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -26,18 +26,19 @@ class StaticThisUsageUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            7  => 1,
-            8  => 1,
-            9  => 1,
-            14 => 1,
-            20 => 1,
-            41 => 1,
-            61 => 1,
-            69 => 1,
-            76 => 1,
-            80 => 1,
-            84 => 1,
-            99 => 1,
+            7   => 1,
+            8   => 1,
+            9   => 1,
+            14  => 1,
+            20  => 1,
+            41  => 1,
+            61  => 1,
+            69  => 1,
+            76  => 1,
+            80  => 1,
+            84  => 1,
+            99  => 1,
+            121 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
+++ b/src/Standards/Squiz/Tests/Scope/StaticThisUsageUnitTest.php
@@ -38,7 +38,7 @@ class StaticThisUsageUnitTest extends AbstractSniffUnitTest
             80  => 1,
             84  => 1,
             99  => 1,
-            121 => 1,
+            125 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -262,6 +262,8 @@ $expr = match( $foo ){
 };
 echo $expr;
 
-enum SomeEnum
-{
+if($true) {
+
+    enum SomeEnum {}
+
 }

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc
@@ -261,3 +261,7 @@ $expr = match( $foo ){
 
 };
 echo $expr;
+
+enum SomeEnum
+{
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -254,6 +254,8 @@ $expr = match($foo){
 
 echo $expr;
 
-enum SomeEnum
-{
+if($true) {
+
+    enum SomeEnum {}
+
 }

--- a/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ControlStructureSpacingUnitTest.inc.fixed
@@ -253,3 +253,7 @@ $expr = match($foo){
 };
 
 echo $expr;
+
+enum SomeEnum
+{
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc
@@ -365,3 +365,10 @@ class HasAttributes
     #[ThirdAttribute]
     protected $propertyWithoutSpacing;
 }
+
+enum SomeEnum
+{
+    // Enum cannot have properties
+
+    case ONE = 'one';
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/MemberVarSpacingUnitTest.inc.fixed
@@ -350,3 +350,10 @@ class HasAttributes
     #[ThirdAttribute]
     protected $propertyWithoutSpacing;
 }
+
+enum SomeEnum
+{
+    // Enum cannot have properties
+
+    case ONE = 'one';
+}

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.inc
@@ -120,3 +120,12 @@ $anonClass = new class() {
 echo $obj?->varName;
 echo $obj?->var_name;
 echo $obj?->varName;
+
+enum SomeEnum
+{
+    public function foo($foo, $_foo, $foo_bar) {
+        $bar = 1;
+        $_bar = 2;
+        $bar_foo = 3;
+    }
+}

--- a/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
+++ b/src/Standards/Zend/Tests/NamingConventions/ValidVariableNameUnitTest.php
@@ -54,6 +54,8 @@ class ValidVariableNameUnitTest extends AbstractSniffUnitTest
             113 => 1,
             116 => 1,
             121 => 1,
+            126 => 1,
+            129 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Based on https://github.com/squizlabs/PHP_CodeSniffer/pull/3478