### PR TITLE
Cyclomatic complexity updates and fixes

### DIFF
--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -84,6 +84,7 @@ class CyclomaticComplexitySniff implements Sniff
             T_INLINE_THEN    => true,
             T_COALESCE       => true,
             T_COALESCE_EQUAL => true,
+            T_MATCH_ARROW    => true,
         ];
 
         $complexity = 1;

--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -71,16 +71,19 @@ class CyclomaticComplexitySniff implements Sniff
 
         // Predicate nodes for PHP.
         $find = [
-            T_CASE    => true,
-            T_DEFAULT => true,
-            T_CATCH   => true,
-            T_IF      => true,
-            T_FOR     => true,
-            T_FOREACH => true,
-            T_WHILE   => true,
+            T_CASE           => true,
+            T_DEFAULT        => true,
+            T_CATCH          => true,
+            T_IF             => true,
+            T_FOR            => true,
+            T_FOREACH        => true,
+            T_WHILE          => true,
             // T_DO is not required for incrementing CYC, as the terminating while in a do/while loop triggers the branch.
             // T_DO      => true.
-            T_ELSEIF  => true,
+            T_ELSEIF         => true,
+            T_INLINE_THEN    => true,
+            T_COALESCE       => true,
+            T_COALESCE_EQUAL => true,
         ];
 
         $complexity = 1;

--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -78,7 +78,8 @@ class CyclomaticComplexitySniff implements Sniff
             T_FOR     => true,
             T_FOREACH => true,
             T_WHILE   => true,
-            T_DO      => true,
+            // T_DO is not required for incrementing CYC, as the terminating while in a do/while loop triggers the branch.
+            // T_DO      => true.
             T_ELSEIF  => true,
         ];
 

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
@@ -79,9 +79,11 @@ function complexityTwenty()
 
     switch ($condition) {
         case '1':
-            if ($condition) {
-            } else if ($cond) {
-            }
+            do {
+                if ($condition) {
+                } else if ($cond) {
+                }
+            } while ($cond);
         break;
         case '2':
             while ($cond) {
@@ -116,9 +118,11 @@ function complexityTwenty()
 function complexityTwentyOne()
 {
     while ($condition === true) {
-        if ($condition) {
-        } else if ($cond) {
-        }
+        do {
+            if ($condition) {
+            } else if ($cond) {
+            }
+        } while ($cond);
     }
 
     switch ($condition) {

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
@@ -161,4 +161,245 @@ function complexityTwentyOne()
     }
 }
 
+
+function complexityTenWithTernaries()
+{
+    $value1 = (empty($condition1)) ? $value1A : $value1B;
+    $value2 = (empty($condition2)) ? $value2A : $value2B;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityElevenWithTernaries()
+{
+    $value1 = (empty($condition1)) ? $value1A : $value1B;
+    $value2 = (empty($condition2)) ? $value2A : $value2B;
+    $value3 = (empty($condition3)) ? $value3A : $value3B;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityTenWithNestedTernaries()
+{
+    $value1 = true ? $value1A : false ? $value1B : $value1C;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityElevenWithNestedTernaries()
+{
+    $value1 = (empty($condition1)) ? $value1A : $value1B;
+    $value2 = true ? $value2A : false ? $value2B : $value2C;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityTenWithNullCoalescence()
+{
+    $value1 = $value1A ?? $value1B;
+    $value2 = $value2A ?? $value2B;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityElevenWithNullCoalescence()
+{
+    $value1 = $value1A ?? $value1B;
+    $value2 = $value2A ?? $value2B;
+    $value3 = $value3A ?? $value3B;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityTenWithNestedNullCoalescence()
+{
+    $value1 = $value1A ?? $value1B ?? $value1C;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityElevenWithNestedNullCoalescence()
+{
+    $value1 = $value1A ?? $value1B;
+    $value2 = $value2A ?? $value2B ?? $value2C;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityTenWithNullCoalescenceAssignment()
+{
+    $value1 ??= $default1;
+    $value2 ??= $default2;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
+
+function complexityElevenWithNullCoalescenceAssignment()
+{
+    $value1 ??= $default1;
+    $value2 ??= $default2;
+    $value3 ??= $default3;
+
+    switch ($condition) {
+        case '1':
+            if ($condition) {
+            } else if ($cond) {
+            }
+            break;
+        case '2':
+            while ($cond) {
+                echo 'hi';
+            }
+            break;
+        case '3':
+            break;
+        default:
+            break;
+    }
+}
+
 ?>

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
@@ -402,4 +402,35 @@ function complexityElevenWithNullCoalescenceAssignment()
     }
 }
 
+
+function complexityFiveWithMatch()
+{
+    return match(strtolower(substr($monthName, 0, 3))){
+        'apr', 'jun', 'sep',  'nov'  => 30,
+        'jan', 'mar', 'may', 'jul', 'aug',  'oct', 'dec'  => 31,
+        'feb' => is_leap_year($year) ? 29 : 28,
+        default => throw new InvalidArgumentException("Invalid month"),
+    }
+}
+
+
+function complexityFourteenWithMatch()
+{
+    return match(strtolower(substr($monthName, 0, 3))) {
+        'jan' => 31,
+        'feb' => is_leap_year($year) ? 29 : 28,
+        'mar' => 31,
+        'apr' => 30,
+        'may' => 31,
+        'jun' => 30,
+        'jul' => 31,
+        'aug' => 31,
+        'sep' => 30,
+        'oct' => 31,
+        'nov' => 30,
+        'dec' => 31,
+        default => throw new InvalidArgumentException("Invalid month"),
+    };
+}
+
 ?>

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -48,6 +48,7 @@ class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
             285 => 1,
             333 => 1,
             381 => 1,
+            417 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -41,8 +41,13 @@ class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            45 => 1,
-            72 => 1,
+            45  => 1,
+            72  => 1,
+            189 => 1,
+            237 => 1,
+            285 => 1,
+            333 => 1,
+            381 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -25,7 +25,7 @@ class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
      */
     public function getErrorList()
     {
-        return [116 => 1];
+        return [118 => 1];
 
     }//end getErrorList()
 


### PR DESCRIPTION
Resolve 3 issues with the Cyclometric Complexity sniff

 - Fix for Issue [#3468](https://github.com/squizlabs/PHP_CodeSniffer/issues/3468)
  do/while loops are double-counted in the Generic.Metrics.CyclomaticComplexity sniff
 - Fix for Issue [#3469](https://github.com/squizlabs/PHP_CodeSniffer/issues/3469)
  Ternary Operator and Null Coalescing Operator are not counted in the Generic.Metrics.CyclomaticComplexity sniff
 - Issue [#3472](https://github.com/squizlabs/PHP_CodeSniffer/issues/3472)
  PHP 8 match() expression is not counted in the Generic.Metrics.CyclomaticComplexity sniff

This PR replaces [PR #3470](https://github.com/squizlabs/PHP_CodeSniffer/pull/3470), [PR #3471](https://github.com/squizlabs/PHP_CodeSniffer/pull/3471) and [PR #3473 ](https://github.com/squizlabs/PHP_CodeSniffer/pull/3473)
