### PR TITLE
PSR12: Add closing and Opening spaces in functions for PSR12 Standard

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1136,6 +1136,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="OpenTagSniff.php" role="php" />
        </dir>
        <dir name="Functions">
+        <file baseinstalldir="PHP/CodeSniffer" name="FunctionClosingBraceSpaceSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FunctionOpeningBraceSpaceSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="NullableTypeDeclarationSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ReturnTypeDeclarationSniff.php" role="php" />
        </dir>


### PR DESCRIPTION
If I follow this issue https://github.com/squizlabs/PHP_CodeSniffer/issues/3437 resolvment

Should we also trim spaces on functions for PSR-12 standard