### PR TITLE
PSR12: Ensure there are no empty line before and after function body

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1136,6 +1136,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="OpenTagSniff.php" role="php" />
        </dir>
        <dir name="Functions">
+        <file baseinstalldir="PHP/CodeSniffer" name="FunctionClosingBraceSpaceSniff.php" role="php" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FunctionOpeningBraceSpaceSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="NullableTypeDeclarationSniff.php" role="php" />
         <file baseinstalldir="PHP/CodeSniffer" name="ReturnTypeDeclarationSniff.php" role="php" />
        </dir>

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
@@ -21,7 +21,6 @@ class FunctionClosingBraceSpaceSniff implements Sniff
      */
     public $supportedTokenizers = [
         'PHP',
-        'JS',
     ];
 
 
@@ -60,26 +59,6 @@ class FunctionClosingBraceSpaceSniff implements Sniff
 
         $closeBrace  = $tokens[$stackPtr]['scope_closer'];
         $prevContent = $phpcsFile->findPrevious(T_WHITESPACE, ($closeBrace - 1), null, true);
-
-        // Special case for empty JS functions.
-        if ($phpcsFile->tokenizerType === 'JS' && $prevContent === $tokens[$stackPtr]['scope_opener']) {
-            // In this case, the opening and closing brace must be
-            // right next to each other.
-            if ($tokens[$stackPtr]['scope_closer'] !== ($tokens[$stackPtr]['scope_opener'] + 1)) {
-                $error = 'The opening and closing braces of empty functions must be directly next to each other; e.g., function () {}';
-                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'SpacingBetween');
-                if ($fix === true) {
-                    $phpcsFile->fixer->beginChangeset();
-                    for ($i = ($tokens[$stackPtr]['scope_opener'] + 1); $i < $closeBrace; $i++) {
-                        $phpcsFile->fixer->replaceToken($i, '');
-                    }
-
-                    $phpcsFile->fixer->endChangeset();
-                }
-            }
-
-            return;
-        }
 
         $nestedFunction = false;
         if ($phpcsFile->hasCondition($stackPtr, [T_FUNCTION, T_CLOSURE]) === true

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
@@ -70,68 +70,31 @@ class FunctionClosingBraceSpaceSniff implements Sniff
         $prevLine  = $tokens[$prevContent]['line'];
         $found     = ($braceLine - $prevLine - 1);
 
-        if ($nestedFunction === true) {
-            if ($found < 0) {
-                $error = 'Closing brace of nested function must be on a new line';
-                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'ContentBeforeClose');
-                if ($fix === true) {
-                    $phpcsFile->fixer->addNewlineBefore($closeBrace);
-                }
-            } else if ($found > 0) {
-                $error = 'Expected 0 blank lines before closing brace of nested function; %s found';
-                $data  = [$found];
-                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'SpacingBeforeNestedClose', $data);
+        if ($found > 0) {
+            $error = 'Expected 0 blank lines before closing brace of nested function; %s found';
+            $data  = [$found];
+            $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'SpacingBeforeNestedClose', $data);
 
-                if ($fix === true) {
-                    $phpcsFile->fixer->beginChangeset();
-                    $changeMade = false;
-                    for ($i = ($prevContent + 1); $i < $closeBrace; $i++) {
-                        // Try and maintain indentation.
-                        if ($tokens[$i]['line'] === ($braceLine - 1)) {
-                            break;
-                        }
-
-                        $phpcsFile->fixer->replaceToken($i, '');
-                        $changeMade = true;
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $changeMade = false;
+                for ($i = ($prevContent + 1); $i < $closeBrace; $i++) {
+                    // Try and maintain indentation.
+                    if ($tokens[$i]['line'] === ($braceLine - 1)) {
+                        break;
                     }
 
-                    // Special case for when the last content contains the newline
-                    // token as well, like with a comment.
-                    if ($changeMade === false) {
-                        $phpcsFile->fixer->replaceToken(($prevContent + 1), '');
-                    }
-
-                    $phpcsFile->fixer->endChangeset();
-                }//end if
-            }//end if
-        } else {
-            if ($found !== 1) {
-                if ($found < 0) {
-                    $found = 0;
+                    $phpcsFile->fixer->replaceToken($i, '');
+                    $changeMade = true;
                 }
 
-                $error = 'Expected 1 blank line before closing function brace; %s found';
-                $data  = [$found];
-                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'SpacingBeforeClose', $data);
-
-                if ($fix === true) {
-                    if ($found > 1) {
-                        $phpcsFile->fixer->beginChangeset();
-                        for ($i = ($prevContent + 1); $i < ($closeBrace - 1); $i++) {
-                            $phpcsFile->fixer->replaceToken($i, '');
-                        }
-
-                        $phpcsFile->fixer->replaceToken($i, $phpcsFile->eolChar);
-                        $phpcsFile->fixer->endChangeset();
-                    } else {
-                        // Try and maintain indentation.
-                        if ($tokens[($closeBrace - 1)]['code'] === T_WHITESPACE) {
-                            $phpcsFile->fixer->addNewlineBefore($closeBrace - 1);
-                        } else {
-                            $phpcsFile->fixer->addNewlineBefore($closeBrace);
-                        }
-                    }
+                // Special case for when the last content contains the newline
+                // token as well, like with a comment.
+                if ($changeMade === false) {
+                    $phpcsFile->fixer->replaceToken(($prevContent + 1), '');
                 }
+
+                $phpcsFile->fixer->endChangeset();
             }//end if
         }//end if
 

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Checks that there is one empty line before the closing brace of a function.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\PSR12;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class FunctionClosingBraceSpaceSniff implements Sniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION,
+            T_CLOSURE,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+            // Probably an interface method.
+            return;
+        }
+
+        $closeBrace  = $tokens[$stackPtr]['scope_closer'];
+        $prevContent = $phpcsFile->findPrevious(T_WHITESPACE, ($closeBrace - 1), null, true);
+
+        // Special case for empty JS functions.
+        if ($phpcsFile->tokenizerType === 'JS' && $prevContent === $tokens[$stackPtr]['scope_opener']) {
+            // In this case, the opening and closing brace must be
+            // right next to each other.
+            if ($tokens[$stackPtr]['scope_closer'] !== ($tokens[$stackPtr]['scope_opener'] + 1)) {
+                $error = 'The opening and closing braces of empty functions must be directly next to each other; e.g., function () {}';
+                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'SpacingBetween');
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($tokens[$stackPtr]['scope_opener'] + 1); $i < $closeBrace; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+
+            return;
+        }
+
+        $nestedFunction = false;
+        if ($phpcsFile->hasCondition($stackPtr, [T_FUNCTION, T_CLOSURE]) === true
+            || isset($tokens[$stackPtr]['nested_parenthesis']) === true
+        ) {
+            $nestedFunction = true;
+        }
+
+        $braceLine = $tokens[$closeBrace]['line'];
+        $prevLine  = $tokens[$prevContent]['line'];
+        $found     = ($braceLine - $prevLine - 1);
+
+        if ($nestedFunction === true) {
+            if ($found < 0) {
+                $error = 'Closing brace of nested function must be on a new line';
+                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'ContentBeforeClose');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addNewlineBefore($closeBrace);
+                }
+            } else if ($found > 0) {
+                $error = 'Expected 0 blank lines before closing brace of nested function; %s found';
+                $data  = [$found];
+                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'SpacingBeforeNestedClose', $data);
+
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    $changeMade = false;
+                    for ($i = ($prevContent + 1); $i < $closeBrace; $i++) {
+                        // Try and maintain indentation.
+                        if ($tokens[$i]['line'] === ($braceLine - 1)) {
+                            break;
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, '');
+                        $changeMade = true;
+                    }
+
+                    // Special case for when the last content contains the newline
+                    // token as well, like with a comment.
+                    if ($changeMade === false) {
+                        $phpcsFile->fixer->replaceToken(($prevContent + 1), '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }//end if
+            }//end if
+        } else {
+            if ($found !== 1) {
+                if ($found < 0) {
+                    $found = 0;
+                }
+
+                $error = 'Expected 1 blank line before closing function brace; %s found';
+                $data  = [$found];
+                $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'SpacingBeforeClose', $data);
+
+                if ($fix === true) {
+                    if ($found > 1) {
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($i = ($prevContent + 1); $i < ($closeBrace - 1); $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, $phpcsFile->eolChar);
+                        $phpcsFile->fixer->endChangeset();
+                    } else {
+                        // Try and maintain indentation.
+                        if ($tokens[($closeBrace - 1)]['code'] === T_WHITESPACE) {
+                            $phpcsFile->fixer->addNewlineBefore($closeBrace - 1);
+                        } else {
+                            $phpcsFile->fixer->addNewlineBefore($closeBrace);
+                        }
+                    }
+                }
+            }//end if
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionClosingBraceSpaceSniff.php
@@ -14,14 +14,13 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class FunctionClosingBraceSpaceSniff implements Sniff
 {
+
     /**
      * A list of tokenizers this sniff supports.
      *
      * @var array
      */
-    public $supportedTokenizers = [
-        'PHP',
-    ];
+    public $supportedTokenizers = ['PHP'];
 
 
     /**

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Checks that there is no empty line after the opening brace of a function.
+ * Checks that there is one empty line after the opening brace of a function.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
@@ -14,14 +14,13 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class FunctionOpeningBraceSpaceSniff implements Sniff
 {
+
     /**
      * A list of tokenizers this sniff supports.
      *
      * @var array
      */
-    public $supportedTokenizers = [
-        'PHP',
-    ];
+    public $supportedTokenizers = ['PHP'];
 
 
     /**

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Checks that there is no empty line after the opening brace of a function.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\PSR12;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class FunctionOpeningBraceSpaceSniff implements Sniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            T_FUNCTION,
+            T_CLOSURE,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            // Probably an interface or abstract method.
+            return;
+        }
+
+        $openBrace   = $tokens[$stackPtr]['scope_opener'];
+        $nextContent = $phpcsFile->findNext(T_WHITESPACE, ($openBrace + 1), null, true);
+
+        if ($nextContent === $tokens[$stackPtr]['scope_closer']) {
+             // The next bit of content is the closing brace, so this
+             // is an empty function and should have a blank line
+             // between the opening and closing braces.
+            return;
+        }
+
+        $braceLine = $tokens[$openBrace]['line'];
+        $nextLine  = $tokens[$nextContent]['line'];
+
+        $found = ($nextLine - $braceLine - 1);
+        if ($found > 0) {
+            $error = 'Expected 0 blank lines after opening function brace; %s found';
+            $data  = [$found];
+            $fix   = $phpcsFile->addFixableError($error, $openBrace, 'SpacingAfter', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($openBrace + 1); $i < $nextContent; $i++) {
+                    if ($tokens[$i]['line'] === $nextLine) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->addNewline($openBrace);
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
+++ b/src/Standards/PSR12/Sniffs/Functions/FunctionOpeningBraceSpaceSniff.php
@@ -21,7 +21,6 @@ class FunctionOpeningBraceSpaceSniff implements Sniff
      */
     public $supportedTokenizers = [
         'PHP',
-        'JS',
     ];
 
 

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc
@@ -1,0 +1,24 @@
+<?php
+
+function MyFunction() {
+    // Some code goes here.
+
+}
+
+class MyClass
+{
+    function MyFunction() {
+        // Some code goes here.
+
+    }
+
+    public function register();
+}
+
+$a = function()
+{
+    echo 'Testing a closure';
+
+
+
+};

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc
@@ -7,16 +7,14 @@ function MyFunction() {
 
 class MyClass
 {
-    function MyFunction() {
+    function MyFunction()
+    {
         // Some code goes here.
 
     }
-
-    public function register();
 }
 
-$a = function()
-{
+$a = function() {
     echo 'Testing a closure';
 
 

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc.fixed
@@ -1,0 +1,19 @@
+<?php
+
+function MyFunction() {
+    // Some code goes here.
+}
+
+class MyClass
+{
+    function MyFunction() {
+        // Some code goes here.
+    }
+
+    public function register();
+}
+
+$a = function()
+{
+    echo 'Testing a closure';
+};

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.inc.fixed
@@ -6,14 +6,12 @@ function MyFunction() {
 
 class MyClass
 {
-    function MyFunction() {
+    function MyFunction()
+    {
         // Some code goes here.
     }
-
-    public function register();
 }
 
-$a = function()
-{
+$a = function() {
     echo 'Testing a closure';
 };

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Unit test class for the ReturnTypeDeclaration sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    protected function getErrorList()
+    {
+        return [
+            5 => 1,
+            12 => 1,
+            21 => 1,
+            22 => 1,
+            23 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    protected function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
 class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
 {
+
+
     /**
      * Returns the lines where errors should occur.
      *
@@ -24,7 +26,7 @@ class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
     protected function getErrorList()
     {
         return [
-            5 => 1,
+            5  => 1,
             12 => 1,
             21 => 1,
             22 => 1,

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
@@ -27,10 +27,10 @@ class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
     {
         return [
             5  => 1,
-            12 => 1,
+            13 => 1,
+            19 => 1,
+            20 => 1,
             21 => 1,
-            22 => 1,
-            23 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionClosingBraceSpaceUnitTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit test class for the ReturnTypeDeclaration sniff.
+ * Unit test class for the FunctionOpeningBraceSpaceSniff sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
-class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
+class FunctionClosingBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc
@@ -3,7 +3,6 @@
 function MyFunction() {
 
     // Some code goes here.
-    echo $code;
 }
 
 class MyClass
@@ -12,14 +11,10 @@ class MyClass
     {
 
         // Some code goes here.
-        echo $code;
     }
-
-    public function register();
 }
 
-$a = function()
-{
+$a = function() {
 
 
 

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc
@@ -1,0 +1,27 @@
+<?php
+
+function MyFunction() {
+
+    // Some code goes here.
+    echo $code;
+}
+
+class MyClass
+{
+    function MyFunction()
+    {
+
+        // Some code goes here.
+        echo $code;
+    }
+
+    public function register();
+}
+
+$a = function()
+{
+
+
+
+	echo 'Testing a closure';
+};

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc.fixed
@@ -1,0 +1,23 @@
+<?php
+
+function MyFunction()
+{
+    // Some code goes here.
+    echo $code;
+}
+
+class MyClass
+{
+    function MyFunction()
+    {
+        // Some code goes here.
+        echo $code;
+    }
+
+    public function register();
+}
+
+$a = function()
+{
+	echo 'Testing a closure';
+};

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.inc.fixed
@@ -1,7 +1,6 @@
 <?php
 
-function MyFunction()
-{
+function MyFunction() {
     // Some code goes here.
     echo $code;
 }
@@ -17,7 +16,6 @@ class MyClass
     public function register();
 }
 
-$a = function()
-{
+$a = function() {
 	echo 'Testing a closure';
 };

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
@@ -27,10 +27,10 @@ class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
     {
         return [
             4  => 1,
-            13 => 1,
-            23 => 1,
-            24 => 1,
-            25 => 1,
+            12 => 1,
+            18 => 1,
+            19 => 1,
+            20 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit test class for the ReturnTypeDeclaration sniff.
+ * Unit test class for the FunctionOpeningBraceSpaceSniff sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
@@ -11,7 +11,7 @@ namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
 
-class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
+class FunctionOpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
 {
 
 

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
@@ -26,7 +26,7 @@ class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
     protected function getErrorList()
     {
         return [
-            4 => 1,
+            4  => 1,
             13 => 1,
             23 => 1,
             24 => 1,

--- a/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Functions/FunctionOpeningBraceSpaceUnitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Unit test class for the ReturnTypeDeclaration sniff.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2018 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Standards\PSR12\Tests\Functions;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ReturnTypeDeclarationUnitTest extends AbstractSniffUnitTest
+{
+
+
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    protected function getErrorList()
+    {
+        return [
+            4 => 1,
+            13 => 1,
+            23 => 1,
+            24 => 1,
+            25 => 1,
+        ];
+
+    }//end getErrorList()
+
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of warnings that should occur on that line.
+     *
+     * @return array<int, int>
+     */
+    protected function getWarningList()
+    {
+        return [];
+
+    }//end getWarningList()
+
+
+}//end class


### PR DESCRIPTION
If I follow this issue https://github.com/squizlabs/PHP_CodeSniffer/issues/3437 resolvment
Should we also trim spaces on functions for PSR-12 standard