### PR TITLE
Fix PHP 8.1 deprecation errors, take two

### DIFF
--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -170,7 +170,7 @@ class FileList implements \Iterator, \Countable
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->files);
@@ -183,7 +183,7 @@ class FileList implements \Iterator, \Countable
      *
      * @return \PHP_CodeSniffer\Files\File
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $path = key($this->files);
@@ -201,7 +201,7 @@ class FileList implements \Iterator, \Countable
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->files);
@@ -214,7 +214,7 @@ class FileList implements \Iterator, \Countable
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->files);
@@ -227,7 +227,7 @@ class FileList implements \Iterator, \Countable
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if (current($this->files) === false) {
@@ -244,7 +244,7 @@ class FileList implements \Iterator, \Countable
      *
      * @return integer
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->numFiles;

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -90,7 +90,7 @@ class Filter extends \RecursiveFilterIterator
      *
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         $filePath = $this->current();
@@ -132,7 +132,7 @@ class Filter extends \RecursiveFilterIterator
      *
      * @return \RecursiveIterator
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function getChildren()
     {
         $filterClass = get_called_class();

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -436,7 +436,7 @@ class Something implements JsonSerializable {
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {}
 
     /**
@@ -454,7 +454,7 @@ class Something implements JsonSerializable {
      * @return mixed
      */
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function blankLineDetectionA() {}
 
     /**
@@ -462,7 +462,7 @@ class Something implements JsonSerializable {
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
 
     public function blankLineDetectionB() {}
 
@@ -472,7 +472,7 @@ class Something implements JsonSerializable {
      * @return mixed
      */
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
 
     public function blankLineDetectionC() {}
 }

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -436,7 +436,7 @@ class Something implements JsonSerializable {
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {}
 
     /**
@@ -454,7 +454,7 @@ class Something implements JsonSerializable {
      * @return mixed
      */
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function blankLineDetectionA() {}
 
     /**
@@ -462,7 +462,7 @@ class Something implements JsonSerializable {
      *
      * @return mixed
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
 
     public function blankLineDetectionB() {}
 
@@ -472,7 +472,7 @@ class Something implements JsonSerializable {
      * @return mixed
      */
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
 
     public function blankLineDetectionC() {}
 }


### PR DESCRIPTION
Fixes a series of deprecation errors, originally meant to be fixed in
#3400.

Fixes #3497 

```
PHP Deprecated:  Return type of PHP_CodeSniffer\Files\FileList::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Files\FileList::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2
PHP Deprecated:  Return type of PHP_CodeSniffer\Files\FileList::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Files\FileList::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2
PHP Deprecated:  Return type of PHP_CodeSniffer\Files\FileList::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Files\FileList::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2
PHP Deprecated:  Return type of PHP_CodeSniffer\Files\FileList::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Files\FileList::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2
PHP Deprecated:  Return type of PHP_CodeSniffer\Files\FileList::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Files\FileList::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2
PHP Deprecated:  Return type of PHP_CodeSniffer\Files\FileList::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Files\FileList::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Files/FileList.php on line 2
PHP Deprecated:  Return type of PHP_CodeSniffer\Filters\Filter::getChildren() should either be compatible with RecursiveFilterIterator::getChildren(): ?RecursiveFilterIterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Filters/Filter.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Filters\Filter::getChildren() should either be compatible with RecursiveFilterIterator::getChildren(): ?RecursiveFilterIterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Filters/Filter.php on line 2
PHP Deprecated:  Return type of PHP_CodeSniffer\Filters\Filter::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Filters/Filter.php on line 2

Deprecated: Return type of PHP_CodeSniffer\Filters\Filter::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/local/Cellar/php-code-sniffer/3.6.2/bin/phpcs/src/Filters/Filter.php on line 2
```