### PR TITLE
Include NullSafe operator in calculation for Cyclomatic Complexity Sniff

### DIFF
--- a/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
+++ b/src/Standards/Generic/Sniffs/Metrics/CyclomaticComplexitySniff.php
@@ -71,18 +71,19 @@ class CyclomaticComplexitySniff implements Sniff
 
         // Predicate nodes for PHP.
         $find = [
-            T_CASE           => true,
-            T_DEFAULT        => true,
-            T_CATCH          => true,
-            T_IF             => true,
-            T_FOR            => true,
-            T_FOREACH        => true,
-            T_WHILE          => true,
-            T_ELSEIF         => true,
-            T_INLINE_THEN    => true,
-            T_COALESCE       => true,
-            T_COALESCE_EQUAL => true,
-            T_MATCH_ARROW    => true,
+            T_CASE                     => true,
+            T_DEFAULT                  => true,
+            T_CATCH                    => true,
+            T_IF                       => true,
+            T_FOR                      => true,
+            T_FOREACH                  => true,
+            T_WHILE                    => true,
+            T_ELSEIF                   => true,
+            T_INLINE_THEN              => true,
+            T_COALESCE                 => true,
+            T_COALESCE_EQUAL           => true,
+            T_MATCH_ARROW              => true,
+            T_NULLSAFE_OBJECT_OPERATOR => true,
         ];
 
         $complexity = 1;

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.inc
@@ -433,4 +433,22 @@ function complexityFourteenWithMatch()
     };
 }
 
+
+function complexitySevenWithNullSafeOperator()
+{
+    $foo = $object1->getX()?->getY()?->getZ();
+    $bar = $object2->getX()?->getY()?->getZ();
+    $baz = $object3->getX()?->getY()?->getZ();
+}
+
+
+function complexityElevenWithNullSafeOperator()
+{
+    $foo = $object1->getX()?->getY()?->getZ();
+    $bar = $object2->getX()?->getY()?->getZ();
+    $baz = $object3->getX()?->getY()?->getZ();
+    $bacon = $object4->getX()?->getY()?->getZ();
+    $bits = $object5->getX()?->getY()?->getZ();
+}
+
 ?>

--- a/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
+++ b/src/Standards/Generic/Tests/Metrics/CyclomaticComplexityUnitTest.php
@@ -49,6 +49,7 @@ class CyclomaticComplexityUnitTest extends AbstractSniffUnitTest
             333 => 1,
             381 => 1,
             417 => 1,
+            445 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
Issue [#3505](https://github.com/squizlabs/PHP_CodeSniffer/issues/3505)

Add nullsafe object operator to tokens that trigger an increase in cyclomatic complexity