### PR TITLE
PHP 8.1 | Tokenizer/PHP: readonly bug fix

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2856,6 +2856,7 @@ class PHP extends Tokenizer
                     T_NAME_QUALIFIED       => T_NAME_QUALIFIED,
                     T_TYPE_UNION           => T_TYPE_UNION,
                     T_BITWISE_OR           => T_BITWISE_OR,
+                    T_BITWISE_AND          => T_BITWISE_AND,
                     T_ARRAY                => T_ARRAY,
                     T_CALLABLE             => T_CALLABLE,
                     T_SELF                 => T_SELF,

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.inc
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.inc
@@ -52,6 +52,9 @@ class Foo
     public function __construct(private readonly bool $constructorPropertyPromotion)
     {
     }
+
+    /* testReadonlyConstructorPropertyPromotionWithReference */
+    public function __construct(private ReadOnly bool &$constructorPropertyPromotion) {}
 }
 
 $anonymousClass = new class () {

--- a/tests/Core/Tokenizer/BackfillReadonlyTest.php
+++ b/tests/Core/Tokenizer/BackfillReadonlyTest.php
@@ -140,6 +140,10 @@ class BackfillReadonlyTest extends AbstractMethodUnitTest
                 'readonly',
             ],
             [
+                '/* testReadonlyConstructorPropertyPromotionWithReference */',
+                'ReadOnly',
+            ],
+            [
                 '/* testReadonlyPropertyInAnonymousClass */',
                 'readonly',
             ],


### PR DESCRIPTION
Follow up on #3480

While going through some sniffs to add support, I realized that parameters with a reference were not accounted for correctly. Didn't think of this before either.

Fixed now, including test.

/cc @kukulich 