### PR TITLE
PHP 8.1 | Generic/LowerCaseKeyword: allow for readonly keyword

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseKeywordSniff.php
@@ -82,6 +82,7 @@ class LowerCaseKeywordSniff implements Sniff
             T_PRIVATE,
             T_PROTECTED,
             T_PUBLIC,
+            T_READONLY,
             T_REQUIRE,
             T_REQUIRE_ONCE,
             T_RETURN,

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc
@@ -35,5 +35,9 @@ $r = Match ($x) {
     DEFAULT, => 3,
 };
 
+class Reading {
+    Public READOnly int $var;
+}
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.inc.fixed
@@ -35,5 +35,9 @@ $r = match ($x) {
     default, => 3,
 };
 
+class Reading {
+    public readonly int $var;
+}
+
 __HALT_COMPILER(); // An exception due to phar support.
 function

--- a/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseKeywordUnitTest.php
@@ -40,6 +40,7 @@ class LowerCaseKeywordUnitTest extends AbstractSniffUnitTest
             31 => 1,
             32 => 1,
             35 => 1,
+            39 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes tests.