### PR TITLE
PHP 8.1 | Squiz/BlockComment: prevent false positives for readonly keyword

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/BlockCommentSniff.php
@@ -93,6 +93,7 @@ class BlockCommentSniff implements Sniff
                 T_ABSTRACT  => true,
                 T_CONST     => true,
                 T_VAR       => true,
+                T_READONLY  => true,
             ];
             if (isset($ignore[$tokens[$nextToken]['code']]) === true) {
                 return;

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc
@@ -288,3 +288,14 @@ final class MyClass
     #[AttributeB]
     final public function test() {}
 }
+
+/**
+ * Comment should be ignored.
+ */
+abstract class MyClass
+{
+    /**
+     * Comment should be ignored.
+     */
+    readonly public string $prop;
+}

--- a/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/BlockCommentUnitTest.inc.fixed
@@ -290,3 +290,14 @@ final class MyClass
     #[AttributeB]
     final public function test() {}
 }
+
+/**
+ * Comment should be ignored.
+ */
+abstract class MyClass
+{
+    /**
+     * Comment should be ignored.
+     */
+    readonly public string $prop;
+}


### PR DESCRIPTION
Includes tests.