### PR TITLE
PHP 8.1 | Squiz/DocCommentAlignment: allow for readonly keyword

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -74,6 +74,7 @@ class DocCommentAlignmentSniff implements Sniff
             T_OBJECT    => true,
             T_PROTOTYPE => true,
             T_VAR       => true,
+            T_READONLY  => true,
         ];
 
         if ($nextToken === false || isset($ignore[$tokens[$nextToken]['code']]) === false) {

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
@@ -77,6 +77,14 @@ class MyClass2
     var $x;
 }
 
+abstract class MyClass
+{
+    /**
+* Property comment
+   */
+    readonly public string $prop;
+}
+
 /** ************************************************************************
  * Example with no errors.
  **************************************************************************/

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
@@ -77,6 +77,14 @@ class MyClass2
     var $x;
 }
 
+abstract class MyClass
+{
+    /**
+     * Property comment
+     */
+    readonly public string $prop;
+}
+
 /** ************************************************************************
  * Example with no errors.
  **************************************************************************/

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -45,6 +45,8 @@ class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
 
         if ($testFile === 'DocCommentAlignmentUnitTest.inc') {
             $errors[75] = 1;
+            $errors[83] = 1;
+            $errors[84] = 1;
         }
 
         return $errors;


### PR DESCRIPTION
Includes tests.