### PR TITLE
PHP 8.1 | Squiz/VariableComment: allow for readonly keyword

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -35,6 +35,7 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_PROTECTED    => T_PROTECTED,
             T_VAR          => T_VAR,
             T_STATIC       => T_STATIC,
+            T_READONLY     => T_READONLY,
             T_WHITESPACE   => T_WHITESPACE,
             T_STRING       => T_STRING,
             T_NS_SEPARATOR => T_NS_SEPARATOR,

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -383,3 +383,22 @@ class HasAttributes
     #[ORM\Column(ORM\Column::T_INTEGER)]
     protected $height;
 }
+
+class ReadOnlyProps
+{
+    /**
+     * Short description of the member variable.
+     *
+     * @var array
+     */
+     public readonly array $variableName = array();
+
+    /**
+     * Short description of the member variable.
+     *
+     * @var
+     */
+     readonly protected ?int $variableName = 10;
+
+     private readonly string $variable;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -383,3 +383,22 @@ class HasAttributes
     #[ORM\Column(ORM\Column::T_INTEGER)]
     protected $height;
 }
+
+class ReadOnlyProps
+{
+    /**
+     * Short description of the member variable.
+     *
+     * @var array
+     */
+     public readonly array $variableName = array();
+
+    /**
+     * Short description of the member variable.
+     *
+     * @var
+     */
+     readonly protected ?int $variableName = 10;
+
+     private readonly string $variable;
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.php
@@ -58,6 +58,8 @@ class VariableCommentUnitTest extends AbstractSniffUnitTest
             336 => 1,
             361 => 1,
             364 => 1,
+            399 => 1,
+            403 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes tests.