### PR TITLE
PHP 8.1 | PSR2/PropertyDeclaration: allow for readonly keyword

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -41,6 +41,7 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
         $find   = Tokens::$scopeModifiers;
         $find[] = T_VARIABLE;
         $find[] = T_VAR;
+        $find[] = T_READONLY;
         $find[] = T_SEMICOLON;
         $find[] = T_OPEN_CURLY_BRACKET;
 

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
@@ -71,3 +71,13 @@ class MyClass
     public int   $var = null;
     public static int/*comment*/$var = null;
 }
+
+class ReadOnlyProp {
+    public readonly int $foo,
+        $bar,
+        $var = null;
+
+    protected readonly ?string    $foo;
+
+    readonly array $foo;
+}

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
@@ -68,3 +68,13 @@ class MyClass
     public int $var = null;
     public static int /*comment*/$var = null;
 }
+
+class ReadOnlyProp {
+    public readonly int $foo,
+        $bar,
+        $var = null;
+
+    protected readonly ?string $foo;
+
+    readonly array $foo;
+}

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -46,6 +46,9 @@ class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
             69 => 1,
             71 => 1,
             72 => 1,
+            76 => 1,
+            80 => 1,
+            82 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes tests.