### PR TITLE
PHP 8.1 | Tokenizer/PHP: readonly vs union types bug fix

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2710,7 +2710,8 @@ class PHP extends Tokenizer
 
                     if ($suspectedType === 'property or parameter'
                         && (isset(Util\Tokens::$scopeModifiers[$this->tokens[$x]['code']]) === true
-                        || $this->tokens[$x]['code'] === T_VAR)
+                        || $this->tokens[$x]['code'] === T_VAR
+                        || $this->tokens[$x]['code'] === T_READONLY)
                     ) {
                         // This will also confirm constructor property promotion parameters, but that's fine.
                         $confirmed = true;

--- a/tests/Core/Tokenizer/BitwiseOrTest.inc
+++ b/tests/Core/Tokenizer/BitwiseOrTest.inc
@@ -33,6 +33,9 @@ class TypeUnion
     /* testTypeUnionPropertyFullyQualified */
     public \Fully\Qualified\NameA|\Fully\Qualified\NameB $fullyQual;
 
+    /* testTypeUnionPropertyWithReadOnlyKeyword */
+    protected readonly string|null $array;
+
     public function paramTypes(
         /* testTypeUnionParam1 */
         int|float $paramA /* testBitwiseOrParamDefaultValue */ = CONSTANT_A | CONSTANT_B,

--- a/tests/Core/Tokenizer/BitwiseOrTest.php
+++ b/tests/Core/Tokenizer/BitwiseOrTest.php
@@ -105,6 +105,7 @@ class BitwiseOrTest extends AbstractMethodUnitTest
             ['/* testTypeUnionPropertyNamespaceRelative */'],
             ['/* testTypeUnionPropertyPartiallyQualified */'],
             ['/* testTypeUnionPropertyFullyQualified */'],
+            ['/* testTypeUnionPropertyWithReadOnlyKeyword */'],
             ['/* testTypeUnionParam1 */'],
             ['/* testTypeUnionParam2 */'],
             ['/* testTypeUnionParam3 */'],


### PR DESCRIPTION
More follow up on #3480.

Done some more stress testing and found that the retokenization of `|` to `T_TYPE_UNION` was broken when combined with the `readonly` keyword.

Fixed now, includes test.

/cc @kukulich 