### PR TITLE
PHP 8.1 | File::getMethodParameters(): allow for readonly keyword

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1310,6 +1310,8 @@ class File
      * Parameters declared using PHP 8 constructor property promotion, have these additional array indexes:
      *         'property_visibility' => string,  // The property visibility as declared.
      *         'visibility_token'    => integer, // The stack pointer to the visibility modifier token.
+     *         'property_readonly'   => bool,    // TRUE if the readonly keyword was found.
+     *         'readonly_token'      => integer, // The stack pointer to the readonly modifier token.
      *
      * @param int $stackPtr The position in the stack of the function token
      *                      to acquire the parameters for.
@@ -1366,6 +1368,7 @@ class File
         $typeHintEndToken = false;
         $nullableType     = false;
         $visibilityToken  = null;
+        $readonlyToken    = null;
 
         for ($i = $paramStart; $i <= $closer; $i++) {
             // Check to see if this token has a parenthesis or bracket opener. If it does
@@ -1491,6 +1494,11 @@ class File
                     $visibilityToken = $i;
                 }
                 break;
+            case T_READONLY:
+                if ($defaultStart === null) {
+                    $readonlyToken = $i;
+                }
+                break;
             case T_CLOSE_PARENTHESIS:
             case T_COMMA:
                 // If it's null, then there must be no parameters for this
@@ -1523,6 +1531,12 @@ class File
                 if ($visibilityToken !== null) {
                     $vars[$paramCount]['property_visibility'] = $this->tokens[$visibilityToken]['content'];
                     $vars[$paramCount]['visibility_token']    = $visibilityToken;
+                    $vars[$paramCount]['property_readonly']   = false;
+                }
+
+                if ($readonlyToken !== null) {
+                    $vars[$paramCount]['property_readonly'] = true;
+                    $vars[$paramCount]['readonly_token']    = $readonlyToken;
                 }
 
                 if ($this->tokens[$i]['code'] === T_COMMA) {
@@ -1546,6 +1560,7 @@ class File
                 $typeHintEndToken = false;
                 $nullableType     = false;
                 $visibilityToken  = null;
+                $readonlyToken    = null;
 
                 $paramCount++;
                 break;

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -108,6 +108,11 @@ class ConstructorPropertyPromotionAndNormalParams {
     public function __construct(public int $promotedProp, ?int $normalArg) {}
 }
 
+class ConstructorPropertyPromotionWithReadOnly {
+    /* testPHP81ConstructorPropertyPromotionWithReadOnly */
+    public function __construct(public readonly ?int $promotedProp, readonly private string|bool &$promotedToo) {}
+}
+
 /* testPHP8ConstructorPropertyPromotionGlobalFunction */
 // Intentional fatal error. Property promotion not allowed in non-constructor, but that's not the concern of this method.
 function globalFunction(private $x) {}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -696,6 +696,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'type_hint'           => '',
             'nullable_type'       => false,
             'property_visibility' => 'public',
+            'property_readonly'   => false,
         ];
         $expected[1] = [
             'name'                => '$y',
@@ -707,6 +708,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'type_hint'           => '',
             'nullable_type'       => false,
             'property_visibility' => 'protected',
+            'property_readonly'   => false,
         ];
         $expected[2] = [
             'name'                => '$z',
@@ -718,6 +720,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'type_hint'           => '',
             'nullable_type'       => false,
             'property_visibility' => 'private',
+            'property_readonly'   => false,
         ];
 
         $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -742,6 +745,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'type_hint'           => 'float|int',
             'nullable_type'       => false,
             'property_visibility' => 'protected',
+            'property_readonly'   => false,
         ];
         $expected[1] = [
             'name'                => '$y',
@@ -753,6 +757,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'type_hint'           => '?string',
             'nullable_type'       => true,
             'property_visibility' => 'public',
+            'property_readonly'   => false,
         ];
         $expected[2] = [
             'name'                => '$z',
@@ -763,6 +768,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'type_hint'           => 'mixed',
             'nullable_type'       => false,
             'property_visibility' => 'private',
+            'property_readonly'   => false,
         ];
 
         $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
@@ -787,6 +793,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
             'type_hint'           => 'int',
             'nullable_type'       => false,
             'property_visibility' => 'public',
+            'property_readonly'   => false,
         ];
         $expected[1] = [
             'name'              => '$normalArg',
@@ -801,6 +808,42 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
         $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testPHP8ConstructorPropertyPromotionAndNormalParam()
+
+
+    /**
+     * Verify recognition of PHP8 constructor with property promotion using PHP 8.1 readonly keyword.
+     *
+     * @return void
+     */
+    public function testPHP81ConstructorPropertyPromotionWithReadOnly()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'                => '$promotedProp',
+            'content'             => 'public readonly ?int $promotedProp',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => '?int',
+            'nullable_type'       => true,
+            'property_visibility' => 'public',
+            'property_readonly'   => true,
+        ];
+        $expected[1] = [
+            'name'                => '$promotedToo',
+            'content'             => 'readonly private string|bool &$promotedToo',
+            'has_attributes'      => false,
+            'pass_by_reference'   => true,
+            'variable_length'     => false,
+            'type_hint'           => 'string|bool',
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+            'property_readonly'   => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP81ConstructorPropertyPromotionWithReadOnly()
 
 
     /**


### PR DESCRIPTION
... in constructor property promotion.

Note: the `property_readonly` key will always be added when constructor property promotion has been detected. The `readonly_token` only when the `readonly` token has actually been found.

Includes unit tests.