### PR TITLE
PHP 8.1 | Squiz/ScopeKeywordSpacing: allow for readonly keyword

### DIFF
--- a/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/WhiteSpace/ScopeKeywordSpacingSniff.php
@@ -26,6 +26,7 @@ class ScopeKeywordSpacingSniff implements Sniff
     {
         $register   = Tokens::$scopeModifiers;
         $register[] = T_STATIC;
+        $register[] = T_READONLY;
         return $register;
 
     }//end register()

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc
@@ -126,3 +126,16 @@ class ConstructorPropertyPromotionTest {
 class ConstructorPropertyPromotionWithTypesTest {
     public function __construct(protected   float|int $x, public?string &$y = 'test', private mixed $z) {}
 }
+
+// PHP 8.1 readonly keywords.
+class ReadonlyTest {
+    public readonly int $publicReadonlyProperty;
+
+    protected    readonly    int $protectedReadonlyProperty;
+
+    readonly protected int $protectedReadonlyProperty;
+
+    readonly   private   int $privateReadonlyProperty;
+
+    public function __construct(readonly  protected  float|int $x, public readonly?string &$y = 'test') {}
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.inc.fixed
@@ -120,3 +120,16 @@ class ConstructorPropertyPromotionTest {
 class ConstructorPropertyPromotionWithTypesTest {
     public function __construct(protected float|int $x, public ?string &$y = 'test', private mixed $z) {}
 }
+
+// PHP 8.1 readonly keywords.
+class ReadonlyTest {
+    public readonly int $publicReadonlyProperty;
+
+    protected readonly int $protectedReadonlyProperty;
+
+    readonly protected int $protectedReadonlyProperty;
+
+    readonly private int $privateReadonlyProperty;
+
+    public function __construct(readonly protected float|int $x, public readonly ?string &$y = 'test') {}
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeKeywordSpacingUnitTest.php
@@ -44,6 +44,9 @@ class ScopeKeywordSpacingUnitTest extends AbstractSniffUnitTest
             119 => 1,
             121 => 1,
             127 => 2,
+            134 => 2,
+            138 => 2,
+            140 => 3,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Includes tests.