### PR TITLE
Get rid of busy-waiting in the parent process

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -460,10 +460,7 @@ class Runner
                 if ($pid === -1) {
                     throw new RuntimeException('Failed to create child process');
                 } else if ($pid !== 0) {
-                    $childProcs[] = [
-                        'pid' => $pid,
-                        'out' => $childOutFilename,
-                    ];
+                    $childProcs[$pid] = $childOutFilename;
                 } else {
                     // Move forward to the start of the batch.
                     $todo->rewind();
@@ -536,7 +533,7 @@ class Runner
 
                     $output .= ";\n?".'>';
                     file_put_contents($childOutFilename, $output);
-                    exit($pid);
+                    exit();
                 }//end if
             }//end for
 
@@ -719,54 +716,53 @@ class Runner
         $success = true;
 
         while (count($childProcs) > 0) {
-            foreach ($childProcs as $key => $procData) {
-                $res = pcntl_waitpid($procData['pid'], $status, WNOHANG);
-                if ($res === $procData['pid']) {
-                    if (file_exists($procData['out']) === true) {
-                        include $procData['out'];
+            $pid = pcntl_waitpid(0, $status);
+            if ($pid > 0) {
+                $out = $childProcs[$pid];
+                unset($childProcs[$pid]);
+                if (file_exists($out) === true) {
+                    include $out;
 
-                        unlink($procData['out']);
-                        unset($childProcs[$key]);
+                    unlink($out);
 
-                        $numProcessed++;
+                    $numProcessed++;
 
-                        if (isset($childOutput) === false) {
-                            // The child process died, so the run has failed.
-                            $file = new DummyFile('', $this->ruleset, $this->config);
-                            $file->setErrorCounts(1, 0, 0, 0);
-                            $this->printProgress($file, $totalBatches, $numProcessed);
-                            $success = false;
-                            continue;
-                        }
-
-                        $this->reporter->totalFiles    += $childOutput['totalFiles'];
-                        $this->reporter->totalErrors   += $childOutput['totalErrors'];
-                        $this->reporter->totalWarnings += $childOutput['totalWarnings'];
-                        $this->reporter->totalFixable  += $childOutput['totalFixable'];
-                        $this->reporter->totalFixed    += $childOutput['totalFixed'];
-
-                        if (isset($debugOutput) === true) {
-                            echo $debugOutput;
-                        }
-
-                        if (isset($childCache) === true) {
-                            foreach ($childCache as $path => $cache) {
-                                Cache::set($path, $cache);
-                            }
-                        }
-
-                        // Fake a processed file so we can print progress output for the batch.
+                    if (isset($childOutput) === false) {
+                        // The child process died, so the run has failed.
                         $file = new DummyFile('', $this->ruleset, $this->config);
-                        $file->setErrorCounts(
-                            $childOutput['totalErrors'],
-                            $childOutput['totalWarnings'],
-                            $childOutput['totalFixable'],
-                            $childOutput['totalFixed']
-                        );
+                        $file->setErrorCounts(1, 0, 0, 0);
                         $this->printProgress($file, $totalBatches, $numProcessed);
-                    }//end if
+                        $success = false;
+                        continue;
+                    }
+
+                    $this->reporter->totalFiles    += $childOutput['totalFiles'];
+                    $this->reporter->totalErrors   += $childOutput['totalErrors'];
+                    $this->reporter->totalWarnings += $childOutput['totalWarnings'];
+                    $this->reporter->totalFixable  += $childOutput['totalFixable'];
+                    $this->reporter->totalFixed    += $childOutput['totalFixed'];
+
+                    if (isset($debugOutput) === true) {
+                        echo $debugOutput;
+                    }
+
+                    if (isset($childCache) === true) {
+                        foreach ($childCache as $path => $cache) {
+                            Cache::set($path, $cache);
+                        }
+                    }
+
+                    // Fake a processed file so we can print progress output for the batch.
+                    $file = new DummyFile('', $this->ruleset, $this->config);
+                    $file->setErrorCounts(
+                        $childOutput['totalErrors'],
+                        $childOutput['totalWarnings'],
+                        $childOutput['totalFixable'],
+                        $childOutput['totalFixed']
+                    );
+                    $this->printProgress($file, $totalBatches, $numProcessed);
                 }//end if
-            }//end foreach
+            }//end if
         }//end while
 
         return $success;


### PR DESCRIPTION
This patch simplifies the logic of waiting for child processes during parallel processing and may address #3144.

Change summary:

1. Instead of busy-waiting using `pcntl_waitpid(WNOHANG)` in a loop, let `pcntl_waitpid()` block until a child exits. This should address the following symptom:
   > Some processes seem to do nothing `0 wait4(18694, 0x7ffe6ddd6cbc, WNOHANG, NULL) = 0` (strace) but still need max CPU power (top).
2. Index child processes by PID to simplify the logic of unsetting exited children.
3. Do not use `$pid` as the exit code. This is unnecessary and violates the [API](https://www.php.net/manual/en/function.exit.php),
   > Exit statuses should be in the range 0 to 254, the exit status 255 is reserved by PHP and shall not be used.
