### PR TITLE
Tokenizer/PHP: fix incorrect condition order

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2098,7 +2098,7 @@ class PHP extends Tokenizer
                         }
                     }
 
-                    if ($tokens[$i] !== '(' && $i !== $numTokens) {
+                    if ($i !== $numTokens && $tokens[$i] !== '(') {
                         $newToken['code'] = T_STRING;
                         $newToken['type'] = 'T_STRING';
                     }


### PR DESCRIPTION
Follow up on #3350

As things were, `$tokens[i]` may not exist and the current condition order would lead to a `PHP Warning:  Undefined array key 517 in php_codesniffer/src/Tokenizers/PHP.php on line 2101` notice if the end of the file was reached.

Fixed now.