### PR TITLE
PHP 8.1 | PSR12/ConstantVisibility: allow for class constants to be `final`

### DIFF
--- a/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
+++ b/src/Standards/PSR12/Sniffs/Properties/ConstantVisibilitySniff.php
@@ -47,7 +47,10 @@ class ConstantVisibilitySniff implements Sniff
             return;
         }
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $ignore   = Tokens::$emptyTokens;
+        $ignore[] = T_FINAL;
+
+        $prev = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
         if (isset(Tokens::$scopeModifiers[$tokens[$prev]['code']]) === true) {
             return;
         }

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.inc
@@ -5,3 +5,13 @@ class Foo {
 }
 
 const APPLICATION_ENV = 'development';
+
+// Issue 3526, PHP 8.1 final constants.
+class SampleEnum
+{
+    final const FOO = 'SAMPLE';
+
+    public final const BAR = 'SAMPLE';
+
+    final private const BAZ = 'SAMPLE';
+}

--- a/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
+++ b/src/Standards/PSR12/Tests/Properties/ConstantVisibilityUnitTest.php
@@ -40,7 +40,10 @@ class ConstantVisibilityUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [4 => 1];
+        return [
+            4  => 1,
+            12 => 1,
+        ];
 
     }//end getWarningList()
 


### PR DESCRIPTION
PHP 8.1 introduces the ability to declare class constants as `final`.

The tokenization of the `final` keyword in this context appears to be consistent PHPCS cross-version, so AFAICS no changes are needed to the PHP tokenizer.

However, the `PSR12.Properties.ConstantVisibility` sniff does need to allow for them.

Includes unit tests.

Ref: https://wiki.php.net/rfc/final_class_const

Fixes #3526

Related to #3479

---

Notes:
* The test failures are unrelated to this PR and PR #3525 is already open to fix those.
* I've done a cursory scan of all sniffs referring to the `T_CONST` token and could not find any other sniffs which would need adjusting for this PHP change.