### PR TITLE
Name of typed enum tokenized as T_GOTO_LABEL

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -1905,6 +1905,7 @@ class PHP extends Tokenizer
                     T_OPEN_TAG           => true,
                     T_OPEN_CURLY_BRACKET => true,
                     T_INLINE_THEN        => true,
+                    T_ENUM               => true,
                 ];
 
                 for ($x = ($newStackPtr - 1); $x > 0; $x--) {
@@ -1915,6 +1916,7 @@ class PHP extends Tokenizer
 
                 if ($finalTokens[$x]['code'] !== T_CASE
                     && $finalTokens[$x]['code'] !== T_INLINE_THEN
+                    && $finalTokens[$x]['code'] !== T_ENUM
                 ) {
                     $finalTokens[$newStackPtr] = [
                         'content' => $token[1].':',

--- a/tests/Core/Tokenizer/BackfillEnumTest.inc
+++ b/tests/Core/Tokenizer/BackfillEnumTest.inc
@@ -13,7 +13,7 @@ enum Boo: int {
 }
 
 /* testBackedStringEnum */
-enum Hoo: string
+enum Hoo : string
 {
     case ONE = 'one';
     case TWO = 'two';

--- a/tests/Core/Tokenizer/BackfillEnumTest.php
+++ b/tests/Core/Tokenizer/BackfillEnumTest.php
@@ -87,20 +87,20 @@ class BackfillEnumTest extends AbstractMethodUnitTest
             [
                 '/* testBackedIntEnum */',
                 'enum',
-                6,
-                28,
+                7,
+                29,
             ],
             [
                 '/* testBackedStringEnum */',
                 'enum',
-                6,
-                28,
+                8,
+                30,
             ],
             [
                 '/* testComplexEnum */',
                 'enum',
-                10,
-                71,
+                11,
+                72,
             ],
             [
                 '/* testEnumWithEnumAsClassName */',

--- a/tests/Core/Tokenizer/GotoLabelTest.inc
+++ b/tests/Core/Tokenizer/GotoLabelTest.inc
@@ -51,3 +51,6 @@ switch (true) {
         // Do something.
         break;
 }
+
+/* testNotGotoDeclarationEnumWithType */
+enum Suit: string implements Colorful, CardGame {}

--- a/tests/Core/Tokenizer/GotoLabelTest.php
+++ b/tests/Core/Tokenizer/GotoLabelTest.php
@@ -163,6 +163,10 @@ class GotoLabelTest extends AbstractMethodUnitTest
                 '/* testNotGotoDeclarationGlobalConstantInTernary */',
                 'CONST_B',
             ],
+            [
+                '/* testNotGotoDeclarationEnumWithType */',
+                'Suit',
+            ],
         ];
 
     }//end dataNotAGotoDeclaration()


### PR DESCRIPTION
Follow up on #3478.

When an `enum` would be backed by a type and the colon would directly follow the name of the `enum`, the name would be incorrectly tokenized (including the colon) as `T_GOTO_LABEL`.

Discovered while reviewing #3482

Also related to #3161

/cc @kukulich 

---

### Tests/BackfillEnum: update token calculations

... after the bugfix for `T_GOTO_LABEL`.

Also added a minor tweak to one test case to make sure that spacing around the type colon is handled correctly.