### PR TITLE
Added check for blank indented lines in functions

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -45,6 +45,14 @@ class ScopeIndentSniff implements Sniff
     public $exact = false;
 
     /**
+     * Enforces the entire scope of a function to be indented. Including
+     * blank lines.
+     *
+     * @var boolean
+     */
+    public $indentWhitespaceInScope = false;
+
+    /**
      * Should tabs be used for indenting?
      *
      * If TRUE, fixes will be made using tabs instead of spaces.
@@ -256,6 +264,9 @@ class ScopeIndentSniff implements Sniff
                     ) {
                         $checkToken  = ($i + 1);
                         $tokenIndent = ($tokens[($i + 1)]['column'] - 1);
+                    } else if ($this->indentWhitespaceInScope === true) {
+                        $checkToken  = ($i);
+                        $tokenIndent = ($tokens[($i)]['length']);
                     }
                 } else {
                     $checkToken  = $i;
@@ -1532,7 +1543,9 @@ class ScopeIndentSniff implements Sniff
             }
         }
 
-        if ($tokens[$stackPtr]['column'] === 1) {
+        if ($tokens[$stackPtr]['column'] === 1 && $tokens[$stackPtr]['code'] === T_WHITESPACE) {
+            $accepted = $phpcsFile->fixer->replaceToken(($stackPtr), $padding.PHP_EOL);
+        } else if ($tokens[$stackPtr]['column'] === 1) {
             $trimmed  = ltrim($tokens[$stackPtr]['content']);
             $accepted = $phpcsFile->fixer->replaceToken($stackPtr, $padding.$trimmed);
         } else {


### PR DESCRIPTION
I'd like to preface this saying that I am very grateful for phpcs and that I understand that this PR represents an unpopular opinion. But while unpopular, it's consistent. I slightly modified the `ScopeIndentSniff` to allow a user to opt-into enforcing a consistent indentation with the rest of the code when a line is blank.

Usually PHPCS will rewrite a function with blank lines, trimming the whitespace. So the function:

```php
function x($y)
{
/*4s*/$z = $y * 2;
/*4s*//*[LF]*/
/*4s*/return $s;
}
```

Becomes:

```php
function x($y)
{
/*4s*/$z = $y * 2;
/*[LF]*/
/*4s*/return $s;
}
```

I find it incredibly frustrating when linters and IDEs trim the whitespace of blank lines. When I leave a line blank, and then attempt to write into it, the cursor will be at the wrong position and force me to jump back to the actual indentation level of the function.

I consider a blank line that is indented according to the surrounding scope to not be extraneous whitespace, since the indentation (at least my understanding of it) makes an indented blank line consistent with the rest of the lines within the function or method. Which is the reason why I personally like to include them.

This issue gets compounded when a collaborator submits code and their IDE just trimmed the whitespace that I purposefully left in there, causing the diffs to include a ton of whitespace changes that have nothing to do with the change they submitted.

I'd like to request this opt-in feature to be included. I know it represents a small user base. But, It's opt-in, represents a very small change to the codebase and does provide a ton of creature comforts for teams that wish to use it.

Thank you very much for your attention and I look forward to being able to set the `indentWhitespaceInScope` flag in the future. 