### PR TITLE
CodeSniffer.conf: end code with semicolon

### DIFF
--- a/CodeSniffer.conf.dist
+++ b/CodeSniffer.conf.dist
@@ -5,5 +5,5 @@
   'show_warnings' => '0',
   'show_progress' => '1',
   'report_width' => '120',
-)
+);
 ?>

--- a/src/Config.php
+++ b/src/Config.php
@@ -1597,7 +1597,7 @@ class Config
         if ($temp === false) {
             $output  = '<'.'?php'."\n".' $phpCodeSnifferConfig = ';
             $output .= var_export($phpCodeSnifferConfig, true);
-            $output .= "\n?".'>';
+            $output .= ";\n?".'>';
 
             if (file_put_contents($configFile, $output) === false) {
                 $error = 'ERROR: Config file '.$configFile.' could not be written'.PHP_EOL.PHP_EOL;


### PR DESCRIPTION
While not problematic, it just feels very untidy for the `CodeSniffer.conf` file not to end the code block with a semicolon.