### PR TITLE
PHPCS -i: display standards in same order cross-platform

### DIFF
--- a/src/Util/Standards.php
+++ b/src/Util/Standards.php
@@ -180,7 +180,8 @@ class Standards
             // Check if the installed dir is actually a standard itself.
             $csFile = $standardsDir.'/ruleset.xml';
             if (is_file($csFile) === true) {
-                $installedStandards[] = basename($standardsDir);
+                $basename = basename($standardsDir);
+                $installedStandards[$basename] = $basename;
                 continue;
             }
 
@@ -190,6 +191,7 @@ class Standards
             }
 
             $di = new \DirectoryIterator($standardsDir);
+            $standardsInDir = [];
             foreach ($di as $file) {
                 if ($file->isDir() === true && $file->isDot() === false) {
                     $filename = $file->getFilename();
@@ -202,10 +204,13 @@ class Standards
                     // Valid coding standard dirs include a ruleset.
                     $csFile = $file->getPathname().'/ruleset.xml';
                     if (is_file($csFile) === true) {
-                        $installedStandards[] = $filename;
+                        $standardsInDir[$filename] = $filename;
                     }
                 }
             }
+
+            natsort($standardsInDir);
+            $installedStandards += $standardsInDir;
         }//end foreach
 
         return $installedStandards;


### PR DESCRIPTION
I noticed this while debugging something completely different: the display order of the registered standards can vary wildly between different computers/OSes.

For example, on Windows, they always seem to be ordered alphabetically:
> The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz and Zend

And in case there are external standards registered, they are sorted alphabetically per "set of standards", i.e. per registered "installed path":
> The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz, Zend, WordPress, WordPress-Core, WordPress-Docs, WordPress-Extra and PHPCompatibility

However, on Linux, I was seeing a completely different (more random) order, like for example:
> The installed coding standards are PEAR, PSR2, PSR1, Squiz, PSR12, MySource and Zend

**I'd like to propose to always display the standards in the same order and to use natural ordering per "set of standards" for this.**

The order of external standards would still be determined by the order in which those standards are registered to the `installed_paths` configuration setting, but for a group of standards within the same `installed_path`, the standards would now be ordered by natural order too.

For the PHPCS native standards, this will result in the standards displaying the same cross-OS, like this:
> The installed coding standards are MySource, PEAR, PSR1, PSR2, PSR12, Squiz and Zend

Take note of the "saner" ordering of the PSR standards which also improves the experience on Windows.

Implementation note: to avoid using the `array_merge()`, I've added the standards name as keys to the array as well, which allows for safely using array union instead.