### PR TITLE
allow stdin fix to exit sucessfully

### DIFF
--- a/src/Reports/Cbf.php
+++ b/src/Reports/Cbf.php
@@ -57,7 +57,7 @@ class Cbf implements Report
             // even if nothing was fixed. Exit here because we
             // can't process any more than 1 file in this setup.
             $fixedContent = $phpcsFile->fixer->getContents();
-            throw new DeepExitException($fixedContent, 1);
+            throw new DeepExitException($fixedContent, $errors > 0);
         }
 
         if ($errors === 0) {


### PR DESCRIPTION
When submitting a file to phpcbf from stdin, phpcbf always fails.

I propose to make it succeed (exit 0) when no errors were found, given that cbf has no direct concept of "non-fixable errors".

It would allow tools to swap content of a buffered file when exit code is non-zero, and discard if nothing has been fixed.