### PR TITLE
Ruleset::explain(): fix plural vs singular phrasing

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -249,7 +249,12 @@ class Ruleset
         // one last time and clear the output buffer.
         $sniffs[] = '';
 
-        echo PHP_EOL."The $this->name standard contains $sniffCount sniffs".PHP_EOL;
+        $summaryLine = PHP_EOL."The $this->name standard contains 1 sniff".PHP_EOL;
+        if ($sniffCount !== 1) {
+            $summaryLine = str_replace('1 sniff', "$sniffCount sniffs", $summaryLine);
+        }
+
+        echo $summaryLine;
 
         ob_start();
 


### PR DESCRIPTION
When running the `phpcs --standard=Name -e` command, the line at the top of the output would always presumes that a standard contains more than one sniff.
The sniff count for the standards within the standard - `StandardName (# sniff[s])` - already handled this correctly.

Fixed the top line now.

Output without this fix:
```
The DummySubDir standard contains 1 sniffs

DummySubDir (1 sniff)
----------------------
  DummySubDir.Demo.Demo
```

Output with this fix:
```
The DummySubDir standard contains 1 sniff

DummySubDir (1 sniff)
----------------------
  DummySubDir.Demo.Demo
```