### PR TITLE
Tokenizer/PHP: bug fix - parent/static keywords in class instantiations

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -608,8 +608,11 @@ class PHP extends Tokenizer
             ) {
                 $preserveKeyword = false;
 
-                // `new class` should be preserved
-                if ($token[0] === T_CLASS && $finalTokens[$lastNotEmptyToken]['code'] === T_NEW) {
+                // `new class`, and `new static` should be preserved.
+                if ($finalTokens[$lastNotEmptyToken]['code'] === T_NEW
+                    && ($token[0] === T_CLASS
+                    || $token[0] === T_STATIC)
+                ) {
                     $preserveKeyword = true;
                 }
 
@@ -1968,16 +1971,24 @@ class PHP extends Tokenizer
                     && $token[0] === T_STRING
                     && isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
                 ) {
-                    // Special case for syntax like: return new self
-                    // where self should not be a string.
+                    // Special case for syntax like: return new self/new parent
+                    // where self/parent should not be a string.
+                    $tokenContentLower = strtolower($token[1]);
                     if ($finalTokens[$lastNotEmptyToken]['code'] === T_NEW
-                        && strtolower($token[1]) === 'self'
+                        && ($tokenContentLower === 'self' || $tokenContentLower === 'parent')
                     ) {
                         $finalTokens[$newStackPtr] = [
                             'content' => $token[1],
-                            'code'    => T_SELF,
-                            'type'    => 'T_SELF',
                         ];
+                        if ($tokenContentLower === 'self') {
+                            $finalTokens[$newStackPtr]['code'] = T_SELF;
+                            $finalTokens[$newStackPtr]['type'] = 'T_SELF';
+                        }
+
+                        if ($tokenContentLower === 'parent') {
+                            $finalTokens[$newStackPtr]['code'] = T_PARENT;
+                            $finalTokens[$newStackPtr]['type'] = 'T_PARENT';
+                        }
                     } else {
                         $finalTokens[$newStackPtr] = [
                             'content' => $token[1],

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
@@ -206,5 +206,9 @@ $anonymousClass = new /* testAnonymousClassIsKeyword */ class {};
 $anonymousClass2 = new class /* testExtendsInAnonymousClassIsKeyword */ extends SomeParent {};
 $anonymousClass3 = new class /* testImplementsInAnonymousClassIsKeyword */ implements SomeInterface {};
 
+$instantiated1 = new /* testClassInstantiationParentIsKeyword */ parent();
+$instantiated2 = new /* testClassInstantiationSelfIsKeyword */ SELF;
+$instantiated3 = new /* testClassInstantiationStaticIsKeyword */ static($param);
+
 class Foo extends /* testNamespaceInNameIsKeyword */ namespace\Exception
 {}

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -463,6 +463,18 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
                 'T_IMPLEMENTS',
             ],
             [
+                '/* testClassInstantiationParentIsKeyword */',
+                'T_PARENT',
+            ],
+            [
+                '/* testClassInstantiationSelfIsKeyword */',
+                'T_SELF',
+            ],
+            [
+                '/* testClassInstantiationStaticIsKeyword */',
+                'T_STATIC',
+            ],
+            [
                 '/* testNamespaceInNameIsKeyword */',
                 'T_NAMESPACE',
             ],


### PR DESCRIPTION
Follow up on #3484 /cc @kukulich 

Just like `new class`, `new parent`, `new self` and `new static` should also be preserved and with the `parent`, `self` and `static` keywords remaining as their dedicated token.

* For `new static`, the tokenization changed due to the context sensitive keywords change. This has now been fixed.
* `new self` was fine before and is still fine.
* `new parent` apparently wasn't handled correctly, even before the change. The condition which was in place for handling the same situation for `self` has now been updated to also handle `parent`.

Includes unit tests.