### PR TITLE
PSR2/SwitchDeclaration: bug fix when determining terminating statement

### DIFF
--- a/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/ControlStructures/SwitchDeclarationSniff.php
@@ -247,7 +247,7 @@ class SwitchDeclarationSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $lastToken = $phpcsFile->findPrevious(T_WHITESPACE, ($end - 1), $stackPtr, true);
+        $lastToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($end - 1), $stackPtr, true);
         if ($lastToken === false) {
             return false;
         }

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc
@@ -511,7 +511,7 @@ switch ( $a ) {
     case 1:
         if ($a) {
             try {
-                return true;
+                return true; // Comment.
             } catch (MyException $e) {
                 throw new Exception($e->getMessage());
             }
@@ -582,5 +582,17 @@ switch ( $a ) {
         }
     default:
         $other = $code;
+        break;
+}
+
+// Issue 3550 - comment after terminating statement.
+switch (rand()) {
+    case 1:
+        if (rand() === 1) {
+            break;
+        } else {
+            break; // comment
+        }
+    default:
         break;
 }

--- a/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/ControlStructures/SwitchDeclarationUnitTest.inc.fixed
@@ -506,7 +506,7 @@ switch ( $a ) {
     case 1:
         if ($a) {
             try {
-                return true;
+                return true; // Comment.
             } catch (MyException $e) {
                 throw new Exception($e->getMessage());
             }
@@ -577,5 +577,17 @@ switch ( $a ) {
         }
     default:
         $other = $code;
+        break;
+}
+
+// Issue 3550 - comment after terminating statement.
+switch (rand()) {
+    case 1:
+        if (rand() === 1) {
+            break;
+        } else {
+            break; // comment
+        }
+    default:
         break;
 }


### PR DESCRIPTION
Trailing comments within control structures nested within a switch case would break the determination of whether or not there is a terminating statement within the nested control structure.

Making the `findNestedTerminator()` method look for non-empty instead of non-whitespace tokens fixes that and shouldn't break the `TerminatingComment` check as that has it's own check whether the last token in the case statement is a comment.

Includes unit tests.

Fixes #3550