### PR TITLE
PHP 8.1 | Tokenizer/PHP: bug fix for overeager explicit octal notation backfill

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -728,7 +728,8 @@ class PHP extends Tokenizer
                 && (isset($tokens[($stackPtr + 1)]) === true
                 && is_array($tokens[($stackPtr + 1)]) === true
                 && $tokens[($stackPtr + 1)][0] === T_STRING
-                && strtolower($tokens[($stackPtr + 1)][1][0]) === 'o')
+                && strtolower($tokens[($stackPtr + 1)][1][0]) === 'o'
+                && $tokens[($stackPtr + 1)][1][1] !== '_')
             ) {
                 $finalTokens[$newStackPtr] = [
                     'code'    => T_LNUMBER,

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.inc
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.inc
@@ -5,3 +5,12 @@ $foo = 0o137041;
 
 /* testExplicitOctalCapitalised */
 $bar = 0O137041;
+
+/* testExplicitOctalWithNumericSeparator */
+$octal = 0o137_041;
+
+/* testInvalid1 */
+$foo = 0o_137;
+
+/* testInvalid2 */
+$foo = 0O_41;

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
@@ -62,6 +62,27 @@ class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
                     'value'  => '0O137041',
                 ],
             ],
+            [
+                [
+                    'marker' => '/* testExplicitOctalWithNumericSeparator */',
+                    'type'   => 'T_LNUMBER',
+                    'value'  => '0o137_041',
+                ],
+            ],
+            [
+                [
+                    'marker' => '/* testInvalid1 */',
+                    'type'   => 'T_LNUMBER',
+                    'value'  => '0',
+                ],
+            ],
+            [
+                [
+                    'marker' => '/* testInvalid2 */',
+                    'type'   => 'T_LNUMBER',
+                    'value'  => '0',
+                ],
+            ],
         ];
 
     }//end dataExplicitOctalNotation()

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.inc
@@ -77,6 +77,12 @@ $testValue = 107_925_284 .88;
 /* testInvalid10 */
 $testValue = 107_925_284/*comment*/.88;
 
+/* testInvalid11 */
+$foo = 0o_137;
+
+/* testInvalid12 */
+$foo = 0O_41;
+
 /*
  * Ensure that legitimate calculations are not touched by the backfill.
  */

--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -337,6 +337,32 @@ class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
                 ],
             ],
             [
+                '/* testInvalid11 */',
+                [
+                    [
+                        'code'    => T_LNUMBER,
+                        'content' => '0',
+                    ],
+                    [
+                        'code'    => T_STRING,
+                        'content' => 'o_137',
+                    ],
+                ],
+            ],
+            [
+                '/* testInvalid12 */',
+                [
+                    [
+                        'code'    => T_LNUMBER,
+                        'content' => '0',
+                    ],
+                    [
+                        'code'    => T_STRING,
+                        'content' => 'O_41',
+                    ],
+                ],
+            ],
+            [
                 '/* testCalc1 */',
                 [
                     [


### PR DESCRIPTION
Follow up on #3481. /cc @MarkBaker 

Just like for all other type of integer notations, if a numeric literal separator is used, it is not allowed between the prefix and the actual number.
```php
// This is fine.
$b = 0b1_0;
$o = 0o6_3;

// This is an invalid use of the numeric literal separator.
$b = 0b_10;
$o = 0o_63;
```

This PR fixes the backfill for explicit octal notation to NOT backfill these type of invalid sequences as the inconsistent tokenization across PHP versions which that causes, can create havoc in sniffs.

Includes adding additional unit tests.

@gsherwood Greg - can this PR please be earmarked for PHPCS 3.7.0 to prevent the incorrect tokenization getting into a released version ?