### PR TITLE
PHP 8.1 | Add `enum` support to various additional sniffs

### DIFF
--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
@@ -152,3 +152,13 @@ $match = match ($test) {
     1 => 'a',
     2 => 'b'
     };
+
+enum Enum
+{
+}
+
+enum Suits {}
+
+enum Cards
+{
+    }

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
@@ -157,3 +157,14 @@ $match = match ($test) {
     1 => 'a',
     2 => 'b'
 };
+
+enum Enum
+{
+}
+
+enum Suits {
+}
+
+enum Cards
+{
+}

--- a/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/PEAR/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -42,6 +42,8 @@ class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
             146 => 1,
             149 => 1,
             154 => 1,
+            160 => 1,
+            164 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.inc
@@ -47,3 +47,11 @@ $instance = new class extends \Foo implements \HandleableInterface {
     // Class content
 };
 
+enum Valid
+{
+}
+
+enum Invalid
+{
+
+}

--- a/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.inc.fixed
@@ -39,3 +39,10 @@ $instance = new class extends \Foo implements \HandleableInterface {
     // Class content
 };
 
+enum Valid
+{
+}
+
+enum Invalid
+{
+}

--- a/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/OpeningBraceSpaceUnitTest.php
@@ -31,6 +31,7 @@ class OpeningBraceSpaceUnitTest extends AbstractSniffUnitTest
             24 => 1,
             34 => 1,
             41 => 1,
+            55 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClosingDeclarationCommentSniff.php
@@ -27,6 +27,7 @@ class ClosingDeclarationCommentSniff implements Sniff
             T_FUNCTION,
             T_CLASS,
             T_INTERFACE,
+            T_ENUM,
         ];
 
     }//end register()
@@ -69,8 +70,10 @@ class ClosingDeclarationCommentSniff implements Sniff
             $comment = '//end '.$decName.'()';
         } else if ($tokens[$stackPtr]['code'] === T_CLASS) {
             $comment = '//end class';
-        } else {
+        } else if ($tokens[$stackPtr]['code'] === T_INTERFACE) {
             $comment = '//end interface';
+        } else {
+            $comment = '//end enum';
         }//end if
 
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -64,6 +64,8 @@ class DocCommentAlignmentSniff implements Sniff
         $ignore    = [
             T_CLASS     => true,
             T_INTERFACE => true,
+            T_ENUM      => true,
+            T_ENUM_CASE => true,
             T_FUNCTION  => true,
             T_PUBLIC    => true,
             T_PRIVATE   => true,

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.inc
@@ -79,4 +79,8 @@ class TestClass
 }
 //end class
 
-?>
+enum MissingClosingComment {
+}
+
+enum HasClosingComment {
+}//end enum

--- a/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClosingDeclarationCommentUnitTest.php
@@ -34,6 +34,7 @@ class ClosingDeclarationCommentUnitTest extends AbstractSniffUnitTest
             63 => 1,
             67 => 1,
             79 => 1,
+            83 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
@@ -85,6 +85,18 @@ abstract class MyClass
     readonly public string $prop;
 }
 
+/**
+ * Some info about the enum here
+  *
+*/
+enum Suits: string
+{
+    /**
+      * Some info about the case here.
+       */
+    case HEARTS;
+}
+
 /** ************************************************************************
  * Example with no errors.
  **************************************************************************/

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
@@ -85,6 +85,18 @@ abstract class MyClass
     readonly public string $prop;
 }
 
+/**
+ * Some info about the enum here
+ *
+ */
+enum Suits: string
+{
+    /**
+     * Some info about the case here.
+     */
+    case HEARTS;
+}
+
 /** ************************************************************************
  * Example with no errors.
  **************************************************************************/

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.php
@@ -47,6 +47,10 @@ class DocCommentAlignmentUnitTest extends AbstractSniffUnitTest
             $errors[75] = 1;
             $errors[83] = 1;
             $errors[84] = 1;
+            $errors[90] = 1;
+            $errors[91] = 1;
+            $errors[95] = 1;
+            $errors[96] = 1;
         }
 
         return $errors;

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc
@@ -120,3 +120,15 @@ $match = match ($test) {
 <div class="container">
 
 </div> <?php endif; ?>
+
+<?php
+
+enum Enum
+{
+}
+
+enum Suits {}
+
+enum Cards
+{
+    }

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.inc.fixed
@@ -123,3 +123,16 @@ $match = match ($test) {
 
 </div> 
 <?php endif; ?>
+
+<?php
+
+enum Enum
+{
+}
+
+enum Suits {
+}
+
+enum Cards
+{
+}

--- a/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/ScopeClosingBraceUnitTest.php
@@ -34,6 +34,8 @@ class ScopeClosingBraceUnitTest extends AbstractSniffUnitTest
             111 => 1,
             116 => 1,
             122 => 1,
+            130 => 1,
+            134 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Follow up on #3482 as per https://github.com/squizlabs/PHP_CodeSniffer/pull/3482#issuecomment-1016007608

### PEAR/ScopeClosingBrace: add tests for enum support

### PSR12/OpeningBraceSpace: add tests for enum support

### Squiz/ClosingDeclarationComment: add support for enums

### Squiz/DocCommentAlignment: add support for enums

### Squiz/ScopeClosingBrace: add tests for enum support