### PR TITLE
Squiz.Scope.MethodScope misses visibility keyword on previous line

### DIFF
--- a/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
+++ b/src/Standards/Squiz/Sniffs/Scope/MethodScopeSniff.php
@@ -54,17 +54,8 @@ class MethodScopeSniff extends AbstractScopeSniff
             return;
         }
 
-        $modifier = null;
-        for ($i = ($stackPtr - 1); $i > 0; $i--) {
-            if ($tokens[$i]['line'] < $tokens[$stackPtr]['line']) {
-                break;
-            } else if (isset(Tokens::$scopeModifiers[$tokens[$i]['code']]) === true) {
-                $modifier = $i;
-                break;
-            }
-        }
-
-        if ($modifier === null) {
+        $properties = $phpcsFile->getMethodProperties($stackPtr);
+        if ($properties['scope_specified'] === false) {
             $error = 'Visibility must be declared on method "%s"';
             $data  = [$methodName];
             $phpcsFile->addError($error, $stackPtr, 'Missing', $data);

--- a/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Scope/MethodScopeUnitTest.inc
@@ -48,3 +48,10 @@ enum SomeEnum
     private function func1() {}
     protected function func1() {}
 }
+
+class UnconventionalSpacing {
+    public
+    static
+    function
+    myFunction() {}
+}


### PR DESCRIPTION
The `Squiz.Scope.MethodScope` sniff is intended to check whether each method has visibility declared, but would in actual fact also enforce that the visibility should be on the same line as the `function` keyword as it stopped searching for the visibility keyword once it reached the start of the line.

Fixed now by using the `File::getMethodProperties()` method for determining visibility instead of searching with sniff specific logic.

Includes unit test.