### PR TITLE
PHP 8.1 | File::getMemberProperties(): handle `enum` properties same as interface properties

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1791,23 +1791,26 @@ class File
             && $this->tokens[$ptr]['code'] !== T_TRAIT)
         ) {
             if (isset($this->tokens[$ptr]) === true
-                && $this->tokens[$ptr]['code'] === T_INTERFACE
+                && ($this->tokens[$ptr]['code'] === T_INTERFACE
+                || $this->tokens[$ptr]['code'] === T_ENUM)
             ) {
-                // T_VARIABLEs in interfaces can actually be method arguments
+                // T_VARIABLEs in interfaces/enums can actually be method arguments
                 // but they wont be seen as being inside the method because there
                 // are no scope openers and closers for abstract methods. If it is in
                 // parentheses, we can be pretty sure it is a method argument.
                 if (isset($this->tokens[$stackPtr]['nested_parenthesis']) === false
                     || empty($this->tokens[$stackPtr]['nested_parenthesis']) === true
                 ) {
-                    $error = 'Possible parse error: interfaces may not include member vars';
-                    $this->addWarning($error, $stackPtr, 'Internal.ParseError.InterfaceHasMemberVar');
+                    $error = 'Possible parse error: %ss may not include member vars';
+                    $code  = sprintf('Internal.ParseError.%sHasMemberVar', ucfirst($this->tokens[$ptr]['content']));
+                    $data  = [strtolower($this->tokens[$ptr]['content'])];
+                    $this->addWarning($error, $stackPtr, $code, $data);
                     return [];
                 }
             } else {
                 throw new RuntimeException('$stackPtr is not a class member var');
             }
-        }
+        }//end if
 
         // Make sure it's not a method parameter.
         if (empty($this->tokens[$stackPtr]['nested_parenthesis']) === false) {

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -261,3 +261,18 @@ $anon = class {
     ]
     private mixed $baz;
 };
+
+enum Suit
+{
+    /* testEnumProperty */
+    protected $anonymous;
+}
+
+enum Direction implements ArrayAccess
+{
+    case Up;
+    case Down;
+
+    /* testEnumMethodParamNotProperty */
+    public function offsetGet($val) { ... }
+}

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -662,6 +662,10 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'nullable_type'   => false,
                 ],
             ],
+            [
+                '/* testEnumProperty */',
+                [],
+            ],
         ];
 
     }//end dataGetMemberProperties()
@@ -703,6 +707,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
             ['/* testGlobalVariable */'],
             ['/* testNestedMethodParam 1 */'],
             ['/* testNestedMethodParam 2 */'],
+            ['/* testEnumMethodParamNotProperty */'],
         ];
 
     }//end dataNotClassProperty()


### PR DESCRIPTION
Neither enums nor interfaces support properties being declared on them.

This adjusts the `File::getMemberProperties()` method to handle properties declared on an `enum` in the same way as properties declared on an `interface` were already being handled.

Includes unit test.