### PR TITLE
PHP 8.1 | File::findImplementedInterfaceNames(): add support for enums implementing interfaces

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2765,11 +2765,11 @@ class File
 
 
     /**
-     * Returns the names of the interfaces that the specified class implements.
+     * Returns the names of the interfaces that the specified class or enum implements.
      *
      * Returns FALSE on error or if there are no implemented interface names.
      *
-     * @param int $stackPtr The stack position of the class.
+     * @param int $stackPtr The stack position of the class or enum token.
      *
      * @return array|false
      */
@@ -2782,6 +2782,7 @@ class File
 
         if ($this->tokens[$stackPtr]['code'] !== T_CLASS
             && $this->tokens[$stackPtr]['code'] !== T_ANON_CLASS
+            && $this->tokens[$stackPtr]['code'] !== T_ENUM
         ) {
             return false;
         }

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.inc
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.inc
@@ -24,3 +24,12 @@ class testFECNClassThatExtendsAndImplements extends testFECNClass implements Int
 
 /* testClassThatImplementsAndExtends */
 class testFECNClassThatImplementsAndExtends implements \InterfaceA, InterfaceB extends testFECNClass {}
+
+/* testBackedEnumWithoutImplements */
+enum Suit:string {}
+
+/* testEnumImplements */
+enum Suit implements Colorful {}
+
+/* testBackedEnumImplements */
+enum Suit: string implements Colorful, \Deck {}

--- a/tests/Core/File/FindImplementedInterfaceNamesTest.php
+++ b/tests/Core/File/FindImplementedInterfaceNamesTest.php
@@ -27,7 +27,7 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
      */
     public function testFindImplementedInterfaceNames($identifier, $expected)
     {
-        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
+        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE, T_ENUM]);
         $result  = self::$phpcsFile->findImplementedInterfaceNames($OOToken);
         $this->assertSame($expected, $result);
 
@@ -79,6 +79,21 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
                 [
                     '\InterfaceA',
                     'InterfaceB',
+                ],
+            ],
+            [
+                '/* testBackedEnumWithoutImplements */',
+                false,
+            ],
+            [
+                '/* testEnumImplements */',
+                ['Colorful'],
+            ],
+            [
+                '/* testBackedEnumImplements */',
+                [
+                    'Colorful',
+                    '\Deck',
                 ],
             ],
         ];


### PR DESCRIPTION
An `enum` declaration can implement one or more interfaces.

This commit updates the `File::findImplementedInterfaceNames()` method to allow it to find the interfaces implemented by an `enum` as well.

Includes unit tests.