### PR TITLE
PHP 8.1: Added missing tests of intersection types for `LowerCaseTypeSniff`

### DIFF
--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -85,3 +85,7 @@ class ConstructorPropertyPromotionAndNormalParams {
 function (): NeVeR {
     exit;
 };
+
+function intersectionParamTypes (\Package\ClassName&\Package\Other_Class $var) {}
+
+function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class {}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -85,3 +85,7 @@ class ConstructorPropertyPromotionAndNormalParams {
 function (): never {
     exit;
 };
+
+function intersectionParamTypes (\Package\ClassName&\Package\Other_Class $var) {}
+
+function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class {}


### PR DESCRIPTION
Removed during rebase by mistake...