### PR TITLE
Tokenizer/PHP: bug fix for double quoted strings using `${`

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -182,6 +182,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="DefaultKeywordTest.php" role="test" />
       <file baseinstalldir="" name="DoubleArrowTest.inc" role="test" />
       <file baseinstalldir="" name="DoubleArrowTest.php" role="test" />
+      <file baseinstalldir="" name="DoubleQuotedStringTest.inc" role="test" />
+      <file baseinstalldir="" name="DoubleQuotedStringTest.php" role="test" />
       <file baseinstalldir="" name="EnumCaseTest.inc" role="test" />
       <file baseinstalldir="" name="EnumCaseTest.php" role="test" />
       <file baseinstalldir="" name="FinallyTest.inc" role="test" />
@@ -2153,6 +2155,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.php" name="tests/Core/Tokenizer/DoubleArrowTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.inc" name="tests/Core/Tokenizer/DoubleArrowTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleQuotedStringTest.php" name="tests/Core/Tokenizer/DoubleQuotedStringTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleQuotedStringTest.inc" name="tests/Core/Tokenizer/DoubleQuotedStringTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/EnumCaseTest.php" name="tests/Core/Tokenizer/EnumCaseTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/EnumCaseTest.inc" name="tests/Core/Tokenizer/EnumCaseTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/FinallyTest.php" name="tests/Core/Tokenizer/FinallyTest.php" />
@@ -2255,6 +2259,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Tokenizer/DefaultKeywordTest.inc" name="tests/Core/Tokenizer/DefaultKeywordTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.php" name="tests/Core/Tokenizer/DoubleArrowTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/DoubleArrowTest.inc" name="tests/Core/Tokenizer/DoubleArrowTest.inc" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleQuotedStringTest.php" name="tests/Core/Tokenizer/DoubleQuotedStringTest.php" />
+   <install as="CodeSniffer/Core/Tokenizer/DoubleQuotedStringTest.inc" name="tests/Core/Tokenizer/DoubleQuotedStringTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/EnumCaseTest.php" name="tests/Core/Tokenizer/EnumCaseTest.php" />
    <install as="CodeSniffer/Core/Tokenizer/EnumCaseTest.inc" name="tests/Core/Tokenizer/EnumCaseTest.inc" />
    <install as="CodeSniffer/Core/Tokenizer/FinallyTest.php" name="tests/Core/Tokenizer/FinallyTest.php" />

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -789,7 +789,8 @@ class PHP extends Tokenizer
 
                     if ($subTokenIsArray === true) {
                         $tokenContent .= $subToken[1];
-                        if ($subToken[1] === '{'
+                        if (($subToken[1] === '{'
+                            || $subToken[1] === '${')
                             && $subToken[0] !== T_ENCAPSED_AND_WHITESPACE
                         ) {
                             $nestedVars[] = $i;

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.inc
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.inc
@@ -47,3 +47,6 @@
 "${foo->{${'a'}}}";
 /* testNested5 */
 "${foo->{"${'a'}"}}";
+
+/* testParseError */
+"${foo["${bar

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.inc
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.inc
@@ -1,0 +1,49 @@
+<?php
+
+// Test source: https://gist.github.com/iluuu1994/72e2154fc4150f2258316b0255b698f2#file-test-php
+
+/* testSimple1 */
+"$foo";
+/* testSimple2 */
+"{$foo}";
+/* testSimple3 */
+"${foo}";
+
+/* testDIM1 */
+"$foo[bar]";
+/* testDIM2 */
+"{$foo['bar']}";
+/* testDIM3 */
+"${foo['bar']}";
+
+/* testProperty1 */
+"$foo->bar";
+/* testProperty2 */
+"{$foo->bar}";
+
+/* testMethod1 */
+"{$foo->bar()}";
+
+/* testClosure1 */
+"{$foo()}";
+
+/* testChain1 */
+"{$foo['bar']->baz()()}";
+
+/* testVariableVar1 */
+"${$bar}";
+/* testVariableVar2 */
+"${(foo)}";
+/* testVariableVar3 */
+"${foo->bar}";
+
+/* testNested1 */
+"${foo["${bar}"]}";
+/* testNested2 */
+"${foo["${bar['baz']}"]}";
+/* testNested3 */
+"${foo->{$baz}}";
+/* testNested4 */
+"${foo->{${'a'}}}";
+/* testNested5 */
+"${foo->{"${'a'}"}}";

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.php
@@ -123,6 +123,11 @@ class DoubleQuotedStringTest extends AbstractMethodUnitTest
                 'testMarker'      => '/* testNested5 */',
                 'expectedContent' => '"${foo->{"${\'a\'}"}}"',
             ],
+            [
+                'testMarker'      => '/* testParseError */',
+                'expectedContent' => '"${foo["${bar
+',
+            ],
         ];
 
     }//end dataDoubleQuotedString()

--- a/tests/Core/Tokenizer/DoubleQuotedStringTest.php
+++ b/tests/Core/Tokenizer/DoubleQuotedStringTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests that embedded variables and expressions in double quoted strings are tokenized
+ * as one double quoted string token.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2022 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Tokenizer;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class DoubleQuotedStringTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test that double quoted strings contain the complete string.
+     *
+     * @param string $testMarker      The comment which prefaces the target token in the test file.
+     * @param string $expectedContent The expected content of the double quoted string.
+     *
+     * @dataProvider dataDoubleQuotedString
+     * @covers       PHP_CodeSniffer\Tokenizers\PHP::tokenize
+     *
+     * @return void
+     */
+    public function testDoubleQuotedString($testMarker, $expectedContent)
+    {
+        $tokens = self::$phpcsFile->getTokens();
+
+        $target = $this->getTargetToken($testMarker, T_DOUBLE_QUOTED_STRING);
+        $this->assertSame($expectedContent, $tokens[$target]['content']);
+
+    }//end testDoubleQuotedString()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testDoubleQuotedString()
+     *
+     * @return array
+     */
+    public function dataDoubleQuotedString()
+    {
+        return [
+            [
+                'testMarker'      => '/* testSimple1 */',
+                'expectedContent' => '"$foo"',
+            ],
+            [
+                'testMarker'      => '/* testSimple2 */',
+                'expectedContent' => '"{$foo}"',
+            ],
+            [
+                'testMarker'      => '/* testSimple3 */',
+                'expectedContent' => '"${foo}"',
+            ],
+            [
+                'testMarker'      => '/* testDIM1 */',
+                'expectedContent' => '"$foo[bar]"',
+            ],
+            [
+                'testMarker'      => '/* testDIM2 */',
+                'expectedContent' => '"{$foo[\'bar\']}"',
+            ],
+            [
+                'testMarker'      => '/* testDIM3 */',
+                'expectedContent' => '"${foo[\'bar\']}"',
+            ],
+            [
+                'testMarker'      => '/* testProperty1 */',
+                'expectedContent' => '"$foo->bar"',
+            ],
+            [
+                'testMarker'      => '/* testProperty2 */',
+                'expectedContent' => '"{$foo->bar}"',
+            ],
+            [
+                'testMarker'      => '/* testMethod1 */',
+                'expectedContent' => '"{$foo->bar()}"',
+            ],
+            [
+                'testMarker'      => '/* testClosure1 */',
+                'expectedContent' => '"{$foo()}"',
+            ],
+            [
+                'testMarker'      => '/* testChain1 */',
+                'expectedContent' => '"{$foo[\'bar\']->baz()()}"',
+            ],
+            [
+                'testMarker'      => '/* testVariableVar1 */',
+                'expectedContent' => '"${$bar}"',
+            ],
+            [
+                'testMarker'      => '/* testVariableVar2 */',
+                'expectedContent' => '"${(foo)}"',
+            ],
+            [
+                'testMarker'      => '/* testVariableVar3 */',
+                'expectedContent' => '"${foo->bar}"',
+            ],
+            [
+                'testMarker'      => '/* testNested1 */',
+                'expectedContent' => '"${foo["${bar}"]}"',
+            ],
+            [
+                'testMarker'      => '/* testNested2 */',
+                'expectedContent' => '"${foo["${bar[\'baz\']}"]}"',
+            ],
+            [
+                'testMarker'      => '/* testNested3 */',
+                'expectedContent' => '"${foo->{$baz}}"',
+            ],
+            [
+                'testMarker'      => '/* testNested4 */',
+                'expectedContent' => '"${foo->{${\'a\'}}}"',
+            ],
+            [
+                'testMarker'      => '/* testNested5 */',
+                'expectedContent' => '"${foo->{"${\'a\'}"}}"',
+            ],
+        ];
+
+    }//end dataDoubleQuotedString()
+
+
+}//end class


### PR DESCRIPTION
While creating a sniff for PHPCompatibility to detect the PHP 8.2 deprecation of two of the four syntaxes to embed variables/expressions within text strings, I realized that for select examples of the "type 4" syntax - "Variable variables (`“${expr}”`, equivalent to (string) `${expr})`" -, PHPCS did not, and probably never did, tokenize those correctly.

Double quoted strings in PHPCS are normally tokenized as one token (per line), including any and all embedded variables and expressions to prevent problems in the scope map caused by braces within the string/expression.

However, for some double quoted strings using `${` syntax, this was not the case and these were tokenized as outlined below, which would still lead to the problems in the scope map.

Luckily, these syntax variants aren't used that frequently. Though I suspect if they were, this bug would have been discovered a lot sooner.

Either way, fixed now.

Including adding a dedicated test file based on examples related to the PHP 8.2 RFC.

Note: this test file tests that these embedding syntaxes are tokenized correctly, it doesn't test the other parts of the related `Tokenizers\PHP` code block (re-tokenizing to one token per line, handling of binary casts).


Refs:
* https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
* https://gist.github.com/iluuu1994/72e2154fc4150f2258316b0255b698f2

---

Example of some code for which the tokenizer was buggy:
```php
echo "${foo["${bar}"]}";
```

Was originally tokenized like so:
```
Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
-------------------------------------------------------------------------
  2 | L3 | C  1 | CC 0 | ( 0) | T_ECHO                     | [  4]: echo
  3 | L3 | C  5 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
  4 | L3 | C  6 | CC 0 | ( 0) | T_DOUBLE_QUOTED_STRING     | [  8]: "${foo["
  5 | L3 | C 14 | CC 0 | ( 0) | T_DOLLAR_OPEN_CURLY_BRACES | [  2]: ${
  6 | L3 | C 16 | CC 0 | ( 0) | T_STRING_VARNAME           | [  3]: bar
  7 | L3 | C 19 | CC 0 | ( 0) | T_CLOSE_CURLY_BRACKET      | [  1]: }
  8 | L3 | C 20 | CC 0 | ( 0) | T_DOUBLE_QUOTED_STRING     | [  4]: "]}"
  9 | L3 | C 24 | CC 0 | ( 0) | T_SEMICOLON                | [  1]: ;
 10 | L3 | C 25 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
```

Will be tokenized (correctly) like so with the fix included in this PR:
```
Ptr | Ln | Col  | Cond | ( #) | Token Type                 | [len]: Content
-------------------------------------------------------------------------
  2 | L3 | C  1 | CC 0 | ( 0) | T_ECHO                     | [  4]: echo
  3 | L3 | C  5 | CC 0 | ( 0) | T_WHITESPACE               | [  1]: ⸱
  4 | L3 | C  6 | CC 0 | ( 0) | T_DOUBLE_QUOTED_STRING     | [ 18]: "${foo["${bar}"]}"
  5 | L3 | C 24 | CC 0 | ( 0) | T_SEMICOLON                | [  1]: ;
  6 | L3 | C 25 | CC 0 | ( 0) | T_WHITESPACE               | [  0]:
```
