### PR TITLE
[Hot fix] Tokenizer/PHP: 2 bug fixes for improved context sensitive keyword support

### DIFF
--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -694,6 +694,7 @@ final class Tokens
         T_ENDSWITCH    => T_ENDSWITCH,
         T_ENDWHILE     => T_ENDWHILE,
         T_ENUM         => T_ENUM,
+        T_EVAL         => T_EVAL,
         T_EXIT         => T_EXIT,
         T_EXTENDS      => T_EXTENDS,
         T_FINAL        => T_FINAL,

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
@@ -29,6 +29,7 @@ class ContextSensitiveKeywords
     const /* testEndSwitch */ ENDSWITCH = 'ENDSWITCH';
     const /* testEndWhile */ ENDWHILE = 'ENDWHILE';
     const /* testEnum */ ENUM = 'ENUM';
+    const /* testEval */ EVAL = 'EVAL';
     const /* testExit */ EXIT = 'EXIT';
     const /* testExtends */ EXTENDS = 'EXTENDS';
     const /* testFinal */ FINAL = 'FINAL';
@@ -165,6 +166,8 @@ echo $foo;
 print $foo;
 /* testDieIsKeyword */
 die($foo);
+/* testEvalIsKeyword */
+eval('<?php echo 5;');
 /* testExitIsKeyword */
 exit;
 
@@ -212,3 +215,5 @@ $instantiated3 = new /* testClassInstantiationStaticIsKeyword */ static($param);
 
 class Foo extends /* testNamespaceInNameIsKeyword */ namespace\Exception
 {}
+
+function /* testKeywordAfterFunctionShouldBeString */ eval() {}

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
@@ -217,3 +217,4 @@ class Foo extends /* testNamespaceInNameIsKeyword */ namespace\Exception
 {}
 
 function /* testKeywordAfterFunctionShouldBeString */ eval() {}
+function /* testKeywordAfterFunctionByRefShouldBeString */ &switch() {}

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -72,6 +72,7 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
             ['/* testEndSwitch */'],
             ['/* testEndWhile */'],
             ['/* testEnum */'],
+            ['/* testEval */'],
             ['/* testExit */'],
             ['/* testExtends */'],
             ['/* testFinal */'],
@@ -121,6 +122,8 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
             ['/* testNamespaceNameIsString1 */'],
             ['/* testNamespaceNameIsString2 */'],
             ['/* testNamespaceNameIsString3 */'],
+
+            ['/* testKeywordAfterFunctionShouldBeString */'],
         ];
 
     }//end dataStrings()
@@ -375,6 +378,10 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
             [
                 '/* testDieIsKeyword */',
                 'T_EXIT',
+            ],
+            [
+                '/* testEvalIsKeyword */',
+                'T_EVAL',
             ],
             [
                 '/* testExitIsKeyword */',

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -124,6 +124,7 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
             ['/* testNamespaceNameIsString3 */'],
 
             ['/* testKeywordAfterFunctionShouldBeString */'],
+            ['/* testKeywordAfterFunctionByRefShouldBeString */'],
         ];
 
     }//end dataStrings()


### PR DESCRIPTION
### Tokenizer/PHP: bug fix in improved context sensitive keyword support [1]

As reported in #3607, the `eval` keyword was not included in the list of context sensitive keyword. This is a regression compared to PHPCS 3.6.2.

Fixed now, including unit tests.

Fixes #3607

### Tokenizer/PHP: bug fix in improved context sensitive keyword support [2]

While investigating #3607, I figured adding a test with a function declared to return by reference would also not be amiss and found that that situation was not accounted for.

This commit fixes that.
Includes unit test.