### PR TITLE
Tokens::$functionNameTokens: include the `parent` keyword

### DIFF
--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc
@@ -163,3 +163,15 @@ $a = (
 if (true) {} ( 1+2) === 3 ? $a = 1 : $a = 2;
 class A {} ( 1+2) === 3 ? $a = 1 : $a = 2;
 function foo() {} ( 1+2) === 3 ? $a = 1 : $a = 2;
+
+// Issue #3618.
+class NonArbitraryParenthesesWithKeywords {
+    public static function baz( $foo, $bar ) {
+        $a = new self();
+        $b = new parent();
+        $c = new static();
+
+        // self/static are already tested above, round line 45.
+        $d = new parent( $foo,$bar );
+    }
+}

--- a/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/ArbitraryParenthesesSpacingUnitTest.inc.fixed
@@ -151,3 +151,15 @@ $a = (
 if (true) {} (1+2) === 3 ? $a = 1 : $a = 2;
 class A {} (1+2) === 3 ? $a = 1 : $a = 2;
 function foo() {} (1+2) === 3 ? $a = 1 : $a = 2;
+
+// Issue #3618.
+class NonArbitraryParenthesesWithKeywords {
+    public static function baz( $foo, $bar ) {
+        $a = new self();
+        $b = new parent();
+        $c = new static();
+
+        // self/static are already tested above, round line 45.
+        $d = new parent( $foo,$bar );
+    }
+}

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -628,6 +628,7 @@ final class Tokens
         T_UNSET        => T_UNSET,
         T_EMPTY        => T_EMPTY,
         T_SELF         => T_SELF,
+        T_PARENT       => T_PARENT,
         T_STATIC       => T_STATIC,
     ];
 


### PR DESCRIPTION
Follow up to PR #3546, which changed how the `parent` keyword in a `new parent` snippet was tokenized from `T_STRING` to `T_PARENT`.

The `T_PARENT` keyword token, however, was not included in the `Tokens::$functionNameTokens` array, which was the underlying cause for the bug reported in #3618.

Fixed now.

Tested by adding additional tests to the `Generic.WhiteSpace.ArbitraryParenthesesSpacing` sniff. These tests passed in PHPCS 3.6.2 and started failing in PHPCS 3.7.0. Once this fix has been merged, the tests will pass again.

Fixes #3618