### PR TITLE
Squiz/DisallowComparisonAssignment: bug fix - ignore match structures

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/DisallowComparisonAssignmentSniff.php
@@ -52,17 +52,18 @@ class DisallowComparisonAssignmentSniff implements Sniff
             }
         }
 
-        // Ignore values in array definitions.
-        $array = $phpcsFile->findNext(
-            T_ARRAY,
+        // Ignore values in array definitions or match structures.
+        $nextNonEmpty = $phpcsFile->findNext(
+            Tokens::$emptyTokens,
             ($stackPtr + 1),
-            null,
-            false,
             null,
             true
         );
 
-        if ($array !== false) {
+        if ($nextNonEmpty !== false
+            && ($tokens[$nextNonEmpty]['code'] === \T_ARRAY
+            || $tokens[$nextNonEmpty]['code'] === \T_MATCH)
+        ) {
             return;
         }
 

--- a/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DisallowComparisonAssignmentUnitTest.inc
@@ -71,3 +71,13 @@ $callback = function ($value) {
         return false;
     }
 };
+
+function issue3616() {
+    $food = 'cake';
+
+    $returnValue = match (true) {
+        $food === 'apple' => 'This food is an apple',
+        $food === 'bar' => 'This food is a bar',
+        $food === 'cake' => 'This food is a cake',
+    };
+}


### PR DESCRIPTION
Fixes #3616

Note: I've changed the `findNext()` call from an exhaustive call to the end of the statement to a faster check for the first non-empty token, which I believe was the actual _intention_ of the function call.

As no tests are failing, I'm fairly certain my suspicion is correct ;-)