### PR TITLE
PHP 8.2 | Ruleset: prevent notices about dynamic properties being set

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -138,6 +138,16 @@ http://pear.php.net/dtd/package-2.0.xsd">
       </dir>
      </dir>
      <dir name="Ruleset">
+      <dir name="Fixtures">
+       <dir name="Sniffs">
+        <dir name="Category">
+         <file baseinstalldir="" name="SetPropertyAllowedAsDeclaredSniff.php" role="test" />
+         <file baseinstalldir="" name="SetPropertyAllowedViaMagicMethodSniff.php" role="test" />
+         <file baseinstalldir="" name="SetPropertyAllowedViaStdClassSniff.php" role="test" />
+         <file baseinstalldir="" name="SetPropertyNotAllowedViaAttributeSniff.php" role="test" />
+        </dir>
+       </dir>
+      </dir>
       <file baseinstalldir="" name="RuleInclusionTest.php" role="test" />
       <file baseinstalldir="" name="RuleInclusionTest.xml" role="test" />
       <file baseinstalldir="" name="RuleInclusionTest-include.xml" role="test" />
@@ -145,6 +155,15 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="RuleInclusionAbsoluteLinuxTest.xml" role="test" />
       <file baseinstalldir="" name="RuleInclusionAbsoluteWindowsTest.php" role="test" />
       <file baseinstalldir="" name="RuleInclusionAbsoluteWindowsTest.xml" role="test" />
+      <file baseinstalldir="" name="SetSniffPropertyTest.php" role="test" />
+      <file baseinstalldir="" name="SetPropertyAllowedAsDeclaredTest.xml" role="test" />
+      <file baseinstalldir="" name="SetPropertyAllowedViaMagicMethodTest.xml" role="test" />
+      <file baseinstalldir="" name="SetPropertyAllowedViaStdClassTest.xml" role="test" />
+      <file baseinstalldir="" name="SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml" role="test" />
+      <file baseinstalldir="" name="SetPropertyThrowsErrorOnInvalidPropertyTest.xml" role="test" />
+      <file baseinstalldir="" name="SetPropertyNotAllowedViaAttributeTest.xml" role="test" />
+      <file baseinstalldir="" name="SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml" role="test" />
+      <file baseinstalldir="" name="SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml" role="test" />
      </dir>
      <dir name="Sniffs">
       <file baseinstalldir="" name="AbstractArraySniffTest.inc" role="test" />
@@ -2128,6 +2147,19 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" />
    <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" />
    <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetSniffPropertyTest.php" name="tests/Core/Ruleset/SetSniffPropertyTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml" name="tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml" name="tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml" name="tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml" name="tests/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml" name="tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml" name="tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml" name="tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml" name="tests/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php" />
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTest.inc" name="tests/Core/Sniffs/AbstractArraySniffTest.inc" />
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTest.php" name="tests/Core/Sniffs/AbstractArraySniffTest.php" />
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTestable.php" name="tests/Core/Sniffs/AbstractArraySniffTestable.php" />
@@ -2236,6 +2268,19 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteLinuxTest.xml" />
    <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.php" />
    <install as="CodeSniffer/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" name="tests/Core/Ruleset/RuleInclusionAbsoluteWindowsTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetSniffPropertyTest.php" name="tests/Core/Ruleset/SetSniffPropertyTest.php" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml" name="tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml" name="tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml" name="tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml" name="tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml" name="tests/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml" name="tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml" name="tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml" name="tests/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php" />
+   <install as="CodeSniffer/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php" name="tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php" />
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTest.inc" name="tests/Core/Sniffs/AbstractArraySniffTest.inc" />
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTest.php" name="tests/Core/Sniffs/AbstractArraySniffTest.php" />
    <install as="CodeSniffer/Core/Sniffs/AbstractArraySniffTestable.php" name="tests/Core/Sniffs/AbstractArraySniffTestable.php" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
 
     <exclude-pattern>*/src/Standards/*/Tests/*\.(inc|css|js)$</exclude-pattern>
     <exclude-pattern>*/tests/Core/*/*\.(inc|css|js)$</exclude-pattern>
+    <exclude-pattern>*/tests/Core/*/Fixtures/*\.php$</exclude-pattern>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>

--- a/scripts/ValidatePEAR/ValidatePEARPackageXML.php
+++ b/scripts/ValidatePEAR/ValidatePEARPackageXML.php
@@ -232,10 +232,11 @@ class ValidatePEARPackageXML
                     $valid = false;
                 } else {
                     // Limited validation of the "role" tags.
-                    if (strpos($name, 'Test.') !== false && $role !== 'test') {
+                    if ((strpos($name, 'tests/') === 0 || strpos($name, 'Test.') !== false) && $role !== 'test') {
                         echo "- Test files should have the role 'test'. Found: '$role' for file '{$name}'.".PHP_EOL;
                         $valid = false;
-                    } else if ((strpos($name, 'Standard.xml') !== false || strpos($name, 'Sniff.php') !== false)
+                    } else if (strpos($name, 'tests/') !== 0
+                        && (strpos($name, 'Standard.xml') !== false || strpos($name, 'Sniff.php') !== false)
                         && $role !== 'php'
                     ) {
                         echo "- Sniff files, including sniff documentation files should have the role 'php'. Found: '$role' for file '{$name}'.".PHP_EOL;

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -379,9 +379,12 @@ class File
                                 if (isset($this->ruleset->sniffCodes[$parts[0]]) === true) {
                                     $listenerCode  = array_shift($parts);
                                     $propertyCode  = array_shift($parts);
-                                    $propertyValue = rtrim(implode(' ', $parts), " */\r\n");
+                                    $settings      = [
+                                        'value' => rtrim(implode(' ', $parts), " */\r\n"),
+                                        'scope' => 'sniff',
+                                    ];
                                     $listenerClass = $this->ruleset->sniffCodes[$listenerCode];
-                                    $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $propertyValue);
+                                    $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $settings);
                                 }
                             }
                         }
@@ -403,9 +406,12 @@ class File
                         $listenerCode = $token['sniffCode'];
                         if (isset($this->ruleset->sniffCodes[$listenerCode]) === true) {
                             $propertyCode  = $token['sniffProperty'];
-                            $propertyValue = $token['sniffPropertyValue'];
+                            $settings      = [
+                                'value' => $token['sniffPropertyValue'],
+                                'scope' => 'sniff',
+                            ];
                             $listenerClass = $this->ruleset->sniffCodes[$listenerCode];
-                            $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $propertyValue);
+                            $this->ruleset->setSniffProperty($listenerClass, $propertyCode, $settings);
                         }
                     }
                 }//end if

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -13,6 +13,7 @@ namespace PHP_CodeSniffer;
 
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Util;
+use stdClass;
 
 class Ruleset
 {
@@ -960,6 +961,11 @@ class Ruleset
             if (isset($rule->properties) === true
                 && $this->shouldProcessElement($rule->properties) === true
             ) {
+                $propertyScope = 'standard';
+                if ($code === $ref || substr($ref, -9) === 'Sniff.php') {
+                    $propertyScope = 'sniff';
+                }
+
                 foreach ($rule->properties->property as $prop) {
                     if ($this->shouldProcessElement($prop) === false) {
                         continue;
@@ -980,9 +986,9 @@ class Ruleset
                         $values = [];
                         if (isset($prop['extend']) === true
                             && (string) $prop['extend'] === 'true'
-                            && isset($this->ruleset[$code]['properties'][$name]) === true
+                            && isset($this->ruleset[$code]['properties'][$name]['value']) === true
                         ) {
-                            $values = $this->ruleset[$code]['properties'][$name];
+                            $values = $this->ruleset[$code]['properties'][$name]['value'];
                         }
 
                         if (isset($prop->element) === true) {
@@ -1017,7 +1023,10 @@ class Ruleset
                             }
                         }//end if
 
-                        $this->ruleset[$code]['properties'][$name] = $values;
+                        $this->ruleset[$code]['properties'][$name] = [
+                            'value' => $values,
+                            'scope' => $propertyScope,
+                        ];
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
                             echo str_repeat("\t", $depth);
                             echo "\t\t=> array property \"$name\" set to \"$printValue\"";
@@ -1028,7 +1037,10 @@ class Ruleset
                             echo PHP_EOL;
                         }
                     } else {
-                        $this->ruleset[$code]['properties'][$name] = (string) $prop['value'];
+                        $this->ruleset[$code]['properties'][$name] = [
+                            'value' => (string) $prop['value'],
+                            'scope' => $propertyScope,
+                        ];
                         if (PHP_CODESNIFFER_VERBOSITY > 1) {
                             echo str_repeat("\t", $depth);
                             echo "\t\t=> property \"$name\" set to \"".(string) $prop['value'].'"';
@@ -1218,8 +1230,8 @@ class Ruleset
 
             // Set custom properties.
             if (isset($this->ruleset[$sniffCode]['properties']) === true) {
-                foreach ($this->ruleset[$sniffCode]['properties'] as $name => $value) {
-                    $this->setSniffProperty($sniffClass, $name, $value);
+                foreach ($this->ruleset[$sniffCode]['properties'] as $name => $settings) {
+                    $this->setSniffProperty($sniffClass, $name, $settings);
                 }
             }
 
@@ -1286,18 +1298,48 @@ class Ruleset
      *
      * @param string $sniffClass The class name of the sniff.
      * @param string $name       The name of the property to change.
-     * @param string $value      The new value of the property.
+     * @param array  $settings   Array with the new value of the property and the scope of the property being set.
      *
      * @return void
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException When attempting to set a non-existent property on a sniff
+     *                                                      which doesn't declare the property or explicitly supports
+     *                                                      dynamic properties.
      */
-    public function setSniffProperty($sniffClass, $name, $value)
+    public function setSniffProperty($sniffClass, $name, $settings)
     {
         // Setting a property for a sniff we are not using.
         if (isset($this->sniffs[$sniffClass]) === false) {
             return;
         }
 
-        $name = trim($name);
+        $name         = trim($name);
+        $propertyName = $name;
+        if (substr($propertyName, -2) === '[]') {
+            $propertyName = substr($propertyName, 0, -2);
+        }
+
+        $isSettable  = false;
+        $sniffObject = $this->sniffs[$sniffClass];
+        if (property_exists($sniffObject, $propertyName) === true
+            || ($sniffObject instanceof stdClass) === true
+            || method_exists($sniffObject, '__set') === true
+        ) {
+            $isSettable = true;
+        }
+
+        if ($isSettable === false) {
+            if ($settings['scope'] === 'sniff') {
+                $notice  = "Ruleset invalid. Property \"$propertyName\" does not exist on sniff ";
+                $notice .= array_search($sniffClass, $this->sniffCodes, true);
+                throw new RuntimeException($notice);
+            }
+
+            return;
+        }
+
+        $value = $settings['value'];
+
         if (is_string($value) === true) {
             $value = trim($value);
         }
@@ -1312,7 +1354,7 @@ class Ruleset
         } else if ($value === 'false') {
             $value = false;
         } else if (substr($name, -2) === '[]') {
-            $name   = substr($name, 0, -2);
+            $name   = $propertyName;
             $values = [];
             if ($value !== null) {
                 foreach (explode(',', $value) as $val) {
@@ -1328,7 +1370,7 @@ class Ruleset
             $value = $values;
         }
 
-        $this->sniffs[$sniffClass]->$name = $value;
+        $sniffObject->$name = $value;
 
     }//end setSniffProperty()
 

--- a/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
+ */
+
+namespace Fixtures\Sniffs\Category;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class SetPropertyAllowedAsDeclaredSniff implements Sniff
+{
+
+    public $arbitrarystring;
+    public $arbitraryarray;
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
+ */
+
+namespace Fixtures\Sniffs\Category;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class SetPropertyAllowedViaMagicMethodSniff implements Sniff
+{
+    private $magic = [];
+
+    public function __set($name, $value)
+    {
+        $this->magic[$name] = $value;
+    }
+
+    public function __get($name)
+    {
+        if (isset($this->magic[$name])) {
+            return $this->magic[$name];
+        }
+
+        return null;
+    }
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
+ */
+
+namespace Fixtures\Sniffs\Category;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use stdClass;
+
+class SetPropertyAllowedViaStdClassSniff extends stdClass implements Sniff
+{
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php
+++ b/tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Test fixture.
+ *
+ * @see \PHP_CodeSniffer\Tests\Core\Ruleset\SetSniffPropertyTest
+ */
+
+namespace Fixtures\Sniffs\Category;
+
+use AllowDynamicProperties;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+#[AllowDynamicProperties]
+class SetPropertyNotAllowedViaAttributeSniff implements Sniff
+{
+
+    public function register()
+    {
+        return [T_WHITESPACE];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Do something.
+    }
+}

--- a/tests/Core/Ruleset/RuleInclusionTest.php
+++ b/tests/Core/Ruleset/RuleInclusionTest.php
@@ -114,13 +114,13 @@ class RuleInclusionTest extends TestCase
     public function testHasSniffCodes()
     {
         $this->assertObjectHasAttribute('sniffCodes', self::$ruleset);
-        $this->assertCount(14, self::$ruleset->sniffCodes);
+        $this->assertCount(48, self::$ruleset->sniffCodes);
 
     }//end testHasSniffCodes()
 
 
     /**
-     * Test that sniffs are correctly registered, independently on the syntax used to include the sniff.
+     * Test that sniffs are correctly registered, independently of the syntax used to include the sniff.
      *
      * @param string $key   Expected array key.
      * @param string $value Expected array value.
@@ -147,6 +147,54 @@ class RuleInclusionTest extends TestCase
     public function dataRegisteredSniffCodes()
     {
         return [
+            [
+                'PSR2.Classes.ClassDeclaration',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff',
+            ],
+            [
+                'PSR2.Classes.PropertyDeclaration',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff',
+            ],
+            [
+                'PSR2.ControlStructures.ControlStructureSpacing',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ControlStructureSpacingSniff',
+            ],
+            [
+                'PSR2.ControlStructures.ElseIfDeclaration',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\ElseIfDeclarationSniff',
+            ],
+            [
+                'PSR2.ControlStructures.SwitchDeclaration',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\SwitchDeclarationSniff',
+            ],
+            [
+                'PSR2.Files.ClosingTag',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\ClosingTagSniff',
+            ],
+            [
+                'PSR2.Files.EndFileNewline',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\EndFileNewlineSniff',
+            ],
+            [
+                'PSR2.Methods.FunctionCallSignature',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff',
+            ],
+            [
+                'PSR2.Methods.FunctionClosingBrace',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionClosingBraceSniff',
+            ],
+            [
+                'PSR2.Methods.MethodDeclaration',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff',
+            ],
+            [
+                'PSR2.Namespaces.NamespaceDeclaration',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\NamespaceDeclarationSniff',
+            ],
+            [
+                'PSR2.Namespaces.UseDeclaration',
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Namespaces\UseDeclarationSniff',
+            ],
             [
                 'PSR1.Classes.ClassDeclaration',
                 'PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff',
@@ -180,8 +228,100 @@ class RuleInclusionTest extends TestCase
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\UpperCaseConstantNameSniff',
             ],
             [
-                'Zend.NamingConventions.ValidVariableName',
-                'PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions\ValidVariableNameSniff',
+                'Generic.Files.LineEndings',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineEndingsSniff',
+            ],
+            [
+                'Generic.Files.LineLength',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff',
+            ],
+            [
+                'Squiz.WhiteSpace.SuperfluousWhitespace',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SuperfluousWhitespaceSniff',
+            ],
+            [
+                'Generic.Formatting.DisallowMultipleStatements',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\DisallowMultipleStatementsSniff',
+            ],
+            [
+                'Generic.WhiteSpace.ScopeIndent',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff',
+            ],
+            [
+                'Generic.WhiteSpace.DisallowTabIndent',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowTabIndentSniff',
+            ],
+            [
+                'Generic.PHP.LowerCaseKeyword',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseKeywordSniff',
+            ],
+            [
+                'Generic.PHP.LowerCaseConstant',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseConstantSniff',
+            ],
+            [
+                'Squiz.Scope.MethodScope',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MethodScopeSniff',
+            ],
+            [
+                'Squiz.WhiteSpace.ScopeKeywordSpacing',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeKeywordSpacingSniff',
+            ],
+            [
+                'Squiz.Functions.FunctionDeclaration',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationSniff',
+            ],
+            [
+                'Squiz.Functions.LowercaseFunctionKeywords',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\LowercaseFunctionKeywordsSniff',
+            ],
+            [
+                'Squiz.Functions.FunctionDeclarationArgumentSpacing',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationArgumentSpacingSniff',
+            ],
+            [
+                'PEAR.Functions.ValidDefaultValue',
+                'PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\ValidDefaultValueSniff',
+            ],
+            [
+                'Squiz.Functions.MultiLineFunctionDeclaration',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\MultiLineFunctionDeclarationSniff',
+            ],
+            [
+                'Generic.Functions.FunctionCallArgumentSpacing',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\FunctionCallArgumentSpacingSniff',
+            ],
+            [
+                'Squiz.ControlStructures.ControlSignature',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff',
+            ],
+            [
+                'Squiz.WhiteSpace.ControlStructureSpacing',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff',
+            ],
+            [
+                'Squiz.WhiteSpace.ScopeClosingBrace',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff',
+            ],
+            [
+                'Squiz.ControlStructures.ForEachLoopDeclaration',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForEachLoopDeclarationSniff',
+            ],
+            [
+                'Squiz.ControlStructures.ForLoopDeclaration',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ForLoopDeclarationSniff',
+            ],
+            [
+                'Squiz.ControlStructures.LowercaseDeclaration',
+                'PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\LowercaseDeclarationSniff',
+            ],
+            [
+                'Generic.ControlStructures.InlineControlStructure',
+                'PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\InlineControlStructureSniff',
+            ],
+            [
+                'PSR12.Operators.OperatorSpacing',
+                'PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff',
             ],
             [
                 'Generic.Arrays.ArrayIndent',
@@ -190,10 +330,6 @@ class RuleInclusionTest extends TestCase
             [
                 'Generic.Metrics.CyclomaticComplexity',
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff',
-            ],
-            [
-                'Generic.Files.LineLength',
-                'PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff',
             ],
             [
                 'Generic.NamingConventions.CamelCapsFunctionName',
@@ -242,49 +378,54 @@ class RuleInclusionTest extends TestCase
     public function dataSettingProperties()
     {
         return [
-            'ClassDeclarationSniff'                           => [
-                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff',
-                'setforallsniffs',
-                true,
+            'Set property for complete standard: PSR2 ClassDeclaration'                                  => [
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff',
+                'indent',
+                '20',
             ],
-            'SideEffectsSniff'                                => [
-                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Files\SideEffectsSniff',
-                'setforallsniffs',
-                true,
+            'Set property for complete standard: PSR2 SwitchDeclaration'                                 => [
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\SwitchDeclarationSniff',
+                'indent',
+                '20',
             ],
-            'ValidVariableNameSniff'                          => [
-                'PHP_CodeSniffer\Standards\Zend\Sniffs\NamingConventions\ValidVariableNameSniff',
-                'setforallincategory',
-                true,
+            'Set property for complete standard: PSR2 FunctionCallSignature'                             => [
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff',
+                'indent',
+                '20',
             ],
-            'ArrayIndentSniff'                                => [
+            'Set property for complete category: PSR12 OperatorSpacing'                                  => [
+                'PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff',
+                'ignoreSpacingBeforeAssignments',
+                false,
+            ],
+            'Set property for individual sniff: Generic ArrayIndent'                                     => [
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\ArrayIndentSniff',
                 'indent',
                 '2',
             ],
-            'LineLengthSniff'                                 => [
+            'Set property for individual sniff using sniff file inclusion: Generic LineLength'           => [
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff',
                 'lineLimit',
                 '10',
             ],
-            'CamelCapsFunctionNameSniff'                      => [
+            'Set property for individual sniff using sniff file inclusion: CamelCapsFunctionName'        => [
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff',
                 'strict',
                 false,
             ],
-            'NestingLevelSniff-nestingLevel'                  => [
+            'Set property for individual sniff via included ruleset: NestingLevel - nestingLevel'        => [
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff',
                 'nestingLevel',
                 '2',
             ],
-            'NestingLevelSniff-setforsniffsinincludedruleset' => [
+            'Set property for all sniffs in an included ruleset: NestingLevel - absoluteNestingLevel'    => [
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff',
-                'setforsniffsinincludedruleset',
+                'absoluteNestingLevel',
                 true,
             ],
 
             // Testing that setting a property at error code level does *not* work.
-            'CyclomaticComplexitySniff'                       => [
+            'Set property for error code will not change the sniff property value: CyclomaticComplexity' => [
                 'PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff',
                 'complexity',
                 10,
@@ -292,6 +433,55 @@ class RuleInclusionTest extends TestCase
         ];
 
     }//end dataSettingProperties()
+
+
+    /**
+     * Test that setting properties for standards, categories on sniffs which don't support the property will
+     * silently ignore the property and not set it.
+     *
+     * @param string $sniffClass   The name of the sniff class.
+     * @param string $propertyName The name of the property which should not be set.
+     *
+     * @dataProvider dataSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails
+     *
+     * @return void
+     */
+    public function testSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails($sniffClass, $propertyName)
+    {
+        $this->assertObjectHasAttribute('sniffs', self::$ruleset, 'Ruleset does not have property sniffs');
+        $this->assertArrayHasKey($sniffClass, self::$ruleset->sniffs, 'Sniff class '.$sniffClass.' not listed in registered sniffs');
+
+        $sniffObject = self::$ruleset->sniffs[$sniffClass];
+        $this->assertObjectNotHasAttribute($propertyName, $sniffObject, 'Property '.$propertyName.' registered for sniff '.$sniffClass.' which does not support it');
+
+    }//end testSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()
+
+
+    /**
+     * Data provider.
+     *
+     * @see self::testSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()
+     *
+     * @return array
+     */
+    public function dataSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()
+    {
+        return [
+            'Set property for complete standard: PSR2 ClassDeclaration'      => [
+                'PHP_CodeSniffer\Standards\PSR1\Sniffs\Classes\ClassDeclarationSniff',
+                'setforallsniffs',
+            ],
+            'Set property for complete standard: PSR2 FunctionCallSignature' => [
+                'PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff',
+                'setforallsniffs',
+            ],
+            'Set property for complete category: PSR12 OperatorSpacing'      => [
+                'PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff',
+                'setforallincategory',
+            ],
+        ];
+
+    }//end dataSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()
 
 
 }//end class

--- a/tests/Core/Ruleset/RuleInclusionTest.xml
+++ b/tests/Core/Ruleset/RuleInclusionTest.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RuleInclusionTest" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 
-    <rule ref="PSR1">
+    <rule ref="PSR2">
         <properties>
             <property name="setforallsniffs" value="true" />
+            <property name="indent" value="20" />
         </properties>
     </rule>
 
-    <rule ref="Zend.NamingConventions">
+    <rule ref="PSR12.Operators">
         <properties>
             <property name="setforallincategory" value="true" />
+            <property name="ignoreSpacingBeforeAssignments" value="false" />
         </properties>
     </rule>
 
@@ -38,8 +40,9 @@
     </rule>
 
     <rule ref="./RuleInclusionTest-include.xml">
+        <!-- Property being set for all sniffs included in this ruleset. -->
         <properties>
-            <property name="setforsniffsinincludedruleset" value="true" />
+            <property name="absoluteNestingLevel" value="true" />
         </properties>
     </rule>
 

--- a/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedAsDeclaredTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedAsDeclaredSniff.php">
+        <properties>
+            <property name="arbitrarystring" value="arbitraryvalue"/>
+            <property name="arbitraryarray" type="array">
+                <element key="mykey" value="myvalue"/>
+            </property>
+            <property name="arbitraryarray" type="array" extend="true">
+                <element key="otherkey" value="othervalue"/>
+            </property>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaMagicMethodTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaMagicMethodSniff.php">
+        <properties>
+            <property name="arbitrarystring" value="arbitraryvalue"/>
+            <property name="arbitraryarray" type="array">
+                <element key="mykey" value="myvalue"/>
+            </property>
+            <property name="arbitraryarray" type="array" extend="true">
+                <element key="otherkey" value="othervalue"/>
+            </property>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAllowedViaStdClassTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyAllowedViaStdClassSniff.php">
+        <properties>
+            <property name="arbitrarystring" value="arbitraryvalue"/>
+            <property name="arbitraryarray" type="array">
+                <element key="mykey" value="myvalue"/>
+            </property>
+            <property name="arbitraryarray" type="array" extend="true">
+                <element key="otherkey" value="othervalue"/>
+            </property>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml
+++ b/tests/Core/Ruleset/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="PEAR.Functions">
+        <properties>
+            <property name="indent" value="10"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml
+++ b/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="Generic.Arrays">
+        <properties>
+            <property name="doesnotexist" value="2"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml
+++ b/tests/Core/Ruleset/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="Generic">
+        <properties>
+            <property name="doesnotexist" value="2"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
+++ b/tests/Core/Ruleset/SetPropertyNotAllowedViaAttributeTest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="./tests/Core/Ruleset/Fixtures/Sniffs/Category/SetPropertyNotAllowedViaAttributeSniff.php">
+        <properties>
+            <property name="arbitrarystring" value="arbitraryvalue"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/tests/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml
+++ b/tests/Core/Ruleset/SetPropertyThrowsErrorOnInvalidPropertyTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Fixtures" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <rule ref="Generic.Arrays.ArrayIndent">
+        <properties>
+            <property name="indentation" value="2"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/tests/Core/Ruleset/SetSniffPropertyTest.php
+++ b/tests/Core/Ruleset/SetSniffPropertyTest.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Tests for the handling of properties being set via the ruleset.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2022 Juliette Reinders Folmer. All rights reserved.
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\Ruleset;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * These tests specifically focus on the changes made to work around the PHP 8.2 dynamic properties deprecation.
+ *
+ * @covers \PHP_CodeSniffer\Ruleset::setSniffProperty
+ */
+class SetSniffPropertyTest extends TestCase
+{
+
+
+    /**
+     * Initialize the test.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        if ($GLOBALS['PHP_CODESNIFFER_PEAR'] === true) {
+            // PEAR installs test and sniff files into different locations
+            // so these tests will not pass as they directly reference files
+            // by relative location.
+            $this->markTestSkipped('Test cannot run from a PEAR install');
+        }
+
+    }//end setUp()
+
+
+    /**
+     * Test that setting a property via the ruleset works in all situations which allow for it.
+     *
+     * @param string $name Name of the test. Used for the sniff name, the ruleset file name etc.
+     *
+     * @dataProvider dataSniffPropertiesGetSetWhenAllowed
+     *
+     * @return void
+     */
+    public function testSniffPropertiesGetSetWhenAllowed($name)
+    {
+        $sniffCode  = "Fixtures.Category.{$name}";
+        $sniffClass = 'Fixtures\Sniffs\Category\\'.$name.'Sniff';
+        $properties = [
+            'arbitrarystring' => 'arbitraryvalue',
+            'arbitraryarray'  => [
+                'mykey'    => 'myvalue',
+                'otherkey' => 'othervalue',
+            ],
+        ];
+
+        // Set up the ruleset.
+        $standard = __DIR__."/{$name}Test.xml";
+        $config   = new Config(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        // Verify that the sniff has been registered.
+        $this->assertGreaterThan(0, count($ruleset->sniffCodes), 'No sniff codes registered');
+
+        // Verify that our target sniff has been registered.
+        $this->assertArrayHasKey($sniffCode, $ruleset->sniffCodes, 'Target sniff not registered');
+        $this->assertSame($sniffClass, $ruleset->sniffCodes[$sniffCode], 'Target sniff not registered with the correct class');
+
+        // Test that the property as declared in the ruleset has been set on the sniff.
+        $this->assertArrayHasKey($sniffClass, $ruleset->sniffs, 'Sniff class not listed in registered sniffs');
+
+        $sniffObject = $ruleset->sniffs[$sniffClass];
+        foreach ($properties as $name => $expectedValue) {
+            $this->assertSame($expectedValue, $sniffObject->$name, 'Property value not set to expected value');
+        }
+
+    }//end testSniffPropertiesGetSetWhenAllowed()
+
+
+    /**
+     * Data provider.
+     *
+     * @see self::testSniffPropertiesGetSetWhenAllowed()
+     *
+     * @return array
+     */
+    public function dataSniffPropertiesGetSetWhenAllowed()
+    {
+        return [
+            'Property allowed as explicitly declared'            => ['SetPropertyAllowedAsDeclared'],
+            'Property allowed as sniff extends stdClass'         => ['SetPropertyAllowedViaStdClass'],
+            'Property allowed as sniff has magic __set() method' => ['SetPropertyAllowedViaMagicMethod'],
+        ];
+
+    }//end dataSniffPropertiesGetSetWhenAllowed()
+
+
+    /**
+     * Test that setting a property for a category will apply it correctly to those sniffs which support the
+     * property, but won't apply it to sniffs which don't.
+     *
+     * Note: this test intentionally uses the `PEAR.Functions` category as two sniffs in that category
+     * have a public property with the same name (`indent`) and one sniff doesn't, which makes it a great
+     * test case for this.
+     *
+     * @return void
+     */
+    public function testSetPropertyAppliesPropertyToMultipleSniffsInCategory()
+    {
+        $propertyName  = 'indent';
+        $expectedValue = '10';
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/SetPropertyAppliesPropertyToMultipleSniffsInCategoryTest.xml';
+        $config   = new Config(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+        // Test that the two sniffs which support the property have received the value.
+        $sniffClass = 'PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionCallSignatureSniff';
+        $this->assertArrayHasKey($sniffClass, $ruleset->sniffs, 'Sniff class '.$sniffClass.' not listed in registered sniffs');
+        $sniffObject = $ruleset->sniffs[$sniffClass];
+        $this->assertSame($expectedValue, $sniffObject->$propertyName, 'Property value not set to expected value for '.$sniffClass);
+
+        $sniffClass = 'PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\FunctionDeclarationSniff';
+        $this->assertArrayHasKey($sniffClass, $ruleset->sniffs, 'Sniff class '.$sniffClass.' not listed in registered sniffs');
+        $sniffObject = $ruleset->sniffs[$sniffClass];
+        $this->assertSame($expectedValue, $sniffObject->$propertyName, 'Property value not set to expected value for '.$sniffClass);
+
+        // Test that the property doesn't get set for the one sniff which doesn't support the property.
+        $sniffClass = 'PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\ValidDefaultValueSniff';
+        $this->assertArrayHasKey($sniffClass, $ruleset->sniffs, 'Sniff class '.$sniffClass.' not listed in registered sniffs');
+        $sniffObject = $ruleset->sniffs[$sniffClass];
+        $this->assertObjectNotHasAttribute($propertyName, $sniffObject, 'Property registered for sniff '.$sniffClass.' which does not support it');
+
+    }//end testSetPropertyAppliesPropertyToMultipleSniffsInCategory()
+
+
+    /**
+     * Test that attempting to set a non-existent property directly on a sniff will throw an error
+     * when the sniff does not explicitly declare the property, extends stdClass or has magic methods.
+     *
+     * @return void
+     */
+    public function testSetPropertyThrowsErrorOnInvalidProperty()
+    {
+        $exceptionClass = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+        $exceptionMsg   = 'Ruleset invalid. Property "indentation" does not exist on sniff Generic.Arrays.ArrayIndent';
+        if (method_exists($this, 'expectException') === true) {
+            $this->expectException($exceptionClass);
+            $this->expectExceptionMessage($exceptionMsg);
+        } else {
+            // PHPUnit < 5.2.0.
+            $this->setExpectedException($exceptionClass, $exceptionMsg);
+        }
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/SetPropertyThrowsErrorOnInvalidPropertyTest.xml';
+        $config   = new Config(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+    }//end testSetPropertyThrowsErrorOnInvalidProperty()
+
+
+    /**
+     * Test that attempting to set a non-existent property directly on a sniff will throw an error
+     * when the sniff does not explicitly declare the property, extends stdClass or has magic methods,
+     * even though the sniff has the PHP 8.2 `#[AllowDynamicProperties]` attribute set.
+     *
+     * @return void
+     */
+    public function testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
+    {
+        $exceptionClass = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+        $exceptionMsg   = 'Ruleset invalid. Property "arbitrarystring" does not exist on sniff Fixtures.Category.SetPropertyNotAllowedViaAttribute';
+        if (method_exists($this, 'expectException') === true) {
+            $this->expectException($exceptionClass);
+            $this->expectExceptionMessage($exceptionMsg);
+        } else {
+            // PHPUnit < 5.2.0.
+            $this->setExpectedException($exceptionClass, $exceptionMsg);
+        }
+
+        // Set up the ruleset.
+        $standard = __DIR__.'/SetPropertyNotAllowedViaAttributeTest.xml';
+        $config   = new Config(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+    }//end testSetPropertyThrowsErrorWhenPropertyOnlyAllowedViaAttribute()
+
+
+    /**
+     * Test that attempting to set a non-existent property on a sniff when the property directive is
+     * for the whole standard, does not yield an error.
+     *
+     * @doesNotPerformAssertions
+     *
+     * @return void
+     */
+    public function testSetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandard()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandardTest.xml';
+        $config   = new Config(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+    }//end testSetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForStandard()
+
+
+    /**
+     * Test that attempting to set a non-existent property on a sniff when the property directive is
+     * for a whole category, does not yield an error.
+     *
+     * @doesNotPerformAssertions
+     *
+     * @return void
+     */
+    public function testSetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategory()
+    {
+        // Set up the ruleset.
+        $standard = __DIR__.'/SetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategoryTest.xml';
+        $config   = new Config(["--standard=$standard"]);
+        $ruleset  = new Ruleset($config);
+
+    }//end testSetPropertyDoesNotThrowErrorOnInvalidPropertyWhenSetForCategory()
+
+
+}//end class


### PR DESCRIPTION
### :warning: This PR contains two - albeit small - BC-breaks! :warning:

The BC-breaks can be broken down as follows:

### For end-users

If a property is set via a ruleset for an **_individual_** sniff and that sniff does not have the property explicitly declared, nor does the sniff declare the PHP magic `__set()` method or `extend stdClass`, the ruleset will now be regarded as invalid.

In practice, this means the PHPCS run will halt and will show an informative notice to the end-user about the invalid property setting and the PHPCS run will exit with exit code `3`.

![image](https://user-images.githubusercontent.com/663378/178088860-52c9f4c1-20c0-4a6a-babb-d48ebde66f2a.png)


For properties being set for a complete category of sniffs or a complete standard, the PHPCS run will not halt, nor show an error when the property isn't supported for all sniffs in the category/standard.
In that case, the property will only be set on those sniffs which support it (i.e. either have the property explicitly declared on the sniff, or have the magic `__set()` method declared on the sniff, or `extend stdClass`) and will be silently ignored for all other sniffs.

:point_right: Aside from possibly surfacing some incidental typos in property settings in rulesets, I expect this change to go mostly unnoticed by end-users.

### For developers of PHPCS standards/integrations

1. The format of the `$ruleset['sniff code']['properties']['property name']` sub-array has changed from a `array|string` type property value to a sub-array containing two entries:
    1. `'value'` - containing the `array|string` type property value.
    2. `'scope'` - containing a string, either `sniff` or `standard`, to indicate whether the ruleset property directive was for an individual sniff or for a whole standard/category of sniffs.
2. The third parameter for the `Ruleset::setSniffProperty()` method has been changed to expect the above mentioned array of `$settings` instead of just a property value.

This change is necessary to allow for throwing the error notice when an invalid property is being set on an invalid sniff versus silently ignoring the invalid property if the ruleset specified it on a standard/category.

:point_right: The impact of this BC-break is expected to be small, as it would require for an external standard or integration of PHPCS to:
* `extend` the `Ruleset` class **and** overload the `setSniffProperty()` method to have any impact;
* or to call the `setSniffProperty()` method on the `Ruleset` object directly (which _may_ happen in custom test frameworks for external standards).

Note:
* The change to the `processRule()` method cannot be overloaded as it is a `private` method.
* The change in the `populateTokenListeners()` method is only cosmetic and has no functional impact.

---

### Technical choices made:

For consistent handling of properties set in a (custom) ruleset across PHP versions, I have chosen to only support setting properties when:
* A property is explicitly declared on a sniff class.
* A sniff class explicitly declares (or inherits) the magic `__set()` method.
* A sniff class `extends` `stdClass`.

Note: no additional check has been added to verify that a declared property is `public`. If that is not the case a PHP native error would be thrown previously and still will be now. This behaviour has not changed.

I have chosen **not** to respect the `#[\AllowDynamicProperties]` attribute as it is not possible (without tokenizing the sniff files which would create a lot of overhead) to determine whether that attribute exists on a class when PHPCS runs on PHP < 8.0 as the Reflection method needed to detect the attribute is only available on PHP 8.0+.

In other words, adding support for the attribute would introduce an inconsistency in how properties set in a ruleset are handled based on the PHP version on which PHPCS is being run.
It would also mean that the error notice for invalid properties set on individual sniffs would only be available on PHP 8.2+, which would greatly reduce the usefulness of the error notice.

In my opinion, consistency here is more important than supporting the attribute, especially as there are three fully supported ways to allow for supporting properties to be set from a ruleset.
The three above mentioned ways to allow for setting properties from a ruleset for a sniff are all fully supported on all PHP versions currently supported by PHPCS, so there is no compelling reason to also allow for the attribute.

### Suggested changelog entry

> PHP 8.2: prevent deprecation notices for properties set in a (custom) ruleset for complete standards/complete sniff categories
> - Invalid properties set for individual sniffs will now result in an error and halt the execution of PHPCS.
> - Properties set for complete standards/complete sniff categories will now only be set on sniffs which explicitly support the property.
>       The property will be silently ignored for those sniffs which do not support the property.
> - For sniff developers: it is strongly recommended for sniffs to explicitly declare any user-adjustable `public` properties.
>    If dynamic properties need to be supported for a sniff, either declare the magic `__set()`/`__get()`/`__isset()`/`__unset()` methods on the sniff or let the sniff extend `stdClass`.
>    Note: The `#[\AllowDynamicProperties]` attribute will have **no effect** for properties which are being set in rulesets.
> - Sniff developers/integrators of PHPCS may need to make some small adjustments to allow for changes to the PHPCS internals. See the PR description of PR #3629 for full details.

### Other notes

The changes are accompanied by a full set of tests covering the change.
There is a little overlap between the `RuleInclusionTest` class and the new `SetSniffPropertyTest` class, but for the most part, the tests compliment each other.

Includes:
* Correct handling of properties being set via `phpcs:set` annotations.
* The `RuleInclusionTest` XML fixture and test expectations have been adjusted to allow for these changes.
    1. As we now need "settable" properties to exist on sniffs to use for the `testSettingProperties()` test, the `PSR1` ruleset is not sufficient as the sniffs in that ruleset don't have public properties.
        For that reason, the "set property for complete standard" test has been changed to use `PSR2` instead and set the `indent` property.
        The test expectations has been adjusted to match.
    2. Along the same lines, the `Zend.NamingConventions` sniffs don't have public properties, so the "setting property for complete category" test has been switched to `PSR12.Operators` and set the `ignoreSpacingBeforeAssignments` property.
        The test expectations has been adjusted to match.
    3. In both these cases, the XML `<rule>` now contains both a property which is valid for at least some sniffs in the standard/category and a property which is invalid in for all sniffs.
        For the _invalid_ properties, a separate `testSettingInvalidPropertiesOnStandardsAndCategoriesSilentlyFails()` test with data provider has been added to verify these will not be set.
    4. As the ruleset has changed, the expectations for the `testHasSniffCodes()` test and the `testRegisteredSniffCodes()` test have been updated to match.
    5. The test descriptions for the test cases in the `dataSettingProperties()` have also been updated to make it more explicit what each test case is testing.
* The PHPCS ruleset has been updated to exclude sniffs which function as test fixtures from the PHPCS check for this repo.
* A minor tweak has been made to the `ValidatePEARPackageXML` script to prevent a warning about sniffs which function as test fixtures.
    These test fixtures should receive the `role="test"` attribute, not a `role="php"` attribute.

Fixes #3489