### PR TITLE
PHP 8.1 | PSR2/PropertyDeclaration: add check for visibility before readonly keyword

### DIFF
--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc
@@ -80,4 +80,8 @@ class ReadOnlyProp {
     protected readonly ?string    $foo;
 
     readonly array $foo;
+
+    readonly public int $wrongOrder1;
+
+    readonly protected ?string $wrongOrder2;
 }

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
@@ -77,4 +77,8 @@ class ReadOnlyProp {
     protected readonly ?string $foo;
 
     readonly array $foo;
+
+    public readonly int $wrongOrder1;
+
+    protected readonly ?string $wrongOrder2;
 }

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -49,6 +49,8 @@ class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
             76 => 1,
             80 => 1,
             82 => 1,
+            84 => 1,
+            86 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
The `PSR2.Classes.PropertyDeclaration` sniff includes a check to verify that the `static` keyword is _after_ the visibility in a property declaration.

PHP 8.1 introduced the `readonly` keyword for properties, ~~but as PSR2/PSR12 were both released before PHP 8.1, no PSR rules have (yet) been defined for the modifier keyword order for `readonly` properties.~~

++[PSR PER 2.0.0](https://www.php-fig.org/per/coding-style/#46-modifier-keywords) dictates that visibility is declared before the `readonly` keyword.++

~~Having said that,~~ all code samples in both the RFC as well as the PHP manual use the `visibility - readonly` modifier keyword order, so it is likely that this will become the standard modifier keyword order.

A search for PHP projects which have started to use the `readonly` keyword, also shows these predominantly use the `visibility - readonly` modifier keyword order.

With that in mind, I'm proposing to add a check for this order to the `PSR2.Classes.PropertyDeclaration` sniff - this being the only PHPCS native sniff which checks the modifier keyword order for properties.

~~As PSR2/PSR12 do not formally have rules for the order (yet), the new error code being introduced is excluded for those rulesets (for the time being).~~

++As this sniff is included in PSR2 and PSR12, the new check will automatically apply the PSR-PER property modifier keyword order rules to PSR2/PSR12.++

Includes unit tests.

Ref:
* https://wiki.php.net/rfc/readonly_properties_v2
* https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.readonly-properties
* https://sourcegraph.com/search?q=context:global+%5Cs%28public%7Cprotected%7Cprivate%29%5Cs%2Breadonly%5Cs%2B+lang:php+-file:%28%5E%7C/%29%28vendor%7Ctests%3F%29/+fork:no+archived:no&patternType=regexp (searching `visibility - readonly` order - > 500 results)
* https://sourcegraph.com/search?q=context:global+%5Csreadonly%5Cs%2B%28public%7Cprotected%7Cprivate%29%5Cs%2B+lang:php+-file:%28%5E%7C/%29%28vendor%7Ctests%3F%29/+fork:no+archived:no&patternType=regexp (searching `readonly - visibility` order - 41 (non false positive) results)