### PR TITLE
Generic.WhiteSpace.DisallowTabIndent not reporting errors for PHP 7.3 flexible heredoc/nowdoc syntax

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -785,6 +785,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.1.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.2.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.3.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.3.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="DisallowTabIndentUnitTest.php" role="test" />

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -76,6 +76,8 @@ class DisallowTabIndentSniff implements Sniff
             T_DOC_COMMENT_WHITESPACE => true,
             T_DOC_COMMENT_STRING     => true,
             T_COMMENT                => true,
+            T_END_HEREDOC            => true,
+            T_END_NOWDOC             => true,
         ];
 
         for ($i = 0; $i < $phpcsFile->numTokens; $i++) {

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.3.inc
@@ -1,0 +1,13 @@
+<?php
+
+$heredoc = <<<"END"
+		a
+		b
+		c
+	END;
+
+$nowdoc = <<<'END'
+		a
+		b
+		c
+	END;

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.3.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.3.inc.fixed
@@ -1,0 +1,13 @@
+<?php
+
+$heredoc = <<<"END"
+		a
+		b
+		c
+    END;
+
+$nowdoc = <<<'END'
+		a
+		b
+		c
+    END;

--- a/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/WhiteSpace/DisallowTabIndentUnitTest.php
@@ -83,7 +83,7 @@ class DisallowTabIndentUnitTest extends AbstractSniffUnitTest
                 92 => 1,
                 93 => 1,
             ];
-            break;
+
         case 'DisallowTabIndentUnitTest.2.inc':
             return [
                 6  => 1,
@@ -96,23 +96,33 @@ class DisallowTabIndentUnitTest extends AbstractSniffUnitTest
                 13 => 1,
                 19 => 1,
             ];
-            break;
+
+        case 'DisallowTabIndentUnitTest.3.inc':
+            if (\PHP_VERSION_ID >= 70300) {
+                return [
+                    7  => 1,
+                    13 => 1,
+                ];
+            }
+
+            // PHP 7.2 or lower: PHP version which doesn't support flexible heredocs/nowdocs yet.
+            return [];
+
         case 'DisallowTabIndentUnitTest.js':
             return [
                 3 => 1,
                 5 => 1,
                 6 => 1,
             ];
-            break;
+
         case 'DisallowTabIndentUnitTest.css':
             return [
                 1 => 1,
                 2 => 1,
             ];
-            break;
+
         default:
             return [];
-            break;
         }//end switch
 
     }//end getErrorList()


### PR DESCRIPTION
Since PHP 7.3, heredoc/nowdoc closers may be indented.
This indent can use either tabs or spaces and the indent is included in the `T_END_HEREDOC`/`T_END_NOWDOC` token contents as received from the PHP native tokenizer.

However, these tokens where not included in the tokens to look at for the `Generic.WhiteSpace.DisallowTabIndent` sniff, which could lead to false negatives.

Fixed now, includes tests.