### PR TITLE
Expore ignore tests directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@ phpcs.xml.dist export-ignore
 phpstan.neon export-ignore
 phpunit.xml.dist export-ignore
 scripts/ export-ignore
+/tests export-ignore
 
 # Declare files that should always have CRLF line endings on checkout.
 *WinTest.inc text eol=crlf


### PR DESCRIPTION
Tests are useless outside the actual project.
It also gets in the way of IDE's because it suggests global test functions like `function variable($var) {}` from `GetMethodParametersTest`