### PR TITLE
PHPCS can show 0 exit code when running in parallel even if child process has fatal error

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -713,12 +713,20 @@ class Runner
         $numProcessed = 0;
         $totalBatches = count($childProcs);
 
-        $success = true;
+        $success            = true;
+        $childProcessFailed = false;
 
         while (count($childProcs) > 0) {
             $pid = pcntl_waitpid(0, $status);
+
             if ($pid <= 0) {
                 continue;
+            }
+
+            $childProcessStatus = pcntl_wexitstatus($status);
+
+            if ($childProcessStatus !== 0) {
+                $childProcessFailed = true;
             }
 
             $out = $childProcs[$pid];
@@ -768,7 +776,7 @@ class Runner
             $this->printProgress($file, $totalBatches, $numProcessed);
         }//end while
 
-        return $success;
+        return $success && !$childProcessFailed;
 
     }//end processChildProcs()
 


### PR DESCRIPTION
When a child process fails, e.g. with a FatalError, it might still return empty list of errors. Although, child process failure is definitely not a thing we want to ignore.

Therefore, we check exit status of each child process and make sure parent process fails (and returns non-zero status code) as well.