### PR TITLE
Generic/SpreadOperatorSpacingAfter: minor message readability improvement

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
@@ -54,8 +54,12 @@ class SpreadOperatorSpacingAfterSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens        = $phpcsFile->getTokens();
-        $this->spacing = (int) $this->spacing;
+        $tokens         = $phpcsFile->getTokens();
+        $this->spacing  = (int) $this->spacing;
+        $pluralizeSpace = 's';
+        if ($this->spacing === 1) {
+            $pluralizeSpace = '';
+        }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
@@ -81,8 +85,11 @@ class SpreadOperatorSpacingAfterSniff implements Sniff
 
         $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
         if ($nextNonEmpty !== $nextNonWhitespace) {
-            $error = 'Expected %s space(s) after the spread operator; comment found';
-            $data  = [$this->spacing];
+            $error = 'Expected %s space%s after the spread operator; comment found';
+            $data  = [
+                $this->spacing,
+                $pluralizeSpace,
+            ];
             $phpcsFile->addError($error, $stackPtr, 'CommentFound', $data);
 
             if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
@@ -107,9 +114,10 @@ class SpreadOperatorSpacingAfterSniff implements Sniff
             return;
         }
 
-        $error = 'Expected %s space(s) after the spread operator; %s found';
+        $error = 'Expected %s space%s after the spread operator; %s found';
         $data  = [
             $this->spacing,
+            $pluralizeSpace,
             $found,
         ];
 


### PR DESCRIPTION
Use `space`/`spaces` depending on the value of the `$spacing` property instead of using `space(s)` in the error message.

Original output:
![image](https://user-images.githubusercontent.com/663378/184382722-c6f403b1-73e1-49c6-ad3d-15c86cc94b81.png)

Improved output:
![image](https://user-images.githubusercontent.com/663378/184382888-f1d77688-6249-49b0-a800-600416c58c86.png)
