### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "keywords": [
         "phpcs",
-        "standards"
+        "standards",
+        "static analysis",
     ],
     "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
     "license": "BSD-3-Clause",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": [
         "phpcs",
         "standards",
-        "static analysis",
+        "static analysis"
     ],
     "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
     "license": "BSD-3-Clause",


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.