### PR TITLE
Generic/LowerCaseType: examine types in arrow function declarations

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -52,6 +52,7 @@ class LowerCaseTypeSniff implements Sniff
         $tokens   = Tokens::$castTokens;
         $tokens[] = T_FUNCTION;
         $tokens[] = T_CLOSURE;
+        $tokens[] = T_FN;
         $tokens[] = T_VARIABLE;
         return $tokens;
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -89,3 +89,6 @@ function (): NeVeR {
 function intersectionParamTypes (\Package\ClassName&\Package\Other_Class $var) {}
 
 function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class {}
+
+$arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : int => $a * $b;
+$arrow = fn (Int $a, String $b, BOOL $c, Array $d, Foo\Bar $e) : Float => $a * $b;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -89,3 +89,6 @@ function (): never {
 function intersectionParamTypes (\Package\ClassName&\Package\Other_Class $var) {}
 
 function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class {}
+
+$arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : int => $a * $b;
+$arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : float => $a * $b;

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -66,6 +66,7 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
             78 => 3,
             82 => 2,
             85 => 1,
+            94 => 5,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
PHP 7.4 arrow functions were not yet being taken into account for this sniff.

Fixed now.
Includes unit tests.