### PR TITLE
PEAR/FunctionDeclaration: examine arrow function declarations + fix fixer conflict

### DIFF
--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -465,3 +465,24 @@ new ExceptionMessage(),
     ) {
     }
 }
+
+$arrowNoArgs = fn () => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn (Type $param1, int $param2, string $param3): \ReturnType => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1,
+    $longerVar2,
+    &...$muchLongerVar3
+) => $longVar1;
+
+$arrowNoArgs = fn(  )
+    => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn( Type   $param1  ,   int   $param2, string $param3
+   )  : \ReturnType   => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1, $longerVar2,
+
+  & ...  $muchLongerVar3) => $longVar1;

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -486,3 +486,17 @@ $arrowMultiLineArgs = fn (
     $longVar1, $longerVar2,
 
   & ...  $muchLongerVar3) => $longVar1;
+
+// Prevent fixer conflict with itself.
+function foo(
+    $param1,
+)
+: \SomeClass
+  {
+  }
+
+function foo(
+    $param1,
+    $param2
+) : // comment.
+   \Package\Sub\SomeClass   {}

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
@@ -484,3 +484,16 @@ $arrowMultiLineArgs = fn (
     $longVar1, $longerVar2,
     & ...  $muchLongerVar3
 ) => $longVar1;
+
+// Prevent fixer conflict with itself.
+function foo(
+    $param1,
+)
+: \SomeClass {
+  }
+
+function foo(
+    $param1,
+    $param2
+) : // comment.
+   \Package\Sub\SomeClass {}

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
@@ -463,3 +463,24 @@ new ExceptionMessage(),
     ) {
     }
 }
+
+$arrowNoArgs = fn () => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn (Type $param1, int $param2, string $param3): \ReturnType => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1,
+    $longerVar2,
+    &...$muchLongerVar3
+) => $longVar1;
+
+$arrowNoArgs = fn (  )
+    => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn ( Type   $param1  ,   int   $param2, string $param3
+)  : \ReturnType => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1, $longerVar2,
+    & ...  $muchLongerVar3
+) => $longVar1;

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -99,6 +99,11 @@ class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
                 371 => 1,
                 402 => 1,
                 406 => 1,
+                479 => 1,
+                482 => 1,
+                483 => 2,
+                487 => 1,
+                488 => 2,
             ];
         } else {
             $errors = [

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.php
@@ -104,6 +104,8 @@ class FunctionDeclarationUnitTest extends AbstractSniffUnitTest
                 483 => 2,
                 487 => 1,
                 488 => 2,
+                495 => 1,
+                502 => 2,
             ];
         } else {
             $errors = [

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc
@@ -302,3 +302,24 @@ new ExceptionMessage(),
     ) {
     }
 }
+
+$arrowNoArgs = fn () => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn (Type $param1, int $param2, string $param3): \ReturnType => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1,
+    $longerVar2,
+    &...$muchLongerVar3
+) => $longVar1;
+
+$arrowNoArgs = fn(  )
+    => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn( Type   $param1  ,   int   $param2, string $param3
+   )  : \ReturnType   => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1, $longerVar2,
+
+  & ...  $muchLongerVar3) => $longVar1;

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
@@ -314,3 +314,24 @@ new ExceptionMessage(),
     ) {
     }
 }
+
+$arrowNoArgs = fn () => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn (Type $param1, int $param2, string $param3): \ReturnType => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1,
+    $longerVar2,
+    &...$muchLongerVar3
+) => $longVar1;
+
+$arrowNoArgs = fn (  )
+    => $retrievedfromscope;
+
+$arrowSingleLineArgs = fn ( Type   $param1  ,   int   $param2, string $param3)  : \ReturnType   => $retrievedfromscope;
+
+$arrowMultiLineArgs = fn (
+    $longVar1,
+    $longerVar2,
+    & ...  $muchLongerVar3
+) => $longVar1;

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.php
@@ -70,6 +70,12 @@ class MultiLineFunctionDeclarationUnitTest extends AbstractSniffUnitTest
                 252 => 1,
                 253 => 1,
                 254 => 1,
+                316 => 1,
+                319 => 1,
+                320 => 1,
+                323 => 1,
+                324 => 1,
+                325 => 2,
             ];
         } else {
             $errors = [


### PR DESCRIPTION
### PEAR/FunctionDeclaration: examine arrow function declarations

PHP 7.4 arrow functions were not yet being taken into account for this sniff.

Note: I've explicitly left the sniff to not have an opinion on the formatting for "arrow on same line/new line".

Fixed now.
Includes unit tests.


### Squiz/MultiLineFunctionDeclaration: add tests for arrow function declarations

The Squiz sniff inherits the change from the `PEAR.Functions.FunctionDeclaration` sniff.

This commit adds tests to document the behaviour and safeguard the inherited change.


### PEAR/FunctionDeclaration: prevent fixer conflict

If a return type declaration was not confined to one line, the sniff could have a fixer conflict with itself.
The fixer would also potentially remove a close curly on the same line, causing parse errors.

Fixed now. The diff will be most straight forward to review while ignoring whitespace changes.
Includes unit tests.