### PR TITLE
PEAR/FunctionCallSignature: minor tweaks + extra test

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -340,7 +340,8 @@ class FunctionCallSignatureSniff implements Sniff
         // call itself is, so we can work out how far to
         // indent the arguments.
         $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $stackPtr, true);
-        if ($tokens[$first]['code'] === T_CONSTANT_ENCAPSED_STRING
+        if ($first !== false
+            && $tokens[$first]['code'] === T_CONSTANT_ENCAPSED_STRING
             && $tokens[($first - 1)]['code'] === T_CONSTANT_ENCAPSED_STRING
         ) {
             // We are in a multi-line string, so find the start and use
@@ -386,8 +387,10 @@ class FunctionCallSignatureSniff implements Sniff
 
             $fix = $phpcsFile->addFixableError($error, $first, 'OpeningIndent', $data);
             if ($fix === true) {
+                // Set adjustment for use later to determine whether argument indentation is correct when fixing.
                 $adjustment = ($functionIndent - $foundFunctionIndent);
-                $padding    = str_repeat(' ', $functionIndent);
+
+                $padding = str_repeat(' ', $functionIndent);
                 if ($foundFunctionIndent === 0) {
                     $phpcsFile->fixer->addContentBefore($first, $padding);
                 } else if ($tokens[$first]['code'] === T_INLINE_HTML) {

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc
@@ -567,3 +567,10 @@ content
       <p><?php require get_theme_file_path(
       '/theme_extra/test_block.php'
 ); ?></p>
+
+<!-- If the first token is inline HTML, the token itself should be adjusted, not the token before. -->
+<?php if (check_me() == 'value'): ?>
+  <?php include get_file_path(
+    'my_file.php'
+  ); ?>
+<?php endif; ?>

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.inc.fixed
@@ -582,3 +582,10 @@ content
     <p><?php require get_theme_file_path(
         '/theme_extra/test_block.php'
 ); ?></p>
+
+<!-- If the first token is inline HTML, the token itself should be adjusted, not the token before. -->
+<?php if (check_me() == 'value'): ?>
+<?php include get_file_path(
+    'my_file.php'
+); ?>
+<?php endif; ?>

--- a/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
+++ b/src/Standards/PEAR/Tests/Functions/FunctionCallSignatureUnitTest.php
@@ -134,6 +134,8 @@ class FunctionCallSignatureUnitTest extends AbstractSniffUnitTest
             559 => 1,
             567 => 1,
             568 => 1,
+            573 => 1,
+            574 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Originally reported in https://github.com/WordPress/WordPress-Coding-Standards/issues/2083


The fixer for the `OpeningIndent` error for multi-line function calls could inadvertently remove a PHP close tag (or other inline HTML content) on the previous line if the first non-whitespace token on a line was `T_INLINE_HTML`. In the case of a PHP close tag, this would cause a parse error in the file.

This parse error would then result in the file being incorrectly tokenized for the second fixer loop, with the `<?php` after the inline HTML being tokenized as below, which causes problems with other sniffs:
```
 13 | L1 | C 43 | CC 1 | ( 0) | T_WHITESPACE               | [  3]: ⸱⸱⸱
 14 | L1 | C 46 | CC 1 | ( 0) | T_LESS_THAN                | [  1]: <
 15 | L1 | C 47 | CC 1 | ( 0) | T_INLINE_THEN              | [  1]: ?
 16 | L1 | C 48 | CC 1 | ( 0) | T_STRING                   | [  3]: php
```

Fixed now.

Includes unit test.

Includes minor defensive coding fix (`$first !== false`) on line 345 and adding of an inline comment to clarify the code within the fixer.