### PR TITLE
PSR12/ClassInstantiation: fix regression for `new parent`

### DIFF
--- a/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/ClassInstantiationSniff.php
@@ -48,6 +48,7 @@ class ClassInstantiationSniff implements Sniff
             T_NS_SEPARATOR             => T_NS_SEPARATOR,
             T_SELF                     => T_SELF,
             T_STATIC                   => T_STATIC,
+            T_PARENT                   => T_PARENT,
             T_VARIABLE                 => T_VARIABLE,
             T_DOLLAR                   => T_DOLLAR,
             T_OBJECT_OPERATOR          => T_OBJECT_OPERATOR,

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc
@@ -42,3 +42,6 @@ $class = new ${$obj?->classname};
 $anonWithAttribute = new #[SomeAttribute('summary')] class {
     public const SOME_STUFF = 'foo';
 };
+
+$foo = new parent();
+$foo = new parent;

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.inc.fixed
@@ -42,3 +42,6 @@ $class = new ${$obj?->classname}();
 $anonWithAttribute = new #[SomeAttribute('summary')] class {
     public const SOME_STUFF = 'foo';
 };
+
+$foo = new parent();
+$foo = new parent();

--- a/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/ClassInstantiationUnitTest.php
@@ -43,6 +43,7 @@ class ClassInstantiationUnitTest extends AbstractSniffUnitTest
             34 => 1,
             37 => 1,
             38 => 1,
+            47 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Related to #3546 which fixed an inconsistency after #3484.

The change of the tokenization from `T_STRING` to `T_PARENT` for the `parent` keyword in `new parent` caused a regression in the `PSR12.Classes.ClassInstantiation` sniff.

Fixed now.

Includes unit tests.

Fixes #3668