### PR TITLE
Generic/FunctionCallArgumentSpacing: fix regression for `new parent`

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -30,6 +30,7 @@ class FunctionCallArgumentSpacingSniff implements Sniff
             T_UNSET,
             T_SELF,
             T_STATIC,
+            T_PARENT,
             T_VARIABLE,
             T_CLOSE_CURLY_BRACKET,
             T_CLOSE_PARENTHESIS,

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
@@ -153,3 +153,12 @@ $foobar = functionCallAnonClassParam(
 $result = myFunction(param1: $arg1, param2: $arg2);
 $result = myFunction(param1: $arg1 ,  param2:$arg2);
 $result = myFunction(param1: $arg1, param2:$arg2, param3: $arg3,param4:$arg4, param5:$arg5);
+
+class Testing extends Bar
+{
+    public static function baz($foo, $bar)
+    {
+        $a = new parent($foo, $bar);
+        $a = new parent($foo ,$bar);
+    }
+}

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
@@ -153,3 +153,12 @@ $foobar = functionCallAnonClassParam(
 $result = myFunction(param1: $arg1, param2: $arg2);
 $result = myFunction(param1: $arg1, param2:$arg2);
 $result = myFunction(param1: $arg1, param2:$arg2, param3: $arg3, param4:$arg4, param5:$arg5);
+
+class Testing extends Bar
+{
+    public static function baz($foo, $bar)
+    {
+        $a = new parent($foo, $bar);
+        $a = new parent($foo, $bar);
+    }
+}

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -54,6 +54,7 @@ class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
             134 => 1,
             154 => 2,
             155 => 1,
+            162 => 2,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Related to #3546 which fixed an inconsistency after #3484.

The change of the tokenization from `T_STRING` to `T_PARENT` for the `parent` keyword in `new parent` caused a regression in the `Generic.Functions.FunctionCallArgumentSpacing` sniff.

Fixed now.

Includes unit tests.