### PR TITLE
Squiz/OperatorBracket: fix regression for `new parent`

### DIFF
--- a/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
+++ b/src/Standards/Squiz/Sniffs/Formatting/OperatorBracketSniff.php
@@ -142,6 +142,7 @@ class OperatorBracketSniff implements Sniff
             T_THIS,
             T_SELF,
             T_STATIC,
+            T_PARENT,
             T_OBJECT_OPERATOR,
             T_NULLSAFE_OBJECT_OPERATOR,
             T_DOUBLE_COLON,

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc
@@ -199,3 +199,5 @@ match ($a) {
     'b', 'c', 'd' => -2,
     default => -3,
 };
+
+$cntPages = ceil(count($items) / parent::ON_PAGE);

--- a/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Formatting/OperatorBracketUnitTest.inc.fixed
@@ -199,3 +199,5 @@ match ($a) {
     'b', 'c', 'd' => -2,
     default => -3,
 };
+
+$cntPages = ceil(count($items) / parent::ON_PAGE);


### PR DESCRIPTION
Related to #3546 which fixed an inconsistency after #3484.

The change of the tokenization from `T_STRING` to `T_PARENT` for the `parent` keyword caused a regression in the `Squiz.Formatting.OperatorBracket` sniff.

Fixed now.

Includes unit tests.