### PR TITLE
Docs: fix invalid XML docs for three sniffs

### DIFF
--- a/src/Standards/Generic/Docs/Classes/OpeningBraceSameLineStandard.xml
+++ b/src/Standards/Generic/Docs/Classes/OpeningBraceSameLineStandard.xml
@@ -18,6 +18,14 @@ class Foo
 }
         ]]>
         </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Valid: Opening brace is the last thing on the line.">
+        <![CDATA[
+class Foo <em>{</em>
+}
+        ]]>
+        </code>
         <code title="Invalid: Opening brace not last thing on the line.">
         <![CDATA[
 class Foo {<em> // Start of class.</em>

--- a/src/Standards/Generic/Docs/Formatting/SpaceAfterNotStandard.xml
+++ b/src/Standards/Generic/Docs/Formatting/SpaceAfterNotStandard.xml
@@ -10,13 +10,10 @@
 if (!<em> </em>$someVar || !<em> </em>$x instanceOf stdClass) {};
         ]]>
         </code>
-        <code title="Invalid: A NOT operator not followed by whitespace.">
+        <code title="Invalid: A NOT operator not followed by whitespace or followed by too much whitespace.">
         <![CDATA[
 if (!<em></em>$someVar || !<em></em>$x instanceOf stdClass) {};
-        ]]>
-        </code>
-        <code title="Invalid: A NOT operator followed by a new line or more than one space.">
-        <![CDATA[
+
 if (!<em>     </em>$someVar || !<em>
     </em>$x instanceOf stdClass) {};
         ]]>

--- a/src/Standards/Generic/Docs/WhiteSpace/ArbitraryParenthesesSpacingStandard.xml
+++ b/src/Standards/Generic/Docs/WhiteSpace/ArbitraryParenthesesSpacingStandard.xml
@@ -10,13 +10,10 @@
 $a = (null !== $extra);
         ]]>
         </code>
-        <code title="Invalid: spaces on the inside of a set of arbitrary parentheses.">
+        <code title="Invalid: spaces or new lines on the inside of a set of arbitrary parentheses.">
         <![CDATA[
 $a = ( null !== $extra );
-        ]]>
-        </code>
-        <code title="Invalid: new lines on the inside of a set of arbitrary parentheses.">
-        <![CDATA[
+
 $a = (
     null !== $extra
 );


### PR DESCRIPTION
Each of these three sniffs had a `<code_comparison>` block containing _three_ `<code>` elements instead of two.

Discovered by validating the docs against the XSD schema created by the amazing @dingo-d. The XSD schema is now available in [PHPCSDevTools](https://github.com/PHPCSStandards/PHPCSDevTools) 1.2.0 as discussed in #3585.

If you're interested, I could refresh (a variation of) PR #2872 to add XML doc validation against the schema to the GH Actions checks.