### PR TITLE
Fix php 8.1 error for trim() function

### DIFF
--- a/src/Files/LocalFile.php
+++ b/src/Files/LocalFile.php
@@ -29,7 +29,7 @@ class LocalFile extends File
      */
     public function __construct($path, Ruleset $ruleset, Config $config)
     {
-        $this->path = trim($path);
+        $this->path = trim((string) $path);
         if (Common::isReadable($this->path) === false) {
             parent::__construct($this->path, $ruleset, $config);
             $error = 'Error opening file; file no longer exists or you do not have access to read the file';


### PR DESCRIPTION
This is a quick fix, but I don't know if it's normal that some $this->files array keys are 'null'