### PR TITLE
PHP 8.2 | File::getClassProperties(): add support for readonly classes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -100,6 +100,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="FindImplementedInterfaceNamesTest.php" role="test" />
       <file baseinstalldir="" name="FindStartOfStatementTest.inc" role="test" />
       <file baseinstalldir="" name="FindStartOfStatementTest.php" role="test" />
+      <file baseinstalldir="" name="GetClassPropertiesTest.inc" role="test" />
+      <file baseinstalldir="" name="GetClassPropertiesTest.php" role="test" />
       <file baseinstalldir="" name="GetMemberPropertiesTest.inc" role="test" />
       <file baseinstalldir="" name="GetMemberPropertiesTest.php" role="test" />
       <file baseinstalldir="" name="GetMethodParametersTest.inc" role="test" />
@@ -2083,6 +2085,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/FindImplementedInterfaceNamesTest.inc" name="tests/Core/File/FindImplementedInterfaceNamesTest.inc" />
    <install as="CodeSniffer/Core/File/FindStartOfStatementTest.php" name="tests/Core/File/FindStartOfStatementTest.php" />
    <install as="CodeSniffer/Core/File/FindStartOfStatementTest.inc" name="tests/Core/File/FindStartOfStatementTest.inc" />
+   <install as="CodeSniffer/Core/File/GetClassPropertiesTest.php" name="tests/Core/File/GetClassPropertiesTest.php" />
+   <install as="CodeSniffer/Core/File/GetClassPropertiesTest.inc" name="tests/Core/File/GetClassPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/GetMemberPropertiesTest.php" name="tests/Core/File/GetMemberPropertiesTest.php" />
    <install as="CodeSniffer/Core/File/GetMemberPropertiesTest.inc" name="tests/Core/File/GetMemberPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/GetMethodParametersTest.php" name="tests/Core/File/GetMethodParametersTest.php" />
@@ -2187,6 +2191,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/FindImplementedInterfaceNamesTest.inc" name="tests/Core/File/FindImplementedInterfaceNamesTest.inc" />
    <install as="CodeSniffer/Core/File/FindStartOfStatementTest.php" name="tests/Core/File/FindStartOfStatementTest.php" />
    <install as="CodeSniffer/Core/File/FindStartOfStatementTest.inc" name="tests/Core/File/FindStartOfStatementTest.inc" />
+   <install as="CodeSniffer/Core/File/GetClassPropertiesTest.php" name="tests/Core/File/GetClassPropertiesTest.php" />
+   <install as="CodeSniffer/Core/File/GetClassPropertiesTest.inc" name="tests/Core/File/GetClassPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/GetMemberPropertiesTest.php" name="tests/Core/File/GetMemberPropertiesTest.php" />
    <install as="CodeSniffer/Core/File/GetMemberPropertiesTest.inc" name="tests/Core/File/GetMemberPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/GetMethodParametersTest.php" name="tests/Core/File/GetMethodParametersTest.php" />

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1947,6 +1947,7 @@ class File
      *   array(
      *    'is_abstract' => false, // true if the abstract keyword was found.
      *    'is_final'    => false, // true if the final keyword was found.
+     *    'is_readonly' => false, // true if the readonly keyword was found.
      *   );
      * </code>
      *
@@ -1966,6 +1967,7 @@ class File
         $valid = [
             T_FINAL       => T_FINAL,
             T_ABSTRACT    => T_ABSTRACT,
+            T_READONLY    => T_READONLY,
             T_WHITESPACE  => T_WHITESPACE,
             T_COMMENT     => T_COMMENT,
             T_DOC_COMMENT => T_DOC_COMMENT,
@@ -1973,6 +1975,7 @@ class File
 
         $isAbstract = false;
         $isFinal    = false;
+        $isReadonly = false;
 
         for ($i = ($stackPtr - 1); $i > 0; $i--) {
             if (isset($valid[$this->tokens[$i]['code']]) === false) {
@@ -1987,12 +1990,17 @@ class File
             case T_FINAL:
                 $isFinal = true;
                 break;
+
+            case T_READONLY:
+                $isReadonly = true;
+                break;
             }
         }//end for
 
         return [
             'is_abstract' => $isAbstract,
             'is_final'    => $isFinal,
+            'is_readonly' => $isReadonly,
         ];
 
     }//end getClassProperties()

--- a/tests/Core/File/GetClassPropertiesTest.inc
+++ b/tests/Core/File/GetClassPropertiesTest.inc
@@ -1,0 +1,58 @@
+<?php
+
+/* testNotAClass */
+interface NotAClass {}
+
+/* testAnonClass */
+$anon = new class() {};
+
+/* testEnum */
+enum NotAClassEither {}
+
+/* testClassWithoutProperties */
+class ClassWithoutProperties {}
+
+/* testAbstractClass */
+abstract class AbstractClass {}
+
+/* testFinalClass */
+final class FinalClass {}
+
+/* testReadonlyClass */
+readonly class ReadOnlyClass {}
+
+/* testFinalReadonlyClass */
+final readonly class FinalReadOnlyClass extends Foo {}
+
+/* testReadonlyFinalClass */
+readonly /*comment*/ final class ReadOnlyFinalClass {}
+
+/* testAbstractReadonlyClass */
+abstract readonly class AbstractReadOnlyClass {}
+
+/* testReadonlyAbstractClass */
+readonly
+abstract
+class ReadOnlyAbstractClass {}
+
+/* testWithCommentsAndNewLines */
+abstract
+    /* comment */
+    class ClassWithCommentsAndNewLines {}
+
+/* testWithDocblockWithoutProperties */
+/**
+ * Class docblock.
+ *
+ * @package SomePackage
+ *
+ * @phpcs:disable Standard.Cat.SniffName -- Just because.
+ */
+class ClassWithDocblock {}
+
+/* testParseErrorAbstractFinal */
+final /* comment */
+
+    abstract // Intentional parse error, class cannot both be final and abstract.
+
+        class AbstractFinal {}

--- a/tests/Core/File/GetClassPropertiesTest.php
+++ b/tests/Core/File/GetClassPropertiesTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:getClassProperties method.
+ *
+ * @author    Juliette Reinders Folmer <phpcs_nospam@adviesenzo.nl>
+ * @copyright 2022 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class GetClassPropertiesTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test receiving an expected exception when a non class token is passed.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $tokenType  The type of token to look for after the marker.
+     *
+     * @dataProvider dataNotAClassException
+     *
+     * @expectedException        PHP_CodeSniffer\Exceptions\RuntimeException
+     * @expectedExceptionMessage $stackPtr must be of type T_CLASS
+     *
+     * @return void
+     */
+    public function testNotAClassException($testMarker, $tokenType)
+    {
+        $target = $this->getTargetToken($testMarker, $tokenType);
+        self::$phpcsFile->getClassProperties($target);
+
+    }//end testNotAClassException()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testNotAClassException() For the array format.
+     *
+     * @return array
+     */
+    public function dataNotAClassException()
+    {
+        return [
+            'interface'  => [
+                '/* testNotAClass */',
+                \T_INTERFACE,
+            ],
+            'anon-class' => [
+                '/* testAnonClass */',
+                \T_ANON_CLASS,
+            ],
+            'enum'       => [
+                '/* testEnum */',
+                \T_ENUM,
+            ],
+        ];
+
+    }//end dataNotAClassException()
+
+
+    /**
+     * Test retrieving the properties for a class declaration.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   Expected function output.
+     *
+     * @dataProvider dataGetClassProperties
+     *
+     * @return void
+     */
+    public function testGetClassProperties($testMarker, $expected)
+    {
+        $class  = $this->getTargetToken($testMarker, \T_CLASS);
+        $result = self::$phpcsFile->getClassProperties($class);
+        $this->assertSame($expected, $result);
+
+    }//end testGetClassProperties()
+
+
+    /**
+     * Data provider.
+     *
+     * @see testGetClassProperties() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetClassProperties()
+    {
+        return [
+            'no-properties'               => [
+                '/* testClassWithoutProperties */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => false,
+                    'is_readonly' => false,
+                ],
+            ],
+            'abstract'                    => [
+                '/* testAbstractClass */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => false,
+                    'is_readonly' => false,
+                ],
+            ],
+            'final'                       => [
+                '/* testFinalClass */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => true,
+                    'is_readonly' => false,
+                ],
+            ],
+            'readonly'                    => [
+                '/* testReadonlyClass */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => false,
+                    'is_readonly' => true,
+                ],
+            ],
+            'final-readonly'              => [
+                '/* testFinalReadonlyClass */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => true,
+                    'is_readonly' => true,
+                ],
+            ],
+            'readonly-final'              => [
+                '/* testReadonlyFinalClass */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => true,
+                    'is_readonly' => true,
+                ],
+            ],
+            'abstract-readonly'           => [
+                '/* testAbstractReadonlyClass */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => false,
+                    'is_readonly' => true,
+                ],
+            ],
+            'readonly-abstract'           => [
+                '/* testReadonlyAbstractClass */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => false,
+                    'is_readonly' => true,
+                ],
+            ],
+            'comments-and-new-lines'      => [
+                '/* testWithCommentsAndNewLines */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => false,
+                    'is_readonly' => false,
+                ],
+            ],
+            'no-properties-with-docblock' => [
+                '/* testWithDocblockWithoutProperties */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => false,
+                    'is_readonly' => false,
+                ],
+            ],
+            'abstract-final-parse-error'  => [
+                '/* testParseErrorAbstractFinal */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => true,
+                    'is_readonly' => false,
+                ],
+            ],
+        ];
+
+    }//end dataGetClassProperties()
+
+
+}//end class


### PR DESCRIPTION
PHP 8.2 introduces `readonly` classes. The `readonly` keyword can be combined with the `abstract` or `final` keyword. See: https://3v4l.org/VIXgD

Includes adding a full set of tests for the `File::getClassProperties()` method, which was so far untested.

Ref:
* https://wiki.php.net/rfc/readonly_classes