### PR TITLE
Added support for array multi line function comments

### DIFF
--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1046,3 +1046,20 @@ public function ignored() {
  * @return void
  * @throws Exception If any other error occurs. */
 function throwCommentOneLine() {}
+
+
+/**
+ * @param array{foo: int} $a A.
+ * @param array{x: int} $ccc C.
+ * @param array{xxxx: int} $dddd D.
+ * @param array<array{
+ *            foo: array{foo: int},
+ *            bar: int
+ *        }> $bb B.
+ *
+ * @return integer
+ */
+public function multiLineArray(array $a, array $ccc, array $dddd, array $bb)
+{
+    return 1;
+}//end multiLineArray()

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1046,3 +1046,20 @@ public function ignored() {
  * @return void
  * @throws Exception If any other error occurs. */
 function throwCommentOneLine() {}
+
+
+/**
+ * @param array{foo: int}  $a    A.
+ * @param array{x: int}    $ccc  C.
+ * @param array{xxxx: int} $dddd D.
+ * @param array<array{
+ *            foo: array{foo: int},
+ *            bar: int
+ *        }> $bb B.
+ *
+ * @return integer
+ */
+public function multiLineArray(array $a, array $ccc, array $dddd, array $bb)
+{
+    return 1;
+}//end multiLineArray()

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -116,6 +116,8 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
             1004 => 2,
             1006 => 1,
             1029 => 1,
+            1052 => 2,
+            1053 => 2,
         ];
 
         // Scalar type hints only work from PHP 7 onwards.


### PR DESCRIPTION
This change adds the ability to define array structures over several lines.

### Background:
PHPStan allows using [array shapes](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes) that can quickly turn into very long comment lines and this change allows them to be broken over several lines for readability purposes without having to disable the given Sniff.

```php
/**
 * @param array<array{
 *            foo: array{foo: int},
 *            bar: int
 *        }> $bb B.
 */
public function multiLineArray(array $bb)
{
}
```

#### Before:
Would result in `Squiz.Commenting.FunctionComment.MissingParamName` or `Squiz.Commenting.FunctionComment.MissingParamTag` or similar errors.

And the doc block would need to be written as:
```php
/**
 * @param array<array{foo: array{foo: int}, bar: int}> $bb B.
 */
```

#### After:
No errors are being reported.