### PR TITLE
Tests: various small improvements

### DIFF
--- a/tests/Core/File/FindEndOfStatementTest.inc
+++ b/tests/Core/File/FindEndOfStatementTest.inc
@@ -39,6 +39,8 @@ $a = [
 /* testStaticArrowFunction */
 static fn ($a) => $a;
 
+return 0;
+
 /* testArrowFunctionReturnValue */
 fn(): array => [a($a, $b)];
 
@@ -101,5 +103,3 @@ $result = match ($key) {
         2 => 'one',
     },
 };
-
-return 0;

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -211,6 +211,17 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                 ],
             ],
             [
+                '/* testNoPrefix */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
                 '/* testPublicStaticWithDocblock */',
                 [
                     'scope'           => 'public',
@@ -285,17 +296,6 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'is_readonly'     => false,
                     'type'            => '?string',
                     'nullable_type'   => true,
-                ],
-            ],
-            [
-                '/* testNoPrefix */',
-                [
-                    'scope'           => 'public',
-                    'scope_specified' => false,
-                    'is_static'       => false,
-                    'is_readonly'     => false,
-                    'type'            => '',
-                    'nullable_type'   => false,
                 ],
             ],
             [

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -62,6 +62,87 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify variable.
+     *
+     * @return void
+     */
+    public function testVariable()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => '$var',
+            'has_attributes'    => false,
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testVariable()
+
+
+    /**
+     * Verify default value parsing with a single function param.
+     *
+     * @return void
+     */
+    public function testSingleDefaultValue()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '$var1=self::CONSTANT',
+            'has_attributes'    => false,
+            'default'           => 'self::CONSTANT',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testSingleDefaultValue()
+
+
+    /**
+     * Verify default value parsing.
+     *
+     * @return void
+     */
+    public function testDefaultValues()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '$var1=1',
+            'has_attributes'    => false,
+            'default'           => '1',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+        $expected[1] = [
+            'name'              => '$var2',
+            'content'           => "\$var2='value'",
+            'has_attributes'    => false,
+            'default'           => "'value'",
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testDefaultValues()
+
+
+    /**
      * Verify type hint parsing.
      *
      * @return void
@@ -148,87 +229,6 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
         $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
 
     }//end testNullableTypeHint()
-
-
-    /**
-     * Verify variable.
-     *
-     * @return void
-     */
-    public function testVariable()
-    {
-        $expected    = [];
-        $expected[0] = [
-            'name'              => '$var',
-            'content'           => '$var',
-            'has_attributes'    => false,
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
-        ];
-
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testVariable()
-
-
-    /**
-     * Verify default value parsing with a single function param.
-     *
-     * @return void
-     */
-    public function testSingleDefaultValue()
-    {
-        $expected    = [];
-        $expected[0] = [
-            'name'              => '$var1',
-            'content'           => '$var1=self::CONSTANT',
-            'has_attributes'    => false,
-            'default'           => 'self::CONSTANT',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
-        ];
-
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testSingleDefaultValue()
-
-
-    /**
-     * Verify default value parsing.
-     *
-     * @return void
-     */
-    public function testDefaultValues()
-    {
-        $expected    = [];
-        $expected[0] = [
-            'name'              => '$var1',
-            'content'           => '$var1=1',
-            'has_attributes'    => false,
-            'default'           => '1',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
-        ];
-        $expected[1] = [
-            'name'              => '$var2',
-            'content'           => "\$var2='value'",
-            'has_attributes'    => false,
-            'default'           => "'value'",
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
-        ];
-
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testDefaultValues()
 
 
     /**

--- a/tests/Core/File/GetMethodPropertiesTest.php
+++ b/tests/Core/File/GetMethodPropertiesTest.php
@@ -775,7 +775,6 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
 
 
     /**
-    /**
      * Verify recognition of PHP8.1 intersection type declaration.
      *
      * @return void

--- a/tests/Core/File/IsReferenceTest.inc
+++ b/tests/Core/File/IsReferenceTest.inc
@@ -12,7 +12,7 @@ $a = [ $something & $somethingElse ];
 $a = [ $first, $something & self::$somethingElse ];
 
 /* testBitwiseAndD */
-$a = array $first, $something & $somethingElse );
+$a = array( $first, $something & $somethingElse );
 
 /* testBitwiseAndE */
 $a = [ 'a' => $first, 'b' => $something & $somethingElse ];
@@ -51,7 +51,7 @@ function myFunction(array &$one) {}
 $closure = function (\MyClass &$one) {};
 
 /* testFunctionPassByReferenceG */
-$closure = function myFunc($param, &...$moreParams) {};
+$closure = function ($param, &...$moreParams) {};
 
 /* testForeachValueByReference */
 foreach( $array as $key => &$value ) {}

--- a/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc
+++ b/tests/Core/Tokenizer/ScopeSettingWithNamespaceOperatorTest.inc
@@ -13,7 +13,7 @@ interface FooBar extends namespace\BarFoo {}
 function foo() : namespace\Baz {}
 
 /* testClosureReturnType */
-$closure = function () : namespace\Baz {}
+$closure = function () : namespace\Baz {};
 
 /* testArrowFunctionReturnType */
 $fn = fn() : namespace\Baz => new namespace\Baz;


### PR DESCRIPTION
... picked up along the way.

## Commits

### ScopeSettingWithNamespaceOperatorTest: fix unintentional parse error

### IsReferenceTest: fix two unintentional parse errors in the test case file

### GetMemberPropertiesTest: sync the order of the data sets with the test case file

### FindEndOfStatementTest: fix broken test

The `return 0;` statement belongs with the `testStaticArrowFunction` test and was introduced to test a specific bug in #2749.

This brings the test back to its correct state.

### GetMethodParametersTest: sync the order of the data sets with the test case file

(while the diff may look weird, in reality, it just moves three tests up)

### GetMethodPropertiesTest: remove stray docblock opener