### PR TITLE
GH Actions: update the xmllint-problem-matcher

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1
+      - uses: korelstar/xmllint-problem-matcher@v1.1
 
       # Validate the XML ruleset files.
       # @link http://xmlsoft.org/xmllint.html


### PR DESCRIPTION
The `xmllint-problem-matcher` action runner has released a new version which updates it to use node 16. This gets rid of a warning which was shown in the action logs.

Note: I've [suggested to the author to use long-running branches for the action runner instead](https://github.com/korelstar/xmllint-problem-matcher/pull/7), which would make this update redundant, but no telling if or when they'll respond to that, let alone if they will follow my suggestion.

Refs:
* https://github.com/korelstar/xmllint-problem-matcher/releases/tag/v1.1