### PR TITLE
Generic.WhiteSpace.SpreadOperatorSpacingAfter does not ignore spread operator in PHP 8.1 first class callables

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/SpreadOperatorSpacingAfterSniff.php
@@ -62,6 +62,11 @@ class SpreadOperatorSpacingAfterSniff implements Sniff
             return;
         }
 
+        if ($tokens[$nextNonEmpty]['code'] === T_CLOSE_PARENTHESIS) {
+            // Ignore PHP 8.1 first class callable syntax.
+            return;
+        }
+
         if ($this->ignoreNewlines === true
             && $tokens[$stackPtr]['line'] !== $tokens[$nextNonEmpty]['line']
         ) {

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc
@@ -67,7 +67,13 @@ function bar( &   ... $spread ) {
     );
 }
 
+// Ignore PHP 8.1 first class callable declarations.
+$map = array_map(strtolower(...), $map);
+
 // phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 0
+
+// Ignore PHP 8.1 first class callable declarations.
+$map = array_map(strtolower( ... ), $map);
 
 // Intentional parse error. This has to be the last test in the file.
 function bar( ...

--- a/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/WhiteSpace/SpreadOperatorSpacingAfterUnitTest.inc.fixed
@@ -62,7 +62,13 @@ function bar( &   ...  $spread ) {
     );
 }
 
+// Ignore PHP 8.1 first class callable declarations.
+$map = array_map(strtolower(...), $map);
+
 // phpcs:set Generic.WhiteSpace.SpreadOperatorSpacingAfter spacing 0
+
+// Ignore PHP 8.1 first class callable declarations.
+$map = array_map(strtolower( ... ), $map);
 
 // Intentional parse error. This has to be the last test in the file.
 function bar( ...


### PR DESCRIPTION
... as in that case the spread operator does not apply to a variable/function call and the likelihood of the sniff conflicting with other sniffs which examine the spacing on the inside of parenthesis is high.

Includes unit tests.

Ref:
* https://wiki.php.net/rfc/first_class_callable_syntax
* https://3v4l.org/YTTO1