### PR TITLE
NamedFunctionCallArgumentsTest: add test with PHP 8.1 enum keyword

### DIFF
--- a/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.inc
+++ b/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.inc
@@ -208,6 +208,9 @@ foobar(elseif: $value, /* testReservedKeywordElseif2 */ elseif: $value);
 /* testReservedKeywordEmpty1 */
 foobar(empty: $value, /* testReservedKeywordEmpty2 */ empty: $value);
 
+/* testReservedKeywordEnum1 */
+foobar(enum: $value, /* testReservedKeywordEnum2 */ enum: $value);
+
 /* testReservedKeywordEnddeclare1 */
 foobar(enddeclare: $value, /* testReservedKeywordEnddeclare2 */ enddeclare: $value);
 

--- a/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
+++ b/tests/Core/Tokenizer/NamedFunctionCallArgumentsTest.php
@@ -776,6 +776,7 @@ class NamedFunctionCallArgumentsTest extends AbstractMethodUnitTest
             'endif',
             'endswitch',
             'endwhile',
+            'enum',
             'eval',
             'exit',
             'extends',


### PR DESCRIPTION
(this is to safeguard that the `enum` retokenization doesn't interfere with the parameter label retokenization)