### PR TITLE
Updated Outdated PHP Docblocks

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -305,7 +305,7 @@ class Config
      *
      * @param array<string, mixed> $settings The array of config settings.
      *
-     * @return void
+     * @return array
      */
     public function setSettings($settings)
     {

--- a/src/Files/FileList.php
+++ b/src/Files/FileList.php
@@ -199,7 +199,7 @@ class FileList implements \Iterator, \Countable
     /**
      * Return the file path of the current file being processed.
      *
-     * @return void
+     * @return int|string|null
      */
     #[ReturnTypeWillChange]
     public function key()

--- a/src/Reports/Gitblame.php
+++ b/src/Reports/Gitblame.php
@@ -28,7 +28,7 @@ class Gitblame extends VersionControl
      *
      * @param string $line Line to parse.
      *
-     * @return mixed string or false if impossible to recover.
+     * @return array|false|string|string[]|null string or false if impossible to recover.
      */
     protected function getAuthor($line)
     {

--- a/src/Reports/Hgblame.php
+++ b/src/Reports/Hgblame.php
@@ -28,7 +28,7 @@ class Hgblame extends VersionControl
      *
      * @param string $line Line to parse.
      *
-     * @return mixed string or false if impossible to recover.
+     * @return false|string string or false if impossible to recover.
      */
     protected function getAuthor($line)
     {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -595,7 +595,7 @@ class Runner
      * @param string $file    The path of the file that raised the error.
      * @param int    $line    The line number the error was raised at.
      *
-     * @return void
+     * @return bool
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException
      */
     public function handleErrors($code, $message, $file, $line)

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -34,7 +34,7 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
     /**
      * Registers the tokens that this sniff wants to listen for.
      *
-     * @return void
+     * @return array
      */
     public function register()
     {

--- a/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/SyntaxSniff.php
@@ -48,7 +48,7 @@ class SyntaxSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/GitMergeConflictSniff.php
@@ -49,7 +49,7 @@ class GitMergeConflictSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
+++ b/src/Standards/Generic/Sniffs/VersionControl/SubversionPropertiesSniff.php
@@ -50,7 +50,7 @@ class SubversionPropertiesSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowSpaceIndentSniff.php
@@ -56,7 +56,7 @@ class DisallowSpaceIndentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/DisallowTabIndentSniff.php
@@ -56,7 +56,7 @@ class DisallowTabIndentSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/CSSLintUnitTest.php
@@ -19,7 +19,7 @@ class CSSLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ClosureLinterUnitTest.php
@@ -19,7 +19,7 @@ class ClosureLinterUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/ESLintUnitTest.php
@@ -66,7 +66,7 @@ class ESLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
@@ -19,7 +19,7 @@ class JSHintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
+++ b/src/Standards/Generic/Tests/Files/ExecutableFileUnitTest.php
@@ -18,7 +18,7 @@ class ExecutableFileUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
+++ b/src/Standards/Generic/Tests/VersionControl/SubversionPropertiesUnitTest.php
@@ -18,7 +18,7 @@ class SubversionPropertiesUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
+++ b/src/Standards/MySource/Sniffs/Channels/IncludeOwnSystemSniff.php
@@ -82,7 +82,7 @@ class IncludeOwnSystemSniff implements Sniff
      * @param int                         $stackPtr  The position in the tokens array of the
      *                                               potentially included class.
      *
-     * @return string
+     * @return false
      */
     protected function getIncludedClassFromToken(
         $phpcsFile,

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -36,7 +36,7 @@ class SideEffectsSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the token stack.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -283,7 +283,7 @@ class FileHeaderSniff implements Sniff
      * @param array                       $headerLines Header information, as sourced
      *                                                 from getHeaderLines().
      *
-     * @return int|null
+     * @return void
      */
     public function processHeaderLines(File $phpcsFile, $headerLines)
     {

--- a/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
+++ b/src/Standards/PSR2/Sniffs/Files/EndFileNewlineSniff.php
@@ -38,7 +38,7 @@ class EndFileNewlineSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
+++ b/src/Standards/PSR2/Sniffs/Methods/FunctionCallSignatureSniff.php
@@ -35,7 +35,7 @@ class FunctionCallSignatureSniff extends PEARFunctionCallSignatureSniff
      * @param array                       $tokens      The stack of tokens that make up
      *                                                 the file.
      *
-     * @return void
+     * @return bool
      */
     public function isMultiLineCall(File $phpcsFile, $stackPtr, $openBracket, $tokens)
     {

--- a/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -37,7 +37,7 @@ class MultiLineFunctionDeclarationSniff extends PEARFunctionDeclarationSniff
      * @param array                       $tokens      The stack of tokens that make up
      *                                                 the file.
      *
-     * @return void
+     * @return bool
      */
     public function isMultiLineDeclaration($phpcsFile, $stackPtr, $openBracket, $tokens)
     {

--- a/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
+++ b/src/Standards/Squiz/Sniffs/Strings/DoubleQuoteUsageSniff.php
@@ -38,7 +38,7 @@ class DoubleQuoteUsageSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token
      *                                               in the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JSLintUnitTest.php
@@ -19,7 +19,7 @@ class JSLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
+++ b/src/Standards/Squiz/Tests/Debug/JavaScriptLintUnitTest.php
@@ -19,7 +19,7 @@ class JavaScriptLintUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
+++ b/src/Standards/Zend/Sniffs/Files/ClosingTagSniff.php
@@ -36,7 +36,7 @@ class ClosingTagSniff implements Sniff
      * @param int                         $stackPtr  The position of the current token in
      *                                               the stack passed in $tokens.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {

--- a/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
+++ b/src/Standards/Zend/Tests/Debug/CodeAnalyzerUnitTest.php
@@ -19,7 +19,7 @@ class CodeAnalyzerUnitTest extends AbstractSniffUnitTest
     /**
      * Should this test be skipped for some reason.
      *
-     * @return void
+     * @return bool
      */
     protected function shouldSkipTest()
     {

--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -80,8 +80,7 @@ abstract class Tokenizer
      * @param string                         $eolChar The EOL char used in the content.
      *
      * @return void
-     * @throws \PHP_CodeSniffer\Exceptions\TokenizerException If the file appears to be minified.
-     */
+	 */
     public function __construct($content, $config, $eolChar='\n')
     {
         $this->eolChar = $eolChar;

--- a/src/Util/Common.php
+++ b/src/Util/Common.php
@@ -35,7 +35,7 @@ class Common
      *
      * @param string $path The path to use.
      *
-     * @return mixed
+     * @return boolean
      */
     public static function isPharFile($path)
     {
@@ -83,7 +83,7 @@ class Common
      *
      * @param string $path The path to use.
      *
-     * @return mixed
+     * @return array|false|string|string[]
      */
     public static function realpath($path)
     {


### PR DESCRIPTION
I saw that quite a few PHP Docblocks were showing the wrong return type and one with a throw tag which was no longer relevant. I updated the comments, please let me know if I missed something here or made some other mistake and I'm happy to fix it 🙂 

I also noticed that the codebase uses a mix short and long names for types e.g.  int vs integer, bool vs boolean. Which is the correct one to use? I'm happy to create another PR to make them the same throughout the codebase!