### PR TITLE
Generic/UnusedFunctionParameter: bug fix x 2 (magic methods and error codes)

### DIFF
--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnusedFunctionParameterSniff.php
@@ -69,14 +69,17 @@ class UnusedFunctionParameterSniff implements Sniff
         $errorCode  = 'Found';
         $implements = false;
         $extends    = false;
-        $classPtr   = $phpcsFile->getCondition($stackPtr, T_CLASS);
-        if ($classPtr !== false) {
-            $implements = $phpcsFile->findImplementedInterfaceNames($classPtr);
-            $extends    = $phpcsFile->findExtendedClassName($classPtr);
-            if ($extends !== false) {
-                $errorCode .= 'InExtendedClass';
-            } else if ($implements !== false) {
-                $errorCode .= 'InImplementedInterface';
+
+        if ($token['code'] === T_FUNCTION) {
+            $classPtr   = $phpcsFile->getCondition($stackPtr, T_CLASS);
+            if ($classPtr !== false) {
+                $implements = $phpcsFile->findImplementedInterfaceNames($classPtr);
+                $extends    = $phpcsFile->findExtendedClassName($classPtr);
+                if ($extends !== false) {
+                    $errorCode .= 'InExtendedClass';
+                } else if ($implements !== false) {
+                    $errorCode .= 'InImplementedInterface';
+                }
             }
         }
 

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -44,13 +44,13 @@ HERE;
     $x = $parameter; // This line must be immediately after the HERE; with no intervening blank lines.
     $tango = <<<HERE
 1 Must be a HEREdoc
-2 
-3 
-4 
-5   
+2
+3
+4
+5
 6
 7
-8 
+8
 9 at least 9 lines long
 HERE;
 }
@@ -170,5 +170,82 @@ class MyExtendedClass implements SomeInterface {
     public function something($a, $b) {
         $c = $a + $b;
         $fn = fn($c, $d) => $c[2];
+    }
+}
+
+
+/**
+ * Magic methods must match the function signature dictated by PHP.
+ * Flagging unused parameters leads to notices which cannot be solved.
+ */
+class MagicMethodsWithParams {
+    public function __set(string $name, mixed $value) {
+        // Forbid dynamic properties & overloading inaccessible properties.
+        throw new RuntimeException('Forbidden');
+    }
+
+    public function __get(string $name) {
+        throw new RuntimeException('Forbidden');
+    }
+
+    public function __isset(string $name) {
+        throw new RuntimeException('Forbidden');
+    }
+
+    public function __unset(string $name) {
+        throw new RuntimeException('Forbidden');
+    }
+
+    public function __unserialize( array $data ) {
+        // Prevent unserializing from a stored representation of the object for security reasons.
+        $this->instance = new self();
+    }
+
+    public static function __set_state(array $properties) {
+        return new self();
+    }
+
+    public function __call(string $name, array $arguments) {
+        if (method_exists($this, $name)) {
+            // None of the methods which can be called in this class take arguments, so not passing them.
+            return $this->$name();
+        }
+    }
+
+    public static function __callStatic(string $name, array $arguments) {
+        if (method_exists($this, $name)) {
+            // None of the methods which can be called in this class take arguments, so not passing them.
+            return self::$name();
+        }
+    }
+}
+
+/**
+ * Unused parameters in magic methods which have flexible function signatures should still be flagged.
+ */
+class MagicMethodsWithParamsNotDictatedByPHP {
+    public $foo;
+    public function __construct($foo, $bar, $baz) {
+        $this->foo = $foo;
+    }
+
+    public function __invoke($foo, $bar, $baz) {
+        $this->foo = $foo;
+    }
+}
+
+/**
+ * Unused parameters in magic methods which have flexible function signatures
+ * where the method potentially overloads a parent method should still be flagged,
+ * but should use the `FoundInExtendedClassAfterLastUsed` error code.
+ */
+class MagicMethodsWithParamsNotDictatedByPHPInChildClass extends SomeParent{
+    public $foo;
+    public function __construct($foo, $bar, $baz) {
+        $this->foo = $foo;
+    }
+
+    public function __invoke($foo, $bar, $baz) {
+        $this->foo = $foo;
     }
 }

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.inc
@@ -152,3 +152,23 @@ class ConstructorPropertyPromotionWithContentInMethod {
 }
 
 $found = in_array_cb($needle, $haystack, fn($array, $needle) => $array[2] === $needle);
+
+
+/*
+ * Don't adjust the error code for closures and arrow functions in extended classes/classes implementing interfaces.
+ */
+class MyExtendedClass extends SomeClass {
+    public function something($a, $b) {
+        $c = $a + $b;
+        $closure = function ($c, $d) {
+            return $c * 2;
+        };
+    }
+}
+
+class MyExtendedClass implements SomeInterface {
+    public function something($a, $b) {
+        $c = $a + $b;
+        $fn = fn($c, $d) => $c[2];
+    }
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -50,6 +50,8 @@ class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
             117 => 1,
             121 => 2,
             125 => 2,
+            163 => 1,
+            172 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnusedFunctionParameterUnitTest.php
@@ -52,6 +52,10 @@ class UnusedFunctionParameterUnitTest extends AbstractSniffUnitTest
             125 => 2,
             163 => 1,
             172 => 1,
+            228 => 2,
+            232 => 2,
+            244 => 2,
+            248 => 2,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
### Generic/UnusedFunctionParameter: ignore class context for closures/arrow functions

As things were, if a closure or arrow function declared within a class which extends or implements would have an unused function parameter, it would get the `InExtendedClass` or `InImplementedInterface` addition in the error code.

Those additions were only intended for function declarations where the declaration would potentially be overloading a method from a parent and would have to comply with the method signature of the method in the parent class/interface.

This could lead to underreporting if a standard explicitly excludes the error codes contain `InExtendedClass` and/or `InImplementedInterface`.

Fixed now.

Includes additional unit test, though the tests don't safeguard this much as they don't check the error codes of the messages thrown.

The change can be tested manually by running the new tests against `master`, which will show:
```
 163 | WARNING | The method parameter $d is never used (Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed)
 172 | WARNING | The method parameter $d is never used
     |         | (Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceAfterLastUsed)
```

... while with the change in this commit, this will be fixed to:
```
 163 | WARNING | The method parameter $d is never used (Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed)
 172 | WARNING | The method parameter $d is never used (Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed)
```

### Generic/UnusedFunctionParameter: ignore magic methods

The function signature of magic methods - with the exception of `__construct()` and `__invoke()` - is dictated by PHP and unused parameters cannot be removed, which means that the warnings for these can never be resolved, only ignored via annotations.

This commit fixes this by checking whether a function is a magic method and if so, bowing out.

Includes unit tests.

Note: while not all magic methods take arguments, I'm still including the (nearly) full list of magic methods in the property as the other magic methods can be ignored anyway (no arguments).