### PR TITLE
Fix `Squiz.Commenting.FunctionComment.InvalidNoReturn` false positive when return type is `never`

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -143,9 +143,12 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
                             }
                         }
                     }//end if
-                } else if ($returnType !== 'mixed' && in_array('void', $typeNames, true) === false) {
-                    // If return type is not void, there needs to be a return statement
-                    // somewhere in the function that returns something.
+                } else if ($returnType !== 'mixed'
+                    && $returnType !== 'never'
+                    && in_array('void', $typeNames, true) === false
+                ) {
+                    // If return type is not void, never, or mixed, there needs to be a
+                    // return statement somewhere in the function that returns something.
                     if (isset($tokens[$stackPtr]['scope_closer']) === true) {
                         $endToken = $tokens[$stackPtr]['scope_closer'];
                         for ($returnToken = $stackPtr; $returnToken < $endToken; $returnToken++) {

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1129,3 +1129,8 @@ public function variableCaseTest(
 public function variableOrderMismatch($bar, $baz, $foo) {
     return;
 }
+
+/**
+ * @return never
+ */
+function foo() {}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1129,3 +1129,8 @@ public function variableCaseTest(
 public function variableOrderMismatch($bar, $baz, $foo) {
     return;
 }
+
+/**
+ * @return never
+ */
+function foo() {}


### PR DESCRIPTION
The `Squiz.Commenting.FunctionComment.InvalidNoReturn` causes false positives when it encounters the `never` return type.

Tested this locally with:

```xml
<rule ref="Squiz.Commenting.FunctionComment.InvalidNoReturn"/>
```

```php
/**
 * @return never
 */
private function foo()
{
    throw new \RuntimeException('This method never returns');
}
```