### PR TITLE
Generic/RequireStrictTypes: various bugfixes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -771,6 +771,15 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.8.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.9.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.10.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.11.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.11.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.12.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.12.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.13.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.14.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.14.inc.fixed" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.15.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.15.inc.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.php" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -763,6 +763,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="NoSilencedErrorsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.2.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.3.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.4.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.php" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -765,6 +765,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.4.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.5.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.6.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.7.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.php" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -768,6 +768,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.5.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.6.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.7.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.8.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.9.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.10.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="RequireStrictTypesUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SAPIUsageUnitTest.php" role="test" />

--- a/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
@@ -77,6 +77,25 @@ class RequireStrictTypesSniff implements Sniff
         if ($found === false) {
             $error = 'Missing required strict_types declaration';
             $phpcsFile->addError($error, $stackPtr, 'MissingDeclaration');
+
+            return $phpcsFile->numTokens;
+        }
+
+        // Strict types declaration found, make sure strict types is enabled.
+        $skip     = Tokens::$emptyTokens;
+        $skip[]   = T_EQUAL;
+        $valuePtr = $phpcsFile->findNext($skip, ($next + 1), null, true);
+
+        if ($valuePtr !== false
+            && $tokens[$valuePtr]['code'] === T_LNUMBER
+            && $tokens[$valuePtr]['content'] === '0'
+        ) {
+            $error = 'Required strict_types declaration found, but strict types is disabled. Set the value to 1 to enable';
+            $fix   = $phpcsFile->addFixableWarning($error, $valuePtr, 'Disabled');
+
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($valuePtr, '1');
+            }
         }
 
         // Skip the rest of the file so we don't pick up additional

--- a/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/RequireStrictTypesSniff.php
@@ -51,20 +51,27 @@ class RequireStrictTypesSniff implements Sniff
                 return $phpcsFile->numTokens;
             }
 
-            $next = $phpcsFile->findNext(
-                Tokens::$emptyTokens,
-                ($tokens[$declare]['parenthesis_opener'] + 1),
-                $tokens[$declare]['parenthesis_closer'],
-                true
-            );
+            $next = $tokens[$declare]['parenthesis_opener'];
 
-            if ($next !== false
-                && $tokens[$next]['code'] === T_STRING
-                && strtolower($tokens[$next]['content']) === 'strict_types'
-            ) {
-                // There is a strict types declaration.
-                $found = true;
-            }
+            do {
+                $next = $phpcsFile->findNext(
+                    Tokens::$emptyTokens,
+                    ($next + 1),
+                    $tokens[$declare]['parenthesis_closer'],
+                    true
+                );
+
+                if ($next !== false
+                    && $tokens[$next]['code'] === T_STRING
+                    && strtolower($tokens[$next]['content']) === 'strict_types'
+                ) {
+                    // There is a strict types declaration.
+                    $found = true;
+                    break;
+                }
+
+                $next = $phpcsFile->findNext(T_COMMA, ($next + 1), $tokens[$declare]['parenthesis_closer']);
+            } while ($next !== false && $next < $tokens[$declare]['parenthesis_closer']);
         }//end if
 
         if ($found === false) {

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.10.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.10.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare(encoding='utf-8', ticks=1);
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.11.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.11.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=0);
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.11.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.11.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.12.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.12.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare(  strict_types  =   /*comment*/   0   );
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.12.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.12.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+
+declare(  strict_types  =   /*comment*/   1   );
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.13.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.13.inc
@@ -1,0 +1,3 @@
+<?php
+// Safeguard sniff handles parse error/live coding correctly.
+declare(strict_types=

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.14.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.14.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare( strict_types = 0, encoding='utf-8' );
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.14.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.14.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+
+declare( strict_types = 1, encoding='utf-8' );
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.15.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.15.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare(encoding='utf-8', strict_types=0);
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.15.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.15.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+
+declare(encoding='utf-8', strict_types=1);
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.3.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.3.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare( Strict_Types = 1 );
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.4.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.4.inc
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Very
+ * Long
+ * Docblock
+ */
+
+declare(strict_types=1);
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.5.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.5.inc
@@ -1,0 +1,6 @@
+<?php
+
+// This is a parse error, but the sniff should still handle this correctly.
+declare($something = $value);
+
+const STRICT_TYPES = 1;

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.6.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.6.inc
@@ -1,0 +1,4 @@
+<?php
+
+// This is a parse error, but the sniff should still handle this correctly.
+declare($something = STRICT_TYPES);

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.7.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.7.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding. This should be ignored.
+declare(

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.8.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.8.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1, encoding='utf-8');
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.9.inc
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.9.inc
@@ -1,0 +1,5 @@
+<?php
+
+declare(encoding='utf-8', strict_types=1);
+
+// some code

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -31,6 +31,7 @@ class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
         case 'RequireStrictTypesUnitTest.2.inc':
         case 'RequireStrictTypesUnitTest.5.inc':
         case 'RequireStrictTypesUnitTest.6.inc':
+        case 'RequireStrictTypesUnitTest.10.inc':
             return [1 => 1];
 
         default:

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -44,14 +44,22 @@ class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
     /**
      * Returns the lines where warnings should occur.
      *
-     * The key of the array should represent the line number and the value
-     * should represent the number of warnings that should occur on that line.
+     * @param string $testFile The name of the file being tested.
      *
      * @return array<int, int>
      */
-    public function getWarningList()
+    public function getWarningList($testFile='')
     {
-        return [];
+        switch ($testFile) {
+        case 'RequireStrictTypesUnitTest.11.inc':
+        case 'RequireStrictTypesUnitTest.12.inc':
+        case 'RequireStrictTypesUnitTest.14.inc':
+        case 'RequireStrictTypesUnitTest.15.inc':
+            return [3 => 1];
+
+        default:
+            return [];
+        }
 
     }//end getWarningList()
 

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -29,6 +29,8 @@ class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
     {
         switch ($testFile) {
         case 'RequireStrictTypesUnitTest.2.inc':
+        case 'RequireStrictTypesUnitTest.5.inc':
+        case 'RequireStrictTypesUnitTest.6.inc':
             return [1 => 1];
 
         default:

--- a/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/RequireStrictTypesUnitTest.php
@@ -28,12 +28,12 @@ class RequireStrictTypesUnitTest extends AbstractSniffUnitTest
     public function getErrorList($testFile='')
     {
         switch ($testFile) {
-        case 'RequireStrictTypesUnitTest.1.inc':
-            return [];
-            break;
-        }
+        case 'RequireStrictTypesUnitTest.2.inc':
+            return [1 => 1];
 
-        return [1 => 1];
+        default:
+            return [];
+        }
 
     }//end getErrorList()
 


### PR DESCRIPTION
### Generic/RequireStrictTypes: add extra tests

These tests safeguard the following, which is already handled correctly by the sniff:
* Execution directives are case-insensitive in PHP.
* The sniff should ignore docblocks between a PHP open tag and a declare statement.

### Generic/RequireStrictTypes: bug fix - limit token search to the statement

While hopefully unlikely in real life, the sniff should handle parse errors correctly.

Along the same lines, live coding should be handled correctly and a `declare()` statement should only be examined once the statement has been completed.

This updates the sniff to handle both situations correctly.
Without these fixes, no error would be thrown in test case file 5 or 6 (false negative), while an error would be thrown in test case file 7 (false positive).

Includes unit tests.

Includes minor efficiency tweak to only start looking for a "next" token _after_ the current token.

### Generic/RequireStrictTypes: bug fix - allow for multi directive statements

PHP allows for multiple directives to be passed in one `declare()` statement.

The sniff, however, did not allow for this, which could lead to false positives.

Fixed now.

Includes unit tests.

### Generic/RequireStrictTypes: add warning for when value is 0

Strict types is disabled when the value for the `strict_types` directive is `0`.

As this sniff is supposed to be about enforcing the use of `strict_types`, `strict_types` declarations which turn the feature off should be flagged as well.

Implemented with a separate error code to allow for selectively turning this warning off.

Includes dedicated tests.


---

## Future Scope

This sniff isn't very efficient as it will walk the whole file until a `declare()` statement is found or until the end of the file is reached.

Declare statements for `strict_types` MUST be the first statement in a file, so IMO there are two options:
* Either refactor the sniff to look for the first statement in a file instead of walking a complete file.
* Or alternatively, keep the token walking, but don't stop on the first `declare()` statement and flag any `strict_types` declarations which are not the first statement in a file with a separate error code.

In both cases, "view" files containing a mix of PHP and HTML should be taken into account, similarly, hashbang lines should be taken into account.