### PR TITLE
Potential "Uninitialized string offset 1" in octal notation backfill

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -750,6 +750,7 @@ class PHP extends Tokenizer
                 && (isset($tokens[($stackPtr + 1)]) === true
                 && is_array($tokens[($stackPtr + 1)]) === true
                 && $tokens[($stackPtr + 1)][0] === T_STRING
+                && isset($tokens[($stackPtr + 1)][1][0], $tokens[($stackPtr + 1)][1][1]) === true
                 && strtolower($tokens[($stackPtr + 1)][1][0]) === 'o'
                 && $tokens[($stackPtr + 1)][1][1] !== '_')
                 && preg_match('`^(o[0-7]+(?:_[0-7]+)?)([0-9_]*)$`i', $tokens[($stackPtr + 1)][1], $matches) === 1

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.inc
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.inc
@@ -26,3 +26,6 @@ $foo = 0o28_2;
 
 /* testInvalid6 */
 $foo = 0o2_82;
+
+/* testInvalid7 */
+$foo = 0o;

--- a/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
+++ b/tests/Core/Tokenizer/BackfillExplicitOctalNotationTest.php
@@ -106,6 +106,12 @@ class BackfillExplicitOctalNotationTest extends AbstractMethodUnitTest
                 'nextToken'   => T_STRING,
                 'nextContent' => '_82',
             ],
+            [
+                'marker'      => '/* testInvalid7 */',
+                'value'       => '0',
+                'nextToken'   => T_STRING,
+                'nextContent' => 'o',
+            ],
         ];
 
     }//end dataExplicitOctalNotation()


### PR DESCRIPTION
... in the backfill for the PHP 8.1 explicit octal notation.

Includes unit tests.