### PR TITLE
restart phpcs/phpcbf when xdebug is loaded

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -73,6 +73,8 @@ if (class_exists('PHP_CodeSniffer\Autoload', false) === false) {
                     return;
                 }
 
+                require_once __DIR__.'/vendor/autoload.php';
+
                 if (strpos(__DIR__, 'phar://') !== 0
                     && @file_exists(__DIR__.'/../../autoload.php') === true
                 ) {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "php": ">=5.4.0",
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*",
-        "ext-simplexml": "*"
+        "ext-simplexml": "*",
+        "composer/xdebug-handler": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -12,6 +12,7 @@
 
 namespace PHP_CodeSniffer;
 
+use Composer\XdebugHandler\XdebugHandler;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\DummyFile;
@@ -53,6 +54,10 @@ class Runner
      */
     public function runPHPCS()
     {
+        $xdebug = new XdebugHandler('phpcs');
+        $xdebug->check();
+        unset($xdebug);
+
         $this->registerOutOfMemoryShutdownMessage('phpcs');
 
         try {
@@ -155,6 +160,10 @@ class Runner
      */
     public function runPHPCBF()
     {
+        $xdebug = new XdebugHandler('phpcbf');
+        $xdebug->check();
+        unset($xdebug);
+
         $this->registerOutOfMemoryShutdownMessage('phpcbf');
 
         if (defined('PHP_CODESNIFFER_CBF') === false) {


### PR DESCRIPTION
closes https://github.com/squizlabs/PHP_CodeSniffer/issues/3337

running `phpcs` on the project itself takes 11-12 seconds when xdebug is loaded.
with the added restart script it takes 6-7 seconds. so its roughly 40-50% faster.

running `phpcs` with a primed cache takes ~1.8 seconds without this PR and ~0.9 seconds with the PR.

test on mac m1 pro 
```
php -v
PHP 8.1.13 (cli) (built: Nov 24 2022 15:58:42) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.13, Copyright (c) Zend Technologies
    with Xdebug v3.1.5, Copyright (c) 2002-2022, by Derick Rethans
    with Zend OPcache v8.1.13, Copyright (c), by Zend Technologies
```