### PR TITLE
PHP 8.2 | PSR1/SideEffects: allow for readonly classes

### DIFF
--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -169,7 +169,9 @@ class SideEffectsSniff implements Sniff
             }
 
             // Ignore function/class prefixes.
-            if (isset(Tokens::$methodPrefixes[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::$methodPrefixes[$tokens[$i]['code']]) === true
+                || $tokens[$i]['code'] === T_READONLY
+            ) {
                 continue;
             }
 

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.1.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.1.inc
@@ -76,4 +76,12 @@ namespace {
 
 defined('APP_BASE_URL') or define('APP_BASE_URL', '/');
 
+readonly class Foo {
+    public function __construct(
+        private string $foo,
+        private string $bar,
+    ) {
+    }
+}
+
 ?>


### PR DESCRIPTION
Includes unit test.

Ref:
* https://wiki.php.net/rfc/readonly_classes

Fixes #3727