### PR TITLE
$data variable should be array

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1053,7 +1053,7 @@ class File
         }
 
         if (empty($data) === false) {
-            $message = vsprintf($message, $data);
+            $message = vsprintf($message, is_array($data) ? $data : [$data] );
         }
 
         if (isset($messages[$line]) === false) {


### PR DESCRIPTION
in some analysis, I was receiving this error "Uncaught TypeError: vsprintf(): Argument #2 ($values) must be of type array, string given" on line 1056