### PR TITLE
Fix failing test

### DIFF
--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.1.inc.fixed
@@ -25,7 +25,7 @@
 * @author
 * @copyright  1997 Squiz Pty Ltd (ABN 77 084 670 600)
 * @copyright  1994-1997 Squiz Pty Ltd (ABN 77 084 670 600)
-* @copyright  2022 Squiz Pty Ltd (ABN 77 084 670 600)
+* @copyright  2023 Squiz Pty Ltd (ABN 77 084 670 600)
 * @license    http://www.php.net/license/3_0.txt
 * @summary    An unknown summary tag
 *


### PR DESCRIPTION
This file includes the current year, and is now failing. I noticed this while working on #3751 / #3752.