### PR TITLE
Allow multiple spaces in PropertyDeclaration sniff to respect more carefully the PSR-12.

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -85,7 +85,9 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
                 if ($tokens[$next]['line'] !== $tokens[$typeToken]['line']) {
                     $found = 'newline';
                 } else {
-                    $found = $tokens[($typeToken + 1)]['length'];
+                    // According to PSR-12: "There MUST be a space between type declaration and property name."
+                    // This does not mean a single space only is expected, but at least 1. So, if many, ignore sniff.
+                    return;
                 }
 
                 $data = [$found];
@@ -96,17 +98,13 @@ class PropertyDeclarationSniff extends AbstractVariableSniff
                 } else {
                     $fix = $phpcsFile->addFixableError($error, $typeToken, 'SpacingAfterType', $data);
                     if ($fix === true) {
-                        if ($found === 'newline') {
-                            $phpcsFile->fixer->beginChangeset();
-                            for ($x = ($typeToken + 1); $x < $next; $x++) {
-                                $phpcsFile->fixer->replaceToken($x, '');
-                            }
-
-                            $phpcsFile->fixer->addContent($typeToken, ' ');
-                            $phpcsFile->fixer->endChangeset();
-                        } else {
-                            $phpcsFile->fixer->replaceToken(($typeToken + 1), ' ');
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($x = ($typeToken + 1); $x < $next; $x++) {
+                            $phpcsFile->fixer->replaceToken($x, '');
                         }
+
+                        $phpcsFile->fixer->addContent($typeToken, ' ');
+                        $phpcsFile->fixer->endChangeset();
                     }
                 }
             }//end if

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.inc.fixed
@@ -38,7 +38,7 @@ class ABC {
     public static $propD;
     protected static
         $propE;
-    private static /*comment*/   $propF;
+    private static    /*comment*/   $propF;
 }
 
 class MyClass
@@ -65,7 +65,7 @@ class MyClass
 {
     public string $var = null;
     protected ?Folder\ClassName $var = null;
-    public int $var = null;
+    public int   $var = null;
     public static int /*comment*/$var = null;
 }
 
@@ -74,7 +74,7 @@ class ReadOnlyProp {
         $bar,
         $var = null;
 
-    protected readonly ?string $foo;
+    protected readonly ?string    $foo;
 
     readonly array $foo;
 }

--- a/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -35,7 +35,6 @@ class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
             23 => 1,
             38 => 1,
             41 => 1,
-            42 => 1,
             50 => 2,
             51 => 1,
             55 => 1,
@@ -45,9 +44,7 @@ class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
             68 => 1,
             69 => 1,
             71 => 1,
-            72 => 1,
             76 => 1,
-            80 => 1,
             82 => 1,
         ];
 


### PR DESCRIPTION
Fix #3729 

Note to maintainers: I wasn't in capacity of unit test this before any push. I'm having PHP 8.0 on my machine and when I run `php vendor/bin/phpunit` I have a fatal error due to a usage of the `each()` internal function by PHPUnit which is now removed from the PHP lib. I really think a more recent version of PHPUnit should be used, but that's another story.