### PR TITLE
Squiz/VariableComment: allow union types to be detected

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/VariableCommentSniff.php
@@ -40,6 +40,7 @@ class VariableCommentSniff extends AbstractVariableSniff
             T_STRING       => T_STRING,
             T_NS_SEPARATOR => T_NS_SEPARATOR,
             T_NULLABLE     => T_NULLABLE,
+            T_TYPE_UNION   => T_TYPE_UNION,
         ];
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc
@@ -402,3 +402,11 @@ class ReadOnlyProps
 
      private readonly string $variable;
 }
+
+class UnionTypes
+{
+    /**
+     * @var array|boolean
+     */
+    private array|bool $variableName = array();
+}

--- a/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/VariableCommentUnitTest.inc.fixed
@@ -402,3 +402,11 @@ class ReadOnlyProps
 
      private readonly string $variable;
 }
+
+class UnionTypes
+{
+    /**
+     * @var array|boolean
+     */
+    private array|bool $variableName = array();
+}


### PR DESCRIPTION
If one uses a union type for an object property, the doc-type-hint could not be related to the variable type.

Fixed now.

Includes unit test.