### PR TITLE
Fix indent for closing function parenthesis

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionCallSignatureSniff.php
@@ -419,7 +419,7 @@ class FunctionCallSignatureSniff implements Sniff
             if ($fix === true) {
                 $phpcsFile->fixer->addContentBefore(
                     $closeBracket,
-                    $phpcsFile->eolChar.str_repeat(' ', ($foundFunctionIndent + $this->indent))
+                    $phpcsFile->eolChar.str_repeat(' ', $foundFunctionIndent)
                 );
             }
         }


### PR DESCRIPTION
I'm having trouble writing a test case for this. This seems to mostly be because changing this line alone doesn't break any existing tests, and I can't find a test case that breaks like the live example does because it seems to be an interaction between `PEAR.Functions.FunctionCallSignature` and `Generic.WhiteSpace.ScopeIndent` / `Squiz.WhiteSpace.ScopeClosingBrace` which causes the issue.

<details><summary>Long explanation with a real example of the problem</summary>

Here's a code snippet that I'm working with:

```php
 70|
 71|        // Use spaceship operator to force the array sort order on the pinned items
 72|        uasort($pinnedOptions, function ($item, $itemComparison) {
 73|            return $item[Option::KEY_SORT_ORDER] <=> $itemComparison[Option::KEY_SORT_ORDER];
 74|        });
 75|
```

The first pass through the fixer says:

```
	PEAR.Functions.FunctionCallSignature:412 replaced token 514 (T_OPEN_PARENTHESIS on line 72) "(" => "(\n············"
	PEAR.Functions.FunctionCallSignature:425 replaced token 551 (T_CLOSE_PARENTHESIS on line 74) ")" => "\n············)"
        => Fixing file: 2/2 violations remaining [made 1 pass]...               
	* fixed 2 violations, starting loop 2 *
```

Which gives us:

```php
 70|
 71|        // Use spaceship operator to force the array sort order on the pinned items
 72|        uasort(
 73|            $pinnedOptions, function ($item, $itemComparison) {
 74|            return $item[Option::KEY_SORT_ORDER] <=> $itemComparison[Option::KEY_SORT_ORDER];
 75|        }
 76|            );
 77|
```

This is the step which I'm fixing in this pull request. The closing parenthesis of the function call is misaligned by one indentation step. (Found 12, expected 8.)

The second pass through the fixer says:

```
	Generic.WhiteSpace.ScopeIndent:1530 replaced token 531 (T_WHITESPACE on line 74) "············return" => "················return"
	Generic.WhiteSpace.ScopeIndent:1530 replaced token 551 (T_WHITESPACE on line 75) "········}" => "············}"
	=> Changeset started by PEAR.Functions.FunctionCallSignature:622
		Q: PEAR.Functions.FunctionCallSignature:628 replaced token 519 (T_WHITESPACE on line 73) "·function" => "function"
		Q: PEAR.Functions.FunctionCallSignature:631 replaced token 520 (T_CLOSURE on line 73) "function" => "\n············function"
		A: PEAR.Functions.FunctionCallSignature:635 replaced token 519 (T_WHITESPACE on line 73) "·function" => "function"
		A: PEAR.Functions.FunctionCallSignature:635 replaced token 520 (T_CLOSURE on line 73) "function" => "\n············function"
	=> Changeset ended: 2 changes applied
	Squiz.WhiteSpace.ScopeClosingBrace:104 replaced token 552 (T_CLOSE_CURLY_BRACKET on line 75) "}" => "····}"
        => Fixing file: 5/2 violations remaining [made 2 passes]...             
	* fixed 5 violations, starting loop 3 *
```

Which gives us:

```php
 70|
 71|        // Use spaceship operator to force the array sort order on the pinned items
 72|        uasort(
 73|            $pinnedOptions,
 74|            function ($item, $itemComparison) {
 75|                return $item[Option::KEY_SORT_ORDER] <=> $itemComparison[Option::KEY_SORT_ORDER];
 76|                }
 77|            );
 78|
```

The third pass through the fixer says:

```
	Generic.WhiteSpace.ScopeIndent:1530 replaced token 552 (T_WHITESPACE on line 76) "················}" => "············}"
	* token 552 has already been modified, skipping *
        => Fixing file: 1/2 violations remaining [made 3 passes]...             
	* fixed 1 violations, starting loop 4 *
```

Which gives us:

```php
 70|
 71|        // Use spaceship operator to force the array sort order on the pinned items
 72|        uasort(
 73|            $pinnedOptions,
 74|            function ($item, $itemComparison) {
 75|                return $item[Option::KEY_SORT_ORDER] <=> $itemComparison[Option::KEY_SORT_ORDER];
 76|            }
 77|            );
 78|
```

And then the fixer declared victory. **However**, it's left the indentation of the closing function call vertically lined up differently from what I expect.

I'm expecting:

```php
 70|
 71|        // Use spaceship operator to force the array sort order on the pinned items
 72|        uasort(
 73|            $pinnedOptions,
 74|            function ($item, $itemComparison) {
 75|                return $item[Option::KEY_SORT_ORDER] <=> $itemComparison[Option::KEY_SORT_ORDER];
 76|            }
 77|        );
 78|
```

</details>

Hopefully the change in this pull request fixes the problem, but I'm having trouble verifying that it actually does. Please can I have some help?