### PR TITLE
Squiz/NonExecutableCode: fix false positives when code goes in and out of PHP/HTML

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1857,6 +1857,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="LowercasePHPFunctionsUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="NonExecutableCodeUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="NonExecutableCodeUnitTest.2.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="NonExecutableCodeUnitTest.3.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="NonExecutableCodeUnitTest.php" role="test" />
        </dir>
        <dir name="Scope">

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -258,6 +258,16 @@ class NonExecutableCodeSniff implements Sniff
                 continue;
             }
 
+            // Skip HTML whitespace.
+            if ($tokens[$i]['code'] === T_INLINE_HTML && \trim($tokens[$i]['content']) === '') {
+                continue;
+            }
+
+            // Skip PHP re-open tag (eg, after inline HTML).
+            if ($tokens[$i]['code'] === T_OPEN_TAG) {
+                continue;
+            }
+
             $line = $tokens[$i]['line'];
             if ($line > $lastLine) {
                 $type    = substr($tokens[$stackPtr]['type'], 2);

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -204,8 +204,8 @@ class NonExecutableCodeSniff implements Sniff
             $end = ($phpcsFile->numTokens - 1);
         }//end if
 
-        // Find the semicolon that ends this statement, skipping
-        // nested statements like FOR loops and closures.
+        // Find the semicolon or closing PHP tag that ends this statement,
+        // skipping nested statements like FOR loops and closures.
         for ($start = ($stackPtr + 1); $start < $phpcsFile->numTokens; $start++) {
             if ($start === $end) {
                 break;
@@ -225,11 +225,7 @@ class NonExecutableCodeSniff implements Sniff
                 continue;
             }
 
-            if ($tokens[$start]['code'] === T_SEMICOLON) {
-                break;
-            }
-
-            if ($tokens[$start]['code'] === T_CLOSE_TAG) {
+            if ($tokens[$start]['code'] === T_SEMICOLON || $tokens[$start]['code'] === T_CLOSE_TAG) {
                 break;
             }
         }//end for

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -228,6 +228,10 @@ class NonExecutableCodeSniff implements Sniff
             if ($tokens[$start]['code'] === T_SEMICOLON) {
                 break;
             }
+
+            if ($tokens[$start]['code'] === T_CLOSE_TAG) {
+                break;
+            }
         }//end for
 
         if (isset($tokens[$start]) === false) {

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
@@ -64,4 +64,10 @@ $a = new class {
 // two here, but not six.)
 echo 'one'; echo 'two'; echo 'three';
 
+// A single statement split across multiple lines. Here we get complaints for
+// each line, even though they're all part of one statement.
+echo 'one' . 'two'
+    . 'three' . 'four'
+    . 'five' . 'six';
+
 interface MyInterface {

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.2.inc
@@ -58,4 +58,10 @@ $a = new class {
     }
 };
 
+// Multiple statements are still one line of unreachable code, so should get
+// only one complaint from this sniff. (Well, technically two here since there
+// are two 'exit()' statements above, so one complaint from each of those. So,
+// two here, but not six.)
+echo 'one'; echo 'two'; echo 'three';
+
 interface MyInterface {

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.3.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.3.inc
@@ -1,0 +1,31 @@
+<!-- no problem here -->
+<?php if (true): ?>
+    <?php foreach ([] as $item): ?>
+        <?php continue; ?>
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<!-- no problem here -->
+<?php if (true) { ?>
+    <?php foreach ([] as $item) { ?>
+        <?php continue; ?>
+    <?php } ?>
+<?php } ?>
+
+<!-- should detect an error here -->
+<?php if (true): ?>
+    <?php foreach ([] as $item): ?>
+        <?php continue; ?>
+        <div>non-executable</div>
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<!-- should detect an error here -->
+<?php if (true): ?>
+    <?php foreach ([] as $item): ?>
+        <?php continue; ?>
+
+        <div>non-executable</div>
+
+    <?php endforeach; ?>
+<?php endif; ?>

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.3.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.3.inc
@@ -12,6 +12,14 @@
     <?php } ?>
 <?php } ?>
 
+<!-- no problem here -->
+<?php if (true) { ?>
+    <?php foreach ([] as $item) { ?>
+        <!-- note missing semicolon on next line -->
+        <?php continue ?>
+    <?php } ?>
+<?php } ?>
+
 <!-- should detect an error here -->
 <?php if (true): ?>
     <?php foreach ([] as $item): ?>
@@ -23,9 +31,34 @@
 <!-- should detect an error here -->
 <?php if (true): ?>
     <?php foreach ([] as $item): ?>
+        <!-- note missing semicolon on next line -->
+        <?php continue ?>
+        <div>non-executable</div>
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<!-- should detect an error here -->
+<?php if (true): ?>
+    <?php foreach ([] as $item): ?>
         <?php continue; ?>
 
         <div>non-executable</div>
 
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<!-- should detect an error here -->
+<?php if (true): ?>
+    <?php foreach ([] as $item): ?>
+        <?php continue; ?>
+        <?= 'unreachable - no semicolon' ?>
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<!-- should detect an error here -->
+<?php if (true): ?>
+    <?php foreach ([] as $item): ?>
+        <?php continue; ?>
+        <?= 'unreachable - with semicolon'; ?>
     <?php endforeach; ?>
 <?php endif; ?>

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -86,6 +86,11 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 54 => 2,
             ];
             break;
+        case 'NonExecutableCodeUnitTest.3.inc':
+            return [
+                19 => 1,
+                28 => 1,
+            ];
         default:
             return [];
             break;

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -84,6 +84,7 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 10 => 2,
                 14 => 1,
                 54 => 2,
+                65 => 2,
             ];
             break;
         case 'NonExecutableCodeUnitTest.3.inc':

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -85,6 +85,9 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 14 => 1,
                 54 => 2,
                 65 => 2,
+                69 => 2,
+                70 => 2,
+                71 => 2,
             ];
             break;
         case 'NonExecutableCodeUnitTest.3.inc':

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -88,8 +88,11 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
             break;
         case 'NonExecutableCodeUnitTest.3.inc':
             return [
-                19 => 1,
-                28 => 1,
+                27 => 1,
+                36 => 1,
+                45 => 1,
+                54 => 1,
+                62 => 1,
             ];
         default:
             return [];


### PR DESCRIPTION
The following code snippet is currently flagging as `Squiz.PHP.NonExecutableCode.Unreachable`, but probably shouldn't.

```php
<?php if (true): ?>
    <?php foreach ([] as $item): ?>
        <?php continue; ?>
    <?php endforeach; ?>
<?php endif; ?>
```

This pull request adds a check to avoid this snippet from being flagged as problematic.