### PR TITLE
Generic/Todo-Fixme sniffs: improve handling of docblock tags and efficiency fix

### DIFF
--- a/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/FixmeSniff.php
@@ -35,7 +35,12 @@ class FixmeSniff implements Sniff
      */
     public function register()
     {
-        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT,
+            T_DOC_COMMENT_TAG,
+            T_DOC_COMMENT_STRING,
+        ];
 
     }//end register()
 

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -34,7 +34,12 @@ class TodoSniff implements Sniff
      */
     public function register()
     {
-        return array_diff(Tokens::$commentTokens, Tokens::$phpcsCommentTokens);
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT,
+            T_DOC_COMMENT_TAG,
+            T_DOC_COMMENT_STRING,
+        ];
 
     }//end register()
 

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.inc
@@ -21,3 +21,17 @@ Debug::bam('test');
 //FIXME.
 //éfixme
 //fixmeé
+
+/**
+ * While there is no official "fix me" tag, only `@todo`, let's support a tag for the purpose of this sniff anyway.
+ *
+ * @fixme This message should be picked up.
+ * @fixme: This message should be picked up too.
+ * @fixme - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @fixme
+ * @anothertag
+ *
+ * @param string $something FIXME: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.js
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.js
@@ -21,3 +21,17 @@ alert('test');
 //FIXME.
 //éfixme
 //fixmeé
+
+/**
+ * While there is no official "fix me" tag, only `@todo`, let's support a tag for the purpose of this sniff anyway.
+ *
+ * @fixme This message should be picked up.
+ * @fixme: This message should be picked up too.
+ * @fixme - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @fixme
+ * @anothertag
+ *
+ * @param string $something FIXME: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/FixmeUnitTest.php
@@ -37,6 +37,11 @@ class FixmeUnitTest extends AbstractSniffUnitTest
             16 => 1,
             18 => 1,
             21 => 1,
+            28 => 1,
+            29 => 1,
+            30 => 1,
+            33 => 1,
+            36 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.inc
@@ -21,3 +21,15 @@ Debug::bam('test');
 //TODO.
 //étodo
 //todoé
+
+/**
+ * @todo This message should be picked up.
+ * @todo: This message should be picked up too.
+ * @todo - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @todo
+ * @anothertag
+ *
+ * @param string $something TODO: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.js
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.js
@@ -21,3 +21,15 @@ alert('test');
 //TODO.
 //étodo
 //todoé
+
+/**
+ * @todo This message should be picked up.
+ * @todo: This message should be picked up too.
+ * @todo - here is a message
+ *
+ * The below should not show a message as there is no description associated with the tag.
+ * @todo
+ * @anothertag
+ *
+ * @param string $something TODO: add description
+ */

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -53,6 +53,11 @@ class TodoUnitTest extends AbstractSniffUnitTest
             16 => 1,
             18 => 1,
             21 => 1,
+            26 => 1,
+            27 => 1,
+            28 => 1,
+            31 => 1,
+            34 => 1,
         ];
 
     }//end getWarningList()


### PR DESCRIPTION
### Generic/Todo-Fixme: make the sniffs more selective

The sniffs as-they-were, would sniff all comment related tokens, including `T_DOC_COMMENT_STAR`, `T_DOC_COMMENT_WHITESPACE` etc.

Sniffing those tokens is redundant and makes the sniffs slower than is needed.

Fixed now by making the tokens being registered by the sniffs more selective/targeted.

### Generic/Todo: improve handling of "todo" tags in docblocks

Until now, the sniff would only examine an individual comment token, while when a `@todo` tag is used in a docblock, the "task description" is normally in the next `T_DOC_COMMENT_STRING` token.

This commit fixes this and the sniff will now take docblock `@todo` tags into account.

Includes additional unit tests.

### Generic/Fixme: improve handling of "fixme" tags in docblocks

Essentially the same fix as applied in the sister-commit for the `Generic.Commenting.Todo` sniff.

Until now, the sniff would only examine an individual comment token, while when a `@fixme` tag is used in a docblock, the "task description" is normally in the next `T_DOC_COMMENT_STRING` token.

This commit fixes this and the sniff will now take docblock `@fixme` tags into account.

Includes additional unit tests.

Fixes #3769 (well, aside from tags without a description, but that can't be helped)