### PR TITLE
PSR1/SideEffects: improve recognition of disable/enable annotations

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1120,6 +1120,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.14.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.15.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.16.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.17.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="SideEffectsUnitTest.php" role="test" />
        </dir>
        <dir name="Methods">

--- a/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
+++ b/src/Standards/PSR1/Sniffs/Files/SideEffectsSniff.php
@@ -103,7 +103,8 @@ class SideEffectsSniff implements Sniff
                 && (empty($tokens[$i]['sniffCodes']) === true
                 || isset($tokens[$i]['sniffCodes']['PSR1']) === true
                 || isset($tokens[$i]['sniffCodes']['PSR1.Files']) === true
-                || isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === true)
+                || isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === true
+                || isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects.FoundWithSymbols']) === true)
             ) {
                 do {
                     $i = $phpcsFile->findNext(T_PHPCS_ENABLE, ($i + 1));
@@ -111,7 +112,8 @@ class SideEffectsSniff implements Sniff
                     && empty($tokens[$i]['sniffCodes']) === false
                     && isset($tokens[$i]['sniffCodes']['PSR1']) === false
                     && isset($tokens[$i]['sniffCodes']['PSR1.Files']) === false
-                    && isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === false);
+                    && isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects']) === false
+                    && isset($tokens[$i]['sniffCodes']['PSR1.Files.SideEffects.FoundWithSymbols']) === false);
 
                 if ($i === false) {
                     // The entire rest of the file is disabled,

--- a/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.17.inc
+++ b/src/Standards/PSR1/Tests/Files/SideEffectsUnitTest.17.inc
@@ -1,0 +1,8 @@
+<?php
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+define("MAXSIZE", 100);
+// phpcs:enable
+$defined = true;
+if (defined('MINSIZE') === false) {
+    $defined = false;
+}


### PR DESCRIPTION
As it was, the sniff would respect PHPCS disable annotations, but only when either unqualified or qualified up to a sniff name. It would not respect a disable annotation using a sniffname with errorcode, i.e. `PSR1.Files.SideEffects.FoundWithSymbols`.

While the `FoundWithSymbols` errorcode is the only error code for this sniff and using `// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols` is effectively the same as using `// phpcs:disable PSR1.Files.SideEffects`, I do believe end-users should not need to be aware of whether or not a sniff has multiple error codes when using disable annotations.

This updates the sniff to also respect disable annotations which include the error code.

Includes unit test.

Fixes #3386