### PR TITLE
Standards/AbstractSniffUnitTest: order test files using natural sort

### DIFF
--- a/tests/Standards/AbstractSniffUnitTest.php
+++ b/tests/Standards/AbstractSniffUnitTest.php
@@ -88,7 +88,7 @@ abstract class AbstractSniffUnitTest extends TestCase
         }
 
         // Put them in order.
-        sort($testFiles);
+        sort($testFiles, SORT_NATURAL);
 
         return $testFiles;
 


### PR DESCRIPTION
When a sniff has multiple test case files, the `AbstractSniffUnitTest::getTestFiles()` sorts the file names before passing them off to be run.

While in most cases, the order of the test case files should not really matter, but in rare cases, like when testing that a property is being reset correctly between files, it does.

As things were, the `sort()` function without flags was being used, making the file order unnatural to work with ( file `11` would be run before file `2` - see: https://3v4l.org/VPO3Z ).

As the `SORT_NATURAL` flag is available since PHP 5.4, adding that flag will resolve this and will ensure the test case files are run in their natural order.

Optionally, the flag could be combined with the `SORT_FLAG_CASE` flag to make the sort case-insensitive.