### PR TITLE
Fix case when jshint is not available

### DIFF
--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -52,7 +52,7 @@ class JSHintSniff implements Sniff
     {
         $rhinoPath  = Config::getExecutablePath('rhino');
         $jshintPath = Config::getExecutablePath('jshint');
-        if ($rhinoPath === null && $jshintPath === null) {
+        if ($jshintPath === null) {
             return;
         }
 

--- a/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
+++ b/src/Standards/Generic/Tests/Debug/JSHintUnitTest.php
@@ -25,7 +25,7 @@ class JSHintUnitTest extends AbstractSniffUnitTest
     {
         $rhinoPath  = Config::getExecutablePath('rhino');
         $jshintPath = Config::getExecutablePath('jshint');
-        if ($rhinoPath === null && $jshintPath === null) {
+        if ($jshintPath === null) {
             return true;
         }
 


### PR DESCRIPTION
When I run the test suite on a system where `jshint` is not installed, I get the following error:

```
............................................................. 1159 / 1729 ( 67%)
............................................................. 1220 / 1729 ( 70%)
............................................................. 1281 / 1729 ( 74%)
............................................................. 1342 / 1729 ( 77%)
............................................................. 1403 / 1729 ( 81%)
............................................................. 1464 / 1729 ( 84%)
.........S................................................... 1525 / 1729 ( 88%)
......SSjs: Couldn't read source file "":  (No such file or directory).
F

80 sniff test files generated 242 unique error codes; 126 were fixable (52%)

Time: 2.03 seconds, Memory: 36.00 MB

There was 1 failure:

1) PHP_CodeSniffer\Standards\Generic\Tests\Debug\JSHintUnitTest::testSniff
[LINE 3] Expected 2 warning(s) in JSHintUnitTest.js but found 0 warning(s).

/path/to/repository/squizlabs-php-codesniffer/tests/Standards/AbstractSniffUnitTest.php:206
/path/to/repository/squizlabs-php-codesniffer/tests/TestSuite7.php:28

FAILURES!
Tests: 1534, Assertions: 9422, Failures: 1, Skipped: 3.
```

Note the error (`js: Couldn't read source file "":  (No such file or directory).`) part-way through the test-suite output.
The command being run is `/usr/bin/rhino "" '/path/to/repository/squizlabs-php-codesniffer/src/Standards/Generic/Tests/Debug/JSHintUnitTest.js'`

This pull request fixes this by skipping the test when `jshint` is not available on the system.