### PR TITLE
Squiz/NonExecutableCode: slew of bug fixes, mostly related to modern PHP

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -68,6 +68,11 @@ class NonExecutableCodeSniff implements Sniff
             if (isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true) {
                 return;
             }
+
+            // Expressions are allowed in the `else` clause of ternaries.
+            if ($tokens[$prev]['code'] === T_INLINE_THEN || $tokens[$prev]['code'] === T_INLINE_ELSE) {
+                return;
+            }
         }
 
         // Check if this token is actually part of a one-line IF or ELSE statement.

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -73,6 +73,11 @@ class NonExecutableCodeSniff implements Sniff
             if ($tokens[$prev]['code'] === T_INLINE_THEN || $tokens[$prev]['code'] === T_INLINE_ELSE) {
                 return;
             }
+
+            // Expressions are allowed with PHP 7.0+ null coalesce and PHP 7.4+ null coalesce equals.
+            if ($tokens[$prev]['code'] === T_COALESCE || $tokens[$prev]['code'] === T_COALESCE_EQUAL) {
+                return;
+            }
         }
 
         // Check if this token is actually part of a one-line IF or ELSE statement.

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -63,9 +63,9 @@ class NonExecutableCodeSniff implements Sniff
 
         // Tokens which can be used in inline expressions need special handling.
         if (isset($this->expressionTokens[$tokens[$stackPtr]['code']]) === true) {
-            // If this token is preceded with an "or", it only relates to one line
+            // If this token is preceded by a logical operator, it only relates to one line
             // and should be ignored. For example: fopen() or die().
-            if ($tokens[$prev]['code'] === T_LOGICAL_OR || $tokens[$prev]['code'] === T_BOOLEAN_OR) {
+            if (isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true) {
                 return;
             }
         }

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -78,7 +78,12 @@ class NonExecutableCodeSniff implements Sniff
             if ($tokens[$prev]['code'] === T_COALESCE || $tokens[$prev]['code'] === T_COALESCE_EQUAL) {
                 return;
             }
-        }
+
+            // Expressions are allowed in arrow functions.
+            if ($tokens[$prev]['code'] === T_FN_ARROW) {
+                return;
+            }
+        }//end if
 
         // Check if this token is actually part of a one-line IF or ELSE statement.
         for ($i = ($stackPtr - 1); $i > 0; $i--) {

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -139,7 +139,6 @@ class NonExecutableCodeSniff implements Sniff
         // This token may be part of an inline condition.
         // If we find a closing parenthesis that belongs to a condition
         // we should ignore this token.
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($tokens[$prev]['parenthesis_owner']) === true) {
             $owner  = $tokens[$prev]['parenthesis_owner'];
             $ignore = [

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -297,5 +297,16 @@ class TestAlternativeControlStructures {
 $var_after_class_in_global_space = 1;
 do_something_else();
 
+// These are parse errors, but that's not the concern of the sniff.
+function parseError1() {
+    defined('FOO') or return 'foo';
+    echo 'unreachable';
+}
+
+function parseError2() {
+    defined('FOO') || continue;
+    echo 'unreachable';
+}
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -308,5 +308,20 @@ function parseError2() {
     echo 'unreachable';
 }
 
+// All logical operators are allowed with inline expressions (but this was not correctly handled by the sniff).
+function exitExpressionsWithLogicalOperators() {
+    $condition = false;
+    $condition || exit();
+    $condition or die();
+
+    $condition = true;
+    $condition && die();
+    $condition and exit;
+
+    $condition xor die();
+
+    echo 'still executable as exit, in all of the above cases, is used as part of an expression';
+}
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -348,5 +348,53 @@ function exitExpressionsInArrowFunction() {
     echo 'still executable';
 }
 
+// PHP 8.0+: throw expressions which don't stop execution.
+function nonStoppingThrowExpressions() {
+    $callable = fn() => throw new Exception();
+
+    $value = $myValue ? 'something' : throw new Exception();
+    $value = $myValue ?: throw new Exception();
+    $value = $myValue ? throw new Exception() : 'something';
+
+    $value = $nullableValue ?? throw new Exception();
+    $value ??= throw new Exception();
+
+    $condition && throw new Exception();
+    $condition || throw new Exception();
+    $condition and throw new Exception();
+    $condition or throw new Exception();
+
+    echo 'still executable as throw, in all of the above cases, is used as part of an expression';
+
+    throw new Exception();
+    echo 'non-executable';
+}
+
+// PHP 8.0+: throw expressions which do stop execution.
+function executionStoppingThrowExpressionsA() {
+    $condition xor throw new Exception();
+    echo 'non-executable';
+}
+
+function executionStoppingThrowExpressionsB() {
+    throw $userIsAuthorized ? new ForbiddenException() : new UnauthorizedException();
+    echo 'non-executable';
+}
+
+function executionStoppingThrowExpressionsC() {
+    throw $condition1 && $condition2 ? new Exception1() : new Exception2();
+    echo 'non-executable';
+}
+
+function executionStoppingThrowExpressionsD() {
+    throw $exception ??= new Exception();
+    echo 'non-executable';
+}
+
+function executionStoppingThrowExpressionsE() {
+    throw $maybeNullException ?? new Exception();
+    echo 'non-executable';
+}
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -342,5 +342,11 @@ function exitExpressionsWithNullCoalesce() {
     echo 'still executable';
 }
 
+// Inline expressions are allowed in arrow functions.
+function exitExpressionsInArrowFunction() {
+    $callable = fn() => die();
+    echo 'still executable';
+}
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -335,5 +335,12 @@ function exitExpressionsInTernary() {
     echo 'still executable';
 }
 
+// Inline expressions are allowed with null coalesce and null coalesce equals.
+function exitExpressionsWithNullCoalesce() {
+    $value = $nullableValue ?? exit();
+    $value ??= die();
+    echo 'still executable';
+}
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -323,5 +323,17 @@ function exitExpressionsWithLogicalOperators() {
     echo 'still executable as exit, in all of the above cases, is used as part of an expression';
 }
 
+// Inline expressions are allowed in ternaries.
+function exitExpressionsInTernary() {
+    $value = $myValue ? $myValue : exit();
+    $value = $myValue ?: exit();
+    $value = $var == 'foo' ? 'bar' : die( 'world' );
+
+    $value = (!$myValue ) ? exit() : $myValue;
+    $value = $var != 'foo' ? die( 'world' ) : 'bar';
+
+    echo 'still executable';
+}
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -74,6 +74,8 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 252 => 1,
                 253 => 1,
                 254 => 2,
+                303 => 1,
+                308 => 1,
             ];
             break;
         case 'NonExecutableCodeUnitTest.2.inc':

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -76,6 +76,12 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 254 => 2,
                 303 => 1,
                 308 => 1,
+                370 => 1,
+                376 => 1,
+                381 => 1,
+                386 => 1,
+                391 => 1,
+                396 => 1,
             ];
             break;
         case 'NonExecutableCodeUnitTest.2.inc':


### PR DESCRIPTION
### Squiz/NonExecutableCode: remove redundant line

`$prev` is already defined in exactly the same way on line 66. No need to re-define it.

### Squiz/NonExecutableCode: only ignore inline statements when PHP allows them

Aside from `T_EXIT`, PHP (prior to PHP 8.0) does not allow for the inline use of the other tokens this sniff registers.
While using those tokens inline would result in a parse error, that is not the concern of this sniff.

By ignoring these, the sniff causes false negatives.

This commit makes the sniff more selective and only ignores inline statements for tokens which are allowed in inline statements.

Includes unit test.

### Squiz/NonExecutableCode: bug fix - allow for all logic operators

The sniff, as it was, only allowed for `or` and `||` logical operators before a termination expression, not for `and`, `&&` or `xor`, while PHP allows these too.

See: https://3v4l.org/OWS4n#veol

Fixed now.

Includes unit tests.

### Squiz/NonExecutableCode: bug fix - expressions in ternary

The `T_EXIT` token can be used in ternaries without affecting code after the ternary expression.

See: https://3v4l.org/oMWuA#veol

Fixed now.

Includes unit test.

Fixes #2857

### Squiz/NonExecutableCode: bug fix - expressions after PHP 7.0/7.4 null coalesce (equals)

PHP 7.0 introduced the null coalesce operator.
PHP 7.4 introduced the null coalesce equals operator.

The `T_EXIT` token can be used in combination with those without affecting the code directly following it.

See: https://3v4l.org/C218d#veol

Fixed now.

Includes unit test.

Related to #2857

### Squiz/NonExecutableCode: bug fix - expressions in PHP 7.4 arrow functions

PHP 7.4 introduced arrow functions. The `T_EXIT` token can be used in those without affecting the code following it.

See: https://3v4l.org/gSrt4#veol

Fixed now.

Includes unit test.

### Squiz/NonExecutableCode: bug fix - PHP 8.0 inline throw expressions

PHP 8.0 introduced the ability to use `throw` as an expression instead of as a statement.
Ref: https://wiki.php.net/rfc/throw_expression

When used as an expression, the `throw` does not necessarily affect the code after it.

See: https://3v4l.org/AmMf2

Fixed now.

Includes unit tests.

Fixes #3592