### PR TITLE
Squiz/LowercasePHPFunctions + Generic/ForbiddenFunctions: bug fix for class names in attributes

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -163,6 +163,11 @@ class ForbiddenFunctionsSniff implements Sniff
             return;
         }
 
+        if (empty($tokens[$stackPtr]['nested_attributes']) === false) {
+            // Class instantiation in attribute, not function call.
+            return;
+        }
+
         $function = strtolower($tokens[$stackPtr]['content']);
         $pattern  = null;
 

--- a/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/ForbiddenFunctionsUnitTest.inc
@@ -55,3 +55,6 @@ function mymodule_form_callback(SizeOf $sizeof) {
 }
 
 $size = $class?->sizeof($array);
+
+#[SizeOf(10)]
+function doSomething() {}

--- a/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/LowercasePHPFunctionsSniff.php
@@ -75,6 +75,11 @@ class LowercasePHPFunctionsSniff implements Sniff
         }
 
         // Make sure this is a function call or a use statement.
+        if (empty($tokens[$stackPtr]['nested_attributes']) === false) {
+            // Class instantiation in attribute, not function call.
+            return;
+        }
+
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($next === false) {
             // Not a function call.

--- a/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/DiscouragedFunctionsUnitTest.inc
@@ -2,4 +2,6 @@
 error_log('test');
 print_r($array);
 var_dump($array);
-?>
+
+#[Var_Dump(10)]
+function debugMe() {}

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc
@@ -41,3 +41,10 @@ $callToNamespacedFunction = namespace\STR_REPEAT($a, 2); // Could potentially be
 $filePath = new \File($path);
 
 $count = $object?->Count();
+
+class AttributesShouldBeIgnored
+{
+    #[Putenv('FOO', 'foo')]
+    public function foo(): void
+    {}
+}

--- a/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/PHP/LowercasePHPFunctionsUnitTest.inc.fixed
@@ -41,3 +41,10 @@ $callToNamespacedFunction = namespace\STR_REPEAT($a, 2); // Could potentially be
 $filePath = new \File($path);
 
 $count = $object?->Count();
+
+class AttributesShouldBeIgnored
+{
+    #[Putenv('FOO', 'foo')]
+    public function foo(): void
+    {}
+}


### PR DESCRIPTION
### Squiz/LowercasePHPFunctions: bug fix for class names in attributes

Attributes cannot contain function calls and in most cases, `T_STRING`s in an attribute will be a class name, not a function name.

As things were, `T_STRING`'s in attributes which _looked_ like function calls (but in actual fact are class instantiations) would lead to false positives.

Fixed now by ignoring all code within attributes.

Includes unit test.

Fixes #3778

### Generic/ForbiddenFunctions: bug fix for class names in attributes

Attributes cannot contain function calls and in most cases, `T_STRING`s in an attribute will be a class name, not a function name.

As things were, `T_STRING`'s in attributes which _looked_ like function calls (but in actual fact are class instantiations) would lead to false positives.

Fixed now by ignoring all code within attributes.

Includes unit test.