### PR TITLE
Fix PHP Fatal error in `Squiz.Commenting.FunctionComment`

### DIFF
--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -406,7 +406,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 
             foreach ($typeNames as $typeName) {
                 // Strip nullable operator.
-                if (strlen($typeName) > 1 && $typeName[0] === '?') {
+                if (isset($typeName[0]) === true && $typeName[0] === '?') {
                     $typeName = substr($typeName, 1);
                 }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -406,7 +406,7 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
 
             foreach ($typeNames as $typeName) {
                 // Strip nullable operator.
-                if ($typeName[0] === '?') {
+                if (strlen($typeName) > 1 && $typeName[0] === '?') {
                     $typeName = substr($typeName, 1);
                 }
 

--- a/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php
@@ -405,8 +405,12 @@ class FunctionCommentSniff extends PEARFunctionCommentSniff
             $suggestedTypeNames = [];
 
             foreach ($typeNames as $typeName) {
+                if ($typeName === '') {
+                    continue;
+                }
+
                 // Strip nullable operator.
-                if (isset($typeName[0]) === true && $typeName[0] === '?') {
+                if ($typeName[0] === '?') {
                     $typeName = substr($typeName, 1);
                 }
 

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1046,3 +1046,11 @@ public function ignored() {
  * @return void
  * @throws Exception If any other error occurs. */
 function throwCommentOneLine() {}
+
+/**
+ * When two adjacent pipe symbols are used (by mistake), the sniff should not throw a PHP Fatal error
+ *
+ * @param stdClass||null $object While invalid, this should not throw a PHP Fatal error.
+ * @return void
+ */
+function doublePipeFatalError(?stdClass $object) {}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1046,3 +1046,11 @@ public function ignored() {
  * @return void
  * @throws Exception If any other error occurs. */
 function throwCommentOneLine() {}
+
+/**
+ * When two adjacent pipe symbols are used (by mistake), the sniff should not throw a PHP Fatal error
+ *
+ * @param stdClass||null $object While invalid, this should not throw a PHP Fatal error.
+ * @return void
+ */
+function doublePipeFatalError(?stdClass $object) {}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -1050,7 +1050,7 @@ function throwCommentOneLine() {}
 /**
  * When two adjacent pipe symbols are used (by mistake), the sniff should not throw a PHP Fatal error
  *
- * @param stdClass||null $object While invalid, this should not throw a PHP Fatal error.
+ * @param stdClass|null $object While invalid, this should not throw a PHP Fatal error.
  * @return void
  */
 function doublePipeFatalError(?stdClass $object) {}

--- a/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FunctionCommentUnitTest.php
@@ -116,6 +116,7 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
             1004 => 2,
             1006 => 1,
             1029 => 1,
+            1053 => 1,
         ];
 
         // Scalar type hints only work from PHP 7 onwards.


### PR DESCRIPTION
Today I have seen an invalid `@param` tag in a docblock, and `Squiz.Commenting.FunctionComment` returned a PHP Fatal error while parsing the file. The error was:

```
There was 1 error:

1) PHP_CodeSniffer\Standards\Squiz\Tests\Commenting\FunctionCommentUnitTest::testSniff
Uninitialized string offset 0

/path/to/squizlabs-php-codesniffer/src/Standards/Squiz/Sniffs/Commenting/FunctionCommentSniff.php:413
/path/to/squizlabs-php-codesniffer/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php:152
/path/to/squizlabs-php-codesniffer/src/Files/File.php:498
/path/to/squizlabs-php-codesniffer/src/Files/LocalFile.php:92
/path/to/squizlabs-php-codesniffer/tests/Standards/AbstractSniffUnitTest.php:173
/path/to/squizlabs-php-codesniffer/tests/TestSuite7.php:28
```

I have tracked this down, added a test case to cover this, and fixed the bug.

**Update 2023-06-08**: by fixing the bug with a different technique (as suggested by @jrfnl on a call - thanks!), the sniff now complains about this case correctly and can auto-fix it.