### PR TITLE
PEAR/Squiz/[MultiLine]FunctionDeclaration: allow for PHP 8.1 new in initializers

### DIFF
--- a/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/src/Standards/PEAR/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -496,6 +496,19 @@ class FunctionDeclarationSniff implements Sniff
                 $lastLine = $tokens[$i]['line'];
             }//end if
 
+            if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer']) === true
+            ) {
+                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
+                if ($tokens[$prevNonEmpty]['code'] !== T_USE) {
+                    // Since PHP 8.1, a default value can contain a class instantiation.
+                    // Skip over these "function calls" as they have their own indentation rules.
+                    $i        = $tokens[$i]['parenthesis_closer'];
+                    $lastLine = $tokens[$i]['line'];
+                    continue;
+                }
+            }
+
             if ($tokens[$i]['code'] === T_ARRAY || $tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
                 // Skip arrays as they have their own indentation rules.
                 if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc
@@ -418,3 +418,50 @@ class ConstructorPropertyPromotionMultiLineAttributesIncorrectIndent
         // Do something.
     }
 }
+
+// PHP 8.1: new in initializers means that class instantiations with parameters can occur in a function declaration.
+function usingNewInInitializersCallParamsIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+        new InjectedDependencyA(),
+        new InjectedDependencyB
+    )
+) {}
+
+function usingNewInInitializersCallParamsNotIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+    new InjectedDependencyA,
+    new InjectedDependencyB()
+    )
+) {}
+
+function usingNewInInitializersCallParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+new InjectedDependencyA(), new InjectedDependencyB()
+)
+) {}
+
+class UsingNewInInitializers {
+    public function doSomething(
+        object $paramA,
+        stdClass $paramB = new stdClass(),
+        Exception $paramC = new Exception(
+            new ExceptionMessage(),
+            new ExceptionCode(),
+        ),
+    ) {
+    }
+
+    public function callParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+        Exception $param = new Exception(
+new ExceptionMessage(),
+    new ExceptionCode(),
+  ),
+    ) {
+    }
+}

--- a/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Functions/FunctionDeclarationUnitTest.inc.fixed
@@ -416,3 +416,50 @@ class ConstructorPropertyPromotionMultiLineAttributesIncorrectIndent
         // Do something.
     }
 }
+
+// PHP 8.1: new in initializers means that class instantiations with parameters can occur in a function declaration.
+function usingNewInInitializersCallParamsIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+        new InjectedDependencyA(),
+        new InjectedDependencyB
+    )
+) {}
+
+function usingNewInInitializersCallParamsNotIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+    new InjectedDependencyA,
+    new InjectedDependencyB()
+    )
+) {}
+
+function usingNewInInitializersCallParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+new InjectedDependencyA(), new InjectedDependencyB()
+)
+) {}
+
+class UsingNewInInitializers {
+    public function doSomething(
+        object $paramA,
+        stdClass $paramB = new stdClass(),
+        Exception $paramC = new Exception(
+            new ExceptionMessage(),
+            new ExceptionCode(),
+        ),
+    ) {
+    }
+
+    public function callParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+        Exception $param = new Exception(
+new ExceptionMessage(),
+    new ExceptionCode(),
+  ),
+    ) {
+    }
+}

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc
@@ -255,3 +255,50 @@ private string $private,
     ) {
     }
 }
+
+// PHP 8.1: new in initializers means that class instantiations with parameters can occur in a function declaration.
+function usingNewInInitializersCallParamsIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+        new InjectedDependencyA(),
+        new InjectedDependencyB
+    )
+) {}
+
+function usingNewInInitializersCallParamsNotIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+    new InjectedDependencyA,
+    new InjectedDependencyB()
+    )
+) {}
+
+function usingNewInInitializersCallParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+new InjectedDependencyA(), new InjectedDependencyB()
+)
+) {}
+
+class UsingNewInInitializers {
+    public function doSomething(
+        object $paramA,
+        stdClass $paramB = new stdClass(),
+        Exception $paramC = new Exception(
+            new ExceptionMessage(),
+            new ExceptionCode(),
+        ),
+    ) {
+    }
+
+    public function callParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+        Exception $param = new Exception(
+new ExceptionMessage(),
+    new ExceptionCode(),
+  ),
+    ) {
+    }
+}

--- a/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Functions/MultiLineFunctionDeclarationUnitTest.inc.fixed
@@ -267,3 +267,50 @@ class ConstructorPropertyPromotionMultiLineDocblockAndAttributeIncorrectIndent
     ) {
     }
 }
+
+// PHP 8.1: new in initializers means that class instantiations with parameters can occur in a function declaration.
+function usingNewInInitializersCallParamsIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+        new InjectedDependencyA(),
+        new InjectedDependencyB
+    )
+) {}
+
+function usingNewInInitializersCallParamsNotIndented(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+    new InjectedDependencyA,
+    new InjectedDependencyB()
+    )
+) {}
+
+function usingNewInInitializersCallParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+    int $paramA,
+    string $paramB,
+    object $paramC = new SomeClass(
+new InjectedDependencyA(), new InjectedDependencyB()
+)
+) {}
+
+class UsingNewInInitializers {
+    public function doSomething(
+        object $paramA,
+        stdClass $paramB = new stdClass(),
+        Exception $paramC = new Exception(
+            new ExceptionMessage(),
+            new ExceptionCode(),
+        ),
+    ) {
+    }
+
+    public function callParamsIncorrectlyIndentedShouldNotBeFlaggedNorFixed(
+        Exception $param = new Exception(
+new ExceptionMessage(),
+    new ExceptionCode(),
+  ),
+    ) {
+    }
+}


### PR DESCRIPTION
Since PHP 8.1, `new ClassName()` expressions can be used as the default value of a parameter in a function declaration.

`new ClassName()` expressions should be treated as function _calls_, which have their own indentation rules, so the `PEAR.Functions.FunctionDeclaration` and the `Squiz.Functions.MultiLineFunctionDeclaration` sniffs should skip over these and not attempt to change the indentation of parameters in those function calls.

This commit implements this change.

Includes unit tests.

Refs:
* https://wiki.php.net/rfc/new_in_initializers
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.new-in-initializer
* https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.new

Fixes #3786

---

**Note**:
* I have also verified that the `File::getMethodParameters()` method handles "new in initializers" correctly.
* And based on a cursory code check of the `Squiz.Functions.FunctionDeclaration`, the `Squiz.Functions.FunctionDeclarationArgumentSpacing` and the `PSR2.Methods.MethodDeclaration` sniffs, I don't foresee that those need changes for "new in initializers".