### PR TITLE
PSR12/AnonClassDeclaration: prevent fixer creating parse error

### DIFF
--- a/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Classes/AnonClassDeclarationSniff.php
@@ -97,7 +97,11 @@ class AnonClassDeclarationSniff extends ClassDeclarationSniff
                 $first  = $phpcsFile->findFirstOnLine(T_WHITESPACE, $stackPtr, true);
                 $indent = str_repeat(' ', ($tokens[$first]['column'] - 1));
                 $phpcsFile->fixer->beginChangeset();
-                $phpcsFile->fixer->replaceToken(($prev + 1), '');
+
+                if ($tokens[($prev + 1)]['code'] === \T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken(($prev + 1), '');
+                }
+
                 $phpcsFile->fixer->addNewline($prev);
                 $phpcsFile->fixer->addContentBefore($opener, $indent);
                 $phpcsFile->fixer->endChangeset();

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc
@@ -82,3 +82,9 @@ $foo->bar(
 
 foo(new class {
 });
+
+// Issue #3790: OpenBraceSameLine fixer should not remove open brace.
+$instance = new class() extends SomeClass implements
+    SomeInterface{
+    public function __construct() {}
+};

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.inc.fixed
@@ -84,3 +84,10 @@ $foo->bar(
 
 foo(new class {
 });
+
+// Issue #3790: OpenBraceSameLine fixer should not remove open brace.
+$instance = new class () extends SomeClass implements
+    SomeInterface
+{
+    public function __construct() {}
+};

--- a/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Classes/AnonClassDeclarationUnitTest.php
@@ -48,6 +48,8 @@ class AnonClassDeclarationUnitTest extends AbstractSniffUnitTest
             56 => 2,
             63 => 1,
             75 => 1,
+            87 => 1,
+            88 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
This fix prevents the fixer from removing the opening brace when there is no whitespace between the last character of the name of an interface and the open brace.

With this fix in place, all other symptoms reported are also gone as they were a side-effect of the parse error being created.

Includes unit test.

Fixes #3790