### PR TITLE
Tokenizer/PHP: bug fix for match within ternary

### DIFF
--- a/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -41,6 +41,13 @@ function nonAssignmentTernary() {
     }
 }
 
+// Test for tokenizer issue #3789.
+$a = $b !== null
+    ? match ($c) {
+        default => 5,
+    }
+    : new Foo;
+
 // Intentional parse error. This must be the last test in the file.
 function new
 ?>

--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2249,11 +2249,12 @@ class PHP extends Tokenizer
 
                             if (is_array($tokens[$i]) === false
                                 && ($tokens[$i] === ';'
-                                || $tokens[$i] === '{')
+                                || $tokens[$i] === '{'
+                                || $tokens[$i] === '}')
                             ) {
                                 break;
                             }
-                        }
+                        }//end for
                     }//end if
 
                     if ($isInlineIf === true) {


### PR DESCRIPTION
This fixes the mis-identification of a `T_DEFAULT` token within a (not yet retokenized) `match` structure as a `switch` `default` token, which resulted in a `T_COLON` token incorrectly not being retokenized to `T_INLINE_ELSE`.

As a complete test file for ternary tokenization does not exist (yet), I've added a unit test to the `Squiz.Objects.ObjectInstantiation` sniff. The code in the test would cause a false positive for the `ObjectInstantiation` sniff without this fix.

Fixes #3789