### PR TITLE
Tokenizer/PHP: more context sensitive keyword fixes

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -682,6 +682,36 @@ class PHP extends Tokenizer
             }//end if
 
             /*
+                Special case for `static` used as a function name, i.e. `static()`.
+            */
+
+            if ($tokenIsArray === true
+                && $token[0] === T_STATIC
+                && $finalTokens[$lastNotEmptyToken]['code'] !== T_NEW
+            ) {
+                for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
+                    if (is_array($tokens[$i]) === true
+                        && isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                    ) {
+                        continue;
+                    }
+
+                    if ($tokens[$i][0] === '(') {
+                        $finalTokens[$newStackPtr] = [
+                            'code'    => T_STRING,
+                            'type'    => 'T_STRING',
+                            'content' => $token[1],
+                        ];
+
+                        $newStackPtr++;
+                        continue 2;
+                    }
+
+                    break;
+                }
+            }//end if
+
+            /*
                 Parse doc blocks into something that can be easily iterated over.
             */
 
@@ -2103,38 +2133,60 @@ class PHP extends Tokenizer
                 }
             } else {
                 // Some T_STRING tokens should remain that way due to their context.
-                if ($tokenIsArray === true
-                    && $token[0] === T_STRING
-                    && isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true
-                ) {
-                    // Special case for syntax like: return new self/new parent
-                    // where self/parent should not be a string.
-                    $tokenContentLower = strtolower($token[1]);
-                    if ($finalTokens[$lastNotEmptyToken]['code'] === T_NEW
-                        && ($tokenContentLower === 'self' || $tokenContentLower === 'parent')
-                    ) {
-                        $finalTokens[$newStackPtr] = [
-                            'content' => $token[1],
-                        ];
-                        if ($tokenContentLower === 'self') {
-                            $finalTokens[$newStackPtr]['code'] = T_SELF;
-                            $finalTokens[$newStackPtr]['type'] = 'T_SELF';
-                        }
+                if ($tokenIsArray === true && $token[0] === T_STRING) {
+                    $preserveTstring = false;
 
-                        if ($tokenContentLower === 'parent') {
-                            $finalTokens[$newStackPtr]['code'] = T_PARENT;
-                            $finalTokens[$newStackPtr]['type'] = 'T_PARENT';
+                    if (isset($this->tstringContexts[$finalTokens[$lastNotEmptyToken]['code']]) === true) {
+                        $preserveTstring = true;
+
+                        // Special case for syntax like: return new self/new parent
+                        // where self/parent should not be a string.
+                        $tokenContentLower = strtolower($token[1]);
+                        if ($finalTokens[$lastNotEmptyToken]['code'] === T_NEW
+                            && ($tokenContentLower === 'self' || $tokenContentLower === 'parent')
+                        ) {
+                            $preserveTstring = false;
+                        }
+                    } else if ($finalTokens[$lastNotEmptyToken]['content'] === '&') {
+                        // Function names for functions declared to return by reference.
+                        for ($i = ($lastNotEmptyToken - 1); $i >= 0; $i--) {
+                            if (isset(Util\Tokens::$emptyTokens[$finalTokens[$i]['code']]) === true) {
+                                continue;
+                            }
+
+                            if ($finalTokens[$i]['code'] === T_FUNCTION) {
+                                $preserveTstring = true;
+                            }
+
+                            break;
                         }
                     } else {
+                        // Keywords with special PHPCS token when used as a function call.
+                        for ($i = ($stackPtr + 1); $i < $numTokens; $i++) {
+                            if (is_array($tokens[$i]) === true
+                                && isset(Util\Tokens::$emptyTokens[$tokens[$i][0]]) === true
+                            ) {
+                                continue;
+                            }
+
+                            if ($tokens[$i][0] === '(') {
+                                $preserveTstring = true;
+                            }
+
+                            break;
+                        }
+                    }//end if
+
+                    if ($preserveTstring === true) {
                         $finalTokens[$newStackPtr] = [
-                            'content' => $token[1],
                             'code'    => T_STRING,
                             'type'    => 'T_STRING',
+                            'content' => $token[1],
                         ];
-                    }
 
-                    $newStackPtr++;
-                    continue;
+                        $newStackPtr++;
+                        continue;
+                    }
                 }//end if
 
                 $newToken = null;

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.inc
@@ -78,6 +78,10 @@ class ContextSensitiveKeywords
     const /* testAnd */ AND = 'LOGICAL_AND';
     const /* testOr */ OR = 'LOGICAL_OR';
     const /* testXor */ XOR = 'LOGICAL_XOR';
+
+    const /* testFalse */ FALSE = 'FALSE',
+    const /* testTrue */ TRUE = 'TRUE',
+    const /* testNull */ NULL = 'NULL',
 }
 
 namespace /* testKeywordAfterNamespaceShouldBeString */ class;
@@ -225,3 +229,36 @@ class Foo extends /* testNamespaceInNameIsKeyword */ namespace\Exception
 
 function /* testKeywordAfterFunctionShouldBeString */ eval() {}
 function /* testKeywordAfterFunctionByRefShouldBeString */ &switch() {}
+
+function /* testKeywordSelfAfterFunctionByRefShouldBeString */ &self() {}
+function /* testKeywordStaticAfterFunctionByRefShouldBeString */ &static() {}
+function /* testKeywordParentAfterFunctionByRefShouldBeString */ &parent() {}
+function /* testKeywordFalseAfterFunctionByRefShouldBeString */ &false() {}
+function /* testKeywordTrueAfterFunctionByRefShouldBeString */ & true () {}
+function /* testKeywordNullAfterFunctionByRefShouldBeString */ &NULL() {}
+
+/* testKeywordAsFunctionCallNameShouldBeStringSelf */ self();
+/* testKeywordAsFunctionCallNameShouldBeStringStatic */ static();
+$obj-> /* testKeywordAsMethodCallNameShouldBeStringStatic */ static();
+/* testKeywordAsFunctionCallNameShouldBeStringParent */ parent();
+/* testKeywordAsFunctionCallNameShouldBeStringFalse */ false();
+/* testKeywordAsFunctionCallNameShouldBeStringTrue */ True ();
+/* testKeywordAsFunctionCallNameShouldBeStringNull */ null /*comment*/ ();
+
+$instantiated4 = new /* testClassInstantiationFalseIsString */ False();
+$instantiated5 = new /* testClassInstantiationTrueIsString */ true ();
+$instantiated6 = new /* testClassInstantiationNullIsString */ null();
+
+$function = /* testStaticIsKeywordBeforeClosure */ static function(/* testStaticIsKeywordWhenParamType */ static $param) {};
+$arrow = /* testStaticIsKeywordBeforeArrow */ static fn(): /* testStaticIsKeywordWhenReturnType */ static => 10;
+
+function standAloneFalseTrueNullTypesAndMore(
+    /* testFalseIsKeywordAsParamType */ false $paramA,
+    /* testTrueIsKeywordAsParamType */ true $paramB,
+    /* testNullIsKeywordAsParamType */ null $paramC,
+) /* testFalseIsKeywordAsReturnType */ false | /* testTrueIsKeywordAsReturnType */ true | /* testNullIsKeywordAsReturnType */ null {
+    if ($a === /* testFalseIsKeywordInComparison */ false
+    || $a === /* testTrueIsKeywordInComparison */ true
+    || $a === /* testNullIsKeywordInComparison */ null
+    ) {}
+}

--- a/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
+++ b/tests/Core/Tokenizer/ContextSensitiveKeywordsTest.php
@@ -30,7 +30,7 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
     {
         $tokens = self::$phpcsFile->getTokens();
 
-        $token = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING]));
+        $token = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_STRING, T_NULL, T_FALSE, T_TRUE, T_PARENT, T_SELF]));
 
         $this->assertSame(T_STRING, $tokens[$token]['code']);
         $this->assertSame('T_STRING', $tokens[$token]['type']);
@@ -120,6 +120,9 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
             ['/* testAnd */'],
             ['/* testOr */'],
             ['/* testXor */'],
+            ['/* testFalse */'],
+            ['/* testTrue */'],
+            ['/* testNull */'],
 
             ['/* testKeywordAfterNamespaceShouldBeString */'],
             ['/* testNamespaceNameIsString1 */'],
@@ -128,6 +131,24 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
 
             ['/* testKeywordAfterFunctionShouldBeString */'],
             ['/* testKeywordAfterFunctionByRefShouldBeString */'],
+            ['/* testKeywordSelfAfterFunctionByRefShouldBeString */'],
+            ['/* testKeywordStaticAfterFunctionByRefShouldBeString */'],
+            ['/* testKeywordParentAfterFunctionByRefShouldBeString */'],
+            ['/* testKeywordFalseAfterFunctionByRefShouldBeString */'],
+            ['/* testKeywordTrueAfterFunctionByRefShouldBeString */'],
+            ['/* testKeywordNullAfterFunctionByRefShouldBeString */'],
+
+            ['/* testKeywordAsFunctionCallNameShouldBeStringSelf */'],
+            ['/* testKeywordAsFunctionCallNameShouldBeStringStatic */'],
+            ['/* testKeywordAsMethodCallNameShouldBeStringStatic */'],
+            ['/* testKeywordAsFunctionCallNameShouldBeStringParent */'],
+            ['/* testKeywordAsFunctionCallNameShouldBeStringFalse */'],
+            ['/* testKeywordAsFunctionCallNameShouldBeStringTrue */'],
+            ['/* testKeywordAsFunctionCallNameShouldBeStringNull */'],
+
+            ['/* testClassInstantiationFalseIsString */'],
+            ['/* testClassInstantiationTrueIsString */'],
+            ['/* testClassInstantiationNullIsString */'],
         ];
 
     }//end dataStrings()
@@ -148,7 +169,10 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
     {
         $tokens = self::$phpcsFile->getTokens();
 
-        $token = $this->getTargetToken($testMarker, (Tokens::$contextSensitiveKeywords + [T_ANON_CLASS, T_MATCH_DEFAULT, T_PARENT, T_SELF, T_STRING]));
+        $token = $this->getTargetToken(
+            $testMarker,
+            (Tokens::$contextSensitiveKeywords + [T_ANON_CLASS, T_MATCH_DEFAULT, T_PARENT, T_SELF, T_STRING, T_NULL, T_FALSE, T_TRUE])
+        );
 
         $this->assertSame(constant($expectedTokenType), $tokens[$token]['code']);
         $this->assertSame($expectedTokenType, $tokens[$token]['type']);
@@ -500,6 +524,60 @@ class ContextSensitiveKeywordsTest extends AbstractMethodUnitTest
             [
                 '/* testNamespaceInNameIsKeyword */',
                 'T_NAMESPACE',
+            ],
+
+            [
+                '/* testStaticIsKeywordBeforeClosure */',
+                'T_STATIC',
+            ],
+            [
+                '/* testStaticIsKeywordWhenParamType */',
+                'T_STATIC',
+            ],
+            [
+                '/* testStaticIsKeywordBeforeArrow */',
+                'T_STATIC',
+            ],
+            [
+                '/* testStaticIsKeywordWhenReturnType */',
+                'T_STATIC',
+            ],
+
+            [
+                '/* testFalseIsKeywordAsParamType */',
+                'T_FALSE',
+            ],
+            [
+                '/* testTrueIsKeywordAsParamType */',
+                'T_TRUE',
+            ],
+            [
+                '/* testNullIsKeywordAsParamType */',
+                'T_NULL',
+            ],
+            [
+                '/* testFalseIsKeywordAsReturnType */',
+                'T_FALSE',
+            ],
+            [
+                '/* testTrueIsKeywordAsReturnType */',
+                'T_TRUE',
+            ],
+            [
+                '/* testNullIsKeywordAsReturnType */',
+                'T_NULL',
+            ],
+            [
+                '/* testFalseIsKeywordInComparison */',
+                'T_FALSE',
+            ],
+            [
+                '/* testTrueIsKeywordInComparison */',
+                'T_TRUE',
+            ],
+            [
+                '/* testNullIsKeywordInComparison */',
+                'T_NULL',
             ],
         ];
 


### PR DESCRIPTION
PHPCS re-tokenizes the `self`, `parent`, `true`, `false` and `null` keywords to a PHPCS native token.

This re-tokenization did not take the following situations into account:
* Those keywords being used as function names when the function is declared to return by reference.
* Those keywords being used as a function call.

Additionally, the PHP native `T_STATIC` token would not be (re-)tokenized to `T_STRING` when used as a function call, though it was tokenized correctly when used as a method call. While using the `static` keyword for a global function declaration is illegal in PHP, the tokenization in PHPCS should still be consistent.

This commit fixes those issues.

Includes additional unit tests.

These issues were discovered while investigating issue PHPCompatibility/PHPCompatibility#1489