### PR TITLE
File::getMethodParameters(): allow for readonly promoted properties without visibility

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -1309,10 +1309,12 @@ class File
      *         'default_equal_token' => integer, // The stack pointer to the equals sign.
      *
      * Parameters declared using PHP 8 constructor property promotion, have these additional array indexes:
-     *         'property_visibility' => string,  // The property visibility as declared.
-     *         'visibility_token'    => integer, // The stack pointer to the visibility modifier token.
-     *         'property_readonly'   => bool,    // TRUE if the readonly keyword was found.
-     *         'readonly_token'      => integer, // The stack pointer to the readonly modifier token.
+     *         'property_visibility' => string,        // The property visibility as declared.
+     *         'visibility_token'    => integer|false, // The stack pointer to the visibility modifier token
+     *                                                 // or FALSE if the visibility is not explicitly declared.
+     *         'property_readonly'   => boolean,       // TRUE if the readonly keyword was found.
+     *         'readonly_token'      => integer,       // The stack pointer to the readonly modifier token.
+     *                                                 // This index will only be set if the property is readonly.
      *
      * @param int $stackPtr The position in the stack of the function token
      *                      to acquire the parameters for.
@@ -1530,15 +1532,20 @@ class File
                 $vars[$paramCount]['type_hint_end_token'] = $typeHintEndToken;
                 $vars[$paramCount]['nullable_type']       = $nullableType;
 
-                if ($visibilityToken !== null) {
-                    $vars[$paramCount]['property_visibility'] = $this->tokens[$visibilityToken]['content'];
-                    $vars[$paramCount]['visibility_token']    = $visibilityToken;
+                if ($visibilityToken !== null || $readonlyToken !== null) {
+                    $vars[$paramCount]['property_visibility'] = 'public';
+                    $vars[$paramCount]['visibility_token']    = false;
                     $vars[$paramCount]['property_readonly']   = false;
-                }
 
-                if ($readonlyToken !== null) {
-                    $vars[$paramCount]['property_readonly'] = true;
-                    $vars[$paramCount]['readonly_token']    = $readonlyToken;
+                    if ($visibilityToken !== null) {
+                        $vars[$paramCount]['property_visibility'] = $this->tokens[$visibilityToken]['content'];
+                        $vars[$paramCount]['visibility_token']    = $visibilityToken;
+                    }
+
+                    if ($readonlyToken !== null) {
+                        $vars[$paramCount]['property_readonly'] = true;
+                        $vars[$paramCount]['readonly_token']    = $readonlyToken;
+                    }
                 }
 
                 if ($this->tokens[$i]['code'] === T_COMMA) {

--- a/tests/Core/File/GetMethodParametersTest.inc
+++ b/tests/Core/File/GetMethodParametersTest.inc
@@ -113,6 +113,11 @@ class ConstructorPropertyPromotionWithReadOnly {
     public function __construct(public readonly ?int $promotedProp, readonly private string|bool &$promotedToo) {}
 }
 
+class ConstructorPropertyPromotionWithOnlyReadOnly {
+    /* testPHP81ConstructorPropertyPromotionWithOnlyReadOnly */
+    public function __construct(readonly Foo&Bar $promotedProp, readonly ?bool $promotedToo,) {}
+}
+
 /* testPHP8ConstructorPropertyPromotionGlobalFunction */
 // Intentional fatal error. Property promotion not allowed in non-constructor, but that's not the concern of this method.
 function globalFunction(private $x) {}

--- a/tests/Core/File/GetMethodParametersTest.php
+++ b/tests/Core/File/GetMethodParametersTest.php
@@ -847,6 +847,43 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
 
 
     /**
+     * Verify recognition of PHP8 constructor with property promotion using PHP 8.1 readonly
+     * keyword without explicit visibility.
+     *
+     * @return void
+     */
+    public function testPHP81ConstructorPropertyPromotionWithOnlyReadOnly()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'                => '$promotedProp',
+            'content'             => 'readonly Foo&Bar $promotedProp',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => 'Foo&Bar',
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+            'property_readonly'   => true,
+        ];
+        $expected[1] = [
+            'name'                => '$promotedToo',
+            'content'             => 'readonly ?bool $promotedToo',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'variable_length'     => false,
+            'type_hint'           => '?bool',
+            'nullable_type'       => true,
+            'property_visibility' => 'public',
+            'property_readonly'   => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPHP81ConstructorPropertyPromotionWithOnlyReadOnly()
+
+
+    /**
      * Verify behaviour when a non-constructor function uses PHP 8 property promotion syntax.
      *
      * @return void


### PR DESCRIPTION
Follow up on PR #3516 which was included in PHPCS 3.7.0.

Turns out that constructor property promotion also allows for declaring properties with the `readonly` keyword, but without explicit visibility set. See: https://3v4l.org/nli62

Readonly properties without explicit visibility are already handled correctly in the `File::getMemberProperties()` method, but were not handled correctly in the `File::getMethodParameters()` method.

Fixed now.

Includes updated documentation and a unit test.