### PR TITLE
Generic/FunctionCallArgumentSpacing: prevent fixer conflict over PHP 7.3+ trailing comma's in function calls

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/FunctionCallArgumentSpacingSniff.php
@@ -156,10 +156,13 @@ class FunctionCallArgumentSpacingSniff implements Sniff
                 }//end if
 
                 if ($tokens[($nextSeparator + 1)]['code'] !== T_WHITESPACE) {
-                    $error = 'No space found after comma in argument list';
-                    $fix   = $phpcsFile->addFixableError($error, $nextSeparator, 'NoSpaceAfterComma');
-                    if ($fix === true) {
-                        $phpcsFile->fixer->addContent($nextSeparator, ' ');
+                    // Ignore trailing comma's after last argument as that's outside the scope of this sniff.
+                    if (($nextSeparator + 1) !== $closeBracket) {
+                        $error = 'No space found after comma in argument list';
+                        $fix   = $phpcsFile->addFixableError($error, $nextSeparator, 'NoSpaceAfterComma');
+                        if ($fix === true) {
+                            $phpcsFile->fixer->addContent($nextSeparator, ' ');
+                        }
                     }
                 } else {
                     // If there is a newline in the space, then they must be formatting

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc
@@ -162,3 +162,13 @@ class Testing extends Bar
         $a = new parent($foo ,$bar);
     }
 }
+
+// Ignore spacing after PHP 7.3+ trailing comma in single-line function calls to prevent fixer conflicts.
+// This is something which should be decided by a sniff dealing with the function call parentheses.
+$foo = new MyClass($obj, 'getMethod',);
+$foo = new MyClass($obj, 'getMethod', );
+$foo = new MyClass($obj, 'getMethod',       );
+$foo = new MyClass(
+    $obj,
+    'getMethod',
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.inc.fixed
@@ -162,3 +162,13 @@ class Testing extends Bar
         $a = new parent($foo, $bar);
     }
 }
+
+// Ignore spacing after PHP 7.3+ trailing comma in single-line function calls to prevent fixer conflicts.
+// This is something which should be decided by a sniff dealing with the function call parentheses.
+$foo = new MyClass($obj, 'getMethod',);
+$foo = new MyClass($obj, 'getMethod', );
+$foo = new MyClass($obj, 'getMethod', );
+$foo = new MyClass(
+    $obj,
+    'getMethod',
+);

--- a/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/FunctionCallArgumentSpacingUnitTest.php
@@ -55,6 +55,7 @@ class FunctionCallArgumentSpacingUnitTest extends AbstractSniffUnitTest
             154 => 2,
             155 => 1,
             162 => 2,
+            170 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
Reported via Mastodon by @WyriHaximus: https://phpc.social/@wyri@haxim.us/110224066521542315

As of PHP 7.3, trailing comma's in function calls are allowed.

This sniff should leave those alone to prevent fixer conflicts with sniffs dealing with the spacing around the parentheses of a function call, like the `PEAR.Functions.FunctionCallSignature` sniff, which this sniff is often combined with.

While the sniff did take trailing comma's into account for multi-line function calls, it did not handle them correctly for single-line function calls.

Note: too _much_ space can still be removed, but space should be added.

Fixed now.

Includes tests.