### PR TITLE
Fix gitblame to not use full path when `chdir`

### DIFF
--- a/src/Reports/Gitblame.php
+++ b/src/Reports/Gitblame.php
@@ -70,7 +70,7 @@ class Gitblame extends VersionControl
         $cwd = getcwd();
 
         chdir(dirname($filename));
-        $command = 'git blame --date=short "'.$filename.'" 2>&1';
+        $command = 'git blame --date=short "'.basename($filename).'" 2>&1';
         $handle  = popen($command, 'r');
         if ($handle === false) {
             $error = 'ERROR: Could not execute "'.$command.'"'.PHP_EOL.PHP_EOL;


### PR DESCRIPTION
When invoking with `--report=gitblame` most or all of the found sniffs do not show up with their author to blame. Instead the report table is empty.

The problem is the following:
In #1249 `chdir` was introduces to change into a directory to resolve the `.git` direcotry more easily when the `phpcs` command is not started from a proper Git directory. But now `GitBlame.php` requests the full path file, but from within the directory of that file.

I'm not sure what happened since #1249 that `--report=gitblame` won't work, but it seemed to work that time and I did not dig deeper. Anyway I'm sure it works now, tested it on my repos locally.

If you want I can attach a more detailed issue.