### PR TITLE
PSR12/FileHeader: bug fix - false positives on PHP 8.2+ readonly classes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1233,6 +1233,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="FileHeaderUnitTest.15.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileHeaderUnitTest.16.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileHeaderUnitTest.17.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FileHeaderUnitTest.18.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileHeaderUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ImportStatementUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="ImportStatementUnitTest.inc.fixed" role="test" />

--- a/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/FileHeaderSniff.php
@@ -188,6 +188,7 @@ class FileHeaderSniff implements Sniff
 
                 if (isset($commentOpeners[$tokens[$docToken]['code']]) === false
                     && isset(Tokens::$methodPrefixes[$tokens[$docToken]['code']]) === false
+                    && $tokens[$docToken]['code'] !== T_READONLY
                 ) {
                     // Check for an @var annotation.
                     $annotation = false;

--- a/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.18.inc
+++ b/src/Standards/PSR12/Tests/Files/FileHeaderUnitTest.18.inc
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test;
+
+/**
+ * Sniff should recognize the PHP 8.2 `readonly` keyword as an OO prefix. 
+ */
+readonly class Example
+{
+    public function test() : void
+    {
+        echo '123';
+    }
+}


### PR DESCRIPTION
As reported in https://github.com/squizlabs/PHP_CodeSniffer/issues/3799#issuecomment-1532870980, the `FileHeader` sniff did not take the new PHP 8.2+ `readonly` OO modifier keyword into account.

Fixed now.

Includes test.