### PR TITLE
Update BackfillNumericSeparatorTest.php

### DIFF
--- a/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
+++ b/tests/Core/Tokenizer/BackfillNumericSeparatorTest.php
@@ -57,7 +57,7 @@ class BackfillNumericSeparatorTest extends AbstractMethodUnitTest
         }
 
         $testIntMoreThanMaxType = 'T_LNUMBER';
-        if (PHP_INT_MAX < 10223372036854775807) {
+        if (PHP_INT_MAX < 9223372036854775807) {
             $testIntMoreThanMaxType = 'T_DNUMBER';
         }
 


### PR DESCRIPTION
I am using a symfony 6 project with php 8.1.13.
The limit of an int is 9223372036854775807.

VS Code was giving me the following error:
The integer number 10223372036854775807 is too big, converting to double insteadPHP(PHP0009)

Why did you write 10 instead of 9?