### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+<!-- Provide a general summary of your changes in the title above. -->
+
+<!--
+Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
+-->
+
+## Description
+<!--
+What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
+Describe your changes in detail and, if relevant, explain which choices you have made and why.
+-->
+
+
+### Suggested changelog entry
+<!-- Please provide a short description of the change for the changelog. -->
+
+
+### Related issues/external references
+
+Fixes #
+
+
+## Types of changes
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix _(non-breaking change which fixes an issue)_
+- [ ] New feature _(non-breaking change which adds functionality)_
+- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
+    - [ ] This change is only breaking for integrators, not for external standards or end-users.
+- [ ] Documentation improvement
+
+
+## PR checklist
+<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] I have checked there is no other PR open for the same change.
+- [ ] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
+- [ ] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
+- [ ] I have added tests to cover my changes.
+- [ ] I have verified that the code complies with the projects coding standards.
+- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
+- [ ] [Required for new files] I have added any new files to the `package.xml` file.
+
+<!--
+============================================================================================
+Please make sure your pull request passes all continuous integration checks!
+
+PRs which are failing their CI checks will likely be ignored by the maintainers.
+
+PRs using atomic, descriptive commits are hugely appreciated as it will make
+reviewing your changes easier for the maintainers.
+============================================================================================
+-->


### PR DESCRIPTION
This pull requests template has been set up to attempt to gather all information needed by the maintainers to evaluate the PR.

It also is intended to act as a reminder for contributors to make sure the PR is complete and ready for review.