### PR TITLE
Bug report template: add notice about external standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,10 +2,21 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'Status: triage', 'Type: bug'
 assignees: ''
 
 ---
+
+<!--
+Before reporting a sniff related bug, please check the error code using `phpcs -s`.
+
+If the error code starts with anything other than `Generic`, `MySource`, `PEAR`,
+`PSR1`, `PSR2`, `PSR12`, `Squiz` or `Zend`, the error is likely coming from an
+external PHP_CodeSniffer standard.
+
+Please report bugs for externally maintained sniffs to the appropriate external
+standard repository (not here).
+-->
 
 **Describe the bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
... in hopes of reducing the number of issues which are incorrectly reported to this repo.

Includes automating the assignment of initial issue labels.