### PR TITLE
PHP 8.2 | Support readonly classes in 11 sniffs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1077,6 +1077,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.2.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.3.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.4.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.php" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FunctionCommentUnitTest.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FunctionCommentUnitTest.inc.fixed" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -1719,6 +1719,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.7.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.8.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.9.inc" role="test" />
+        <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.10.inc" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.js" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.1.js.fixed" role="test" />
         <file baseinstalldir="PHP/CodeSniffer" name="FileCommentUnitTest.2.js" role="test" />

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
@@ -24,7 +24,6 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Util\Tokens;
 
 class UnnecessaryFinalModifierSniff implements Sniff
 {
@@ -56,16 +55,13 @@ class UnnecessaryFinalModifierSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];
 
-        // Skip for-statements without body.
+        // Skip for statements without body.
         if (isset($token['scope_opener']) === false) {
             return;
         }
 
-        // Fetch previous token.
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-
-        // Skip for non final class.
-        if ($prev === false || $tokens[$prev]['code'] !== T_FINAL) {
+        if ($phpcsFile->getClassProperties($stackPtr)['is_final'] === false) {
+            // This class is not final so we don't need to check it.
             return;
         }
 

--- a/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
+++ b/src/Standards/Generic/Sniffs/CodeAnalysis/UnnecessaryFinalModifierSniff.php
@@ -73,6 +73,13 @@ class UnnecessaryFinalModifierSniff implements Sniff
                 $error = 'Unnecessary FINAL modifier in FINAL class';
                 $phpcsFile->addWarning($error, $next, 'Found');
             }
+
+            // Skip over the contents of functions as those can't contain the `final` keyword anyway.
+            if ($tokens[$next]['code'] === T_FUNCTION
+                && isset($tokens[$next]['scope_closer']) === true
+            ) {
+                $next = $tokens[$next]['scope_closer'];
+            }
         }
 
     }//end process()

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.inc
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.inc
@@ -27,3 +27,8 @@ final class Bar_Foo {
     protected function foo() {}
     private function Bar() {}
 }
+
+final readonly class Foo_Bar {
+    public final function fooBar() {}
+    final protected function fool() {}
+}

--- a/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
+++ b/src/Standards/Generic/Tests/CodeAnalysis/UnnecessaryFinalModifierUnitTest.php
@@ -45,6 +45,8 @@ class UnnecessaryFinalModifierUnitTest extends AbstractSniffUnitTest
             12 => 1,
             15 => 1,
             18 => 1,
+            32 => 1,
+            33 => 1,
         ];
 
     }//end getWarningList()

--- a/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/ClassCommentSniff.php
@@ -10,7 +10,6 @@
 namespace PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 
 class ClassCommentSniff extends FileCommentSniff
 {
@@ -48,8 +47,12 @@ class ClassCommentSniff extends FileCommentSniff
         $type      = strtolower($tokens[$stackPtr]['content']);
         $errorData = [$type];
 
-        $find = Tokens::$methodPrefixes;
-        $find[T_WHITESPACE] = T_WHITESPACE;
+        $find = [
+            T_ABSTRACT   => T_ABSTRACT,
+            T_FINAL      => T_FINAL,
+            T_READONLY   => T_READONLY,
+            T_WHITESPACE => T_WHITESPACE,
+        ];
 
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
             if (isset($find[$tokens[$commentEnd]['code']]) === true) {

--- a/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FileCommentSniff.php
@@ -170,6 +170,7 @@ class FileCommentSniff implements Sniff
             T_FINAL,
             T_STATIC,
             T_ABSTRACT,
+            T_READONLY,
             T_CONST,
             T_PROPERTY,
         ];

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.inc
@@ -143,3 +143,21 @@ enum Empty_Enum_Doc
 class TodoController extends AbstractController implements MustBeLoggedInInterface
 {
 }
+
+/**
+ * Docblock
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+abstract readonly class AbstractReadonlyWithDocblock {}
+
+/*
+ * Docblock
+ */
+readonly class ReadonlyWrongStyle {}
+
+readonly final class ReadonlyFinalWithoutDocblock {}

--- a/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/ClassCommentUnitTest.php
@@ -45,6 +45,8 @@ class ClassCommentUnitTest extends AbstractSniffUnitTest
             106 => 5,
             116 => 5,
             126 => 5,
+            161 => 1,
+            163 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.4.inc
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.4.inc
@@ -1,0 +1,7 @@
+<?php
+/**
+ * This should not be recognized as a file comment, but as a class comment.
+ */
+
+readonly class Foo {
+}

--- a/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FileCommentUnitTest.php
@@ -48,9 +48,8 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
             ];
 
         case 'FileCommentUnitTest.2.inc':
-            return [1 => 1];
-
         case 'FileCommentUnitTest.3.inc':
+        case 'FileCommentUnitTest.4.inc':
             return [1 => 1];
 
         default:

--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -71,7 +71,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                 $blankSpace = substr($prevContent, strpos($prevContent, $phpcsFile->eolChar));
                 $spaces     = strlen($blankSpace);
 
-                if (in_array($tokens[($stackPtr - 2)]['code'], [T_ABSTRACT, T_FINAL], true) === true
+                if (in_array($tokens[($stackPtr - 2)]['code'], [T_ABSTRACT, T_FINAL, T_READONLY], true) === true
                     && $spaces !== 1
                 ) {
                     $prevContent = strtolower($tokens[($stackPtr - 2)]['content']);
@@ -89,6 +89,7 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
                 }
             } else if ($tokens[($stackPtr - 2)]['code'] === T_ABSTRACT
                 || $tokens[($stackPtr - 2)]['code'] === T_FINAL
+                || $tokens[($stackPtr - 2)]['code'] === T_READONLY
             ) {
                 $prevContent = strtolower($tokens[($stackPtr - 2)]['content']);
                 $error       = 'Expected 1 space between %s and %s keywords; newline found';

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -239,3 +239,12 @@ C8
 
 foo(new class {
 });
+
+readonly
+class Test
+{
+}
+
+readonly    class Test
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -232,3 +232,11 @@ class C8
 
 foo(new class {
 });
+
+readonly class Test
+{
+}
+
+readonly class Test
+{
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -63,6 +63,8 @@ class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             216 => 1,
             231 => 2,
             235 => 1,
+            244 => 1,
+            248 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/ClassDeclarationSniff.php
@@ -65,6 +65,7 @@ class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
 
                 if ($tokens[($stackPtr - 2)]['code'] !== T_ABSTRACT
                     && $tokens[($stackPtr - 2)]['code'] !== T_FINAL
+                    && $tokens[($stackPtr - 2)]['code'] !== T_READONLY
                 ) {
                     if ($spaces !== 0) {
                         $type  = strtolower($tokens[$stackPtr]['content']);

--- a/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
+++ b/src/Standards/Squiz/Sniffs/Classes/LowercaseClassKeywordsSniff.php
@@ -29,6 +29,7 @@ class LowercaseClassKeywordsSniff implements Sniff
         $targets[] = T_IMPLEMENTS;
         $targets[] = T_ABSTRACT;
         $targets[] = T_FINAL;
+        $targets[] = T_READONLY;
         $targets[] = T_VAR;
         $targets[] = T_CONST;
 

--- a/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/ClassCommentSniff.php
@@ -19,7 +19,6 @@ namespace PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Util\Tokens;
 
 class ClassCommentSniff implements Sniff
 {
@@ -49,8 +48,12 @@ class ClassCommentSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        $find   = Tokens::$methodPrefixes;
-        $find[T_WHITESPACE] = T_WHITESPACE;
+        $find   = [
+            T_ABSTRACT   => T_ABSTRACT,
+            T_FINAL      => T_FINAL,
+            T_READONLY   => T_READONLY,
+            T_WHITESPACE => T_WHITESPACE,
+        ];
 
         $previousContent = null;
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {

--- a/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/FileCommentSniff.php
@@ -104,6 +104,7 @@ class FileCommentSniff implements Sniff
             T_FINAL,
             T_STATIC,
             T_ABSTRACT,
+            T_READONLY,
             T_CONST,
             T_PROPERTY,
             T_INCLUDE,

--- a/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/InlineCommentSniff.php
@@ -83,6 +83,7 @@ class InlineCommentSniff implements Sniff
                 T_FINAL,
                 T_STATIC,
                 T_ABSTRACT,
+                T_READONLY,
                 T_CONST,
                 T_PROPERTY,
                 T_INCLUDE,

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -119,3 +119,12 @@ class IncorrectCodeBeforeClosingBrace
 {
 
 echo phpinfo();}
+
+readonly
+class Test
+{
+}
+
+readonly    class Test
+{
+}

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -130,3 +130,11 @@ class IncorrectCodeBeforeClosingBrace
 
 echo phpinfo();
 }
+
+readonly class Test
+{
+}
+
+readonly class Test
+{
+}

--- a/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/ClassDeclarationUnitTest.php
@@ -61,6 +61,8 @@ class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             116 => 1,
             118 => 1,
             121 => 1,
+            124 => 2,
+            128 => 2,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc
@@ -5,7 +5,7 @@ Interface MyInterface {}
 Trait MyTrait {}
 Enum MyEnum IMPLEMENTS Colorful {}
 
-class MyClass
+ReadOnly class MyClass
 {
     Var $myVar = null;
     Const myConst = true;

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.inc.fixed
@@ -5,7 +5,7 @@ interface MyInterface {}
 trait MyTrait {}
 enum MyEnum implements Colorful {}
 
-class MyClass
+readonly class MyClass
 {
     var $myVar = null;
     const myConst = true;

--- a/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
+++ b/src/Standards/Squiz/Tests/Classes/LowercaseClassKeywordsUnitTest.php
@@ -31,6 +31,7 @@ class LowercaseClassKeywordsUnitTest extends AbstractSniffUnitTest
             4  => 1,
             5  => 1,
             6  => 2,
+            8  => 1,
             10 => 1,
             11 => 1,
             14 => 1,

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.inc
@@ -131,3 +131,15 @@ class Space_At_end
 class AllGood
 {
 }
+
+/**
+ * Docblock
+ */
+abstract readonly class AbstractReadonlyWithDocblock {}
+
+/*
+ * Docblock
+ */
+readonly class ReadonlyWrongStyle {}
+
+readonly final class ReadonlyFinalWithoutDocblock {}

--- a/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/ClassCommentUnitTest.php
@@ -26,10 +26,12 @@ class ClassCommentUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            2  => 1,
-            15 => 1,
-            31 => 1,
-            54 => 1,
+            2   => 1,
+            15  => 1,
+            31  => 1,
+            54  => 1,
+            143 => 1,
+            145 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc
@@ -31,7 +31,7 @@ class MyClass
  * Some info about the class here
   *
 */
-class MyClass
+readonly class MyClass
 {
     /**
      * Some info about the function here.

--- a/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/DocCommentAlignmentUnitTest.inc.fixed
@@ -31,7 +31,7 @@ class MyClass
  * Some info about the class here
  *
  */
-class MyClass
+readonly class MyClass
 {
     /**
      * Some info about the function here.

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.10.inc
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.10.inc
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This should not be recognized as a file comment, but as a class comment.
+ *
+ * @package    Package
+ * @subpackage Subpackage
+ * @author     Squiz Pty Ltd <products@squiz.net>
+ * @copyright  2010-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ */
+
+readonly class Foo {
+}

--- a/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
+++ b/src/Standards/Squiz/Tests/Commenting/FileCommentUnitTest.php
@@ -46,6 +46,7 @@ class FileCommentUnitTest extends AbstractSniffUnitTest
         case 'FileCommentUnitTest.6.inc':
         case 'FileCommentUnitTest.7.inc':
         case 'FileCommentUnitTest.9.inc':
+        case 'FileCommentUnitTest.10.inc':
             return [1 => 1];
 
         case 'FileCommentUnitTest.5.inc':

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc
@@ -173,6 +173,19 @@ enum MyEnum {
 
 }
 
+/**
+ * Comment should be ignored.
+ *
+ */
+readonly class MyClass
+{
+    /**
+     * Comment should be ignored.
+     *
+     */
+    readonly $property = 10;
+}
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace

--- a/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
+++ b/src/Standards/Squiz/Tests/Commenting/InlineCommentUnitTest.inc.fixed
@@ -166,6 +166,19 @@ enum MyEnum {
 
 }
 
+/**
+ * Comment should be ignored.
+ *
+ */
+readonly class MyClass
+{
+    /**
+     * Comment should be ignored.
+     *
+     */
+    readonly $property = 10;
+}
+
 /*
  * N.B.: The below test line must be the last test in the file.
  * Testing that a new line after an inline comment when it's the last non-whitespace


### PR DESCRIPTION
## Description

Follow up after PR #3686

### PHP 8.2 | Generic/UnnecessaryFinalModifier: allow for readonly classes

Includes unit test.

### Generic/UnnecessaryFinalModifier: make the sniff more efficient

No need to token walk the contents of functions as the `final` keyword cannot be used in them anyway.

### PHP 8.2 | PEAR/ClassComment: allow for readonly classes

Includes improving the accuracy of the tokens to skip over.

Includes unit test.

### PHP 8.2 | PEAR/FileComment: allow for readonly classes

Includes unit test.

### PHP 8.2 | PSR2/ClassDeclaration: allow for readonly classes

Includes unit test.

### PHP 8.2 | Squiz/ClassDeclaration: allow for readonly classes

Includes unit test.

### PHP 8.2 | Squiz/LowercaseClassKeywords: add support for readonly classes/properties

Includes unit test.

Ref:
* https://wiki.php.net/rfc/readonly_properties_v2
* https://wiki.php.net/rfc/readonly_classes

### PHP 8.2 | Squiz/ClassComment: allow for readonly classes

Includes improving the accuracy of the tokens to skip over.

Includes unit test.

### PHP 8.2 | Squiz/DocCommentAlignment: add test for readonly classes

Adjust existing unit test to confirm this is already handled correctly.

### PHP 8.2 | Squiz/FileComment: allow for readonly classes

Includes unit test.

### PHP 8.1/8.2 | Squiz/InlineComment: allow for readonly classes and properties

Includes unit test.


### Suggested changelog entry

Support for `readonly` classes has been added to the following sniffs:
... list of the above named sniffs ....


### Related issues/external references

Ref:
* https://wiki.php.net/rfc/readonly_properties_v2
* https://wiki.php.net/rfc/readonly_classes


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

