### PR TITLE
Add `security.md` file

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+The latest patch version of the `3.x` release series is supported for security updates.
+
+## Reporting a Vulnerability
+
+PHP_CodeSniffer is a developer tool and should generally not be used in a production (web accessible) environment.
+
+Having said that, responsible disclosure of security issues is highly appreciated.
+
+**Please do not report or discuss security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Issues can be reported privately to the maintainers by opening a [Security vulnerability report](https://github.com/squizlabs/PHP_CodeSniffer/security/advisories/new).
+
+### Preferences
+
+* Please provide detailed reports with reproducible steps and a clearly defined impact.
+* Include the version number of the vulnerable package in your report.
+* Fixes are most welcome.
+    A private PR can be created from the security report to work on and discuss the patch.


### PR DESCRIPTION
## Description

Add a `security.md` file containing information about how to report security issues and what versions of PHP_CodeSniffer are supported from a security point of view.

The file is placed in the `.github` directory. This will allow for it to be recognized correctly by GitHub, while not cluttering up the project root directory.

### Suggested changelog entry
_N/A_


### Related issues/external references

Ref: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository


## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement

