### PR TITLE
Generic/LowerCaseType: fix potential PHP notice

### DIFF
--- a/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
+++ b/src/Standards/Generic/Sniffs/PHP/LowerCaseTypeSniff.php
@@ -97,6 +97,11 @@ class LowerCaseTypeSniff implements Sniff
                 return;
             }
 
+            if (empty($props) === true) {
+                // Parse error - property in interface or enum. Ignore.
+                return;
+            }
+
             // Strip off potential nullable indication.
             $type = ltrim($props['type'], '?');
 

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc
@@ -92,3 +92,8 @@ function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class
 
 $arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : int => $a * $b;
 $arrow = fn (Int $a, String $b, BOOL $c, Array $d, Foo\Bar $e) : Float => $a * $b;
+
+// Intentional error, should be ignored by the sniff.
+interface PropertiesNotAllowed {
+    public $notAllowed;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.inc.fixed
@@ -92,3 +92,8 @@ function intersectionReturnTypes ($var): \Package\ClassName&\Package\Other_Class
 
 $arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : int => $a * $b;
 $arrow = fn (int $a, string $b, bool $c, array $d, Foo\Bar $e) : float => $a * $b;
+
+// Intentional error, should be ignored by the sniff.
+interface PropertiesNotAllowed {
+    public $notAllowed;
+}

--- a/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/LowerCaseTypeUnitTest.php
@@ -82,7 +82,8 @@ class LowerCaseTypeUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-        return [];
+        // Warning from getMemberProperties() about parse error.
+        return [98 => 1];
 
     }//end getWarningList()
 


### PR DESCRIPTION
## Description
The `Generic.PHP.LowerCaseType` sniff calls the `File::getMemberProperties()` method to get information about potential properties.

That method throws an exception when the `T_VARIABLE` token passed is not a property, but will create an `Internal.ParseError.InterfaceHasMemberVar` warning and return an empty array when the `T_VARIABLE` passed is an _illegal_ property, i.e. a property in a context in which it is not allowed (interface/enum).

As things were, the sniff did not take a potential return value of an empty array into account, which could result in an `Undefined array key "type"` PHP notice.

Fixed now.

Includes unit test.

### Suggested changelog entry
Generic.PHP.LowerCaseType: fixed potential undefined array index notice


### Related issues/external references

N/A


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


