### PR TITLE
Reduce width of table in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,13 +48,13 @@ A clear and concise description of what you expected to happen.
 
 ## Versions (please complete the following information)
 
-|                         |                                                                              |
-|-------------------------|------------------------------------------------------------------------------|
-| Operating System        | [e.g., Windows 10, MacOS 10.15]                                              |
-| PHP version             | [e.g., 7.2, 7.4]                                                             |
-| PHP_CodeSniffer version | [e.g., 3.5.5, master]                                                        |
-| Standard                | [e.g., PSR2, PSR12, Squiz, custom]                                           |
-| Install type            | [e.g. Composer (global/local), PHAR, PEAR, git clone, other (please expand)] |
+| | |
+|-|-|
+| Operating System | [e.g., Windows 10, MacOS 10.15]
+| PHP version | [e.g., 7.2, 7.4]
+| PHP_CodeSniffer version | [e.g., 3.5.5, master]
+| Standard | [e.g., PSR2, PSR12, Squiz, custom]
+| Install type | [e.g. Composer (global/local), PHAR, PEAR, git clone, other (please expand)]
 
 ## Additional context
 Add any other context about the problem here.


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/squizlabs/PHP_CodeSniffer/pull/3829 based on the conversation therein following that being merged.

While the table looks good in a mono-spaced font, the input field on the new issue form in GitHub uses a variable width font, so the table doesn't line up nicely there. Having less white-space (and the lack of trailing pipe) should mean the information is easier to supply, and still displays nicely when rendered as Markdown.

### Suggested changelog entry
_None required_

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement

## PR checklist
- [ ] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.