### PR TITLE
Correct link in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@ Fixes #
 ## PR checklist
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [ ] I have checked there is no other PR open for the same change.
-- [ ] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
+- [ ] I have read the [Contribution Guidelines](https://github.com/squizlabs/PHP_CodeSniffer/blob/HEAD/CONTRIBUTING.md).
 - [ ] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
 - [ ] I have added tests to cover my changes.
 - [ ] I have verified that the code complies with the projects coding standards.


### PR DESCRIPTION
## Description
The link in the pull request template currently goes to https://github.com/squizlabs/PHP_CodeSniffer/compare/.github/CONTRIBUTING.md while creating a pull request, and https://github.com/squizlabs/PHP_CodeSniffer/pull/.github/CONTRIBUTING.md (which redirects to the first) afterwards. We could change the link to `../blob/HEAD/CONTRIBUTING.md` (or `../blob/master/CONTRIBUTING.md`) if we want to keep it relative; feel free to adjust this pull request if that's preferred.

Note too that the URL will need to be updated if https://github.com/squizlabs/PHP_CodeSniffer/pull/3830 gets merged before this, or as part of https://github.com/squizlabs/PHP_CodeSniffer/pull/3830 if this gets merged before that.

### Suggested changelog entry
_None required_

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement

## PR checklist
- [ ] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.