### PR TITLE
Allow array unpacking in ArrayDeclaration multiline Sniff

### DIFF
--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -430,9 +430,22 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 if ($keyUsed === true && $tokens[$lastToken]['code'] === T_COMMA) {
-                    $error = 'No key specified for array entry; first entry specifies key';
-                    $phpcsFile->addError($error, $nextToken, 'NoKeySpecified');
-                    return;
+                    $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($lastToken + 1), null, true);
+
+                    /*
+                        Allow array unpacking
+
+                        $x = [
+                          'foo' => 'bar',
+                          ...$baz,
+                        ];
+                    */
+
+                    if ($tokens[$nextToken]['code'] !== T_ELLIPSIS) {
+                        $error = 'No key specified for array entry; first entry specifies key';
+                        $phpcsFile->addError($error, $nextToken, 'NoKeySpecified');
+                        return;
+                    }
                 }
 
                 if ($keyUsed === false) {

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -474,7 +474,7 @@ class ArrayDeclarationSniff implements Sniff
                         true
                     );
 
-                    $indices[]  = ['value' => $valueContent];
+                    $indices[]          = ['value' => $valueContent];
                     $usesArrayUnpacking = $phpcsFile->findPrevious(
                         Tokens::$emptyTokens,
                         ($nextToken - 2),

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -475,7 +475,16 @@ class ArrayDeclarationSniff implements Sniff
                     );
 
                     $indices[]  = ['value' => $valueContent];
-                    $singleUsed = true;
+                    $usesArrayUnpacking = $phpcsFile->findPrevious(
+                        Tokens::$emptyTokens,
+                        ($nextToken - 2),
+                        null,
+                        true
+                    );
+                    if ($tokens[$usesArrayUnpacking]['code'] !== T_ELLIPSIS) {
+                        // Don't decide if an array is key => value indexed or not when PHP 7.4+ array unpacking is used.
+                        $singleUsed = true;
+                    }
                 }//end if
 
                 $lastToken = $nextToken;

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -431,16 +431,7 @@ class ArrayDeclarationSniff implements Sniff
 
                 if ($keyUsed === true && $tokens[$lastToken]['code'] === T_COMMA) {
                     $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($lastToken + 1), null, true);
-
-                    /*
-                        Allow array unpacking
-
-                        $x = [
-                          'foo' => 'bar',
-                          ...$baz,
-                        ];
-                    */
-
+                    // Allow for PHP 7.4+ array unpacking within an array declaration.
                     if ($tokens[$nextToken]['code'] !== T_ELLIPSIS) {
                         $error = 'No key specified for array entry; first entry specifies key';
                         $phpcsFile->addError($error, $nextToken, 'NoKeySpecified');

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
@@ -487,7 +487,7 @@ $a = array(
       'a' =>
      );
 
-// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+// Safeguard correct errors for key/no key when PHP 7.4+ array unpacking is encountered.
 $x = array(
     ...$a,
       'foo' => 'bar',

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
@@ -475,12 +475,12 @@ yield array(
        static fn () : string => '',
       );
 
-$foo = [
+$foo = array(
         'foo' => match ($anything) {
             'foo' => 'bar',
             default => null,
         },
-       ];
+       );
 
 // Intentional syntax error.
 $a = array(

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
@@ -503,3 +503,29 @@ $x = array(
     ...$a,
       'baz' => 'bar',
      );
+
+$x = array(
+    ...$a,
+    'foo' => 'bar', // OK.
+    'bar', // NoKeySpecified Error (based on second entry).
+     );
+
+$x = array(
+    ...$a,
+    'bar', // OK.
+    'foo' => 'bar', // KeySpecified Error (based on second entry).
+     );
+
+$x = array(
+    'foo' => 'bar',
+    ...$a,
+    'baz' => 'bar',
+    'bar', // NoKeySpecified Error (based on first entry).
+     );
+
+$x = array(
+    'bar',
+    ...$a,
+    'bar',
+    'baz' => 'bar', // KeySpecified (based on first entry).
+     );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
@@ -486,3 +486,20 @@ $foo = [
 $a = array(
       'a' =>
      );
+
+// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+$x = array(
+    ...$a,
+      'foo' => 'bar',
+     );
+
+$x = array(
+      'foo' => 'bar',
+    ...$a,
+     );
+
+$x = array(
+      'foo' => 'bar',
+    ...$a,
+      'baz' => 'bar',
+     );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
@@ -523,7 +523,7 @@ $a = array(
       'a' =>
      );
 
-// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+// Safeguard correct errors for key/no key when PHP 7.4+ array unpacking is encountered.
 $x = array(
     ...$a,
       'foo' => 'bar',
@@ -538,4 +538,30 @@ $x = array(
       'foo' => 'bar',
     ...$a,
       'baz' => 'bar',
+     );
+
+$x = array(
+    ...$a,
+    'foo' => 'bar', // OK.
+    'bar', // NoKeySpecified Error (based on second entry).
+     );
+
+$x = array(
+    ...$a,
+    'bar', // OK.
+    'foo' => 'bar', // KeySpecified Error (based on second entry).
+     );
+
+$x = array(
+    'foo' => 'bar',
+    ...$a,
+    'baz' => 'bar',
+    'bar', // NoKeySpecified Error (based on first entry).
+     );
+
+$x = array(
+    'bar',
+    ...$a,
+    'bar',
+    'baz' => 'bar', // KeySpecified (based on first entry).
      );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
@@ -522,3 +522,20 @@ $foo = [
 $a = array(
       'a' =>
      );
+
+// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+$x = array(
+    ...$a,
+      'foo' => 'bar',
+     );
+
+$x = array(
+      'foo' => 'bar',
+    ...$a,
+     );
+
+$x = array(
+      'foo' => 'bar',
+    ...$a,
+      'baz' => 'bar',
+     );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
@@ -511,12 +511,12 @@ yield array(
        static fn () : string => '',
       );
 
-$foo = [
+$foo = array(
         'foo' => match ($anything) {
             'foo' => 'bar',
             default => null,
         },
-       ];
+       );
 
 // Intentional syntax error.
 $a = array(

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -476,7 +476,7 @@ $a = [
       'a' =>
      ];
 
-// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+// Safeguard correct errors for key/no key when PHP 7.4+ array unpacking is encountered.
 $x = [
     ...$a,
       'foo' => 'bar',

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -464,6 +464,13 @@ yield [
        static fn () : string => '',
       ];
 
+$foo = [
+        'foo' => match ($anything) {
+            'foo' => 'bar',
+            default => null,
+        },
+       ];
+
 // Intentional syntax error.
 $a = [
       'a' =>
@@ -484,4 +491,30 @@ $x = [
       'foo' => 'bar',
     ...$a,
       'baz' => 'bar',
+     ];
+
+$x = [
+    ...$a,
+    'foo' => 'bar', // OK.
+    'bar', // NoKeySpecified Error (based on second entry).
+     ];
+
+$x = [
+    ...$a,
+    'bar', // OK.
+    'foo' => 'bar', // KeySpecified Error (based on second entry).
+     ];
+
+$x = [
+    'foo' => 'bar',
+    ...$a,
+    'baz' => 'bar',
+    'bar', // NoKeySpecified Error (based on first entry).
+     ];
+
+$x = [
+    'bar',
+    ...$a,
+    'bar',
+    'baz' => 'bar', // KeySpecified (based on first entry).
      ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -468,3 +468,9 @@ yield [
 $a = [
       'a' =>
      ];
+
+// Ensure absence of NoKeySpecified error for array unpacking
+$x = [
+      'foo' => 'bar',
+    ...$a,
+     ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -469,8 +469,19 @@ $a = [
       'a' =>
      ];
 
-// Ensure absence of NoKeySpecified error for array unpacking
+// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+$x = [
+    ...$a,
+      'foo' => 'bar',
+     ];
+
 $x = [
       'foo' => 'bar',
     ...$a,
+     ];
+
+$x = [
+      'foo' => 'bar',
+    ...$a,
+      'baz' => 'bar',
      ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -498,6 +498,13 @@ yield [
        static fn () : string => '',
       ];
 
+$foo = [
+        'foo' => match ($anything) {
+            'foo' => 'bar',
+            default => null,
+        },
+       ];
+
 // Intentional syntax error.
 $a = [
       'a' =>
@@ -518,4 +525,30 @@ $x = [
       'foo' => 'bar',
     ...$a,
       'baz' => 'bar',
+     ];
+
+$x = [
+    ...$a,
+    'foo' => 'bar', // OK.
+    'bar', // NoKeySpecified Error (based on second entry).
+     ];
+
+$x = [
+    ...$a,
+    'bar', // OK.
+    'foo' => 'bar', // KeySpecified Error (based on second entry).
+     ];
+
+$x = [
+    'foo' => 'bar',
+    ...$a,
+    'baz' => 'bar',
+    'bar', // NoKeySpecified Error (based on first entry).
+     ];
+
+$x = [
+    'bar',
+    ...$a,
+    'bar',
+    'baz' => 'bar', // KeySpecified (based on first entry).
      ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -503,8 +503,19 @@ $a = [
       'a' =>
      ];
 
-// Ensure absence of NoKeySpecified error for array unpacking
+// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+$x = [
+    ...$a,
+      'foo' => 'bar',
+     ];
+
 $x = [
       'foo' => 'bar',
     ...$a,
+     ];
+
+$x = [
+      'foo' => 'bar',
+    ...$a,
+      'baz' => 'bar',
      ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -502,3 +502,9 @@ yield [
 $a = [
       'a' =>
      ];
+
+// Ensure absence of NoKeySpecified error for array unpacking
+$x = [
+      'foo' => 'bar',
+    ...$a,
+     ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -510,7 +510,7 @@ $a = [
       'a' =>
      ];
 
-// Ensure absence of NoKeySpecified error for PHP 7.4+ array unpacking.
+// Safeguard correct errors for key/no key when PHP 7.4+ array unpacking is encountered.
 $x = [
     ...$a,
       'foo' => 'bar',

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -124,6 +124,10 @@ class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 467 => 1,
                 471 => 1,
                 472 => 1,
+                510 => 1,
+                516 => 1,
+                523 => 1,
+                530 => 1,
             ];
         case 'ArrayDeclarationUnitTest.2.inc':
             return [

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -210,6 +210,10 @@ class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 456 => 1,
                 460 => 1,
                 461 => 1,
+                499 => 1,
+                505 => 1,
+                512 => 1,
+                519 => 1,
             ];
         default:
             return [];


### PR DESCRIPTION
See #3557

## Description

`Squiz.Arrays.ArrayDeclaration.NoKeySpecified` doesn't accept the following snippet:

```php
$x = [
  'foo' => 'bar',
  ...$baz,
];
```

It triggers an error as phpcs doesn't detect that the second entry is array unpacking.

```
Key specified for array entry; first entry has no key (Squiz.Arrays.ArrayDeclaration.KeySpecified)
``` 

The following (single line) array validates:

```php
$x = ['foo' => 'bar',  ...$baz];
```

### Suggested changelog entry

`Squiz.Arrays.ArrayDeclaration.KeySpecified`: Allow array unpacking (`...$array`) in multi-line key-value array definitions.

### Related issues/external references

Fixes #3557

## Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
  - I did not. I'd be happy to, if you give me a pointer on how I can do this without breaking earlier PHP versions, given it's new syntax.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.

## Notes:

The one test failure for PHP 8.2 seems unrelated as it was already present in https://github.com/squizlabs/PHP_CodeSniffer/commit/2e59060b93b3720ff3aab2b57efda0c3ada069b0 
