### PR TITLE
PSR2/ClassDeclaration: bug fix - blank line fixer also removes indent

### DIFF
--- a/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/src/Standards/PSR2/Sniffs/Classes/ClassDeclarationSniff.php
@@ -492,12 +492,12 @@ class ClassDeclarationSniff extends PEARClassDeclarationSniff
 
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
-                for ($i = ($prevContent + 1); $i < $closeBrace; $i++) {
+                for ($i = ($prevContent + 1); $tokens[$i]['line'] !== $tokens[$closeBrace]['line']; $i++) {
                     $phpcsFile->fixer->replaceToken($i, '');
                 }
 
                 if (strpos($tokens[$prevContent]['content'], $phpcsFile->eolChar) === false) {
-                    $phpcsFile->fixer->replaceToken($closeBrace, $phpcsFile->eolChar.$tokens[$closeBrace]['content']);
+                    $phpcsFile->fixer->addNewline($prevContent);
                 }
 
                 $phpcsFile->fixer->endChangeset();

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc
@@ -248,3 +248,12 @@ class Test
 readonly    class Test
 {
 }
+
+if (!class_exists('IndentedDeclaration')) {
+    class IndentedDeclaration
+    {
+        function foo() {}
+
+
+    }
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.inc.fixed
@@ -240,3 +240,10 @@ readonly class Test
 readonly class Test
 {
 }
+
+if (!class_exists('IndentedDeclaration')) {
+    class IndentedDeclaration
+    {
+        function foo() {}
+    }
+}

--- a/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
+++ b/src/Standards/PSR2/Tests/Classes/ClassDeclarationUnitTest.php
@@ -65,6 +65,7 @@ class ClassDeclarationUnitTest extends AbstractSniffUnitTest
             235 => 1,
             244 => 1,
             248 => 1,
+            258 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description
The `PSR2.Classes.ClassDeclaration.CloseBraceAfterBody` related logic checks that there is no blank line between the last content within the class and the close brace.

The fixer for this error code, however, does not take indented class declarations into account and inadvertently also removes (correct) indentation.

Fixed now. Includes unit test.

### Suggested changelog entry
The `PSR2.Classes.ClassDeclaration.CloseBraceAfterBody` fixer will no longer remove potential indentation before the close brace.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
