### PR TITLE
Suppress deprecation notices about return types

### DIFF
--- a/src/Filters/ExactMatch.php
+++ b/src/Filters/ExactMatch.php
@@ -12,6 +12,7 @@
 namespace PHP_CodeSniffer\Filters;
 
 use PHP_CodeSniffer\Util;
+use ReturnTypeWillChange;
 
 abstract class ExactMatch extends Filter
 {
@@ -40,6 +41,7 @@ abstract class ExactMatch extends Filter
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function accept()
     {
         if (parent::accept() === false) {
@@ -79,6 +81,7 @@ abstract class ExactMatch extends Filter
      *
      * @return \RecursiveIterator
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         $children            = parent::getChildren();


### PR DESCRIPTION
## Description

While working on another pull request in this repository, I noticed that `phpstan` was complaining about an unrelated problem to the pull request at hand. I've investigated this further and found that #3400 solves the same problem as here for another class. This can be considered a follow-up to that pull request.

## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.
