### PR TITLE
Gitblame: fix fatal error on `chdir()` when `basepath` is set and phpcs is run from subdir

### DIFF
--- a/src/Reports/VersionControl.php
+++ b/src/Reports/VersionControl.php
@@ -40,7 +40,7 @@ abstract class VersionControl implements Report
      */
     public function generateFileReport($report, File $phpcsFile, $showSources=false, $width=80)
     {
-        $blames = $this->getBlameContent($report['filename']);
+        $blames = $this->getBlameContent($phpcsFile->getFilename());
 
         $authorCache = [];
         $praiseCache = [];


### PR DESCRIPTION
## Description

The `Reporter::prepareFileReport()` method strips the `basepath` off the file name for the `$report['filename']`.

https://github.com/squizlabs/PHP_CodeSniffer/blob/276f68cc74a3e4e1855bab6d01f0089337d00ae0/src/Reporter.php#L337

While this is fine in most cases, for "blame" reports, the full path is needed.

This changes the path passed to the `getBlameContent()` method in subclasses of the `VersionControl` class to the full path, which fixes the fatal error for the `Gitblame` report (and probably similar/related errors in the `Hgblame` and the `Svnblame` reports, but I don't have any repos to test this on).


### Suggested changelog entry

Fixed bug #3854 : Fatal error when using Gitblame report in combination with basepath and running from project subdirectory


### Related issues/external references

Fixes #3854

Loosely related to #3809


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

