### PR TITLE
PSR12.Traits.UseDeclaration: check spacing after use keyword for multi-line statements + fix typo

### DIFF
--- a/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
+++ b/src/Standards/PSR12/Sniffs/Traits/UseDeclarationSniff.php
@@ -655,7 +655,7 @@ class UseDeclarationSniff implements Sniff
         $error = 'Expected 1 space after USE in trait import statement; %s found';
         if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
             $data = ['0'];
-            $fix  = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterAs', $data);
+            $fix  = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterUse', $data);
             if ($fix === true) {
                 $phpcsFile->fixer->addContent($stackPtr, ' ');
             }
@@ -668,7 +668,7 @@ class UseDeclarationSniff implements Sniff
             }
 
             $data = [$found];
-            $fix  = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterAs', $data);
+            $fix  = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterUse', $data);
             if ($fix === true) {
                 if ($found === 'newline') {
                     $phpcsFile->fixer->beginChangeset();

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.inc
@@ -54,7 +54,7 @@ class ClassName7
 
 class ClassName8
 {
-    use A ,  B,
+    use   A ,  B,
     C
     {
 

--- a/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
+++ b/src/Standards/PSR12/Tests/Traits/UseDeclarationUnitTest.php
@@ -30,7 +30,7 @@ class UseDeclarationUnitTest extends AbstractSniffUnitTest
             29  => 2,
             30  => 1,
             42  => 1,
-            57  => 3,
+            57  => 4,
             59  => 3,
             61  => 1,
             63  => 5,


### PR DESCRIPTION
## Description

### PSR12.Traits.UseDeclaration: fix typo in error code

The `processUseStatement()` method checking single-line trait `use` statements checks the spacing after the `use` keyword, but the error did not have the correct error code.

### PSR12.Traits.UseDeclaration: check spacing after use keyword for multi-line statements

While the `processUseStatement()` method checking single-line trait `use` statements would check the spacing after the `use` keyword, the `processUseGroup()` method checking multi-line trait `use` statements did not execute that same check, while the rule applies to both single- as well as multi-line `use` statements.

By moving the check for the spacing after the `use` keyword to the `process()` method, it will now be executed for both situations.

Tested by adjusting a pre-existing test.


### Suggested changelog entry
* PSR12.Traits.UseDeclaration will now report on issues with spacing after the `use` keyword using the `SpaceAfterUse` errorcode.
* PSR12.Traits.UseDeclaration will now report on issues with spacing after the `use` keyword for multi-line trait `use` statements.



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

