### PR TITLE
PHP 8.3 | Generic/ScopeIndent: bug fix - missing defensive coding

### DIFF
--- a/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -1090,8 +1090,11 @@ class ScopeIndentSniff implements Sniff
             if ($tokens[$i]['code'] === T_CONSTANT_ENCAPSED_STRING
                 || $tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING
             ) {
-                $i = $phpcsFile->findNext($tokens[$i]['code'], ($i + 1), null, true);
-                $i--;
+                $nextNonTextString = $phpcsFile->findNext($tokens[$i]['code'], ($i + 1), null, true);
+                if ($nextNonTextString !== false) {
+                    $i = ($nextNonTextString - 1);
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
## Description
As of PHP 8.3, PHP will throw a `Warning: Decrement on type bool has no effect, this will change in the next major version of PHP` notice.

A test run with PHP 8.3 showed this deprecation notice being thrown in the `Generic.WhiteSpace.ScopeIndent` sniff.

Investigation of the notice showed that this was actually a bug due to too little defensive coding.

The sniff tries to skip over multi-line/multi-token text strings, but the `findNext()` will return `false` for a single-line/single-token text string, which would lead to `$i` being reset to `0`.

This commit fixes this by only changing `$i` when the return from the call to `findNext()` is not `false`.

Ref: https://wiki.php.net/rfc/saner-inc-dec-operators

Note: I've not added any extra tests as this issue was discovered via the pre-existing tests, so is already covered.


### Suggested changelog entry
Generic.WhiteSpace.ScopeIndent: bug fix preventing a deprecation notice on PHP 8.3


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
