### PR TITLE
PHP 8.3 | ReportWidthTest: fix deprecation notices for ReflectionProperty::setValue()

### DIFF
--- a/tests/Core/Config/ReportWidthTest.php
+++ b/tests/Core/Config/ReportWidthTest.php
@@ -295,7 +295,7 @@ class ReportWidthTest extends TestCase
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
         $property->setAccessible(true);
-        $property->setValue($value);
+        $property->setValue(null, $value);
         $property->setAccessible(false);
 
     }//end setStaticProperty()


### PR DESCRIPTION
## Description
The `ReflectionProperty::setValue()` method supports three method signatures, two of which are deprecated as of PHP 8.3.

This adjusts the call to `ReflectionProperty::setValue()` in the `Core/Config/ReportWidthTest` to pass `null` as the "object" for setting the value of a static property to make the method call cross-version compatible.

Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue

### Suggested changelog entry
_N/A_ test only change


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

