### PR TITLE
Tokenizer/PHP: bug fix for static typed properties with union/intersection types

### DIFF
--- a/src/Tokenizers/PHP.php
+++ b/src/Tokenizers/PHP.php
@@ -2916,6 +2916,10 @@ class PHP extends Tokenizer
                     continue;
                 }
 
+                if ($suspectedType === 'property or parameter') {
+                    unset($allowed[\T_STATIC]);
+                }
+
                 $typeTokenCount = 0;
                 $typeOperators  = [$i];
                 $confirmed      = false;
@@ -2948,6 +2952,7 @@ class PHP extends Tokenizer
                     if ($suspectedType === 'property or parameter'
                         && (isset(Util\Tokens::$scopeModifiers[$this->tokens[$x]['code']]) === true
                         || $this->tokens[$x]['code'] === T_VAR
+                        || $this->tokens[$x]['code'] === T_STATIC
                         || $this->tokens[$x]['code'] === T_READONLY)
                     ) {
                         // This will also confirm constructor property promotion parameters, but that's fine.

--- a/tests/Core/File/GetMemberPropertiesTest.inc
+++ b/tests/Core/File/GetMemberPropertiesTest.inc
@@ -210,7 +210,8 @@ $anon = class() {
 
     /* testPHP8UnionTypesIllegalTypes */
     // Intentional fatal error - types which are not allowed for properties, but that's not the concern of the method.
-    public callable|static|void $unionTypesIllegalTypes;
+    // Note: static is also not allowed as a type, but using static for a property type is not supported by the tokenizer.
+    public callable|void $unionTypesIllegalTypes;
 
     /* testPHP8UnionTypesNullable */
     // Intentional fatal error - nullability is not allowed with union types, but that's not the concern of the method.

--- a/tests/Core/File/GetMemberPropertiesTest.php
+++ b/tests/Core/File/GetMemberPropertiesTest.php
@@ -584,8 +584,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
                     'scope_specified' => true,
                     'is_static'       => false,
                     'is_readonly'     => false,
-                    // Missing static, but that's OK as not an allowed syntax.
-                    'type'            => 'callable||void',
+                    'type'            => 'callable|void',
                     'nullable_type'   => false,
                 ],
             ],

--- a/tests/Core/Tokenizer/BitwiseOrTest.inc
+++ b/tests/Core/Tokenizer/BitwiseOrTest.inc
@@ -48,6 +48,9 @@ class TypeUnion
     /* testTypeUnionPropertyWithOnlyReadOnlyKeyword */
     readonly string|null $nullableString;
 
+    /* testTypeUnionPropertyWithOnlyStaticKeyword */
+    static Foo|Bar $obj;
+
     public function paramTypes(
         /* testTypeUnionParam1 */
         int|float $paramA /* testBitwiseOrParamDefaultValue */ = CONSTANT_A | CONSTANT_B,

--- a/tests/Core/Tokenizer/BitwiseOrTest.php
+++ b/tests/Core/Tokenizer/BitwiseOrTest.php
@@ -110,6 +110,7 @@ class BitwiseOrTest extends AbstractMethodUnitTest
             ['/* testTypeUnionPropertyWithStaticAndReadOnlyKeywords */'],
             ['/* testTypeUnionPropertyWithVarAndReadOnlyKeywords */'],
             ['/* testTypeUnionPropertyWithOnlyReadOnlyKeyword */'],
+            ['/* testTypeUnionPropertyWithOnlyStaticKeyword */'],
             ['/* testTypeUnionParam1 */'],
             ['/* testTypeUnionParam2 */'],
             ['/* testTypeUnionParam3 */'],

--- a/tests/Core/Tokenizer/TypeIntersectionTest.inc
+++ b/tests/Core/Tokenizer/TypeIntersectionTest.inc
@@ -36,6 +36,9 @@ class TypeIntersection
     /* testTypeIntersectionPropertyWithReadOnlyKeyword */
     protected readonly Foo&Bar $fooBar;
 
+    /* testTypeIntersectionPropertyWithStaticKeyword */
+    static Foo&Bar $obj;
+
     public function paramTypes(
         /* testTypeIntersectionParam1 */
         Foo&Bar $paramA /* testBitwiseAndParamDefaultValue */ = CONSTANT_A & CONSTANT_B,

--- a/tests/Core/Tokenizer/TypeIntersectionTest.php
+++ b/tests/Core/Tokenizer/TypeIntersectionTest.php
@@ -109,6 +109,7 @@ class TypeIntersectionTest extends AbstractMethodUnitTest
             ['/* testTypeIntersectionPropertyPartiallyQualified */'],
             ['/* testTypeIntersectionPropertyFullyQualified */'],
             ['/* testTypeIntersectionPropertyWithReadOnlyKeyword */'],
+            ['/* testTypeIntersectionPropertyWithStaticKeyword */'],
             ['/* testTypeIntersectionParam1 */'],
             ['/* testTypeIntersectionParam2 */'],
             ['/* testTypeIntersectionParam3 */'],


### PR DESCRIPTION
## Description
Just like the `var` keyword, the `static` keyword can also be used stand-alone with property declarations. https://3v4l.org/sbaDM

In that case, the tokenization of the `|` operator was not changed to `T_TYPE_UNION` and the `&` operator was not changed to `T_TYPE_INTERSECTION` as the `static` keyword can also be used in return type declarations, so was seen as part of the type declaration.

Fixed now by removing the `T_STATIC` token from the `$allowed` list before walking backwards from the operator.

Includes tests.

Note: this does mean that one test for the `File::getMemberProperties()` method needs to be changed, but as that was testing an illegal syntax anyway, I'm not concerned about making this change.

### Suggested changelog entry
Tokenizer/PHP: union type and intersection type operators were not correctly tokenized as such for static typed properties without explicit visibility.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


