### PR TITLE
Ruleset::explain(): use natural sorting

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -238,7 +238,7 @@ class Ruleset
     public function explain()
     {
         $sniffs = array_keys($this->sniffCodes);
-        sort($sniffs);
+        sort($sniffs, (SORT_NATURAL | SORT_FLAG_CASE));
 
         ob_start();
 


### PR DESCRIPTION
## Description
Use natural sorting for the list of included sniffs.

The `SORT_NATURAL` and the `SORT_FLAG_CASE` flag are available since PHP 5.4, so can be used without issue.

### Suggested changelog entry
The -e (explain) command will now list sniffs in natural order.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

