### PR TITLE
Generic/OpeningFunctionBrace*: check spacing before brace for empty functions

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceBsdAllmanSniff.php
@@ -170,15 +170,13 @@ class OpeningFunctionBraceBsdAllmanSniff implements Sniff
         $ignore[] = T_WHITESPACE;
         $next     = $phpcsFile->findNext($ignore, ($openingBrace + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openingBrace]['line']) {
-            if ($next === $tokens[$stackPtr]['scope_closer']) {
-                // Ignore empty functions.
-                return;
-            }
-
-            $error = 'Opening brace must be the last content on the line';
-            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'ContentAfterBrace');
-            if ($fix === true) {
-                $phpcsFile->fixer->addNewline($openingBrace);
+            // Only throw this error when this is not an empty function.
+            if ($next !== $tokens[$stackPtr]['scope_closer']) {
+                $error = 'Opening brace must be the last content on the line';
+                $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'ContentAfterBrace');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addNewline($openingBrace);
+                }
             }
         }
 

--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -130,17 +130,15 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
         $ignore[] = T_WHITESPACE;
         $next     = $phpcsFile->findNext($ignore, ($openingBrace + 1), null, true);
         if ($tokens[$next]['line'] === $tokens[$openingBrace]['line']) {
-            if ($next === $tokens[$stackPtr]['scope_closer']
-                || $tokens[$next]['code'] === T_CLOSE_TAG
+            // Only throw this error when this is not an empty function.
+            if ($next !== $tokens[$stackPtr]['scope_closer']
+                && $tokens[$next]['code'] !== T_CLOSE_TAG
             ) {
-                // Ignore empty functions.
-                return;
-            }
-
-            $error = 'Opening brace must be the last content on the line';
-            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'ContentAfterBrace');
-            if ($fix === true) {
-                $phpcsFile->fixer->addNewline($openingBrace);
+                $error = 'Opening brace must be the last content on the line';
+                $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'ContentAfterBrace');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addNewline($openingBrace);
+                }
             }
         }
 

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc
@@ -261,3 +261,10 @@ class Issue3357WithComment
         // code here.
     }
 }
+
+    function myFunction()
+    {}
+    function myFunction()
+          {} // Too many spaces indent with an empty function.
+    function myFunction()
+{} // Too little spaces indent with an empty function.

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.inc.fixed
@@ -278,3 +278,10 @@ class Issue3357WithComment
         // code here.
     }
 }
+
+    function myFunction()
+    {}
+    function myFunction()
+    {} // Too many spaces indent with an empty function.
+    function myFunction()
+    {} // Too little spaces indent with an empty function.

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceBsdAllmanUnitTest.php
@@ -61,6 +61,8 @@ class OpeningFunctionBraceBsdAllmanUnitTest extends AbstractSniffUnitTest
             244 => 1,
             252 => 1,
             260 => 1,
+            268 => 1,
+            270 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc
@@ -208,3 +208,7 @@ function myFunction($a, $lot, $of, $params)
     : array { // phpcs:ignore Standard.Category.Sniff -- for reasons.
     return null;
 }
+
+function myFunction() {}
+function myFunction()      {} // Too many spaces with an empty function.
+function myFunction()	{} // Too many spaces (tab) with an empty function.

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.inc.fixed
@@ -196,3 +196,7 @@ function myFunction($a, $lot, $of, $params)
     : array { // phpcs:ignore Standard.Category.Sniff -- for reasons.
     return null;
 }
+
+function myFunction() {}
+function myFunction() {} // Too many spaces with an empty function.
+function myFunction() {} // Too many spaces (tab) with an empty function.

--- a/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
+++ b/src/Standards/Generic/Tests/Functions/OpeningFunctionBraceKernighanRitchieUnitTest.php
@@ -52,6 +52,8 @@ class OpeningFunctionBraceKernighanRitchieUnitTest extends AbstractSniffUnitTest
             191 => 1,
             197 => 1,
             203 => 1,
+            213 => 1,
+            214 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description

Basically this is the same fix for both sniffs. The sniffs would `return`, instead of _skip over_ a particular check, which meant that other checks after the check which needed to be skipped were not being run.


### Generic/OpeningFunctionBraceKernighanRitchie: check spacing before brace for empty functions

As things were, when an empty function was detected, the sniff would bow out and not execute the "SpaceBeforeBrace" check.

Fixed now.

Includes tests.

### Generic/OpeningFunctionBraceBsdAllman: check spacing before brace for empty functions

As things were, when an empty function was detected, the sniff would bow out and not execute the "BraceIndent" check.

Fixed now.

Includes tests.


### Suggested changelog entry
* Generic/OpeningFunctionBraceKernighanRitchie: spacing before opening brace will now also be checked for empty functions
* Generic/OpeningFunctionBraceBsdAllman: brace indent will now also be checked for empty functions


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

