### PR TITLE
Tokenizer::$eolChar: change default value

### DIFF
--- a/src/Tokenizers/Tokenizer.php
+++ b/src/Tokenizers/Tokenizer.php
@@ -27,7 +27,7 @@ abstract class Tokenizer
      *
      * @var string
      */
-    protected $eolChar = [];
+    protected $eolChar = '';
 
     /**
      * A token-based representation of the content.


### PR DESCRIPTION

## Description

Tokenizer::$eolChar: change default value to be a more logical one. The property is supposed to be a `string`, so having an array as a default value is confusing.


### Suggested changelog entry
_N/A_


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

