### PR TITLE
Generic/OpeningFunctionBraceKernighanRitchie: fix error position

### DIFF
--- a/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
+++ b/src/Standards/Generic/Sniffs/Functions/OpeningFunctionBraceKernighanRitchieSniff.php
@@ -168,7 +168,7 @@ class OpeningFunctionBraceKernighanRitchieSniff implements Sniff
         if ($length !== 1) {
             $error = 'Expected 1 space before opening brace; found %s';
             $data  = [$length];
-            $fix   = $phpcsFile->addFixableError($error, $closeBracket, 'SpaceBeforeBrace', $data);
+            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'SpaceBeforeBrace', $data);
             if ($fix === true) {
                 if ($length === 0 || $length === '\t') {
                     $phpcsFile->fixer->addContentBefore($openingBrace, ' ');


### PR DESCRIPTION
## Description

The `SpaceBeforeBrace` error code is about the space before the scope opener, but was being thrown on the parenthesis closer preceding it, which could be confusing when there is a type declaration between the two.

Fixed now.

I haven't added a test as no meaningful test _can_ be added as the error "column" is not part of the test logic.

To see the issue run the following command over the below code snippet:
```bash
phpcs test.php --standard=Generic --sniffs=Generic.Functions.OpeningFunctionBraceKernighanRitchie --report=code
```

```php
function foo( $param_a, $param_b ): Type       {}
//                       The space here   ^   was originally flagged on the close parens, not the open brace.
```



### Suggested changelog entry
N/A


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
