### PR TITLE
PHP 8.3 | Ruleset::explain() fix deprecation notice

### DIFF
--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -243,7 +243,7 @@ class Ruleset
         ob_start();
 
         $lastStandard = null;
-        $lastCount    = '';
+        $lastCount    = 0;
         $sniffCount   = count($sniffs);
 
         // Add a dummy entry to the end so we loop


### PR DESCRIPTION
## Description
On PHP 8.3, using the `-e` (explain) command would show a `Deprecated: Increment on non-alphanumeric string is deprecated in path/to/src/Ruleset.php on line 297` notice after the very first sniff being listed.

As the `$lastCount` variable is used as a counter, it should have an integer default (start) value, not a text string.

Fixed now.

Testable via the command-line using the following command:
```bash
phpcs -e --standard=PSR1
```

Output without this fix:
```
The PSR1 standard contains 8 sniffs

Generic (4 sniffs)
------------------
  Generic.Files.ByteOrderMark

Deprecated: Increment on non-alphanumeric string is deprecated in D:\000_GitHub\PHPCS\PHP_CodeSniffer\src\Ruleset.php on line 297
  Generic.NamingConventions.UpperCaseConstantName
  Generic.PHP.DisallowAlternativePHPTags
  Generic.PHP.DisallowShortOpenTag

PSR1 (3 sniffs)
---------------
  PSR1.Classes.ClassDeclaration
  PSR1.Files.SideEffects
  PSR1.Methods.CamelCapsMethodName

Squiz (1 sniff)
----------------
  Squiz.Classes.ValidClassName
```

Output with this fix:
```
The PSR1 standard contains 8 sniffs

Generic (4 sniffs)
------------------
  Generic.Files.ByteOrderMark
  Generic.NamingConventions.UpperCaseConstantName
  Generic.PHP.DisallowAlternativePHPTags
  Generic.PHP.DisallowShortOpenTag

PSR1 (3 sniffs)
---------------
  PSR1.Classes.ClassDeclaration
  PSR1.Files.SideEffects
  PSR1.Methods.CamelCapsMethodName

Squiz (1 sniff)
----------------
  Squiz.Classes.ValidClassName
```

👉🏻 **Note**: yes, I'd like to add some tests for this, but it would be much easier to do so without the (partially unclosed) output buffers being created by this function, so I'm pulling this fix first and will refactor the method and add some tests at some point in the future.


### Suggested changelog entry
Explain command: fixed PHP 8.3 deprecation notice


### Related issues/external references

Refs: https://wiki.php.net/rfc/saner-inc-dec-operators


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

