### PR TITLE
fix(docs): change filter arguments to match PascalCase

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -109,41 +109,41 @@ class Config
      * @var array<string, mixed>
      */
     private $settings = [
-        'files'           => null,
-        'standards'       => null,
-        'verbosity'       => null,
-        'interactive'     => null,
-        'parallel'        => null,
-        'cache'           => null,
-        'cacheFile'       => null,
-        'colors'          => null,
-        'explain'         => null,
-        'local'           => null,
-        'showSources'     => null,
-        'showProgress'    => null,
-        'quiet'           => null,
-        'annotations'     => null,
-        'tabWidth'        => null,
-        'encoding'        => null,
-        'extensions'      => null,
-        'sniffs'          => null,
-        'exclude'         => null,
-        'ignored'         => null,
-        'reportFile'      => null,
-        'generator'       => null,
-        'filter'          => null,
-        'bootstrap'       => null,
-        'reports'         => null,
-        'basepath'        => null,
-        'reportWidth'     => null,
-        'errorSeverity'   => null,
+        'files' => null,
+        'standards' => null,
+        'verbosity' => null,
+        'interactive' => null,
+        'parallel' => null,
+        'cache' => null,
+        'cacheFile' => null,
+        'colors' => null,
+        'explain' => null,
+        'local' => null,
+        'showSources' => null,
+        'showProgress' => null,
+        'quiet' => null,
+        'annotations' => null,
+        'tabWidth' => null,
+        'encoding' => null,
+        'extensions' => null,
+        'sniffs' => null,
+        'exclude' => null,
+        'ignored' => null,
+        'reportFile' => null,
+        'generator' => null,
+        'filter' => null,
+        'bootstrap' => null,
+        'reports' => null,
+        'basepath' => null,
+        'reportWidth' => null,
+        'errorSeverity' => null,
         'warningSeverity' => null,
-        'recordErrors'    => null,
-        'suffix'          => null,
-        'stdin'           => null,
-        'stdinContent'    => null,
-        'stdinPath'       => null,
-        'unknown'         => null,
+        'recordErrors' => null,
+        'suffix' => null,
+        'stdin' => null,
+        'stdinContent' => null,
+        'stdinPath' => null,
+        'unknown' => null,
     ];
 
     /**
@@ -209,7 +209,7 @@ class Config
 
         return $this->settings[$name];
 
-    }//end __get()
+    } //end __get()
 
 
     /**
@@ -228,50 +228,50 @@ class Config
         }
 
         switch ($name) {
-        case 'reportWidth' :
-            // Support auto terminal width.
-            if ($value === 'auto' && function_exists('shell_exec') === true) {
-                $dimensions = shell_exec('stty size 2>&1');
-                if (is_string($dimensions) === true && preg_match('|\d+ (\d+)|', $dimensions, $matches) === 1) {
-                    $value = (int) $matches[1];
-                    break;
-                }
-            }
-
-            if (is_int($value) === true) {
-                $value = abs($value);
-            } else if (is_string($value) === true && preg_match('`^\d+$`', $value) === 1) {
-                $value = (int) $value;
-            } else {
-                $value = self::DEFAULT_REPORT_WIDTH;
-            }
-            break;
-        case 'standards' :
-            $cleaned = [];
-
-            // Check if the standard name is valid, or if the case is invalid.
-            $installedStandards = Util\Standards::getInstalledStandards();
-            foreach ($value as $standard) {
-                foreach ($installedStandards as $validStandard) {
-                    if (strtolower($standard) === strtolower($validStandard)) {
-                        $standard = $validStandard;
+            case 'reportWidth':
+                // Support auto terminal width.
+                if ($value === 'auto' && function_exists('shell_exec') === true) {
+                    $dimensions = shell_exec('stty size 2>&1');
+                    if (is_string($dimensions) === true && preg_match('|\d+ (\d+)|', $dimensions, $matches) === 1) {
+                        $value = (int) $matches[1];
                         break;
                     }
                 }
 
-                $cleaned[] = $standard;
-            }
+                if (is_int($value) === true) {
+                    $value = abs($value);
+                } else if (is_string($value) === true && preg_match('`^\d+$`', $value) === 1) {
+                    $value = (int) $value;
+                } else {
+                    $value = self::DEFAULT_REPORT_WIDTH;
+                }
+                break;
+            case 'standards':
+                $cleaned = [];
 
-            $value = $cleaned;
-            break;
-        default :
-            // No validation required.
-            break;
-        }//end switch
+                // Check if the standard name is valid, or if the case is invalid.
+                $installedStandards = Util\Standards::getInstalledStandards();
+                foreach ($value as $standard) {
+                    foreach ($installedStandards as $validStandard) {
+                        if (strtolower($standard) === strtolower($validStandard)) {
+                            $standard = $validStandard;
+                            break;
+                        }
+                    }
+
+                    $cleaned[] = $standard;
+                }
+
+                $value = $cleaned;
+                break;
+            default:
+                // No validation required.
+                break;
+        } //end switch
 
         $this->settings[$name] = $value;
 
-    }//end __set()
+    } //end __set()
 
 
     /**
@@ -285,7 +285,7 @@ class Config
     {
         return isset($this->settings[$name]);
 
-    }//end __isset()
+    } //end __isset()
 
 
     /**
@@ -299,7 +299,7 @@ class Config
     {
         $this->settings[$name] = null;
 
-    }//end __unset()
+    } //end __unset()
 
 
     /**
@@ -311,7 +311,7 @@ class Config
     {
         return $this->settings;
 
-    }//end getSettings()
+    } //end getSettings()
 
 
     /**
@@ -325,7 +325,7 @@ class Config
     {
         return $this->settings = $settings;
 
-    }//end setSettings()
+    } //end setSettings()
 
 
     /**
@@ -337,7 +337,7 @@ class Config
      *
      * @return void
      */
-    public function __construct(array $cliArgs=[], $dieOnUnknownArg=true)
+    public function __construct(array $cliArgs = [], $dieOnUnknownArg = true)
     {
         if (defined('PHP_CODESNIFFER_IN_TESTS') === true) {
             // Let everything through during testing so that we can
@@ -369,17 +369,17 @@ class Config
 
             do {
                 foreach ($defaultFiles as $defaultFilename) {
-                    $default = $currentDir.DIRECTORY_SEPARATOR.$defaultFilename;
+                    $default = $currentDir . DIRECTORY_SEPARATOR . $defaultFilename;
                     if (is_file($default) === true) {
                         $this->standards = [$default];
                         break(2);
                     }
                 }
 
-                $lastDir    = $currentDir;
+                $lastDir = $currentDir;
                 $currentDir = dirname($currentDir);
             } while ($currentDir !== '.' && $currentDir !== $lastDir && Common::isReadable($currentDir) === true);
-        }//end if
+        } //end if
 
         if (defined('STDIN') === false
             || stripos(PHP_OS, 'WIN') === 0
@@ -392,7 +392,7 @@ class Config
         // Check for content on STDIN.
         if ($this->stdin === true
             || (Util\Common::isStdinATTY() === false
-            && feof($handle) === false)
+                && feof($handle) === false)
         ) {
             $readStreams = [$handle];
             $writeSteams = null;
@@ -408,16 +408,16 @@ class Config
             }
 
             if (trim($fileContents) !== '') {
-                $this->stdin        = true;
+                $this->stdin = true;
                 $this->stdinContent = $fileContents;
-                self::$overriddenDefaults['stdin']        = true;
+                self::$overriddenDefaults['stdin'] = true;
                 self::$overriddenDefaults['stdinContent'] = true;
             }
-        }//end if
+        } //end if
 
         fclose($handle);
 
-    }//end __construct()
+    } //end __construct()
 
 
     /**
@@ -430,7 +430,7 @@ class Config
     public function setCommandLineValues($args)
     {
         $this->cliArgs = $args;
-        $numArgs       = count($args);
+        $numArgs = count($args);
 
         for ($i = 0; $i < $numArgs; $i++) {
             $arg = $this->cliArgs[$i];
@@ -465,10 +465,10 @@ class Config
                 }
             } else {
                 $this->processUnknownArgument($arg, $i);
-            }//end if
-        }//end for
+            } //end if
+        } //end for
 
-    }//end setCommandLineValues()
+    } //end setCommandLineValues()
 
 
     /**
@@ -478,46 +478,46 @@ class Config
      */
     public function restoreDefaults()
     {
-        $this->files           = [];
-        $this->standards       = ['PEAR'];
-        $this->verbosity       = 0;
-        $this->interactive     = false;
-        $this->cache           = false;
-        $this->cacheFile       = null;
-        $this->colors          = false;
-        $this->explain         = false;
-        $this->local           = false;
-        $this->showSources     = false;
-        $this->showProgress    = false;
-        $this->quiet           = false;
-        $this->annotations     = true;
-        $this->parallel        = 1;
-        $this->tabWidth        = 0;
-        $this->encoding        = 'utf-8';
-        $this->extensions      = [
+        $this->files = [];
+        $this->standards = ['PEAR'];
+        $this->verbosity = 0;
+        $this->interactive = false;
+        $this->cache = false;
+        $this->cacheFile = null;
+        $this->colors = false;
+        $this->explain = false;
+        $this->local = false;
+        $this->showSources = false;
+        $this->showProgress = false;
+        $this->quiet = false;
+        $this->annotations = true;
+        $this->parallel = 1;
+        $this->tabWidth = 0;
+        $this->encoding = 'utf-8';
+        $this->extensions = [
             'php' => 'PHP',
             'inc' => 'PHP',
-            'js'  => 'JS',
+            'js' => 'JS',
             'css' => 'CSS',
         ];
-        $this->sniffs          = [];
-        $this->exclude         = [];
-        $this->ignored         = [];
-        $this->reportFile      = null;
-        $this->generator       = null;
-        $this->filter          = null;
-        $this->bootstrap       = [];
-        $this->basepath        = null;
-        $this->reports         = ['full' => null];
-        $this->reportWidth     = 'auto';
-        $this->errorSeverity   = 5;
+        $this->sniffs = [];
+        $this->exclude = [];
+        $this->ignored = [];
+        $this->reportFile = null;
+        $this->generator = null;
+        $this->filter = null;
+        $this->bootstrap = [];
+        $this->basepath = null;
+        $this->reports = ['full' => null];
+        $this->reportWidth = 'auto';
+        $this->errorSeverity = 5;
         $this->warningSeverity = 5;
-        $this->recordErrors    = true;
-        $this->suffix          = '';
-        $this->stdin           = false;
-        $this->stdinContent    = null;
-        $this->stdinPath       = null;
-        $this->unknown         = [];
+        $this->recordErrors = true;
+        $this->suffix = '';
+        $this->stdin = false;
+        $this->stdinContent = null;
+        $this->stdinPath = null;
+        $this->unknown = [];
 
         $standard = self::getConfigData('default_standard');
         if ($standard !== null) {
@@ -541,7 +541,7 @@ class Config
 
         $severity = self::getConfigData('severity');
         if ($severity !== null) {
-            $this->errorSeverity   = (int) $severity;
+            $this->errorSeverity = (int) $severity;
             $this->warningSeverity = (int) $severity;
         }
 
@@ -595,7 +595,7 @@ class Config
             }
         }
 
-    }//end restoreDefaults()
+    } //end restoreDefaults()
 
 
     /**
@@ -610,97 +610,97 @@ class Config
     public function processShortArgument($arg, $pos)
     {
         switch ($arg) {
-        case 'h':
-        case '?':
-            ob_start();
-            $this->printUsage();
-            $output = ob_get_contents();
-            ob_end_clean();
-            throw new DeepExitException($output, 0);
-        case 'i' :
-            ob_start();
-            Util\Standards::printInstalledStandards();
-            $output = ob_get_contents();
-            ob_end_clean();
-            throw new DeepExitException($output, 0);
-        case 'v' :
-            if ($this->quiet === true) {
-                // Ignore when quiet mode is enabled.
+            case 'h':
+            case '?':
+                ob_start();
+                $this->printUsage();
+                $output = ob_get_contents();
+                ob_end_clean();
+                throw new DeepExitException($output, 0);
+            case 'i':
+                ob_start();
+                Util\Standards::printInstalledStandards();
+                $output = ob_get_contents();
+                ob_end_clean();
+                throw new DeepExitException($output, 0);
+            case 'v':
+                if ($this->quiet === true) {
+                    // Ignore when quiet mode is enabled.
+                    break;
+                }
+
+                $this->verbosity++;
+                self::$overriddenDefaults['verbosity'] = true;
                 break;
-            }
-
-            $this->verbosity++;
-            self::$overriddenDefaults['verbosity'] = true;
-            break;
-        case 'l' :
-            $this->local = true;
-            self::$overriddenDefaults['local'] = true;
-            break;
-        case 's' :
-            $this->showSources = true;
-            self::$overriddenDefaults['showSources'] = true;
-            break;
-        case 'a' :
-            $this->interactive = true;
-            self::$overriddenDefaults['interactive'] = true;
-            break;
-        case 'e':
-            $this->explain = true;
-            self::$overriddenDefaults['explain'] = true;
-            break;
-        case 'p' :
-            if ($this->quiet === true) {
-                // Ignore when quiet mode is enabled.
+            case 'l':
+                $this->local = true;
+                self::$overriddenDefaults['local'] = true;
                 break;
-            }
+            case 's':
+                $this->showSources = true;
+                self::$overriddenDefaults['showSources'] = true;
+                break;
+            case 'a':
+                $this->interactive = true;
+                self::$overriddenDefaults['interactive'] = true;
+                break;
+            case 'e':
+                $this->explain = true;
+                self::$overriddenDefaults['explain'] = true;
+                break;
+            case 'p':
+                if ($this->quiet === true) {
+                    // Ignore when quiet mode is enabled.
+                    break;
+                }
 
-            $this->showProgress = true;
-            self::$overriddenDefaults['showProgress'] = true;
-            break;
-        case 'q' :
-            // Quiet mode disables a few other settings as well.
-            $this->quiet        = true;
-            $this->showProgress = false;
-            $this->verbosity    = 0;
+                $this->showProgress = true;
+                self::$overriddenDefaults['showProgress'] = true;
+                break;
+            case 'q':
+                // Quiet mode disables a few other settings as well.
+                $this->quiet = true;
+                $this->showProgress = false;
+                $this->verbosity = 0;
 
-            self::$overriddenDefaults['quiet'] = true;
-            break;
-        case 'm' :
-            $this->recordErrors = false;
-            self::$overriddenDefaults['recordErrors'] = true;
-            break;
-        case 'd' :
-            $ini = explode('=', $this->cliArgs[($pos + 1)]);
-            $this->cliArgs[($pos + 1)] = '';
-            if (isset($ini[1]) === true) {
-                ini_set($ini[0], $ini[1]);
-            } else {
-                ini_set($ini[0], true);
-            }
-            break;
-        case 'n' :
-            if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
-                $this->warningSeverity = 0;
-                self::$overriddenDefaults['warningSeverity'] = true;
-            }
-            break;
-        case 'w' :
-            if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
-                $this->warningSeverity = $this->errorSeverity;
-                self::$overriddenDefaults['warningSeverity'] = true;
-            }
-            break;
-        default:
-            if ($this->dieOnUnknownArg === false) {
-                $unknown       = $this->unknown;
-                $unknown[]     = $arg;
-                $this->unknown = $unknown;
-            } else {
-                $this->processUnknownArgument('-'.$arg, $pos);
-            }
-        }//end switch
+                self::$overriddenDefaults['quiet'] = true;
+                break;
+            case 'm':
+                $this->recordErrors = false;
+                self::$overriddenDefaults['recordErrors'] = true;
+                break;
+            case 'd':
+                $ini = explode('=', $this->cliArgs[($pos + 1)]);
+                $this->cliArgs[($pos + 1)] = '';
+                if (isset($ini[1]) === true) {
+                    ini_set($ini[0], $ini[1]);
+                } else {
+                    ini_set($ini[0], true);
+                }
+                break;
+            case 'n':
+                if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
+                    $this->warningSeverity = 0;
+                    self::$overriddenDefaults['warningSeverity'] = true;
+                }
+                break;
+            case 'w':
+                if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
+                    $this->warningSeverity = $this->errorSeverity;
+                    self::$overriddenDefaults['warningSeverity'] = true;
+                }
+                break;
+            default:
+                if ($this->dieOnUnknownArg === false) {
+                    $unknown = $this->unknown;
+                    $unknown[] = $arg;
+                    $this->unknown = $unknown;
+                } else {
+                    $this->processUnknownArgument('-' . $arg, $pos);
+                }
+        } //end switch
 
-    }//end processShortArgument()
+    } //end processShortArgument()
 
 
     /**
@@ -715,528 +715,528 @@ class Config
     public function processLongArgument($arg, $pos)
     {
         switch ($arg) {
-        case 'help':
-            ob_start();
-            $this->printUsage();
-            $output = ob_get_contents();
-            ob_end_clean();
-            throw new DeepExitException($output, 0);
-        case 'version':
-            $output  = 'PHP_CodeSniffer version '.self::VERSION.' ('.self::STABILITY.') ';
-            $output .= 'by Squiz (https://www.squiz.net)'.PHP_EOL;
-            throw new DeepExitException($output, 0);
-        case 'colors':
-            if (isset(self::$overriddenDefaults['colors']) === true) {
-                break;
-            }
+            case 'help':
+                ob_start();
+                $this->printUsage();
+                $output = ob_get_contents();
+                ob_end_clean();
+                throw new DeepExitException($output, 0);
+            case 'version':
+                $output = 'PHP_CodeSniffer version ' . self::VERSION . ' (' . self::STABILITY . ') ';
+                $output .= 'by Squiz (https://www.squiz.net)' . PHP_EOL;
+                throw new DeepExitException($output, 0);
+            case 'colors':
+                if (isset(self::$overriddenDefaults['colors']) === true) {
+                    break;
+                }
 
-            $this->colors = true;
-            self::$overriddenDefaults['colors'] = true;
-            break;
-        case 'no-colors':
-            if (isset(self::$overriddenDefaults['colors']) === true) {
+                $this->colors = true;
+                self::$overriddenDefaults['colors'] = true;
                 break;
-            }
+            case 'no-colors':
+                if (isset(self::$overriddenDefaults['colors']) === true) {
+                    break;
+                }
 
-            $this->colors = false;
-            self::$overriddenDefaults['colors'] = true;
-            break;
-        case 'cache':
-            if (isset(self::$overriddenDefaults['cache']) === true) {
+                $this->colors = false;
+                self::$overriddenDefaults['colors'] = true;
                 break;
-            }
+            case 'cache':
+                if (isset(self::$overriddenDefaults['cache']) === true) {
+                    break;
+                }
 
-            if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
-                $this->cache = true;
+                if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
+                    $this->cache = true;
+                    self::$overriddenDefaults['cache'] = true;
+                }
+                break;
+            case 'no-cache':
+                if (isset(self::$overriddenDefaults['cache']) === true) {
+                    break;
+                }
+
+                $this->cache = false;
                 self::$overriddenDefaults['cache'] = true;
-            }
-            break;
-        case 'no-cache':
-            if (isset(self::$overriddenDefaults['cache']) === true) {
                 break;
-            }
-
-            $this->cache = false;
-            self::$overriddenDefaults['cache'] = true;
-            break;
-        case 'ignore-annotations':
-            if (isset(self::$overriddenDefaults['annotations']) === true) {
-                break;
-            }
-
-            $this->annotations = false;
-            self::$overriddenDefaults['annotations'] = true;
-            break;
-        case 'config-set':
-            if (isset($this->cliArgs[($pos + 1)]) === false
-                || isset($this->cliArgs[($pos + 2)]) === false
-            ) {
-                $error  = 'ERROR: Setting a config option requires a name and value'.PHP_EOL.PHP_EOL;
-                $error .= $this->printShortUsage(true);
-                throw new DeepExitException($error, 3);
-            }
-
-            $key     = $this->cliArgs[($pos + 1)];
-            $value   = $this->cliArgs[($pos + 2)];
-            $current = self::getConfigData($key);
-
-            try {
-                $this->setConfigData($key, $value);
-            } catch (\Exception $e) {
-                throw new DeepExitException($e->getMessage().PHP_EOL, 3);
-            }
-
-            $output = 'Using config file: '.self::$configDataFile.PHP_EOL.PHP_EOL;
-
-            if ($current === null) {
-                $output .= "Config value \"$key\" added successfully".PHP_EOL;
-            } else {
-                $output .= "Config value \"$key\" updated successfully; old value was \"$current\"".PHP_EOL;
-            }
-            throw new DeepExitException($output, 0);
-        case 'config-delete':
-            if (isset($this->cliArgs[($pos + 1)]) === false) {
-                $error  = 'ERROR: Deleting a config option requires the name of the option'.PHP_EOL.PHP_EOL;
-                $error .= $this->printShortUsage(true);
-                throw new DeepExitException($error, 3);
-            }
-
-            $output = 'Using config file: '.self::$configDataFile.PHP_EOL.PHP_EOL;
-
-            $key     = $this->cliArgs[($pos + 1)];
-            $current = self::getConfigData($key);
-            if ($current === null) {
-                $output .= "Config value \"$key\" has not been set".PHP_EOL;
-            } else {
-                try {
-                    $this->setConfigData($key, null);
-                } catch (\Exception $e) {
-                    throw new DeepExitException($e->getMessage().PHP_EOL, 3);
-                }
-
-                $output .= "Config value \"$key\" removed successfully; old value was \"$current\"".PHP_EOL;
-            }
-            throw new DeepExitException($output, 0);
-        case 'config-show':
-            ob_start();
-            $data = self::getAllConfigData();
-            echo 'Using config file: '.self::$configDataFile.PHP_EOL.PHP_EOL;
-            $this->printConfigData($data);
-            $output = ob_get_contents();
-            ob_end_clean();
-            throw new DeepExitException($output, 0);
-        case 'runtime-set':
-            if (isset($this->cliArgs[($pos + 1)]) === false
-                || isset($this->cliArgs[($pos + 2)]) === false
-            ) {
-                $error  = 'ERROR: Setting a runtime config option requires a name and value'.PHP_EOL.PHP_EOL;
-                $error .= $this->printShortUsage(true);
-                throw new DeepExitException($error, 3);
-            }
-
-            $key   = $this->cliArgs[($pos + 1)];
-            $value = $this->cliArgs[($pos + 2)];
-            $this->cliArgs[($pos + 1)] = '';
-            $this->cliArgs[($pos + 2)] = '';
-            self::setConfigData($key, $value, true);
-            if (isset(self::$overriddenDefaults['runtime-set']) === false) {
-                self::$overriddenDefaults['runtime-set'] = [];
-            }
-
-            self::$overriddenDefaults['runtime-set'][$key] = true;
-            break;
-        default:
-            if (substr($arg, 0, 7) === 'sniffs=') {
-                if (isset(self::$overriddenDefaults['sniffs']) === true) {
+            case 'ignore-annotations':
+                if (isset(self::$overriddenDefaults['annotations']) === true) {
                     break;
                 }
 
-                $sniffs = explode(',', substr($arg, 7));
-                foreach ($sniffs as $sniff) {
-                    if (substr_count($sniff, '.') !== 2) {
-                        $error  = 'ERROR: The specified sniff code "'.$sniff.'" is invalid'.PHP_EOL.PHP_EOL;
-                        $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
-                    }
-                }
-
-                $this->sniffs = $sniffs;
-                self::$overriddenDefaults['sniffs'] = true;
-            } else if (substr($arg, 0, 8) === 'exclude=') {
-                if (isset(self::$overriddenDefaults['exclude']) === true) {
-                    break;
-                }
-
-                $sniffs = explode(',', substr($arg, 8));
-                foreach ($sniffs as $sniff) {
-                    if (substr_count($sniff, '.') !== 2) {
-                        $error  = 'ERROR: The specified sniff code "'.$sniff.'" is invalid'.PHP_EOL.PHP_EOL;
-                        $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
-                    }
-                }
-
-                $this->exclude = $sniffs;
-                self::$overriddenDefaults['exclude'] = true;
-            } else if (defined('PHP_CODESNIFFER_IN_TESTS') === false
-                && substr($arg, 0, 6) === 'cache='
-            ) {
-                if ((isset(self::$overriddenDefaults['cache']) === true
-                    && $this->cache === false)
-                    || isset(self::$overriddenDefaults['cacheFile']) === true
+                $this->annotations = false;
+                self::$overriddenDefaults['annotations'] = true;
+                break;
+            case 'config-set':
+                if (isset($this->cliArgs[($pos + 1)]) === false
+                    || isset($this->cliArgs[($pos + 2)]) === false
                 ) {
-                    break;
-                }
-
-                // Turn caching on.
-                $this->cache = true;
-                self::$overriddenDefaults['cache'] = true;
-
-                $this->cacheFile = Util\Common::realpath(substr($arg, 6));
-
-                // It may not exist and return false instead.
-                if ($this->cacheFile === false) {
-                    $this->cacheFile = substr($arg, 6);
-
-                    $dir = dirname($this->cacheFile);
-                    if (is_dir($dir) === false) {
-                        $error  = 'ERROR: The specified cache file path "'.$this->cacheFile.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
-                        $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
-                    }
-
-                    if ($dir === '.') {
-                        // Passed cache file is a file in the current directory.
-                        $this->cacheFile = getcwd().'/'.basename($this->cacheFile);
-                    } else {
-                        if ($dir[0] === '/') {
-                            // An absolute path.
-                            $dir = Util\Common::realpath($dir);
-                        } else {
-                            $dir = Util\Common::realpath(getcwd().'/'.$dir);
-                        }
-
-                        if ($dir !== false) {
-                            // Cache file path is relative.
-                            $this->cacheFile = $dir.'/'.basename($this->cacheFile);
-                        }
-                    }
-                }//end if
-
-                self::$overriddenDefaults['cacheFile'] = true;
-
-                if (is_dir($this->cacheFile) === true) {
-                    $error  = 'ERROR: The specified cache file path "'.$this->cacheFile.'" is a directory'.PHP_EOL.PHP_EOL;
-                    $error .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
-                }
-            } else if (substr($arg, 0, 10) === 'bootstrap=') {
-                $files     = explode(',', substr($arg, 10));
-                $bootstrap = [];
-                foreach ($files as $file) {
-                    $path = Util\Common::realpath($file);
-                    if ($path === false) {
-                        $error  = 'ERROR: The specified bootstrap file "'.$file.'" does not exist'.PHP_EOL.PHP_EOL;
-                        $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
-                    }
-
-                    $bootstrap[] = $path;
-                }
-
-                $this->bootstrap = array_merge($this->bootstrap, $bootstrap);
-                self::$overriddenDefaults['bootstrap'] = true;
-            } else if (substr($arg, 0, 10) === 'file-list=') {
-                $fileList = substr($arg, 10);
-                $path     = Util\Common::realpath($fileList);
-                if ($path === false) {
-                    $error  = 'ERROR: The specified file list "'.$fileList.'" does not exist'.PHP_EOL.PHP_EOL;
+                    $error = 'ERROR: Setting a config option requires a name and value' . PHP_EOL . PHP_EOL;
                     $error .= $this->printShortUsage(true);
                     throw new DeepExitException($error, 3);
                 }
 
-                $files = file($path);
-                foreach ($files as $inputFile) {
-                    $inputFile = trim($inputFile);
+                $key = $this->cliArgs[($pos + 1)];
+                $value = $this->cliArgs[($pos + 2)];
+                $current = self::getConfigData($key);
 
-                    // Skip empty lines.
-                    if ($inputFile === '') {
-                        continue;
-                    }
-
-                    $this->processFilePath($inputFile);
-                }
-            } else if (substr($arg, 0, 11) === 'stdin-path=') {
-                if (isset(self::$overriddenDefaults['stdinPath']) === true) {
-                    break;
+                try {
+                    $this->setConfigData($key, $value);
+                } catch (\Exception $e) {
+                    throw new DeepExitException($e->getMessage() . PHP_EOL, 3);
                 }
 
-                $this->stdinPath = Util\Common::realpath(substr($arg, 11));
+                $output = 'Using config file: ' . self::$configDataFile . PHP_EOL . PHP_EOL;
 
-                // It may not exist and return false instead, so use whatever they gave us.
-                if ($this->stdinPath === false) {
-                    $this->stdinPath = trim(substr($arg, 11));
-                }
-
-                self::$overriddenDefaults['stdinPath'] = true;
-            } else if (PHP_CODESNIFFER_CBF === false && substr($arg, 0, 12) === 'report-file=') {
-                if (isset(self::$overriddenDefaults['reportFile']) === true) {
-                    break;
-                }
-
-                $this->reportFile = Util\Common::realpath(substr($arg, 12));
-
-                // It may not exist and return false instead.
-                if ($this->reportFile === false) {
-                    $this->reportFile = substr($arg, 12);
-
-                    $dir = Util\Common::realpath(dirname($this->reportFile));
-                    if (is_dir($dir) === false) {
-                        $error  = 'ERROR: The specified report file path "'.$this->reportFile.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
-                        $error .= $this->printShortUsage(true);
-                        throw new DeepExitException($error, 3);
-                    }
-
-                    $this->reportFile = $dir.'/'.basename($this->reportFile);
-                }//end if
-
-                self::$overriddenDefaults['reportFile'] = true;
-
-                if (is_dir($this->reportFile) === true) {
-                    $error  = 'ERROR: The specified report file path "'.$this->reportFile.'" is a directory'.PHP_EOL.PHP_EOL;
-                    $error .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
-                }
-            } else if (substr($arg, 0, 13) === 'report-width=') {
-                if (isset(self::$overriddenDefaults['reportWidth']) === true) {
-                    break;
-                }
-
-                $this->reportWidth = substr($arg, 13);
-                self::$overriddenDefaults['reportWidth'] = true;
-            } else if (substr($arg, 0, 9) === 'basepath=') {
-                if (isset(self::$overriddenDefaults['basepath']) === true) {
-                    break;
-                }
-
-                self::$overriddenDefaults['basepath'] = true;
-
-                if (substr($arg, 9) === '') {
-                    $this->basepath = null;
-                    break;
-                }
-
-                $this->basepath = Util\Common::realpath(substr($arg, 9));
-
-                // It may not exist and return false instead.
-                if ($this->basepath === false) {
-                    $this->basepath = substr($arg, 9);
-                }
-
-                if (is_dir($this->basepath) === false) {
-                    $error  = 'ERROR: The specified basepath "'.$this->basepath.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
-                    $error .= $this->printShortUsage(true);
-                    throw new DeepExitException($error, 3);
-                }
-            } else if ((substr($arg, 0, 7) === 'report=' || substr($arg, 0, 7) === 'report-')) {
-                $reports = [];
-
-                if ($arg[6] === '-') {
-                    // This is a report with file output.
-                    $split = strpos($arg, '=');
-                    if ($split === false) {
-                        $report = substr($arg, 7);
-                        $output = null;
-                    } else {
-                        $report = substr($arg, 7, ($split - 7));
-                        $output = substr($arg, ($split + 1));
-                        if ($output === false) {
-                            $output = null;
-                        } else {
-                            $dir = Util\Common::realpath(dirname($output));
-                            if (is_dir($dir) === false) {
-                                $error  = 'ERROR: The specified '.$report.' report file path "'.$output.'" points to a non-existent directory'.PHP_EOL.PHP_EOL;
-                                $error .= $this->printShortUsage(true);
-                                throw new DeepExitException($error, 3);
-                            }
-
-                            $output = $dir.'/'.basename($output);
-
-                            if (is_dir($output) === true) {
-                                $error  = 'ERROR: The specified '.$report.' report file path "'.$output.'" is a directory'.PHP_EOL.PHP_EOL;
-                                $error .= $this->printShortUsage(true);
-                                throw new DeepExitException($error, 3);
-                            }
-                        }//end if
-                    }//end if
-
-                    $reports[$report] = $output;
+                if ($current === null) {
+                    $output .= "Config value \"$key\" added successfully" . PHP_EOL;
                 } else {
-                    // This is a single report.
-                    if (isset(self::$overriddenDefaults['reports']) === true) {
+                    $output .= "Config value \"$key\" updated successfully; old value was \"$current\"" . PHP_EOL;
+                }
+                throw new DeepExitException($output, 0);
+            case 'config-delete':
+                if (isset($this->cliArgs[($pos + 1)]) === false) {
+                    $error = 'ERROR: Deleting a config option requires the name of the option' . PHP_EOL . PHP_EOL;
+                    $error .= $this->printShortUsage(true);
+                    throw new DeepExitException($error, 3);
+                }
+
+                $output = 'Using config file: ' . self::$configDataFile . PHP_EOL . PHP_EOL;
+
+                $key = $this->cliArgs[($pos + 1)];
+                $current = self::getConfigData($key);
+                if ($current === null) {
+                    $output .= "Config value \"$key\" has not been set" . PHP_EOL;
+                } else {
+                    try {
+                        $this->setConfigData($key, null);
+                    } catch (\Exception $e) {
+                        throw new DeepExitException($e->getMessage() . PHP_EOL, 3);
+                    }
+
+                    $output .= "Config value \"$key\" removed successfully; old value was \"$current\"" . PHP_EOL;
+                }
+                throw new DeepExitException($output, 0);
+            case 'config-show':
+                ob_start();
+                $data = self::getAllConfigData();
+                echo 'Using config file: ' . self::$configDataFile . PHP_EOL . PHP_EOL;
+                $this->printConfigData($data);
+                $output = ob_get_contents();
+                ob_end_clean();
+                throw new DeepExitException($output, 0);
+            case 'runtime-set':
+                if (isset($this->cliArgs[($pos + 1)]) === false
+                    || isset($this->cliArgs[($pos + 2)]) === false
+                ) {
+                    $error = 'ERROR: Setting a runtime config option requires a name and value' . PHP_EOL . PHP_EOL;
+                    $error .= $this->printShortUsage(true);
+                    throw new DeepExitException($error, 3);
+                }
+
+                $key = $this->cliArgs[($pos + 1)];
+                $value = $this->cliArgs[($pos + 2)];
+                $this->cliArgs[($pos + 1)] = '';
+                $this->cliArgs[($pos + 2)] = '';
+                self::setConfigData($key, $value, true);
+                if (isset(self::$overriddenDefaults['runtime-set']) === false) {
+                    self::$overriddenDefaults['runtime-set'] = [];
+                }
+
+                self::$overriddenDefaults['runtime-set'][$key] = true;
+                break;
+            default:
+                if (substr($arg, 0, 7) === 'sniffs=') {
+                    if (isset(self::$overriddenDefaults['sniffs']) === true) {
                         break;
                     }
 
-                    $reportNames = explode(',', substr($arg, 7));
-                    foreach ($reportNames as $report) {
-                        $reports[$report] = null;
-                    }
-                }//end if
-
-                // Remove the default value so the CLI value overrides it.
-                if (isset(self::$overriddenDefaults['reports']) === false) {
-                    $this->reports = $reports;
-                } else {
-                    $this->reports = array_merge($this->reports, $reports);
-                }
-
-                self::$overriddenDefaults['reports'] = true;
-            } else if (substr($arg, 0, 7) === 'filter=') {
-                if (isset(self::$overriddenDefaults['filter']) === true) {
-                    break;
-                }
-
-                $this->filter = substr($arg, 7);
-                self::$overriddenDefaults['filter'] = true;
-            } else if (substr($arg, 0, 9) === 'standard=') {
-                $standards = trim(substr($arg, 9));
-                if ($standards !== '') {
-                    $this->standards = explode(',', $standards);
-                }
-
-                self::$overriddenDefaults['standards'] = true;
-            } else if (substr($arg, 0, 11) === 'extensions=') {
-                if (isset(self::$overriddenDefaults['extensions']) === true) {
-                    break;
-                }
-
-                $extensions    = explode(',', substr($arg, 11));
-                $newExtensions = [];
-                foreach ($extensions as $ext) {
-                    $slash = strpos($ext, '/');
-                    if ($slash !== false) {
-                        // They specified the tokenizer too.
-                        list($ext, $tokenizer) = explode('/', $ext);
-                        $newExtensions[$ext]   = strtoupper($tokenizer);
-                        continue;
-                    }
-
-                    if (isset($this->extensions[$ext]) === true) {
-                        $newExtensions[$ext] = $this->extensions[$ext];
-                    } else {
-                        $newExtensions[$ext] = 'PHP';
-                    }
-                }
-
-                $this->extensions = $newExtensions;
-                self::$overriddenDefaults['extensions'] = true;
-            } else if (substr($arg, 0, 7) === 'suffix=') {
-                if (isset(self::$overriddenDefaults['suffix']) === true) {
-                    break;
-                }
-
-                $this->suffix = substr($arg, 7);
-                self::$overriddenDefaults['suffix'] = true;
-            } else if (substr($arg, 0, 9) === 'parallel=') {
-                if (isset(self::$overriddenDefaults['parallel']) === true) {
-                    break;
-                }
-
-                $this->parallel = max((int) substr($arg, 9), 1);
-                self::$overriddenDefaults['parallel'] = true;
-            } else if (substr($arg, 0, 9) === 'severity=') {
-                $this->errorSeverity   = (int) substr($arg, 9);
-                $this->warningSeverity = $this->errorSeverity;
-                if (isset(self::$overriddenDefaults['errorSeverity']) === false) {
-                    self::$overriddenDefaults['errorSeverity'] = true;
-                }
-
-                if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
-                    self::$overriddenDefaults['warningSeverity'] = true;
-                }
-            } else if (substr($arg, 0, 15) === 'error-severity=') {
-                if (isset(self::$overriddenDefaults['errorSeverity']) === true) {
-                    break;
-                }
-
-                $this->errorSeverity = (int) substr($arg, 15);
-                self::$overriddenDefaults['errorSeverity'] = true;
-            } else if (substr($arg, 0, 17) === 'warning-severity=') {
-                if (isset(self::$overriddenDefaults['warningSeverity']) === true) {
-                    break;
-                }
-
-                $this->warningSeverity = (int) substr($arg, 17);
-                self::$overriddenDefaults['warningSeverity'] = true;
-            } else if (substr($arg, 0, 7) === 'ignore=') {
-                if (isset(self::$overriddenDefaults['ignored']) === true) {
-                    break;
-                }
-
-                // Split the ignore string on commas, unless the comma is escaped
-                // using 1 or 3 slashes (\, or \\\,).
-                $patterns = preg_split(
-                    '/(?<=(?<!\\\\)\\\\\\\\),|(?<!\\\\),/',
-                    substr($arg, 7)
-                );
-
-                $ignored = [];
-                foreach ($patterns as $pattern) {
-                    $pattern = trim($pattern);
-                    if ($pattern === '') {
-                        continue;
-                    }
-
-                    $ignored[$pattern] = 'absolute';
-                }
-
-                $this->ignored = $ignored;
-                self::$overriddenDefaults['ignored'] = true;
-            } else if (substr($arg, 0, 10) === 'generator='
-                && PHP_CODESNIFFER_CBF === false
-            ) {
-                if (isset(self::$overriddenDefaults['generator']) === true) {
-                    break;
-                }
-
-                $this->generator = substr($arg, 10);
-                self::$overriddenDefaults['generator'] = true;
-            } else if (substr($arg, 0, 9) === 'encoding=') {
-                if (isset(self::$overriddenDefaults['encoding']) === true) {
-                    break;
-                }
-
-                $this->encoding = strtolower(substr($arg, 9));
-                self::$overriddenDefaults['encoding'] = true;
-            } else if (substr($arg, 0, 10) === 'tab-width=') {
-                if (isset(self::$overriddenDefaults['tabWidth']) === true) {
-                    break;
-                }
-
-                $this->tabWidth = (int) substr($arg, 10);
-                self::$overriddenDefaults['tabWidth'] = true;
-            } else {
-                if ($this->dieOnUnknownArg === false) {
-                    $eqPos = strpos($arg, '=');
-                    try {
-                        if ($eqPos === false) {
-                            $this->values[$arg] = $arg;
-                        } else {
-                            $value = substr($arg, ($eqPos + 1));
-                            $arg   = substr($arg, 0, $eqPos);
-                            $this->values[$arg] = $value;
+                    $sniffs = explode(',', substr($arg, 7));
+                    foreach ($sniffs as $sniff) {
+                        if (substr_count($sniff, '.') !== 2) {
+                            $error = 'ERROR: The specified sniff code "' . $sniff . '" is invalid' . PHP_EOL . PHP_EOL;
+                            $error .= $this->printShortUsage(true);
+                            throw new DeepExitException($error, 3);
                         }
-                    } catch (RuntimeException $e) {
-                        // Value is not valid, so just ignore it.
                     }
-                } else {
-                    $this->processUnknownArgument('--'.$arg, $pos);
-                }
-            }//end if
-            break;
-        }//end switch
 
-    }//end processLongArgument()
+                    $this->sniffs = $sniffs;
+                    self::$overriddenDefaults['sniffs'] = true;
+                } else if (substr($arg, 0, 8) === 'exclude=') {
+                    if (isset(self::$overriddenDefaults['exclude']) === true) {
+                        break;
+                    }
+
+                    $sniffs = explode(',', substr($arg, 8));
+                    foreach ($sniffs as $sniff) {
+                        if (substr_count($sniff, '.') !== 2) {
+                            $error = 'ERROR: The specified sniff code "' . $sniff . '" is invalid' . PHP_EOL . PHP_EOL;
+                            $error .= $this->printShortUsage(true);
+                            throw new DeepExitException($error, 3);
+                        }
+                    }
+
+                    $this->exclude = $sniffs;
+                    self::$overriddenDefaults['exclude'] = true;
+                } else if (defined('PHP_CODESNIFFER_IN_TESTS') === false
+                    && substr($arg, 0, 6) === 'cache='
+                ) {
+                    if ((isset(self::$overriddenDefaults['cache']) === true
+                        && $this->cache === false)
+                        || isset(self::$overriddenDefaults['cacheFile']) === true
+                    ) {
+                        break;
+                    }
+
+                    // Turn caching on.
+                    $this->cache = true;
+                    self::$overriddenDefaults['cache'] = true;
+
+                    $this->cacheFile = Util\Common::realpath(substr($arg, 6));
+
+                    // It may not exist and return false instead.
+                    if ($this->cacheFile === false) {
+                        $this->cacheFile = substr($arg, 6);
+
+                        $dir = dirname($this->cacheFile);
+                        if (is_dir($dir) === false) {
+                            $error = 'ERROR: The specified cache file path "' . $this->cacheFile . '" points to a non-existent directory' . PHP_EOL . PHP_EOL;
+                            $error .= $this->printShortUsage(true);
+                            throw new DeepExitException($error, 3);
+                        }
+
+                        if ($dir === '.') {
+                            // Passed cache file is a file in the current directory.
+                            $this->cacheFile = getcwd() . '/' . basename($this->cacheFile);
+                        } else {
+                            if ($dir[0] === '/') {
+                                // An absolute path.
+                                $dir = Util\Common::realpath($dir);
+                            } else {
+                                $dir = Util\Common::realpath(getcwd() . '/' . $dir);
+                            }
+
+                            if ($dir !== false) {
+                                // Cache file path is relative.
+                                $this->cacheFile = $dir . '/' . basename($this->cacheFile);
+                            }
+                        }
+                    } //end if
+
+                    self::$overriddenDefaults['cacheFile'] = true;
+
+                    if (is_dir($this->cacheFile) === true) {
+                        $error = 'ERROR: The specified cache file path "' . $this->cacheFile . '" is a directory' . PHP_EOL . PHP_EOL;
+                        $error .= $this->printShortUsage(true);
+                        throw new DeepExitException($error, 3);
+                    }
+                } else if (substr($arg, 0, 10) === 'bootstrap=') {
+                    $files = explode(',', substr($arg, 10));
+                    $bootstrap = [];
+                    foreach ($files as $file) {
+                        $path = Util\Common::realpath($file);
+                        if ($path === false) {
+                            $error = 'ERROR: The specified bootstrap file "' . $file . '" does not exist' . PHP_EOL . PHP_EOL;
+                            $error .= $this->printShortUsage(true);
+                            throw new DeepExitException($error, 3);
+                        }
+
+                        $bootstrap[] = $path;
+                    }
+
+                    $this->bootstrap = array_merge($this->bootstrap, $bootstrap);
+                    self::$overriddenDefaults['bootstrap'] = true;
+                } else if (substr($arg, 0, 10) === 'file-list=') {
+                    $fileList = substr($arg, 10);
+                    $path = Util\Common::realpath($fileList);
+                    if ($path === false) {
+                        $error = 'ERROR: The specified file list "' . $fileList . '" does not exist' . PHP_EOL . PHP_EOL;
+                        $error .= $this->printShortUsage(true);
+                        throw new DeepExitException($error, 3);
+                    }
+
+                    $files = file($path);
+                    foreach ($files as $inputFile) {
+                        $inputFile = trim($inputFile);
+
+                        // Skip empty lines.
+                        if ($inputFile === '') {
+                            continue;
+                        }
+
+                        $this->processFilePath($inputFile);
+                    }
+                } else if (substr($arg, 0, 11) === 'stdin-path=') {
+                    if (isset(self::$overriddenDefaults['stdinPath']) === true) {
+                        break;
+                    }
+
+                    $this->stdinPath = Util\Common::realpath(substr($arg, 11));
+
+                    // It may not exist and return false instead, so use whatever they gave us.
+                    if ($this->stdinPath === false) {
+                        $this->stdinPath = trim(substr($arg, 11));
+                    }
+
+                    self::$overriddenDefaults['stdinPath'] = true;
+                } else if (PHP_CODESNIFFER_CBF === false && substr($arg, 0, 12) === 'report-file=') {
+                    if (isset(self::$overriddenDefaults['reportFile']) === true) {
+                        break;
+                    }
+
+                    $this->reportFile = Util\Common::realpath(substr($arg, 12));
+
+                    // It may not exist and return false instead.
+                    if ($this->reportFile === false) {
+                        $this->reportFile = substr($arg, 12);
+
+                        $dir = Util\Common::realpath(dirname($this->reportFile));
+                        if (is_dir($dir) === false) {
+                            $error = 'ERROR: The specified report file path "' . $this->reportFile . '" points to a non-existent directory' . PHP_EOL . PHP_EOL;
+                            $error .= $this->printShortUsage(true);
+                            throw new DeepExitException($error, 3);
+                        }
+
+                        $this->reportFile = $dir . '/' . basename($this->reportFile);
+                    } //end if
+
+                    self::$overriddenDefaults['reportFile'] = true;
+
+                    if (is_dir($this->reportFile) === true) {
+                        $error = 'ERROR: The specified report file path "' . $this->reportFile . '" is a directory' . PHP_EOL . PHP_EOL;
+                        $error .= $this->printShortUsage(true);
+                        throw new DeepExitException($error, 3);
+                    }
+                } else if (substr($arg, 0, 13) === 'report-width=') {
+                    if (isset(self::$overriddenDefaults['reportWidth']) === true) {
+                        break;
+                    }
+
+                    $this->reportWidth = substr($arg, 13);
+                    self::$overriddenDefaults['reportWidth'] = true;
+                } else if (substr($arg, 0, 9) === 'basepath=') {
+                    if (isset(self::$overriddenDefaults['basepath']) === true) {
+                        break;
+                    }
+
+                    self::$overriddenDefaults['basepath'] = true;
+
+                    if (substr($arg, 9) === '') {
+                        $this->basepath = null;
+                        break;
+                    }
+
+                    $this->basepath = Util\Common::realpath(substr($arg, 9));
+
+                    // It may not exist and return false instead.
+                    if ($this->basepath === false) {
+                        $this->basepath = substr($arg, 9);
+                    }
+
+                    if (is_dir($this->basepath) === false) {
+                        $error = 'ERROR: The specified basepath "' . $this->basepath . '" points to a non-existent directory' . PHP_EOL . PHP_EOL;
+                        $error .= $this->printShortUsage(true);
+                        throw new DeepExitException($error, 3);
+                    }
+                } else if ((substr($arg, 0, 7) === 'report=' || substr($arg, 0, 7) === 'report-')) {
+                    $reports = [];
+
+                    if ($arg[6] === '-') {
+                        // This is a report with file output.
+                        $split = strpos($arg, '=');
+                        if ($split === false) {
+                            $report = substr($arg, 7);
+                            $output = null;
+                        } else {
+                            $report = substr($arg, 7, ($split - 7));
+                            $output = substr($arg, ($split + 1));
+                            if ($output === false) {
+                                $output = null;
+                            } else {
+                                $dir = Util\Common::realpath(dirname($output));
+                                if (is_dir($dir) === false) {
+                                    $error = 'ERROR: The specified ' . $report . ' report file path "' . $output . '" points to a non-existent directory' . PHP_EOL . PHP_EOL;
+                                    $error .= $this->printShortUsage(true);
+                                    throw new DeepExitException($error, 3);
+                                }
+
+                                $output = $dir . '/' . basename($output);
+
+                                if (is_dir($output) === true) {
+                                    $error = 'ERROR: The specified ' . $report . ' report file path "' . $output . '" is a directory' . PHP_EOL . PHP_EOL;
+                                    $error .= $this->printShortUsage(true);
+                                    throw new DeepExitException($error, 3);
+                                }
+                            } //end if
+                        } //end if
+
+                        $reports[$report] = $output;
+                    } else {
+                        // This is a single report.
+                        if (isset(self::$overriddenDefaults['reports']) === true) {
+                            break;
+                        }
+
+                        $reportNames = explode(',', substr($arg, 7));
+                        foreach ($reportNames as $report) {
+                            $reports[$report] = null;
+                        }
+                    } //end if
+
+                    // Remove the default value so the CLI value overrides it.
+                    if (isset(self::$overriddenDefaults['reports']) === false) {
+                        $this->reports = $reports;
+                    } else {
+                        $this->reports = array_merge($this->reports, $reports);
+                    }
+
+                    self::$overriddenDefaults['reports'] = true;
+                } else if (substr($arg, 0, 7) === 'filter=') {
+                    if (isset(self::$overriddenDefaults['filter']) === true) {
+                        break;
+                    }
+
+                    $this->filter = substr($arg, 7);
+                    self::$overriddenDefaults['filter'] = true;
+                } else if (substr($arg, 0, 9) === 'standard=') {
+                    $standards = trim(substr($arg, 9));
+                    if ($standards !== '') {
+                        $this->standards = explode(',', $standards);
+                    }
+
+                    self::$overriddenDefaults['standards'] = true;
+                } else if (substr($arg, 0, 11) === 'extensions=') {
+                    if (isset(self::$overriddenDefaults['extensions']) === true) {
+                        break;
+                    }
+
+                    $extensions = explode(',', substr($arg, 11));
+                    $newExtensions = [];
+                    foreach ($extensions as $ext) {
+                        $slash = strpos($ext, '/');
+                        if ($slash !== false) {
+                            // They specified the tokenizer too.
+                            list($ext, $tokenizer) = explode('/', $ext);
+                            $newExtensions[$ext] = strtoupper($tokenizer);
+                            continue;
+                        }
+
+                        if (isset($this->extensions[$ext]) === true) {
+                            $newExtensions[$ext] = $this->extensions[$ext];
+                        } else {
+                            $newExtensions[$ext] = 'PHP';
+                        }
+                    }
+
+                    $this->extensions = $newExtensions;
+                    self::$overriddenDefaults['extensions'] = true;
+                } else if (substr($arg, 0, 7) === 'suffix=') {
+                    if (isset(self::$overriddenDefaults['suffix']) === true) {
+                        break;
+                    }
+
+                    $this->suffix = substr($arg, 7);
+                    self::$overriddenDefaults['suffix'] = true;
+                } else if (substr($arg, 0, 9) === 'parallel=') {
+                    if (isset(self::$overriddenDefaults['parallel']) === true) {
+                        break;
+                    }
+
+                    $this->parallel = max((int) substr($arg, 9), 1);
+                    self::$overriddenDefaults['parallel'] = true;
+                } else if (substr($arg, 0, 9) === 'severity=') {
+                    $this->errorSeverity = (int) substr($arg, 9);
+                    $this->warningSeverity = $this->errorSeverity;
+                    if (isset(self::$overriddenDefaults['errorSeverity']) === false) {
+                        self::$overriddenDefaults['errorSeverity'] = true;
+                    }
+
+                    if (isset(self::$overriddenDefaults['warningSeverity']) === false) {
+                        self::$overriddenDefaults['warningSeverity'] = true;
+                    }
+                } else if (substr($arg, 0, 15) === 'error-severity=') {
+                    if (isset(self::$overriddenDefaults['errorSeverity']) === true) {
+                        break;
+                    }
+
+                    $this->errorSeverity = (int) substr($arg, 15);
+                    self::$overriddenDefaults['errorSeverity'] = true;
+                } else if (substr($arg, 0, 17) === 'warning-severity=') {
+                    if (isset(self::$overriddenDefaults['warningSeverity']) === true) {
+                        break;
+                    }
+
+                    $this->warningSeverity = (int) substr($arg, 17);
+                    self::$overriddenDefaults['warningSeverity'] = true;
+                } else if (substr($arg, 0, 7) === 'ignore=') {
+                    if (isset(self::$overriddenDefaults['ignored']) === true) {
+                        break;
+                    }
+
+                    // Split the ignore string on commas, unless the comma is escaped
+                    // using 1 or 3 slashes (\, or \\\,).
+                    $patterns = preg_split(
+                        '/(?<=(?<!\\\\)\\\\\\\\),|(?<!\\\\),/',
+                        substr($arg, 7)
+                    );
+
+                    $ignored = [];
+                    foreach ($patterns as $pattern) {
+                        $pattern = trim($pattern);
+                        if ($pattern === '') {
+                            continue;
+                        }
+
+                        $ignored[$pattern] = 'absolute';
+                    }
+
+                    $this->ignored = $ignored;
+                    self::$overriddenDefaults['ignored'] = true;
+                } else if (substr($arg, 0, 10) === 'generator='
+                    && PHP_CODESNIFFER_CBF === false
+                ) {
+                    if (isset(self::$overriddenDefaults['generator']) === true) {
+                        break;
+                    }
+
+                    $this->generator = substr($arg, 10);
+                    self::$overriddenDefaults['generator'] = true;
+                } else if (substr($arg, 0, 9) === 'encoding=') {
+                    if (isset(self::$overriddenDefaults['encoding']) === true) {
+                        break;
+                    }
+
+                    $this->encoding = strtolower(substr($arg, 9));
+                    self::$overriddenDefaults['encoding'] = true;
+                } else if (substr($arg, 0, 10) === 'tab-width=') {
+                    if (isset(self::$overriddenDefaults['tabWidth']) === true) {
+                        break;
+                    }
+
+                    $this->tabWidth = (int) substr($arg, 10);
+                    self::$overriddenDefaults['tabWidth'] = true;
+                } else {
+                    if ($this->dieOnUnknownArg === false) {
+                        $eqPos = strpos($arg, '=');
+                        try {
+                            if ($eqPos === false) {
+                                $this->values[$arg] = $arg;
+                            } else {
+                                $value = substr($arg, ($eqPos + 1));
+                                $arg = substr($arg, 0, $eqPos);
+                                $this->values[$arg] = $value;
+                            }
+                        } catch (RuntimeException $e) {
+                            // Value is not valid, so just ignore it.
+                        }
+                    } else {
+                        $this->processUnknownArgument('--' . $arg, $pos);
+                    }
+                } //end if
+                break;
+        } //end switch
+
+    } //end processLongArgument()
 
 
     /**
@@ -1258,14 +1258,14 @@ class Config
                 return;
             }
 
-            $error  = "ERROR: option \"$arg\" not known".PHP_EOL.PHP_EOL;
+            $error = "ERROR: option \"$arg\" not known" . PHP_EOL . PHP_EOL;
             $error .= $this->printShortUsage(true);
             throw new DeepExitException($error, 3);
         }
 
         $this->processFilePath($arg);
 
-    }//end processUnknownArgument()
+    } //end processUnknownArgument()
 
 
     /**
@@ -1289,19 +1289,19 @@ class Config
                 return;
             }
 
-            $error  = 'ERROR: The file "'.$path.'" does not exist.'.PHP_EOL.PHP_EOL;
+            $error = 'ERROR: The file "' . $path . '" does not exist.' . PHP_EOL . PHP_EOL;
             $error .= $this->printShortUsage(true);
             throw new DeepExitException($error, 3);
         } else {
             // Can't modify the files array directly because it's not a real
             // class member, so need to use this little get/modify/set trick.
-            $files       = $this->files;
-            $files[]     = $file;
+            $files = $this->files;
+            $files[] = $file;
             $this->files = $files;
             self::$overriddenDefaults['files'] = true;
         }
 
-    }//end processFilePath()
+    } //end processFilePath()
 
 
     /**
@@ -1321,7 +1321,7 @@ class Config
 
         echo PHP_EOL;
 
-    }//end printUsage()
+    } //end printUsage()
 
 
     /**
@@ -1332,7 +1332,7 @@ class Config
      *
      * @return string|void
      */
-    public function printShortUsage($return=false)
+    public function printShortUsage($return = false)
     {
         if (PHP_CODESNIFFER_CBF === true) {
             $usage = 'Run "phpcbf --help" for usage information';
@@ -1340,7 +1340,7 @@ class Config
             $usage = 'Run "phpcs --help" for usage information';
         }
 
-        $usage .= PHP_EOL.PHP_EOL;
+        $usage .= PHP_EOL . PHP_EOL;
 
         if ($return === true) {
             return $usage;
@@ -1348,7 +1348,7 @@ class Config
 
         echo $usage;
 
-    }//end printShortUsage()
+    } //end printShortUsage()
 
 
     /**
@@ -1358,73 +1358,73 @@ class Config
      */
     public function printPHPCSUsage()
     {
-        echo 'Usage: phpcs [-nwlsaepqvi] [-d key[=value]] [--colors] [--no-colors]'.PHP_EOL;
-        echo '  [--cache[=<cacheFile>]] [--no-cache] [--tab-width=<tabWidth>]'.PHP_EOL;
-        echo '  [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>]'.PHP_EOL;
-        echo '  [--report-width=<reportWidth>] [--basepath=<basepath>] [--bootstrap=<bootstrap>]'.PHP_EOL;
-        echo '  [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
-        echo '  [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]'.PHP_EOL;
-        echo '  [--standard=<standard>] [--sniffs=<sniffs>] [--exclude=<sniffs>]'.PHP_EOL;
-        echo '  [--encoding=<encoding>] [--parallel=<processes>] [--generator=<generator>]'.PHP_EOL;
-        echo '  [--extensions=<extensions>] [--ignore=<patterns>] [--ignore-annotations]'.PHP_EOL;
-        echo '  [--stdin-path=<stdinPath>] [--file-list=<fileList>] [--filter=<filter>] <file> - ...'.PHP_EOL;
+        echo 'Usage: phpcs [-nwlsaepqvi] [-d key[=value]] [--colors] [--no-colors]' . PHP_EOL;
+        echo '  [--cache[=<cacheFile>]] [--no-cache] [--tab-width=<tabWidth>]' . PHP_EOL;
+        echo '  [--report=<report>] [--report-file=<reportFile>] [--report-<report>=<reportFile>]' . PHP_EOL;
+        echo '  [--report-width=<reportWidth>] [--basepath=<basepath>] [--bootstrap=<bootstrap>]' . PHP_EOL;
+        echo '  [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]' . PHP_EOL;
+        echo '  [--runtime-set key value] [--config-set key value] [--config-delete key] [--config-show]' . PHP_EOL;
+        echo '  [--standard=<standard>] [--sniffs=<sniffs>] [--exclude=<sniffs>]' . PHP_EOL;
+        echo '  [--encoding=<encoding>] [--parallel=<processes>] [--generator=<generator>]' . PHP_EOL;
+        echo '  [--extensions=<extensions>] [--ignore=<patterns>] [--ignore-annotations]' . PHP_EOL;
+        echo '  [--stdin-path=<stdinPath>] [--file-list=<fileList>] [--filter=<filter>] <file> - ...' . PHP_EOL;
         echo PHP_EOL;
-        echo ' -     Check STDIN instead of local files and directories'.PHP_EOL;
-        echo ' -n    Do not print warnings (shortcut for --warning-severity=0)'.PHP_EOL;
-        echo ' -w    Print both warnings and errors (this is the default)'.PHP_EOL;
-        echo ' -l    Local directory only, no recursion'.PHP_EOL;
-        echo ' -s    Show sniff codes in all reports'.PHP_EOL;
-        echo ' -a    Run interactively'.PHP_EOL;
-        echo ' -e    Explain a standard by showing the sniffs it includes'.PHP_EOL;
-        echo ' -p    Show progress of the run'.PHP_EOL;
-        echo ' -q    Quiet mode; disables progress and verbose output'.PHP_EOL;
-        echo ' -m    Stop error messages from being recorded'.PHP_EOL;
-        echo '       (saves a lot of memory, but stops many reports from being used)'.PHP_EOL;
-        echo ' -v    Print processed files'.PHP_EOL;
-        echo ' -vv   Print ruleset and token output'.PHP_EOL;
-        echo ' -vvv  Print sniff processing information'.PHP_EOL;
-        echo ' -i    Show a list of installed coding standards'.PHP_EOL;
-        echo ' -d    Set the [key] php.ini value to [value] or [true] if value is omitted'.PHP_EOL;
+        echo ' -     Check STDIN instead of local files and directories' . PHP_EOL;
+        echo ' -n    Do not print warnings (shortcut for --warning-severity=0)' . PHP_EOL;
+        echo ' -w    Print both warnings and errors (this is the default)' . PHP_EOL;
+        echo ' -l    Local directory only, no recursion' . PHP_EOL;
+        echo ' -s    Show sniff codes in all reports' . PHP_EOL;
+        echo ' -a    Run interactively' . PHP_EOL;
+        echo ' -e    Explain a standard by showing the sniffs it includes' . PHP_EOL;
+        echo ' -p    Show progress of the run' . PHP_EOL;
+        echo ' -q    Quiet mode; disables progress and verbose output' . PHP_EOL;
+        echo ' -m    Stop error messages from being recorded' . PHP_EOL;
+        echo '       (saves a lot of memory, but stops many reports from being used)' . PHP_EOL;
+        echo ' -v    Print processed files' . PHP_EOL;
+        echo ' -vv   Print ruleset and token output' . PHP_EOL;
+        echo ' -vvv  Print sniff processing information' . PHP_EOL;
+        echo ' -i    Show a list of installed coding standards' . PHP_EOL;
+        echo ' -d    Set the [key] php.ini value to [value] or [true] if value is omitted' . PHP_EOL;
         echo PHP_EOL;
-        echo ' --help                Print this help message'.PHP_EOL;
-        echo ' --version             Print version information'.PHP_EOL;
-        echo ' --colors              Use colors in output'.PHP_EOL;
-        echo ' --no-colors           Do not use colors in output (this is the default)'.PHP_EOL;
-        echo ' --cache               Cache results between runs'.PHP_EOL;
-        echo ' --no-cache            Do not cache results between runs (this is the default)'.PHP_EOL;
-        echo ' --ignore-annotations  Ignore all phpcs: annotations in code comments'.PHP_EOL;
+        echo ' --help                Print this help message' . PHP_EOL;
+        echo ' --version             Print version information' . PHP_EOL;
+        echo ' --colors              Use colors in output' . PHP_EOL;
+        echo ' --no-colors           Do not use colors in output (this is the default)' . PHP_EOL;
+        echo ' --cache               Cache results between runs' . PHP_EOL;
+        echo ' --no-cache            Do not cache results between runs (this is the default)' . PHP_EOL;
+        echo ' --ignore-annotations  Ignore all phpcs: annotations in code comments' . PHP_EOL;
         echo PHP_EOL;
-        echo ' <cacheFile>    Use a specific file for caching (uses a temporary file by default)'.PHP_EOL;
-        echo ' <basepath>     A path to strip from the front of file paths inside reports'.PHP_EOL;
-        echo ' <bootstrap>    A comma separated list of files to run before processing begins'.PHP_EOL;
-        echo ' <encoding>     The encoding of the files being checked (default is utf-8)'.PHP_EOL;
-        echo ' <extensions>   A comma separated list of file extensions to check'.PHP_EOL;
-        echo '                The type of the file can be specified using: ext/type'.PHP_EOL;
-        echo '                e.g., module/php,es/js'.PHP_EOL;
-        echo ' <file>         One or more files and/or directories to check'.PHP_EOL;
-        echo ' <fileList>     A file containing a list of files and/or directories to check (one per line)'.PHP_EOL;
-        echo ' <filter>       Use either the "gitmodified" or "gitstaged" filter,'.PHP_EOL;
-        echo '                or specify the path to a custom filter class'.PHP_EOL;
-        echo ' <generator>    Use either the "HTML", "Markdown" or "Text" generator'.PHP_EOL;
-        echo '                (forces documentation generation instead of checking)'.PHP_EOL;
-        echo ' <patterns>     A comma separated list of patterns to ignore files and directories'.PHP_EOL;
-        echo ' <processes>    How many files should be checked simultaneously (default is 1)'.PHP_EOL;
-        echo ' <report>       Print either the "full", "xml", "checkstyle", "csv"'.PHP_EOL;
-        echo '                "json", "junit", "emacs", "source", "summary", "diff"'.PHP_EOL;
-        echo '                "svnblame", "gitblame", "hgblame" or "notifysend" report,'.PHP_EOL;
-        echo '                or specify the path to a custom report class'.PHP_EOL;
-        echo '                (the "full" report is printed by default)'.PHP_EOL;
-        echo ' <reportFile>   Write the report to the specified file path'.PHP_EOL;
-        echo ' <reportWidth>  How many columns wide screen reports should be printed'.PHP_EOL;
-        echo '                or set to "auto" to use current screen width, where supported'.PHP_EOL;
-        echo ' <severity>     The minimum severity required to display an error or warning'.PHP_EOL;
-        echo ' <sniffs>       A comma separated list of sniff codes to include or exclude from checking'.PHP_EOL;
-        echo '                (all sniffs must be part of the specified standard)'.PHP_EOL;
-        echo ' <standard>     The name or path of the coding standard to use'.PHP_EOL;
-        echo ' <stdinPath>    If processing STDIN, the file path that STDIN will be processed as'.PHP_EOL;
-        echo ' <tabWidth>     The number of spaces each tab represents'.PHP_EOL;
+        echo ' <cacheFile>    Use a specific file for caching (uses a temporary file by default)' . PHP_EOL;
+        echo ' <basepath>     A path to strip from the front of file paths inside reports' . PHP_EOL;
+        echo ' <bootstrap>    A comma separated list of files to run before processing begins' . PHP_EOL;
+        echo ' <encoding>     The encoding of the files being checked (default is utf-8)' . PHP_EOL;
+        echo ' <extensions>   A comma separated list of file extensions to check' . PHP_EOL;
+        echo '                The type of the file can be specified using: ext/type' . PHP_EOL;
+        echo '                e.g., module/php,es/js' . PHP_EOL;
+        echo ' <file>         One or more files and/or directories to check' . PHP_EOL;
+        echo ' <fileList>     A file containing a list of files and/or directories to check (one per line)' . PHP_EOL;
+        echo ' <filter>       Use either the "GitModified" or "GitStaged" filter,' . PHP_EOL;
+        echo '                or specify the path to a custom filter class' . PHP_EOL;
+        echo ' <generator>    Use either the "HTML", "Markdown" or "Text" generator' . PHP_EOL;
+        echo '                (forces documentation generation instead of checking)' . PHP_EOL;
+        echo ' <patterns>     A comma separated list of patterns to ignore files and directories' . PHP_EOL;
+        echo ' <processes>    How many files should be checked simultaneously (default is 1)' . PHP_EOL;
+        echo ' <report>       Print either the "full", "xml", "checkstyle", "csv"' . PHP_EOL;
+        echo '                "json", "junit", "emacs", "source", "summary", "diff"' . PHP_EOL;
+        echo '                "svnblame", "gitblame", "hgblame" or "notifysend" report,' . PHP_EOL;
+        echo '                or specify the path to a custom report class' . PHP_EOL;
+        echo '                (the "full" report is printed by default)' . PHP_EOL;
+        echo ' <reportFile>   Write the report to the specified file path' . PHP_EOL;
+        echo ' <reportWidth>  How many columns wide screen reports should be printed' . PHP_EOL;
+        echo '                or set to "auto" to use current screen width, where supported' . PHP_EOL;
+        echo ' <severity>     The minimum severity required to display an error or warning' . PHP_EOL;
+        echo ' <sniffs>       A comma separated list of sniff codes to include or exclude from checking' . PHP_EOL;
+        echo '                (all sniffs must be part of the specified standard)' . PHP_EOL;
+        echo ' <standard>     The name or path of the coding standard to use' . PHP_EOL;
+        echo ' <stdinPath>    If processing STDIN, the file path that STDIN will be processed as' . PHP_EOL;
+        echo ' <tabWidth>     The number of spaces each tab represents' . PHP_EOL;
 
-    }//end printPHPCSUsage()
+    } //end printPHPCSUsage()
 
 
     /**
@@ -1434,51 +1434,51 @@ class Config
      */
     public function printPHPCBFUsage()
     {
-        echo 'Usage: phpcbf [-nwli] [-d key[=value]] [--ignore-annotations] [--bootstrap=<bootstrap>]'.PHP_EOL;
-        echo '  [--standard=<standard>] [--sniffs=<sniffs>] [--exclude=<sniffs>] [--suffix=<suffix>]'.PHP_EOL;
-        echo '  [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]'.PHP_EOL;
-        echo '  [--tab-width=<tabWidth>] [--encoding=<encoding>] [--parallel=<processes>]'.PHP_EOL;
-        echo '  [--basepath=<basepath>] [--extensions=<extensions>] [--ignore=<patterns>]'.PHP_EOL;
-        echo '  [--stdin-path=<stdinPath>] [--file-list=<fileList>] [--filter=<filter>] <file> - ...'.PHP_EOL;
+        echo 'Usage: phpcbf [-nwli] [-d key[=value]] [--ignore-annotations] [--bootstrap=<bootstrap>]' . PHP_EOL;
+        echo '  [--standard=<standard>] [--sniffs=<sniffs>] [--exclude=<sniffs>] [--suffix=<suffix>]' . PHP_EOL;
+        echo '  [--severity=<severity>] [--error-severity=<severity>] [--warning-severity=<severity>]' . PHP_EOL;
+        echo '  [--tab-width=<tabWidth>] [--encoding=<encoding>] [--parallel=<processes>]' . PHP_EOL;
+        echo '  [--basepath=<basepath>] [--extensions=<extensions>] [--ignore=<patterns>]' . PHP_EOL;
+        echo '  [--stdin-path=<stdinPath>] [--file-list=<fileList>] [--filter=<filter>] <file> - ...' . PHP_EOL;
         echo PHP_EOL;
-        echo ' -     Fix STDIN instead of local files and directories'.PHP_EOL;
-        echo ' -n    Do not fix warnings (shortcut for --warning-severity=0)'.PHP_EOL;
-        echo ' -w    Fix both warnings and errors (on by default)'.PHP_EOL;
-        echo ' -l    Local directory only, no recursion'.PHP_EOL;
-        echo ' -p    Show progress of the run'.PHP_EOL;
-        echo ' -q    Quiet mode; disables progress and verbose output'.PHP_EOL;
-        echo ' -v    Print processed files'.PHP_EOL;
-        echo ' -vv   Print ruleset and token output'.PHP_EOL;
-        echo ' -vvv  Print sniff processing information'.PHP_EOL;
-        echo ' -i    Show a list of installed coding standards'.PHP_EOL;
-        echo ' -d    Set the [key] php.ini value to [value] or [true] if value is omitted'.PHP_EOL;
+        echo ' -     Fix STDIN instead of local files and directories' . PHP_EOL;
+        echo ' -n    Do not fix warnings (shortcut for --warning-severity=0)' . PHP_EOL;
+        echo ' -w    Fix both warnings and errors (on by default)' . PHP_EOL;
+        echo ' -l    Local directory only, no recursion' . PHP_EOL;
+        echo ' -p    Show progress of the run' . PHP_EOL;
+        echo ' -q    Quiet mode; disables progress and verbose output' . PHP_EOL;
+        echo ' -v    Print processed files' . PHP_EOL;
+        echo ' -vv   Print ruleset and token output' . PHP_EOL;
+        echo ' -vvv  Print sniff processing information' . PHP_EOL;
+        echo ' -i    Show a list of installed coding standards' . PHP_EOL;
+        echo ' -d    Set the [key] php.ini value to [value] or [true] if value is omitted' . PHP_EOL;
         echo PHP_EOL;
-        echo ' --help                Print this help message'.PHP_EOL;
-        echo ' --version             Print version information'.PHP_EOL;
-        echo ' --ignore-annotations  Ignore all phpcs: annotations in code comments'.PHP_EOL;
+        echo ' --help                Print this help message' . PHP_EOL;
+        echo ' --version             Print version information' . PHP_EOL;
+        echo ' --ignore-annotations  Ignore all phpcs: annotations in code comments' . PHP_EOL;
         echo PHP_EOL;
-        echo ' <basepath>    A path to strip from the front of file paths inside reports'.PHP_EOL;
-        echo ' <bootstrap>   A comma separated list of files to run before processing begins'.PHP_EOL;
-        echo ' <encoding>    The encoding of the files being fixed (default is utf-8)'.PHP_EOL;
-        echo ' <extensions>  A comma separated list of file extensions to fix'.PHP_EOL;
-        echo '               The type of the file can be specified using: ext/type'.PHP_EOL;
-        echo '               e.g., module/php,es/js'.PHP_EOL;
-        echo ' <file>        One or more files and/or directories to fix'.PHP_EOL;
-        echo ' <fileList>    A file containing a list of files and/or directories to fix (one per line)'.PHP_EOL;
-        echo ' <filter>      Use either the "gitmodified" or "gitstaged" filter,'.PHP_EOL;
-        echo '               or specify the path to a custom filter class'.PHP_EOL;
-        echo ' <patterns>    A comma separated list of patterns to ignore files and directories'.PHP_EOL;
-        echo ' <processes>   How many files should be fixed simultaneously (default is 1)'.PHP_EOL;
-        echo ' <severity>    The minimum severity required to fix an error or warning'.PHP_EOL;
-        echo ' <sniffs>      A comma separated list of sniff codes to include or exclude from fixing'.PHP_EOL;
-        echo '               (all sniffs must be part of the specified standard)'.PHP_EOL;
-        echo ' <standard>    The name or path of the coding standard to use'.PHP_EOL;
-        echo ' <stdinPath>   If processing STDIN, the file path that STDIN will be processed as'.PHP_EOL;
-        echo ' <suffix>      Write modified files to a filename using this suffix'.PHP_EOL;
-        echo '               ("diff" and "patch" are not used in this mode)'.PHP_EOL;
-        echo ' <tabWidth>    The number of spaces each tab represents'.PHP_EOL;
+        echo ' <basepath>    A path to strip from the front of file paths inside reports' . PHP_EOL;
+        echo ' <bootstrap>   A comma separated list of files to run before processing begins' . PHP_EOL;
+        echo ' <encoding>    The encoding of the files being fixed (default is utf-8)' . PHP_EOL;
+        echo ' <extensions>  A comma separated list of file extensions to fix' . PHP_EOL;
+        echo '               The type of the file can be specified using: ext/type' . PHP_EOL;
+        echo '               e.g., module/php,es/js' . PHP_EOL;
+        echo ' <file>        One or more files and/or directories to fix' . PHP_EOL;
+        echo ' <fileList>    A file containing a list of files and/or directories to fix (one per line)' . PHP_EOL;
+        echo ' <filter>      Use either the "gitmodified" or "gitstaged" filter,' . PHP_EOL;
+        echo '               or specify the path to a custom filter class' . PHP_EOL;
+        echo ' <patterns>    A comma separated list of patterns to ignore files and directories' . PHP_EOL;
+        echo ' <processes>   How many files should be fixed simultaneously (default is 1)' . PHP_EOL;
+        echo ' <severity>    The minimum severity required to fix an error or warning' . PHP_EOL;
+        echo ' <sniffs>      A comma separated list of sniff codes to include or exclude from fixing' . PHP_EOL;
+        echo '               (all sniffs must be part of the specified standard)' . PHP_EOL;
+        echo ' <standard>    The name or path of the coding standard to use' . PHP_EOL;
+        echo ' <stdinPath>   If processing STDIN, the file path that STDIN will be processed as' . PHP_EOL;
+        echo ' <suffix>      Write modified files to a filename using this suffix' . PHP_EOL;
+        echo '               ("diff" and "patch" are not used in this mode)' . PHP_EOL;
+        echo ' <tabWidth>    The number of spaces each tab represents' . PHP_EOL;
 
-    }//end printPHPCBFUsage()
+    } //end printPHPCBFUsage()
 
 
     /**
@@ -1504,7 +1504,7 @@ class Config
 
         return $phpCodeSnifferConfig[$key];
 
-    }//end getConfigData()
+    } //end getConfigData()
 
 
     /**
@@ -1517,7 +1517,7 @@ class Config
      */
     public static function getExecutablePath($name)
     {
-        $data = self::getConfigData($name.'_path');
+        $data = self::getConfigData($name . '_path');
         if ($data !== null) {
             return $data;
         }
@@ -1532,9 +1532,9 @@ class Config
         }
 
         if (stripos(PHP_OS, 'WIN') === 0) {
-            $cmd = 'where '.escapeshellarg($name).' 2> nul';
+            $cmd = 'where ' . escapeshellarg($name) . ' 2> nul';
         } else {
-            $cmd = 'which '.escapeshellarg($name).' 2> /dev/null';
+            $cmd = 'which ' . escapeshellarg($name) . ' 2> /dev/null';
         }
 
         $result = exec($cmd, $output, $retVal);
@@ -1545,7 +1545,7 @@ class Config
         self::$executablePaths[$name] = $result;
         return $result;
 
-    }//end getExecutablePath()
+    } //end getExecutablePath()
 
 
     /**
@@ -1563,7 +1563,7 @@ class Config
      * @see    getConfigData()
      * @throws \PHP_CodeSniffer\Exceptions\DeepExitException If the config file can not be written.
      */
-    public static function setConfigData($key, $value, $temp=false)
+    public static function setConfigData($key, $value, $temp = false)
     {
         if (isset(self::$overriddenDefaults['runtime-set']) === true
             && isset(self::$overriddenDefaults['runtime-set'][$key]) === true
@@ -1578,9 +1578,9 @@ class Config
             }
 
             if ($path !== '') {
-                $configFile = dirname($path).DIRECTORY_SEPARATOR.'CodeSniffer.conf';
+                $configFile = dirname($path) . DIRECTORY_SEPARATOR . 'CodeSniffer.conf';
             } else {
-                $configFile = dirname(__DIR__).DIRECTORY_SEPARATOR.'CodeSniffer.conf';
+                $configFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'CodeSniffer.conf';
                 if (is_file($configFile) === false
                     && strpos('@data_dir@', '@data_dir') === false
                 ) {
@@ -1593,10 +1593,10 @@ class Config
             if (is_file($configFile) === true
                 && is_writable($configFile) === false
             ) {
-                $error = 'ERROR: Config file '.$configFile.' is not writable'.PHP_EOL.PHP_EOL;
+                $error = 'ERROR: Config file ' . $configFile . ' is not writable' . PHP_EOL . PHP_EOL;
                 throw new DeepExitException($error, 3);
             }
-        }//end if
+        } //end if
 
         $phpCodeSnifferConfig = self::getAllConfigData();
 
@@ -1609,12 +1609,12 @@ class Config
         }
 
         if ($temp === false) {
-            $output  = '<'.'?php'."\n".' $phpCodeSnifferConfig = ';
+            $output = '<' . '?php' . "\n" . ' $phpCodeSnifferConfig = ';
             $output .= var_export($phpCodeSnifferConfig, true);
-            $output .= ";\n?".'>';
+            $output .= ";\n?" . '>';
 
             if (file_put_contents($configFile, $output) === false) {
-                $error = 'ERROR: Config file '.$configFile.' could not be written'.PHP_EOL.PHP_EOL;
+                $error = 'ERROR: Config file ' . $configFile . ' could not be written' . PHP_EOL . PHP_EOL;
                 throw new DeepExitException($error, 3);
             }
 
@@ -1634,7 +1634,7 @@ class Config
 
         return true;
 
-    }//end setConfigData()
+    } //end setConfigData()
 
 
     /**
@@ -1656,9 +1656,9 @@ class Config
         }
 
         if ($path !== '') {
-            $configFile = dirname($path).DIRECTORY_SEPARATOR.'CodeSniffer.conf';
+            $configFile = dirname($path) . DIRECTORY_SEPARATOR . 'CodeSniffer.conf';
         } else {
-            $configFile = dirname(__DIR__).DIRECTORY_SEPARATOR.'CodeSniffer.conf';
+            $configFile = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'CodeSniffer.conf';
             if (is_file($configFile) === false
                 && strpos('@data_dir@', '@data_dir') === false
             ) {
@@ -1672,16 +1672,16 @@ class Config
         }
 
         if (Common::isReadable($configFile) === false) {
-            $error = 'ERROR: Config file '.$configFile.' is not readable'.PHP_EOL.PHP_EOL;
+            $error = 'ERROR: Config file ' . $configFile . ' is not readable' . PHP_EOL . PHP_EOL;
             throw new DeepExitException($error, 3);
         }
 
         include $configFile;
         self::$configDataFile = $configFile;
-        self::$configData     = $phpCodeSnifferConfig;
+        self::$configData = $phpCodeSnifferConfig;
         return self::$configData;
 
-    }//end getAllConfigData()
+    } //end getAllConfigData()
 
 
     /**
@@ -1693,7 +1693,7 @@ class Config
      */
     public function printConfigData($data)
     {
-        $max  = 0;
+        $max = 0;
         $keys = array_keys($data);
         foreach ($keys as $key) {
             $len = strlen($key);
@@ -1709,10 +1709,10 @@ class Config
         $max += 2;
         ksort($data);
         foreach ($data as $name => $value) {
-            echo str_pad($name.': ', $max).$value.PHP_EOL;
+            echo str_pad($name . ': ', $max) . $value . PHP_EOL;
         }
 
-    }//end printConfigData()
+    } //end printConfigData()
 
 
-}//end class
+} //end class


### PR DESCRIPTION
## Description
It fixes documentation of the command-line interface for the `filter` command.


### Suggested changelog entry
`Change documentation of filter command to match internally used PascalCase`


### Related issues/external references

Fixes #3877 


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [ ] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.