### PR TITLE
Correct pluralization of the word space/spaces depending on the spacing value

### DIFF
--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -153,6 +153,7 @@ class ArrayIndentSniff extends AbstractArraySniff
         if ($foundIndent === $expectedIndent) {
             return;
         }
+
         $pluralizeSpace = 's';
         if ($expectedIndent === 1) {
             $pluralizeSpace = '';

--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -76,9 +76,15 @@ class ArrayIndentSniff extends AbstractArraySniff
         // check indent levels because it's not valid. But we don't enforce exactly
         // how far indented it should be.
         if ($startIndent < $baseIndent) {
-            $error = 'Array open brace not indented correctly; expected at least %s spaces but found %s';
+            $pluralizeSpace = 's';
+            if ($baseIndent === 1) {
+                $pluralizeSpace = '';
+            }
+
+            $error = 'Array open brace not indented correctly; expected at least %s space%s but found %s';
             $data  = [
                 $baseIndent,
+                $pluralizeSpace,
                 $startIndent,
             ];
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'OpenBraceIncorrect', $data);
@@ -117,9 +123,15 @@ class ArrayIndentSniff extends AbstractArraySniff
                 continue;
             }
 
-            $error = 'Array key not indented correctly; expected %s spaces but found %s';
+            $pluralizeSpace = 's';
+            if ($expectedIndent === 1) {
+                $pluralizeSpace = '';
+            }
+
+            $error = 'Array key not indented correctly; expected %s space%s but found %s';
             $data  = [
                 $expectedIndent,
+                $pluralizeSpace,
                 $foundIndent,
             ];
             $fix   = $phpcsFile->addFixableError($error, $first, 'KeyIncorrect', $data);

--- a/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
+++ b/src/Standards/Generic/Sniffs/Arrays/ArrayIndentSniff.php
@@ -153,10 +153,15 @@ class ArrayIndentSniff extends AbstractArraySniff
         if ($foundIndent === $expectedIndent) {
             return;
         }
+        $pluralizeSpace = 's';
+        if ($expectedIndent === 1) {
+            $pluralizeSpace = '';
+        }
 
-        $error = 'Array close brace not indented correctly; expected %s spaces but found %s';
+        $error = 'Array close brace not indented correctly; expected %s space%s but found %s';
         $data  = [
             $expectedIndent,
+            $pluralizeSpace,
             $foundIndent,
         ];
         $fix   = $phpcsFile->addFixableError($error, $arrayEnd, 'CloseBraceIncorrect', $data);

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
@@ -56,6 +56,10 @@ class SpaceAfterCastSniff implements Sniff
     {
         $tokens        = $phpcsFile->getTokens();
         $this->spacing = (int) $this->spacing;
+        $pluralizeSpace = 's';
+        if ($this->spacing === 1) {
+            $pluralizeSpace = '';
+        }
 
         if ($tokens[$stackPtr]['code'] === T_BINARY_CAST
             && $tokens[$stackPtr]['content'] === 'b'
@@ -83,8 +87,11 @@ class SpaceAfterCastSniff implements Sniff
 
         $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
         if ($nextNonEmpty !== $nextNonWhitespace) {
-            $error = 'Expected %s space(s) after cast statement; comment found';
-            $data  = [$this->spacing];
+            $error = 'Expected %s space%s after cast statement; comment found';
+            $data  = [
+                $this->spacing,
+                $pluralizeSpace,
+            ];
             $phpcsFile->addError($error, $stackPtr, 'CommentFound', $data);
 
             if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
@@ -109,9 +116,10 @@ class SpaceAfterCastSniff implements Sniff
             return;
         }
 
-        $error = 'Expected %s space(s) after cast statement; %s found';
+        $error = 'Expected %s space%s after cast statement; %s found';
         $data  = [
             $this->spacing,
+            $pluralizeSpace,
             $found,
         ];
 

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterCastSniff.php
@@ -54,8 +54,8 @@ class SpaceAfterCastSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens        = $phpcsFile->getTokens();
-        $this->spacing = (int) $this->spacing;
+        $tokens         = $phpcsFile->getTokens();
+        $this->spacing  = (int) $this->spacing;
         $pluralizeSpace = 's';
         if ($this->spacing === 1) {
             $pluralizeSpace = '';

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
@@ -64,8 +64,8 @@ class SpaceAfterNotSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens        = $phpcsFile->getTokens();
-        $this->spacing = (int) $this->spacing;
+        $tokens         = $phpcsFile->getTokens();
+        $this->spacing  = (int) $this->spacing;
         $pluralizeSpace = 's';
         if ($this->spacing === 1) {
             $pluralizeSpace = '';

--- a/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
+++ b/src/Standards/Generic/Sniffs/Formatting/SpaceAfterNotSniff.php
@@ -66,6 +66,10 @@ class SpaceAfterNotSniff implements Sniff
     {
         $tokens        = $phpcsFile->getTokens();
         $this->spacing = (int) $this->spacing;
+        $pluralizeSpace = 's';
+        if ($this->spacing === 1) {
+            $pluralizeSpace = '';
+        }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
@@ -84,8 +88,11 @@ class SpaceAfterNotSniff implements Sniff
 
         $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
         if ($nextNonEmpty !== $nextNonWhitespace) {
-            $error = 'Expected %s space(s) after NOT operator; comment found';
-            $data  = [$this->spacing];
+            $error = 'Expected %s space%s after NOT operator; comment found';
+            $data  = [
+                $this->spacing,
+                $pluralizeSpace,
+            ];
             $phpcsFile->addError($error, $stackPtr, 'CommentFound', $data);
             return;
         }
@@ -101,9 +108,10 @@ class SpaceAfterNotSniff implements Sniff
             return;
         }
 
-        $error = 'Expected %s space(s) after NOT operator; %s found';
+        $error = 'Expected %s space%s after NOT operator; %s found';
         $data  = [
             $this->spacing,
+            $pluralizeSpace,
             $found,
         ];
 

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc
@@ -111,3 +111,19 @@ $array = [
     name: $value
     ),
 ];
+
+// phpcs:set Generic.Arrays.ArrayIndent indent 1
+
+// Testing pluralization of indent text - array item indent.
+$var = [
+ 1 => 'one',
+      2 => 'two',
+    /* three */ 3 => 'three',
+];
+
+// Testing pluralization of indent text - close brace indent.
+ $var = [
+  1 => 'one',
+  ];
+
+// phpcs:set Generic.Arrays.ArrayIndent indent 4

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.inc.fixed
@@ -112,3 +112,19 @@ $array = [
     name: $value
     ),
 ];
+
+// phpcs:set Generic.Arrays.ArrayIndent indent 1
+
+// Testing pluralization of indent text - array item indent.
+$var = [
+ 1 => 'one',
+ 2 => 'two',
+ /* three */ 3 => 'three',
+];
+
+// Testing pluralization of indent text - close brace indent.
+ $var = [
+  1 => 'one',
+ ];
+
+// phpcs:set Generic.Arrays.ArrayIndent indent 4

--- a/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
+++ b/src/Standards/Generic/Tests/Arrays/ArrayIndentUnitTest.php
@@ -45,6 +45,9 @@ class ArrayIndentUnitTest extends AbstractSniffUnitTest
             88  => 1,
             98  => 1,
             110 => 1,
+            120 => 1,
+            121 => 1,
+            127 => 1,
         ];
 
     }//end getErrorList()

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -332,9 +332,14 @@ class ArrayDeclarationSniff implements Sniff
             // Check the closing bracket is lined up under the "a" in array.
             $expected = ($keywordStart - 1);
             $found    = ($tokens[$arrayEnd]['column'] - 1);
-            $error    = 'Closing parenthesis not aligned correctly; expected %s space(s) but found %s';
+            $pluralizeSpace = 's';
+            if ($expected === 1) {
+                $pluralizeSpace = '';
+            }
+            $error    = 'Closing parenthesis not aligned correctly; expected %s space%s but found %s';
             $data     = [
                 $expected,
+                $pluralizeSpace,
                 $found,
             ];
 
@@ -676,10 +681,15 @@ class ArrayDeclarationSniff implements Sniff
 
                     $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $valuePointer, true);
                     $found = ($tokens[$first]['column'] - 1);
+                    $pluralizeSpace = 's';
+                    if ($expected === 1) {
+                        $pluralizeSpace = '';
+                    }
                     if ($found !== $expected) {
-                        $error = 'Array value not aligned correctly; expected %s spaces but found %s';
+                        $error = 'Array value not aligned correctly; expected %s space%s but found %s';
                         $data  = [
                             $expected,
+                            $pluralizeSpace,
                             $found,
                         ];
 
@@ -785,9 +795,14 @@ class ArrayDeclarationSniff implements Sniff
             if ($tokens[$index['arrow']]['column'] !== $arrowStart) {
                 $expected = ($arrowStart - ($index['index_length'] + $tokens[$indexPointer]['column']));
                 $found    = ($tokens[$index['arrow']]['column'] - ($index['index_length'] + $tokens[$indexPointer]['column']));
-                $error    = 'Array double arrow not aligned correctly; expected %s space(s) but found %s';
+                $pluralizeSpace = 's';
+                if ($expected === 1) {
+                    $pluralizeSpace = '';
+                }
+                $error    = 'Array double arrow not aligned correctly; expected %s space%s but found %s';
                 $data     = [
                     $expected,
+                    $pluralizeSpace,
                     $found,
                 ];
 
@@ -810,10 +825,15 @@ class ArrayDeclarationSniff implements Sniff
                 if ($found < 0) {
                     $found = 'newline';
                 }
+                $pluralizeSpace = 's';
+                if ($expected === 1) {
+                    $pluralizeSpace = '';
+                }
 
-                $error = 'Array value not aligned correctly; expected %s space(s) but found %s';
+                $error = 'Array value not aligned correctly; expected %s space%s but found %s';
                 $data  = [
                     $expected,
+                    $pluralizeSpace,
                     $found,
                 ];
 

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -330,14 +330,15 @@ class ArrayDeclarationSniff implements Sniff
             }
         } else if ($tokens[$arrayEnd]['column'] !== $keywordStart) {
             // Check the closing bracket is lined up under the "a" in array.
-            $expected = ($keywordStart - 1);
-            $found    = ($tokens[$arrayEnd]['column'] - 1);
+            $expected       = ($keywordStart - 1);
+            $found          = ($tokens[$arrayEnd]['column'] - 1);
             $pluralizeSpace = 's';
             if ($expected === 1) {
                 $pluralizeSpace = '';
             }
-            $error    = 'Closing parenthesis not aligned correctly; expected %s space%s but found %s';
-            $data     = [
+
+            $error = 'Closing parenthesis not aligned correctly; expected %s space%s but found %s';
+            $data  = [
                 $expected,
                 $pluralizeSpace,
                 $found,
@@ -679,12 +680,13 @@ class ArrayDeclarationSniff implements Sniff
                 } else if ($previousIsWhitespace === true) {
                     $expected = $keywordStart;
 
-                    $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $valuePointer, true);
-                    $found = ($tokens[$first]['column'] - 1);
+                    $first          = $phpcsFile->findFirstOnLine(T_WHITESPACE, $valuePointer, true);
+                    $found          = ($tokens[$first]['column'] - 1);
                     $pluralizeSpace = 's';
                     if ($expected === 1) {
                         $pluralizeSpace = '';
                     }
+
                     if ($found !== $expected) {
                         $error = 'Array value not aligned correctly; expected %s space%s but found %s';
                         $data  = [
@@ -793,14 +795,15 @@ class ArrayDeclarationSniff implements Sniff
 
             $arrowStart = ($tokens[$indexPointer]['column'] + $maxLength + 1);
             if ($tokens[$index['arrow']]['column'] !== $arrowStart) {
-                $expected = ($arrowStart - ($index['index_length'] + $tokens[$indexPointer]['column']));
-                $found    = ($tokens[$index['arrow']]['column'] - ($index['index_length'] + $tokens[$indexPointer]['column']));
+                $expected       = ($arrowStart - ($index['index_length'] + $tokens[$indexPointer]['column']));
+                $found          = ($tokens[$index['arrow']]['column'] - ($index['index_length'] + $tokens[$indexPointer]['column']));
                 $pluralizeSpace = 's';
                 if ($expected === 1) {
                     $pluralizeSpace = '';
                 }
-                $error    = 'Array double arrow not aligned correctly; expected %s space%s but found %s';
-                $data     = [
+
+                $error = 'Array double arrow not aligned correctly; expected %s space%s but found %s';
+                $data  = [
                     $expected,
                     $pluralizeSpace,
                     $found,
@@ -816,7 +819,7 @@ class ArrayDeclarationSniff implements Sniff
                 }
 
                 continue;
-            }
+            }//end if
 
             $valueStart = ($arrowStart + 3);
             if ($tokens[$valuePointer]['column'] !== $valueStart) {
@@ -825,6 +828,7 @@ class ArrayDeclarationSniff implements Sniff
                 if ($found < 0) {
                     $found = 'newline';
                 }
+
                 $pluralizeSpace = 's';
                 if ($expected === 1) {
                     $pluralizeSpace = '';

--- a/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Standards/Squiz/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -775,11 +775,17 @@ class ArrayDeclarationSniff implements Sniff
             }
 
             if ($tokens[$indexPointer]['column'] !== $indicesStart && ($indexPointer - 1) !== $arrayStart) {
-                $expected = ($indicesStart - 1);
-                $found    = ($tokens[$indexPointer]['column'] - 1);
-                $error    = 'Array key not aligned correctly; expected %s spaces but found %s';
-                $data     = [
+                $expected       = ($indicesStart - 1);
+                $found          = ($tokens[$indexPointer]['column'] - 1);
+                $pluralizeSpace = 's';
+                if ($expected === 1) {
+                    $pluralizeSpace = '';
+                }
+
+                $error = 'Array key not aligned correctly; expected %s space%s but found %s';
+                $data  = [
                     $expected,
+                    $pluralizeSpace,
                     $found,
                 ];
 
@@ -791,7 +797,7 @@ class ArrayDeclarationSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($indexPointer - 1), str_repeat(' ', $expected));
                     }
                 }
-            }
+            }//end if
 
             $arrowStart = ($tokens[$indexPointer]['column'] + $maxLength + 1);
             if ($tokens[$index['arrow']]['column'] !== $arrowStart) {

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -112,9 +112,14 @@ class DocCommentAlignmentSniff implements Sniff
             }
 
             if ($tokens[$i]['column'] !== $requiredColumn) {
-                $error = 'Expected %s space(s) before asterisk; %s found';
+                $pluralizeSpace = 's';
+                if ($requiredColumn - 1 === 1) {
+                    $pluralizeSpace = '';
+                }
+                $error = 'Expected %s space%s before asterisk; %s found';
                 $data  = [
                     ($requiredColumn - 1),
+                    $pluralizeSpace,
                     ($tokens[$i]['column'] - 1),
                 ];
                 $fix   = $phpcsFile->addFixableError($error, $i, 'SpaceBeforeStar', $data);

--- a/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/src/Standards/Squiz/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -113,9 +113,10 @@ class DocCommentAlignmentSniff implements Sniff
 
             if ($tokens[$i]['column'] !== $requiredColumn) {
                 $pluralizeSpace = 's';
-                if ($requiredColumn - 1 === 1) {
+                if (($requiredColumn - 1) === 1) {
                     $pluralizeSpace = '';
                 }
+
                 $error = 'Expected %s space%s before asterisk; %s found';
                 $data  = [
                     ($requiredColumn - 1),
@@ -131,7 +132,7 @@ class DocCommentAlignmentSniff implements Sniff
                         $phpcsFile->fixer->replaceToken(($i - 1), $padding);
                     }
                 }
-            }
+            }//end if
 
             if ($tokens[$i]['code'] !== T_DOC_COMMENT_STAR) {
                 continue;

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -109,6 +109,7 @@ class ControlSignatureSniff implements Sniff
             if ($expected === 1) {
                 $pluralizeSpace = '';
             }
+
             $error = 'Expected %s space%s after %s keyword; %s found';
             $data  = [
                 $expected,
@@ -125,7 +126,7 @@ class ControlSignatureSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($stackPtr + 1), str_repeat(' ', $expected));
                 }
             }
-        }
+        }//end if
 
         // Single space after closing parenthesis.
         if (isset($tokens[$stackPtr]['parenthesis_closer']) === true
@@ -155,6 +156,7 @@ class ControlSignatureSniff implements Sniff
                 if ($expected === 1) {
                     $pluralizeSpace = '';
                 }
+
                 $error = 'Expected %s space%s after closing parenthesis; found %s';
                 $data  = [
                     $expected,

--- a/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/Standards/Squiz/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -105,9 +105,14 @@ class ControlSignatureSniff implements Sniff
         }
 
         if ($found !== $expected) {
-            $error = 'Expected %s space(s) after %s keyword; %s found';
+            $pluralizeSpace = 's';
+            if ($expected === 1) {
+                $pluralizeSpace = '';
+            }
+            $error = 'Expected %s space%s after %s keyword; %s found';
             $data  = [
                 $expected,
+                $pluralizeSpace,
                 strtoupper($tokens[$stackPtr]['content']),
                 $found,
             ];
@@ -146,9 +151,14 @@ class ControlSignatureSniff implements Sniff
             }
 
             if ($found !== $expected) {
-                $error = 'Expected %s space(s) after closing parenthesis; found %s';
+                $pluralizeSpace = 's';
+                if ($expected === 1) {
+                    $pluralizeSpace = '';
+                }
+                $error = 'Expected %s space%s after closing parenthesis; found %s';
                 $data  = [
                     $expected,
+                    $pluralizeSpace,
                     $found,
                 ];
 

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc
@@ -529,3 +529,9 @@ $x = array(
     'bar',
     'baz' => 'bar', // KeySpecified (based on first entry).
      );
+
+ $x =
+ array(
+  'a',
+  'b',
+   );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.1.inc.fixed
@@ -565,3 +565,9 @@ $x = array(
     'bar',
     'baz' => 'bar', // KeySpecified (based on first entry).
      );
+
+ $x =
+ array(
+  'a',
+  'b',
+ );

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc
@@ -518,3 +518,9 @@ $x = [
     'bar',
     'baz' => 'bar', // KeySpecified (based on first entry).
      ];
+
+ $x =
+ [
+  'a',
+  'b',
+   ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.2.inc.fixed
@@ -552,3 +552,9 @@ $x = [
     'bar',
     'baz' => 'bar', // KeySpecified (based on first entry).
      ];
+
+ $x =
+ [
+  'a',
+  'b',
+ ];

--- a/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
+++ b/src/Standards/Squiz/Tests/Arrays/ArrayDeclarationUnitTest.php
@@ -128,6 +128,7 @@ class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 516 => 1,
                 523 => 1,
                 530 => 1,
+                537 => 1,
             ];
         case 'ArrayDeclarationUnitTest.2.inc':
             return [
@@ -218,6 +219,7 @@ class ArrayDeclarationUnitTest extends AbstractSniffUnitTest
                 505 => 1,
                 512 => 1,
                 519 => 1,
+                526 => 1,
             ];
         default:
             return [];


### PR DESCRIPTION
This PR fixes more occurences of the word `space(s)` to be either `space` or `spaces` depending on the spacing value. 

## Description
This PR has been created after some brief discussion with @jrfnl in #3647 and addressing the Sniff I've pointed out in https://github.com/squizlabs/PHP_CodeSniffer/pull/3647#pullrequestreview-1593431719

### Suggested changelog entry
Correct pluralization of the word space/spaces depending on the spacing value

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [x] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.
