### PR TITLE
Generic/DocComment: bug fix - don't remove ignore annotations when fixing

### DIFF
--- a/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/DocCommentSniff.php
@@ -11,6 +11,7 @@ namespace PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class DocCommentSniff implements Sniff
 {
@@ -280,9 +281,12 @@ class DocCommentSniff implements Sniff
             }
 
             // Check that there was single blank line after the tag block
-            // but account for a multi-line tag comments.
+            // but account for multi-line tag comments.
+            $find = Tokens::$phpcsCommentTokens;
+            $find[T_DOC_COMMENT_TAG] = T_DOC_COMMENT_TAG;
+
             $lastTag = $group[$pos];
-            $next    = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($lastTag + 3), $commentEnd);
+            $next    = $phpcsFile->findNext($find, ($lastTag + 3), $commentEnd);
             if ($next !== false) {
                 $prev = $phpcsFile->findPrevious([T_DOC_COMMENT_TAG, T_DOC_COMMENT_STRING], ($next - 1), $commentStart);
                 if ($tokens[$next]['line'] !== ($tokens[$prev]['line'] + 2)) {

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc
@@ -249,4 +249,14 @@
  * @link		http://pear.php.net/package/PHP_CodeSniffer
  */
 
+/**
+ * Do something.
+ *
+ * @codeCoverageIgnore
+ *
+ * @phpcs:disable Stnd.Cat.SniffName
+ *
+ * @return void
+ */
+
 /** No docblock close tag. Must be last test without new line.

--- a/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc.fixed
+++ b/src/Standards/Generic/Tests/Commenting/DocCommentUnitTest.inc.fixed
@@ -254,4 +254,14 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
+/**
+ * Do something.
+ *
+ * @codeCoverageIgnore
+ *
+ * @phpcs:disable Stnd.Cat.SniffName
+ *
+ * @return void
+ */
+
 /** No docblock close tag. Must be last test without new line.


### PR DESCRIPTION
## Description
The code sample included in the tests would previously result in an "There must be a single blank line after a tag group" error, even though there _is_ a blank line after the `@codeCoverageIgnore` tag.

The auto-fixer would subsequently fix this by removing the `@phpcs:disable` comment + the blank line after it.

Fixed now.

Includes test.

### Suggested changelog entry
* Generic/DocComment: the SpacingAfterTagGroup fixer could accidentally remove ignore annotations.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

