### PR TITLE
Squiz/NonExecutableCode: simplify + improve handling of comments and closures

### DIFF
--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -94,21 +94,13 @@ class NonExecutableCodeSniff implements Sniff
             }
         }//end if
 
-        // Check if this token is actually part of a one-line IF or ELSE statement.
-        for ($i = ($stackPtr - 1); $i > 0; $i--) {
-            if ($tokens[$i]['code'] === T_CLOSE_PARENTHESIS) {
-                $i = $tokens[$i]['parenthesis_opener'];
-                continue;
-            } else if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
-                continue;
-            }
-
-            break;
-        }
-
-        if ($tokens[$i]['code'] === T_IF
-            || $tokens[$i]['code'] === T_ELSE
-            || $tokens[$i]['code'] === T_ELSEIF
+        // This token may be part of an inline condition.
+        // If we find a closing parenthesis that belongs to a condition,
+        // or an "else", we should ignore this token.
+        if ($tokens[$prev]['code'] === T_ELSE
+            || (isset($tokens[$prev]['parenthesis_owner']) === true
+            && ($tokens[$tokens[$prev]['parenthesis_owner']]['code'] === T_IF
+            || $tokens[$tokens[$prev]['parenthesis_owner']]['code'] === T_ELSEIF))
         ) {
             return;
         }
@@ -175,21 +167,6 @@ class NonExecutableCodeSniff implements Sniff
                 return;
             }//end if
         }//end if
-
-        // This token may be part of an inline condition.
-        // If we find a closing parenthesis that belongs to a condition
-        // we should ignore this token.
-        if (isset($tokens[$prev]['parenthesis_owner']) === true) {
-            $owner  = $tokens[$prev]['parenthesis_owner'];
-            $ignore = [
-                T_IF     => true,
-                T_ELSE   => true,
-                T_ELSEIF => true,
-            ];
-            if (isset($ignore[$tokens[$owner]['code']]) === true) {
-                return;
-            }
-        }
 
         $ourConditions = array_keys($tokens[$stackPtr]['conditions']);
 

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -114,9 +114,9 @@ class NonExecutableCodeSniff implements Sniff
         }
 
         if ($tokens[$stackPtr]['code'] === T_RETURN) {
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($tokens[$next]['code'] === T_SEMICOLON) {
-                $next = $phpcsFile->findNext(T_WHITESPACE, ($next + 1), null, true);
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
                 if ($tokens[$next]['code'] === T_CLOSE_CURLY_BRACKET) {
                     // If this is the closing brace of a function
                     // then this return statement doesn't return anything

--- a/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
+++ b/src/Standards/Squiz/Sniffs/PHP/NonExecutableCodeSniff.php
@@ -122,7 +122,9 @@ class NonExecutableCodeSniff implements Sniff
                     // then this return statement doesn't return anything
                     // and is not required anyway.
                     $owner = $tokens[$next]['scope_condition'];
-                    if ($tokens[$owner]['code'] === T_FUNCTION) {
+                    if ($tokens[$owner]['code'] === T_FUNCTION
+                        || $tokens[$owner]['code'] === T_CLOSURE
+                    ) {
                         $warning = 'Empty return statement not required here';
                         $phpcsFile->addWarning($warning, $stackPtr, 'ReturnNotRequired');
                         return;

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -413,5 +413,11 @@ function returnNotRequiredIgnoreCommentsB()
     /*comment*/
 }
 
+$closure = function ()
+{
+    echo 'foo';
+    return; // This return should be flagged as not required.
+};
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.1.inc
@@ -396,5 +396,22 @@ function executionStoppingThrowExpressionsE() {
     echo 'non-executable';
 }
 
+function returnNotRequiredIgnoreCommentsA()
+{
+    if ($something === TRUE) {
+        return /*comment*/;
+    }
+
+    echo 'foo';
+    return /*comment*/;
+}
+
+function returnNotRequiredIgnoreCommentsB()
+{
+    echo 'foo';
+    return;
+    /*comment*/
+}
+
 // Intentional syntax error.
 return array_map(

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -84,6 +84,7 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 396 => 1,
                 406 => 1,
                 412 => 1,
+                419 => 1,
             ];
             break;
         case 'NonExecutableCodeUnitTest.2.inc':

--- a/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
+++ b/src/Standards/Squiz/Tests/PHP/NonExecutableCodeUnitTest.php
@@ -82,6 +82,8 @@ class NonExecutableCodeUnitTest extends AbstractSniffUnitTest
                 386 => 1,
                 391 => 1,
                 396 => 1,
+                406 => 1,
+                412 => 1,
             ];
             break;
         case 'NonExecutableCodeUnitTest.2.inc':


### PR DESCRIPTION
## Description

Some tweaks for the sniff which I noticed while reviewing #3770.


### Squiz/NonExecutableCode: make sniff more code style independent

When determining whether a `return` statement is the last code token in a function body, comments should be ignored, but weren't.

Fixed now. Includes tests.

### Squiz/NonExecutableCode: flag redundant return statements in closures too

A return statement which doesn't return a value at the end of a function body would be flagged as "not required" for named functions, but not so for anonymous functions.

Fixed now. Includes tests.

### Squiz/NonExecutableCode: fold duplicate code

Follow up on commits 0e10f43 and 01754d9, which both deal with fixing bugs where the sniff would not handle if/elseif/else conditions without curly braces correctly.

This commit merges the two near duplicate code blocks, which the above mentioned commits introduced, each containing code doing essentially the same thing.

Also note that `T_ELSE` is handled separately now as `else` does not take parentheses and can therefore not be a parenthesis owner.

This change is already covered by pre-existing tests.


### Suggested changelog entry
* Squiz/NonExecutableCode: redundant `return` statements just before a function close brace will now be flagged more often.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
