### PR TITLE
Squiz/FunctionDeclarationArgumentSpacing: make the reference operator spacing configurable

### DIFF
--- a/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/src/Standards/Squiz/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -37,6 +37,13 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
      */
     public $requiredSpacesBeforeClose = 0;
 
+    /**
+     * How many spaces should follow the reference operator in by-reference parameter declarations.
+     *
+     * @var integer
+     */
+    public $requiredSpacesAfterReferenceOperator = 0;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -77,7 +84,8 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
 
         $this->equalsSpacing           = (int) $this->equalsSpacing;
         $this->requiredSpacesAfterOpen = (int) $this->requiredSpacesAfterOpen;
-        $this->requiredSpacesBeforeClose = (int) $this->requiredSpacesBeforeClose;
+        $this->requiredSpacesBeforeClose            = (int) $this->requiredSpacesBeforeClose;
+        $this->requiredSpacesAfterReferenceOperator = (int) $this->requiredSpacesAfterReferenceOperator;
 
         $this->processBracket($phpcsFile, $tokens[$stackPtr]['parenthesis_opener']);
 
@@ -148,15 +156,21 @@ class FunctionDeclarationArgumentSpacingSniff implements Sniff
                     $gap = $tokens[($refToken + 1)]['length'];
                 }
 
-                if ($gap !== 0) {
-                    $error = 'Expected 0 spaces after reference operator for argument "%s"; %s found';
+                if ($gap !== $this->requiredSpacesAfterReferenceOperator) {
+                    $error = 'Expected %s spaces after reference operator for argument "%s"; %s found';
                     $data  = [
+                        $this->requiredSpacesAfterReferenceOperator,
                         $param['name'],
                         $gap,
                     ];
                     $fix   = $phpcsFile->addFixableError($error, $refToken, 'SpacingAfterReference', $data);
                     if ($fix === true) {
-                        $phpcsFile->fixer->replaceToken(($refToken + 1), '');
+                        $padding = str_repeat(' ', $this->requiredSpacesAfterReferenceOperator);
+                        if ($gap === 0) {
+                            $phpcsFile->fixer->addContentBefore(($refToken + 1), $padding);
+                        } else {
+                            $phpcsFile->fixer->replaceToken(($refToken + 1), $padding);
+                        }
                     }
                 }
             }//end if


### PR DESCRIPTION
<!--
Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
-->

## Description

Enables the amount of whitespace between the reference operator and the argument name in function declarations to be defined by a property in XML config. The existing sniff fixes this at 0 spaces, meaning function declarations with by-reference arguments must look like this:

```php
function do_something(string &$withThis): void;
```

My coding style follows PSR12, with a few modifications, one of which is to have a space between the reference operator and the argument name:

```php
function do_something(string & $withThis): void;
```

Since the PSR12 standard imports `Standards\Squizz\Sniffs\Functions\FunctionDeclarationArgumentSpacingSniff`, and since at present this sniff has a strict requirement of 0 spaces between the reference operator and the argument name, it's not possible to base my standard off PSR12 and make this customisation. This PR resolves that by making the amount of space between the reference operator and the argument name configurable in the XML file, thus:

```xml
<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
    <properties>
        <property name="requiredSpacesAfterReferenceOperator" value="1"/>
    </properties>
</rule>
```

The feature has been implemented similarly to other properties that are configurable in this sniff. Notably, the property controlling the required number of spaces after the reference operator defaults to 0, ensuring that where no customisation is present for this property for this sniff in the configuration file, the sniff continues to behave as it does currently. Therefore existing workflows using this sniff will be unaffected.

### Suggested changelog entry
Allow the required spacing between the reference operator and the argument name in function declarations to be customised in configuration files for the Squizz standard's FunctionDeclarationArgumentSpacing sniff.


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes. *
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.

\* I've checked the test and it doesn't look like it's possible to test the sniff with alternate configurations. I'm
happy to write one if I've missed how this is done.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
