### PR TITLE
Fix bug in CSS tokenizer

### DIFF
--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.css
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.css
@@ -23,3 +23,10 @@
 }
 /* phpcs:set Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false */
 
+// /**
+//  * This text is in two types of comment: each line is commented out
+//  * individually, and the whole block is in what looks like a
+//  * docblock-comment. This sniff should ignore all this text as there
+//  * is no superfluous white-space here.
+//  */
+

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.css.fixed
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.1.css.fixed
@@ -21,3 +21,10 @@
     float: left;
 }
 /* phpcs:set Squiz.WhiteSpace.SuperfluousWhitespace ignoreBlankLines false */
+
+// /**
+//  * This text is in two types of comment: each line is commented out
+//  * individually, and the whole block is in what looks like a
+//  * docblock-comment. This sniff should ignore all this text as there
+//  * is no superfluous white-space here.
+//  */

--- a/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
+++ b/src/Standards/Squiz/Tests/WhiteSpace/SuperfluousWhitespaceUnitTest.php
@@ -84,7 +84,7 @@ class SuperfluousWhitespaceUnitTest extends AbstractSniffUnitTest
                 8  => 1,
                 9  => 1,
                 11 => 1,
-                25 => 1,
+                32 => 1,
             ];
             break;
         default:

--- a/src/Tokenizers/CSS.php
+++ b/src/Tokenizers/CSS.php
@@ -196,7 +196,11 @@ class CSS extends PHP
 
                 // The first and last tokens are the open/close tags.
                 array_shift($commentTokens);
-                array_pop($commentTokens);
+                $closeTag = array_pop($commentTokens);
+
+                while ($closeTag['content'] !== '?'.'>') {
+                    $closeTag = array_pop($commentTokens);
+                }
 
                 if ($leadingZero === true) {
                     $commentTokens[0]['content'] = substr($commentTokens[0]['content'], 1);


### PR DESCRIPTION
Yes, I know that the non-PHP tokenizers are going away in version 4.0. Meanwhile, the 3.x release line has a bug which can be fixed.

## Description
While working with `phpcbf`, I noticed that some LESS files (which are [parsed as CSS due to the specific ruleset being used](https://github.com/magento/magento-coding-standard/blob/v32/Magento2/ruleset.xml#L6)) had unexpected content injected into them.

```css
/* file: test.less */
// /**
//  * this is a comment
//  * this is also a comment
//  */


```

(Note the extra trailing newline at the end of the file.)

`phpcs --basepath=. -s --standard=Squiz --sniffs=Squiz.WhiteSpace.SuperfluousWhitespace --extensions=less/CSS test.less`

```
FILE: test.less
-------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------------------------------
 7 | ERROR | [x] Additional whitespace found at end of file
   |       |     (Squiz.WhiteSpace.SuperfluousWhitespace.EndFile)
-------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-------------------------------------------------------------------------------------------------------------

Time: 45ms; Memory: 10MB
```

After running `phpcbf` (with the same flags as above), I get a file with this content:

```css
/* file: test.less */
// /**
?>^PHPCS_CSS_T_CLOSE_TAG^^PHPCS_CSS_T_CLOSE_TAG^//  * this is a comment
//  * this is also a comment
//  */
```

(Note the extra newline at the end of the file has been fixed.)

### Suggested changelog entry
Fixed bug in CSS tokenizer

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
