### PR TITLE
Auto-fix PEAR.Commenting.FunctionComment.SpacingAfter

### DIFF
--- a/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/Standards/PEAR/Sniffs/Commenting/FunctionCommentSniff.php
@@ -129,11 +129,25 @@ class FunctionCommentSniff implements Sniff
                     && $tokens[$i]['line'] !== $tokens[($i + 1)]['line']
                 ) {
                     $error = 'There must be no blank lines after the function comment';
-                    $phpcsFile->addError($error, $commentEnd, 'SpacingAfter');
+                    $fix   = $phpcsFile->addFixableError($error, $commentEnd, 'SpacingAfter');
+
+                    if ($fix === true) {
+                        $phpcsFile->fixer->beginChangeset();
+
+                        while ($i < $stackPtr
+                            && $tokens[$i]['code'] === T_WHITESPACE
+                            && $tokens[$i]['line'] !== $tokens[($i + 1)]['line']
+                        ) {
+                            $phpcsFile->fixer->replaceToken($i++, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
+                    }
+
                     break;
                 }
-            }
-        }
+            }//end for
+        }//end if
 
         $commentStart = $tokens[$commentEnd]['comment_opener'];
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -476,3 +476,37 @@ class Something implements JsonSerializable {
 
     public function blankLineDetectionC() {}
 }
+
+class SpacingAfter {
+    /**
+     * There are multiple blank lines between this comment and the next function.
+     *
+     * @return void
+     */
+
+
+
+
+
+
+
+
+    public function multipleBlankLines() {}
+
+    /**
+     * There are multiple blank lines, and some "empty" lines with only
+     * spaces/tabs between this comment and the next function.
+     *
+     * @return void
+     */
+
+
+        
+
+		
+
+	  
+
+
+    public function multipleLinesSomeEmpty() {}
+}

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -453,7 +453,6 @@ class Something implements JsonSerializable {
      *
      * @return mixed
      */
-
     #[ReturnTypeWillChange]
     public function blankLineDetectionA() {}
 
@@ -463,7 +462,6 @@ class Something implements JsonSerializable {
      * @return mixed
      */
     #[ReturnTypeWillChange]
-
     public function blankLineDetectionB() {}
 
     /**
@@ -471,8 +469,23 @@ class Something implements JsonSerializable {
      *
      * @return mixed
      */
-
     #[ReturnTypeWillChange]
-
     public function blankLineDetectionC() {}
+}
+
+class SpacingAfter {
+    /**
+     * There are multiple blank lines between this comment and the next function.
+     *
+     * @return void
+     */
+    public function multipleBlankLines() {}
+
+    /**
+     * There are multiple blank lines, and some "empty" lines with only
+     * spaces/tabs between this comment and the next function.
+     *
+     * @return void
+     */
+    public function multipleLinesSomeEmpty() {}
 }

--- a/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/src/Standards/PEAR/Tests/Commenting/FunctionCommentUnitTest.php
@@ -73,6 +73,8 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
             455 => 1,
             464 => 1,
             473 => 1,
+            485 => 1,
+            501 => 1,
         ];
 
     }//end getErrorList()


### PR DESCRIPTION
## Description
I have witnessed some complaints coming from `Squiz.Commenting.FunctionComment.SpacingAfter` which look like they could be trivially auto-fixed. This pull request adds auto-fixing for this particular complaint. I intend to investigate feasibility of auto-fixing other cases in this sniff another time.

### Suggested changelog entry
Allow auto-fixing `...FunctionComment.SpacingAfter`

## Types of changes
- New feature _(non-breaking change which adds functionality)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.