### PR TITLE
Various sniffs: always return EOF pointer

### DIFF
--- a/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/CSSLintSniff.php
@@ -44,13 +44,13 @@ class CSSLintSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where
      *                                               the token was found.
      *
-     * @return void
+     * @return int
      */
     public function process(File $phpcsFile, $stackPtr)
     {
         $csslintPath = Config::getExecutablePath('csslint');
         if ($csslintPath === null) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $fileName = $phpcsFile->getFilename();
@@ -59,7 +59,7 @@ class CSSLintSniff implements Sniff
         exec($cmd, $output, $retval);
 
         if (is_array($output) === false) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $count = count($output);

--- a/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ClosureLinterSniff.php
@@ -60,14 +60,14 @@ class ClosureLinterSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where
      *                                               the token was found.
      *
-     * @return void
+     * @return int
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jslint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
     {
         $lintPath = Config::getExecutablePath('gjslint');
         if ($lintPath === null) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $fileName = $phpcsFile->getFilename();
@@ -77,7 +77,7 @@ class ClosureLinterSniff implements Sniff
         exec($cmd, $output, $retval);
 
         if (is_array($output) === false) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         foreach ($output as $finding) {

--- a/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/ESLintSniff.php
@@ -51,14 +51,14 @@ class ESLintSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where
      *                                               the token was found.
      *
-     * @return void
+     * @return int
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jshint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
     {
         $eslintPath = Config::getExecutablePath('eslint');
         if ($eslintPath === null) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $filename = $phpcsFile->getFilename();

--- a/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
+++ b/src/Standards/Generic/Sniffs/Debug/JSHintSniff.php
@@ -45,7 +45,7 @@ class JSHintSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where
      *                                               the token was found.
      *
-     * @return void
+     * @return int
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jshint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
@@ -53,7 +53,7 @@ class JSHintSniff implements Sniff
         $rhinoPath  = Config::getExecutablePath('rhino');
         $jshintPath = Config::getExecutablePath('jshint');
         if ($jshintPath === null) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $fileName   = $phpcsFile->getFilename();

--- a/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LineEndingsSniff.php
@@ -79,7 +79,7 @@ class LineEndingsSniff implements Sniff
             if ($tokens[$lastToken]['line'] === 1
                 && $tokens[$lastToken]['content'] !== "\n"
             ) {
-                return;
+                return ($phpcsFile->numTokens + 1);
             }
         }
 

--- a/src/Standards/Generic/Sniffs/Files/LowercasedFilenameSniff.php
+++ b/src/Standards/Generic/Sniffs/Files/LowercasedFilenameSniff.php
@@ -44,7 +44,7 @@ class LowercasedFilenameSniff implements Sniff
     {
         $filename = $phpcsFile->getFilename();
         if ($filename === 'STDIN') {
-            return;
+            return  ($phpcsFile->numTokens + 1);
         }
 
         $filename          = basename($filename);

--- a/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
+++ b/src/Standards/PSR12/Sniffs/Files/OpenTagSniff.php
@@ -54,7 +54,7 @@ class OpenTagSniff implements Sniff
         $next   = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
         if ($next === false) {
             // Empty file.
-            return;
+            return $phpcsFile->numTokens;
         }
 
         if ($tokens[$next]['line'] === $tokens[$stackPtr]['line']) {

--- a/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JSLintSniff.php
@@ -44,7 +44,7 @@ class JSLintSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where
      *                                               the token was found.
      *
-     * @return void
+     * @return int
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If jslint.js could not be run
      */
     public function process(File $phpcsFile, $stackPtr)
@@ -52,7 +52,7 @@ class JSLintSniff implements Sniff
         $rhinoPath  = Config::getExecutablePath('rhino');
         $jslintPath = Config::getExecutablePath('jslint');
         if ($rhinoPath === null || $jslintPath === null) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $fileName = $phpcsFile->getFilename();

--- a/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
+++ b/src/Standards/Squiz/Sniffs/Debug/JavaScriptLintSniff.php
@@ -45,14 +45,14 @@ class JavaScriptLintSniff implements Sniff
      * @param int                         $stackPtr  The position in the stack where
      *                                               the token was found.
      *
-     * @return void
+     * @return int
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If Javascript Lint ran into trouble.
      */
     public function process(File $phpcsFile, $stackPtr)
     {
         $jslPath = Config::getExecutablePath('jsl');
         if ($jslPath === null) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $fileName = $phpcsFile->getFilename();

--- a/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
+++ b/src/Standards/Zend/Sniffs/Debug/CodeAnalyzerSniff.php
@@ -46,7 +46,7 @@ class CodeAnalyzerSniff implements Sniff
     {
         $analyzerPath = Config::getExecutablePath('zend_ca');
         if ($analyzerPath === null) {
-            return;
+            return ($phpcsFile->numTokens + 1);
         }
 
         $fileName = $phpcsFile->getFilename();


### PR DESCRIPTION
## Description

Always return EOF pointer for files scanning the complete file in one go as if any of the error conditions are hit, it is useless to try again for the same file.


### Suggested changelog entry
_N/A_

