### PR TITLE
Config::processLongArgument(): fix storing of unknown arguments

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1219,13 +1219,17 @@ class Config
                 if ($this->dieOnUnknownArg === false) {
                     $eqPos = strpos($arg, '=');
                     try {
+                        $unknown = $this->unknown;
+
                         if ($eqPos === false) {
-                            $this->values[$arg] = $arg;
+                            $unknown[$arg] = $arg;
                         } else {
-                            $value = substr($arg, ($eqPos + 1));
-                            $arg   = substr($arg, 0, $eqPos);
-                            $this->values[$arg] = $value;
+                            $value         = substr($arg, ($eqPos + 1));
+                            $arg           = substr($arg, 0, $eqPos);
+                            $unknown[$arg] = $value;
                         }
+
+                        $this->unknown = $unknown;
                     } catch (RuntimeException $e) {
                         // Value is not valid, so just ignore it.
                     }


### PR DESCRIPTION
## Description

These arguments should be stored in the `unknown` property. There is no `values` property.

Note: the read/write logic is to prevent a `Indirect modification of overloaded property PHP_CodeSniffer\Config::$unknown has no effect` PHP notice.

### Suggested changelog entry
_N/A_ (I don't think this bug had any impact on end-users)


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
