### PR TITLE
Respect all sniffs when reviewing PHP_CodeSniffer itself

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -32,6 +32,7 @@
         <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
         <exclude name="PEAR.Commenting.InlineComment"/>
+        <exclude name="Generic.Files.LineLength"/>
     </rule>
 
     <!-- Include some sniffs from other standards that don't conflict with PEAR -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
     <arg name="basepath" value="."/>
     <arg name="colors"/>
     <arg name="parallel" value="75"/>
-    <arg value="np"/>
+    <arg value="p"/>
 
     <!-- Don't hide tokenizer exceptions -->
     <rule ref="Internal.Tokenizer.Exception">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,10 +17,7 @@
     <arg name="parallel" value="75"/>
     <arg value="p"/>
 
-    <!-- Don't hide tokenizer exceptions -->
-    <rule ref="Internal.Tokenizer.Exception">
-        <type>error</type>
-    </rule>
+    <rule ref="Internal.Tokenizer.Exception"/>
 
     <!-- Include the whole PEAR standard -->
     <rule ref="PEAR">
@@ -77,13 +74,6 @@
     <rule ref="PSR12.Files.OpenTag"/>
     <rule ref="Zend.Files.ClosingTag"/>
 
-    <!-- PEAR uses warnings for inline control structures, so switch back to errors -->
-    <rule ref="Generic.ControlStructures.InlineControlStructure">
-        <properties>
-            <property name="error" value="true"/>
-        </properties>
-    </rule>
-
     <!-- We use custom indent rules for arrays -->
     <rule ref="Generic.Arrays.ArrayIndent"/>
     <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
@@ -112,11 +102,10 @@
         </properties>
     </rule>
 
-    <!-- Have 12 chars padding maximum and always show as errors -->
+    <!-- Have 12 chars padding maximum -->
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>
             <property name="maxPadding" value="12"/>
-            <property name="error" value="true"/>
         </properties>
     </rule>
 
@@ -131,16 +120,6 @@
                 <element key="create_function" value="null"/>
             </property>
         </properties>
-    </rule>
-
-    <!-- Private methods MUST not be prefixed with an underscore -->
-    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
-        <type>error</type>
-    </rule>
-
-    <!-- Private properties MUST not be prefixed with an underscore -->
-    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
-        <type>error</type>
     </rule>
 
     <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->

--- a/scripts/ValidatePEAR/ValidatePEARPackageXML.php
+++ b/scripts/ValidatePEAR/ValidatePEARPackageXML.php
@@ -45,7 +45,7 @@ class ValidatePEARPackageXML
      *
      * @var array
      *
-     * @link https://pear.php.net/manual/en/developers.packagedef.intro.php#developers.packagedef.roles
+     * @see https://pear.php.net/manual/en/developers.packagedef.intro.php#developers.packagedef.roles
      */
     private $validRoles = [
         'data'   => true,

--- a/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
+++ b/src/Standards/Generic/Sniffs/Commenting/TodoSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Warns about TODO comments.
+ * Warns about to-do comments.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)

--- a/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
+++ b/src/Standards/Generic/Tests/Commenting/TodoUnitTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit test class for the Todo sniff.
+ * Unit test class for the to-do sniff.
  *
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)

--- a/src/Util/Tokens.php
+++ b/src/Util/Tokens.php
@@ -650,7 +650,7 @@ final class Tokens
      *
      * @var array <int|string> => <int|string>
      *
-     * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
+     * @see https://www.php.net/language.constants.predefined PHP Manual on magic constants
      */
     public static $magicConstants = [
         T_CLASS_C  => T_CLASS_C,


### PR DESCRIPTION
## Description
While reviewing https://github.com/squizlabs/PHP_CodeSniffer/pull/3912, I was surprised that `Squiz.PHP.NonExecutableCode` did not seem to complain about anything when running this over the main branch (before applying the changes from that pull request). Upon further investigation, I found that the coding standard included a parameter of `-n`, which ignores all warnings by default. Removing this allowed me to properly review #3912.

This pull request removes the `-n` parameter and makes the necessary changes to the code-base (including the rule-set) so that no warnings are omitted. This means that when we add `Squiz.PHP.NonExecutableCode` to the rule-set for PHP_CodeSniffer itself, the warnings it produces won't be ignored.

### Suggested changelog entry
Respect warnings as well as errors from sniffs within the coding standard for PHP_CodeSniffer itself.

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have verified that the code complies with the projects coding standards.
