### PR TITLE
File::addMessage(): do not ignore Internal errors when scanning selectively

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -909,6 +909,7 @@ class File
         // Filter out any messages for sniffs that shouldn't have run
         // due to the use of the --sniffs command line argument.
         if ($includeAll === false
+            && $parts[0] !== 'Internal'
             && ((empty($this->configCache['sniffs']) === false
             && in_array(strtolower($listenerCode), $this->configCache['sniffs'], true) === false)
             || (empty($this->configCache['exclude']) === false

--- a/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowAlternativePHPTagsUnitTest.php
@@ -89,7 +89,15 @@ class DisallowAlternativePHPTagsUnitTest extends AbstractSniffUnitTest
     public function getWarningList($testFile='')
     {
         if ($testFile === 'DisallowAlternativePHPTagsUnitTest.3.inc') {
+            // Check if the Internal.NoCodeFound error can be expected on line 1.
+            $option = (bool) ini_get('short_open_tag');
+            $line1  = 1;
+            if ($option === true) {
+                $line1 = 0;
+            }
+
             return [
+                1 => $line1,
                 3 => 1,
                 4 => 1,
                 5 => 1,

--- a/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/DisallowShortOpenTagUnitTest.php
@@ -88,7 +88,14 @@ class DisallowShortOpenTagUnitTest extends AbstractSniffUnitTest
         case 'DisallowShortOpenTagUnitTest.1.inc':
             return [];
         case 'DisallowShortOpenTagUnitTest.3.inc':
+            // Check if the Internal.NoCodeFound error can be expected on line 1.
+            $option = (bool) ini_get('short_open_tag');
+            $line1  = 1;
+            if ($option === true) {
+                $line1 = 0;
+            }
             return [
+                1  => $line1,
                 3  => 1,
                 6  => 1,
                 11 => 1,

--- a/tests/Core/ErrorSuppressionTest.php
+++ b/tests/Core/ErrorSuppressionTest.php
@@ -550,19 +550,19 @@ EOD;
 
             // Process with line suppression nested within disable/enable suppression.
             'disable/enable: slash comment, next line nested single line suppression'         => [
-                'before' => '// phpcs:disable'.PHP_EOL.'// phpcs:ignore',
+                'before' => '// phpcs:disable'."\n".'// phpcs:ignore',
                 'after'  => '// phpcs:enable',
             ],
             'disable/enable: slash comment, with @, next line nested single line suppression' => [
-                'before' => '// @phpcs:disable'.PHP_EOL.'// @phpcs:ignore',
+                'before' => '// @phpcs:disable'."\n".'// @phpcs:ignore',
                 'after'  => '// @phpcs:enable',
             ],
             'disable/enable: hash comment, next line nested single line suppression'          => [
-                'before' => '# @phpcs:disable'.PHP_EOL.'# @phpcs:ignore',
+                'before' => '# @phpcs:disable'."\n".'# @phpcs:ignore',
                 'after'  => '# @phpcs:enable',
             ],
             'old style: slash comment, next line nested single line suppression'              => [
-                'before' => '// @codingStandardsIgnoreStart'.PHP_EOL.'// @codingStandardsIgnoreLine',
+                'before' => '// @codingStandardsIgnoreStart'."\n".'// @codingStandardsIgnoreLine',
                 'after'  => '// @codingStandardsIgnoreEnd',
             ],
         ];
@@ -734,7 +734,7 @@ EOD;
             'ignoreFile: start of file, hash comment, with @'         => ['before' => '# @phpcs:ignoreFile'],
             'ignoreFile: start of file, single-line star comment'     => ['before' => '/* phpcs:ignoreFile */'],
             'ignoreFile: start of file, multi-line star comment'      => [
-                'before' => '/*'.PHP_EOL.' phpcs:ignoreFile'.PHP_EOL.' */',
+                'before' => '/*'."\n".' phpcs:ignoreFile'."\n".' */',
             ],
             'ignoreFile: start of file, single-line docblock comment' => ['before' => '/** phpcs:ignoreFile */'],
 
@@ -748,7 +748,7 @@ EOD;
             'old style: start of file, slash comment'                 => ['before' => '// @codingStandardsIgnoreFile'],
             'old style: start of file, single-line star comment'      => ['before' => '/* @codingStandardsIgnoreFile */'],
             'old style: start of file, multi-line star comment'       => [
-                'before' => '/*'.PHP_EOL.' @codingStandardsIgnoreFile'.PHP_EOL.' */',
+                'before' => '/*'."\n".' @codingStandardsIgnoreFile'."\n".' */',
             ],
             'old style: start of file, single-line docblock comment'  => ['before' => '/** @codingStandardsIgnoreFile */'],
 
@@ -829,18 +829,18 @@ EOD;
                 'expectedErrors' => 1,
             ],
             'disable: single sniff, docblock'              => [
-                'before'         => '/**'.PHP_EOL.' * phpcs:disable Generic.Commenting.Todo'.PHP_EOL.' */ ',
+                'before'         => '/**'."\n".' * phpcs:disable Generic.Commenting.Todo'."\n".' */ ',
                 'expectedErrors' => 1,
             ],
             'disable: single sniff, docblock, with @'      => [
-                'before'         => '/**'.PHP_EOL.' * @phpcs:disable Generic.Commenting.Todo'.PHP_EOL.' */ ',
+                'before'         => '/**'."\n".' * @phpcs:disable Generic.Commenting.Todo'."\n".' */ ',
                 'expectedErrors' => 1,
             ],
 
             // Multiple sniffs.
             'disable: multiple sniffs in one comment'      => ['before' => '// phpcs:disable Generic.Commenting.Todo,Generic.PHP.LowerCaseConstant'],
             'disable: multiple sniff in multiple comments' => [
-                'before' => '// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'// phpcs:disable Generic.PHP.LowerCaseConstant',
+                'before' => '// phpcs:disable Generic.Commenting.Todo'."\n".'// phpcs:disable Generic.PHP.LowerCaseConstant',
             ],
 
             // Selectiveness variations.
@@ -857,17 +857,17 @@ EOD;
 
             // Wrong category/sniff/code.
             'disable: wrong error code and category'       => [
-                'before'           => '/**'.PHP_EOL.' * phpcs:disable Generic.PHP.LowerCaseConstant.Upper,Generic.Comments'.PHP_EOL.' */ ',
+                'before'           => '/**'."\n".' * phpcs:disable Generic.PHP.LowerCaseConstant.Upper,Generic.Comments'."\n".' */ ',
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 1,
             ],
             'disable: wrong category, docblock'            => [
-                'before'           => '/**'.PHP_EOL.' * phpcs:disable Generic.Files'.PHP_EOL.' */ ',
+                'before'           => '/**'."\n".' * phpcs:disable Generic.Files'."\n".' */ ',
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 1,
             ],
             'disable: wrong category, docblock, with @'    => [
-                'before'           => '/**'.PHP_EOL.' * @phpcs:disable Generic.Files'.PHP_EOL.' */ ',
+                'before'           => '/**'."\n".' * @phpcs:disable Generic.Files'."\n".' */ ',
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 1,
             ],
@@ -1124,7 +1124,7 @@ EOD;
                 'expectedWarnings' => 1,
             ],
             'disable: single sniff; ignore: single sniff' => [
-                'before'           => '// phpcs:disable Generic.Commenting.Todo'.PHP_EOL.'// phpcs:ignore Generic.PHP.LowerCaseConstant',
+                'before'           => '// phpcs:disable Generic.Commenting.Todo'."\n".'// phpcs:ignore Generic.PHP.LowerCaseConstant',
                 'expectedErrors'   => 1,
                 'expectedWarnings' => 0,
             ],


### PR DESCRIPTION
## Description

### ErrorSuppressionTest: prevent Internal errors

... about a mismatch in line endings when the code "template" is defined using a heredoc with Linux line endings, while the code snippets being inserted into the code "template" were using line endings matching the OS on which the tests were being run.

### File::addMessage(): do not ignore Internal errors when scanning selectively

When either the `--sniffs=...` CLI parameter is used, or the `--exclude=...` CLI parameter, the `File::addMessage()` method bows out when an error is passed which is not for one of the selected sniffs/is for one of the excluded sniffs.

Unfortunately, this "bowing out" did not take `Internal` errors into account, meaning those were now hidden, while those - IMO - should _always_ be thrown as they generally inform the end-user of something wrong with the file which impacts the scan results (mixed line endings/no code found etc).

Fixed now.

Includes updating two test files to allow for seeing internal errors.


### Suggested changelog entry
Internal errors will no longer be suppressed when the `--sniffs` or `--exclude` CLI arguments are used.


## Types of changes
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

👉🏻 This _could_ be considered a breaking change, though I'm not sure whether it should be. Opinions welcome.

Most typically, this change may impact tests for external standards which don't expect `Internal` errors.