### PR TITLE
Don't stop scan on invalid inline property annotation

### DIFF
--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.inc
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.inc
@@ -1,2 +1,9 @@
 <?php
 $output = `ls -al`;
+
+// Testing an invalid phpcs:set annotations.
+// This test is unrelated to this sniff, but the issue needs a sniff to be tested.
+// phpcs:set Generic.PHP.BacktickOperator unknown 10
+
+// Make sure errors after an incorrect annotation are still being thrown.
+$output = `ls -al`;

--- a/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
+++ b/src/Standards/Generic/Tests/PHP/BacktickOperatorUnitTest.php
@@ -25,7 +25,10 @@ class BacktickOperatorUnitTest extends AbstractSniffUnitTest
      */
     public function getErrorList()
     {
-        return [2 => 2];
+        return [
+            2 => 2,
+            9 => 2,
+        ];
 
     }//end getErrorList()
 
@@ -40,6 +43,7 @@ class BacktickOperatorUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
+        // Warning about incorrect annotation will be shown on line 1 once PR #3915 would be merged.
         return [];
 
     }//end getWarningList()


### PR DESCRIPTION
## Description
Follow up on #3629, which was merged for PHPCS 3.8.0.

PR #3629 added logic to throw a "Ruleset invalid. Property \"$propertyName\" does not exist on sniff ..." error.

This error is intended for the command-line when reading the `phpcs.xml.dist` ruleset file.

However, this error could _also_ be encountered if an inline `// phpcs:set ...` annotation would try to set a non-existent property.

While the use of `// phpcs:set` is typically reserved for sniff test case files, there is nothing stopping end-users from using the annotation.

The net-effect would be:
* The `Ruleset::setSniffProperty()` throws a `RuntimeException`.
* This exception is then passed to `File::addMessage()` where it is **not** thrown as the line on which the error is being thrown is an annotation line.
* The scan of the file stops dead in its tracks as a `RuntimeException` was encountered.
* The end-user doesn't know the file does not finish scanning as no `Internal` error is shown for the file.

To me, this is counter-intuitive and counter-productive as it may give people a false sense of security (CI is green, while in reality files are not being scanned).

To fix this, I propose the following:
* Collect all `// phpcs:set` related inline annotations encountered while scanning.
* Do **not** stop the file scan for these errors.
* Add a warning with information about the incorrect annotations on line 1 once the file has finished scanning.

Includes a test via the `Generic.PHP.BacktickOperator` sniff.


### Suggested changelog entry
I'd suggest updating the existing changelog entry for the change from PR #3629 and adding:
```
    -- Invalid sniff properties set for sniffs via inline annotations will result in an informative `Internal.PropertyDoesNotExist` errror on line, but will not halt the execution of PHPCS
```


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
