### PR TITLE
Inform user if parallelization is disabled at runtime and why

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -410,11 +410,17 @@ class Runner
         // If verbosity is too high, turn off parallelism so the
         // debug output is clean.
         if (PHP_CODESNIFFER_VERBOSITY > 1) {
+            if ($this->config->parallel > 1) {
+                echo "Parallel processing disabled for clearer output at higher verbosity levels.";
+            }
             $this->config->parallel = 1;
         }
 
         // If the PCNTL extension isn't installed, we can't fork.
         if (function_exists('pcntl_fork') === false) {
+            if ($this->config->parallel > 1) {
+                echo "Parallel processing requires the 'pcntl' PHP extension. Falling back to single-thread execution.";
+            }
             $this->config->parallel = 1;
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Description
This PR introduces messages to inform users when parallelization is disabled at runtime and the reasons for it. These enhancements aim to improve user awareness in scenarios where parallel processing gets disabled due to unmet conditions like the absence of the `pcntl` PHP extension or high verbosity settings. By providing this information, users can better understand the behavior of the system and take appropriate actions if needed.

### Suggested changelog entry
- Added informative messages to notify users when parallel processing is disabled due to the absence of the 'pcntl' extension or high verbosity settings.

### Related issues/external references
Fixes #

### Disclaimer

I'm opening this PR from GitHub web. I don't have a local development copy of PHPCS to test this locally.

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added XML documentation for the sniff.
- [ ] [Required for new files] I have added any new files to the `package.xml` file.
